### PR TITLE
P0: attribution tooling must honor repository no-AI policy and never re-inject trailers

### DIFF
--- a/internal/orchestrator/attribution_amend_test.go
+++ b/internal/orchestrator/attribution_amend_test.go
@@ -90,19 +90,57 @@ func trailerCount(msg string) int {
 	return strings.Count(msg, state.AttributionTrailerKey+":")
 }
 
-func TestEnsureAttributionTrailer_IgnoresOnlyPreservedUntrackedCheckpoint(t *testing.T) {
+func TestAmendHead_NoAttributionPolicyNeverReinjectsOrChangesExactHead(t *testing.T) {
 	origin, wt, _, branch := setupAmendRepo(t)
-	checkpoint := filepath.Join(wt, "CHECKPOINT.md")
-	amendWrite(t, wt, "CHECKPOINT.md", "durable worker progress\n")
-	o := &Orchestrator{tmuxSessionExistsFn: func(string) bool { return false }}
-	sess := &state.Session{
-		Worktree: wt, Branch: branch, Attribution: testAttribution(), CheckpointFile: checkpoint,
+	amendWrite(t, wt, "AGENTS.md", "No AI attribution anywhere in git/GitHub artifacts.\n")
+	amendGit(t, wt, "add", "AGENTS.md")
+	amendGit(t, wt, "commit", "--amend", "-m", "worker: implement feature", "-m", state.FormatAttributionTrailer(testAttribution(), time.Now().UTC()))
+	amendGit(t, wt, "push", "--force-with-lease", "origin", branch)
+
+	// The worker explicitly strips the forbidden trailer before finalization.
+	amendGit(t, wt, "commit", "--amend", "-m", "worker: implement feature")
+	amendGit(t, wt, "push", "--force-with-lease", "origin", branch)
+	cleanHead := amendGit(t, origin, "rev-parse", branch)
+
+	timeline := testAttribution()
+	ended := time.Date(2026, 7, 10, 4, 5, 0, 0, time.UTC)
+	timeline[0].EndedAt = &ended
+	timeline[0].EndReason = "fallover"
+	timeline = append(timeline, state.BackendAttribution{
+		Backend: "sol", Provider: "openai", Model: "gpt-5.6-sol",
+		StartedAt: ended, Reason: "checkpoint_resume",
+	})
+
+	for _, phase := range []string{"fallover", "checkpoint resume", "in-place continuation"} {
+		if err := amendHeadWithAttributionTrailer(wt, branch, timeline, time.Now().UTC()); err != nil {
+			t.Fatalf("%s finalization: %v", phase, err)
+		}
+		if got := amendGit(t, origin, "rev-parse", branch); got != cleanHead {
+			t.Fatalf("%s changed accepted exact head: got %s want %s", phase, got, cleanHead)
+		}
+		msg := amendGit(t, origin, "log", "-1", "--pretty=%B", branch)
+		if strings.Contains(msg, state.AttributionTrailerKey+":") {
+			t.Fatalf("%s re-injected forbidden attribution:\n%s", phase, msg)
+		}
+		timeline = append(timeline, state.BackendAttribution{
+			Backend: "codex", Provider: "openai", Model: "gpt-5.6-codex",
+			StartedAt: time.Now().UTC(), Reason: "in_place_continuation",
+		})
 	}
 
-	if deferred := o.ensureAttributionTrailerOnBranch("slot-checkpoint", sess); deferred {
-		t.Fatal("exact untracked session checkpoint incorrectly deferred attribution")
+	if len(timeline) != 5 || timeline[0].EndReason != "fallover" || timeline[1].Reason != "checkpoint_resume" {
+		t.Fatalf("internal backend attribution was not preserved: %#v", timeline)
 	}
-	if got, err := os.ReadFile(checkpoint); err != nil || string(got) != "durable worker progress\n" {
+}
+
+func TestEnsureAttributionTrailer_IgnoresOnlyPreservedUntrackedCheckpoint(t *testing.T) {
+	origin, wt, _, branch := setupAmendRepo(t)
+	amendWrite(t, wt, "CHECKPOINT.md", "durable worker progress\n")
+
+	if err := amendHeadWithAttributionTrailer(wt, branch, testAttribution(), time.Now().UTC(), "CHECKPOINT.md"); err != nil {
+		t.Fatalf("exact untracked session checkpoint incorrectly blocked historical amend: %v", err)
+	}
+	if got, err := os.ReadFile(filepath.Join(wt, "CHECKPOINT.md")); err != nil || string(got) != "durable worker progress\n" {
 		t.Fatalf("checkpoint was not preserved: content=%q err=%v", got, err)
 	}
 	headMsg := amendGit(t, origin, "log", "-1", "--pretty=%B", branch)

--- a/internal/orchestrator/attribution_merge_guard_test.go
+++ b/internal/orchestrator/attribution_merge_guard_test.go
@@ -33,23 +33,18 @@ func mergeGuardSession(branch string, pr int) *state.Session {
 }
 
 // Attribution is durable in Maestro state and Fleet, not in product commits.
-// The merge path must ignore the legacy amend hook and continue to observe the
-// authoritative PR gate even if that hook would have failed (#1000).
+// The merge path must continue to observe the authoritative PR gate regardless
+// of how many internal backend segments the session carries (#974/#1000).
 func TestAutoMergePRs_InternalAttributionNeverAmendsProductBranch(t *testing.T) {
 	branch := "feat/sup-1000-internal-attribution"
 	s := state.NewState()
 	s.Sessions["sup-858"] = mergeGuardSession(branch, 864)
 
 	ciQueried := false
-	amendCalled := false
 	o := &Orchestrator{
 		cfg: &config.Config{},
 		listOpenPRsFn: func() ([]github.PR, error) {
 			return []github.PR{{Number: 864, HeadRefName: branch}}, nil
-		},
-		amendHeadFn: func(worktreePath, b string, attribution []state.BackendAttribution, now time.Time) error {
-			amendCalled = true
-			return errors.New("legacy amend hook must be unreachable")
 		},
 		ghPRCIStatusFn: func(prNumber int) (string, error) {
 			ciQueried = true
@@ -59,9 +54,6 @@ func TestAutoMergePRs_InternalAttributionNeverAmendsProductBranch(t *testing.T) 
 
 	o.autoMergePRs(s)
 
-	if amendCalled {
-		t.Fatal("merge path invoked legacy attribution amend hook")
-	}
 	if !ciQueried {
 		t.Fatal("normal CI gate observation was blocked by internal attribution state")
 	}

--- a/internal/orchestrator/live_runtime_adoption_test.go
+++ b/internal/orchestrator/live_runtime_adoption_test.go
@@ -76,35 +76,6 @@ func TestReconcileRunningSessionsRefusesForeignLiveTmux(t *testing.T) {
 	}
 }
 
-func TestEnsureAttributionTrailerDefersWhileExactTmuxIsLive(t *testing.T) {
-	worktree := t.TempDir()
-	called := false
-	o := &Orchestrator{
-		cfg:                 &config.Config{},
-		tmuxSessionExistsFn: func(name string) bool { return name == "maestro-slot-1" },
-		tmuxPaneIdentityFn:  func(string) (int, string, error) { return 5151, worktree, nil },
-		amendHeadFn: func(string, string, []state.BackendAttribution, time.Time) error {
-			called = true
-			return nil
-		},
-	}
-	sess := &state.Session{
-		Worktree: worktree,
-		Branch:   "feat/slot-1",
-		Status:   state.StatusPROpen, // persisted status is deliberately stale
-		Attribution: []state.BackendAttribution{{
-			Backend: "sol", StartedAt: time.Now().UTC(),
-		}},
-	}
-
-	if !o.ensureAttributionTrailerOnBranch("slot-1", sess) {
-		t.Fatal("live worker ownership must defer attribution amend")
-	}
-	if called {
-		t.Fatal("attribution amend ran underneath a live worker")
-	}
-}
-
 func TestSaveStatePreservingLiveRuntimeRecoversSameSessionConflict(t *testing.T) {
 	stateDir := t.TempDir()
 	worktreeBase := t.TempDir()

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/befeast/maestro/internal/notify"
 	"github.com/befeast/maestro/internal/outcome"
 	"github.com/befeast/maestro/internal/pipeline"
+	"github.com/befeast/maestro/internal/repopolicy"
 	"github.com/befeast/maestro/internal/router"
 	"github.com/befeast/maestro/internal/selfdeploy"
 	"github.com/befeast/maestro/internal/state"
@@ -73,7 +74,6 @@ type Orchestrator struct {
 	listClosedPRsFn       func() ([]github.PR, error)
 	remoteBranchExistsFn  func(branch string) (bool, error)
 	createPRFn            func(title, body, base, head string) (int, error)
-	amendHeadFn           func(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error
 	hasOpenPRForIssueFn   func(issueNumber int) (bool, error)
 	hasMergedPRForIssueFn func(issueNumber int) (bool, error)
 	mergedPRForIssueFn    func(issueNumber int) (int, error)
@@ -449,6 +449,15 @@ func (o *Orchestrator) remoteBranchExists(branch string) (bool, error) {
 }
 
 func (o *Orchestrator) createPR(title, body, base, head string) (int, error) {
+	if o.cfg != nil {
+		prohibited, err := repopolicy.ProhibitsPublicAIAttribution(o.cfg.LocalPath)
+		if err != nil {
+			return 0, err
+		}
+		if prohibited && repopolicy.ContainsForbiddenPublicAttribution(title+"\n"+body) {
+			return 0, fmt.Errorf("repository policy prohibits AI attribution in public PR text")
+		}
+	}
 	var (
 		prNumber int
 		err      error
@@ -3854,103 +3863,6 @@ Maestro auto-created this pull request for pushed branch %s because no open pull
 `, sess.IssueNumber, branch)
 }
 
-// ensureAttributionTrailerOnBranch is retained only as a compatibility helper
-// for historical trailer tests. Production lifecycle paths no longer call it:
-// backend attribution is internal control-plane state and must never mutate a
-// target repository's commits (#1000).
-//
-// Historically this stamped the durable Maestro-Backend trailer
-// onto the branch head. It returns deferred=true when the amend could not land
-// the trailer this cycle — the branch is advancing under a concurrent push, it
-// diverged from the attributed head, the worktree is mid-write, or the remote
-// tip could not be fetched. The merge flow MUST NOT merge a PR whose amend
-// deferred: merging now would land the PR permanently without the required
-// attribution trailer while the "later retry" the deferral promises never gets
-// to run (#858). A later quiet cycle re-invokes this and completes the trailer
-// before the merge proceeds. Non-merge callers (reconcile, pr_open transitions)
-// can ignore the return: for them the trailer legitimately lands on a later
-// cycle and nothing irreversible happens in between.
-func (o *Orchestrator) ensureAttributionTrailerOnBranch(slotName string, sess *state.Session) (deferred bool) {
-	if sess == nil || len(sess.Attribution) == 0 {
-		return false
-	}
-	// Runtime ownership is stronger evidence than the persisted status. A
-	// repair worker can already be live while a concurrent state write still
-	// shows pr_open/PID=0. Never amend/force-push underneath that agent: doing so
-	// rewrites HEAD while it is editing, testing, or pushing. We intentionally
-	// fail closed even when pane identity is unreadable or foreign; a live exact
-	// tmux name is enough uncertainty to forbid a branch mutation this cycle.
-	tmuxName := strings.TrimSpace(sess.TmuxSession)
-	if tmuxName == "" {
-		tmuxName = worker.TmuxSessionName(slotName)
-	}
-	if o.tmuxSessionExists(tmuxName) {
-		pid, paneWorktree, identityErr := o.tmuxPaneIdentity(tmuxName)
-		if identityErr == nil && pid > 0 && filepath.Clean(paneWorktree) == filepath.Clean(sess.Worktree) {
-			log.Printf("[orch] attribution: deferring amend for %s (live worker owns branch %q via pid=%d tmux=%q)", slotName, sess.Branch, pid, tmuxName)
-		} else {
-			log.Printf("[orch] attribution: deferring amend for %s (tmux %q is live but ownership is not safely readable: pid=%d worktree=%q err=%v)", slotName, tmuxName, pid, paneWorktree, identityErr)
-		}
-		return true
-	}
-	err := o.amendHeadWithAttributionTrailer(sess.Worktree, sess.Branch, sess.Attribution, time.Now().UTC(), sess.CheckpointFile)
-	if err == nil {
-		return false
-	}
-	// Every deferral means the trailer is not on the branch yet, so the merge flow
-	// must wait (autoMergePRs re-invokes this on every cycle, so a later quiet
-	// cycle or the pre-merge pass completes it). The reasons are logged distinctly
-	// so a quiet-branch convergence bug or a missing-branch / network failure is
-	// never masked as an "advancing under concurrent push" race (#858, #873).
-	switch {
-	case errors.Is(err, errAmendDeferred):
-		log.Printf("[orch] attribution: deferring amend for %s (branch %q advancing under concurrent push; will retry next cycle)", slotName, sess.Branch)
-		return true
-	case errors.Is(err, errAmendDiverged):
-		log.Printf("[orch] attribution: deferring amend for %s (branch %q diverged from the attributed head; not overwriting, will retry next cycle)", slotName, sess.Branch)
-		return true
-	case errors.Is(err, errAmendWorktreeBusy):
-		log.Printf("[orch] attribution: deferring amend for %s (branch %q worktree busy mid-write; will retry next cycle)", slotName, sess.Branch)
-		return true
-	case errors.Is(err, errAmendFetchFailed):
-		log.Printf("[orch] attribution: deferring amend for %s (could not fetch remote branch %q: %v; will retry next cycle)", slotName, sess.Branch, err)
-		return true
-	default:
-		// Any unexpected amend failure means the trailer is not known to be on
-		// the remote. Fail closed: block the merge and retry on a later cycle.
-		log.Printf("[orch] attribution: deferring amend for %s (could not amend branch %q: %v; will retry next cycle)", slotName, sess.Branch, err)
-		return true
-	}
-}
-
-func (o *Orchestrator) amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time, checkpointFile string) error {
-	if o.amendHeadFn != nil {
-		return o.amendHeadFn(worktreePath, branch, attribution, now)
-	}
-	// CHECKPOINT.md is a Maestro-owned resumability artifact, not product work.
-	// A completed worker may deliberately leave it untracked in the canonical
-	// worktree. Ignore only this session's exact checkpoint path, and only while
-	// it is untracked; every other dirty path remains a hard amend deferral.
-	ignoredCheckpoint := attributionCheckpointRelativePath(worktreePath, checkpointFile)
-	return amendHeadWithAttributionTrailer(worktreePath, branch, attribution, now, ignoredCheckpoint)
-}
-
-func attributionCheckpointRelativePath(worktreePath, checkpointFile string) string {
-	worktreePath = strings.TrimSpace(worktreePath)
-	checkpointFile = strings.TrimSpace(checkpointFile)
-	if worktreePath == "" || checkpointFile == "" {
-		return ""
-	}
-	if !filepath.IsAbs(checkpointFile) {
-		checkpointFile = filepath.Join(worktreePath, checkpointFile)
-	}
-	rel, err := filepath.Rel(worktreePath, checkpointFile)
-	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-		return ""
-	}
-	return filepath.ToSlash(filepath.Clean(rel))
-}
-
 // amendMaxAttempts bounds how many times amendHeadWithAttributionTrailer will
 // re-fetch and re-apply the trailer after a stale-info lease rejection before
 // deferring to a later cycle: one initial try plus up to two refetch-retries.
@@ -4046,6 +3958,16 @@ func amendHeadWithAttributionTrailer(worktreePath, branch string, attribution []
 	worktreePath = strings.TrimSpace(worktreePath)
 	branch = strings.TrimSpace(branch)
 	if worktreePath == "" || branch == "" || len(attribution) == 0 {
+		return nil
+	}
+	prohibited, err := repopolicy.ProhibitsPublicAIAttribution(worktreePath)
+	if err != nil {
+		return err
+	}
+	if prohibited {
+		// Public attribution is forbidden by the repository's authoritative
+		// policy. Finalization is a no-op even if internal attribution gained new
+		// fallover, retry, checkpoint-resume, or continuation segments.
 		return nil
 	}
 	if _, err := os.Stat(worktreePath); err != nil {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -487,7 +487,6 @@ func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing
 	}
 
 	var gotTitle, gotBody, gotBase, gotHead string
-	var amended bool
 	o := &Orchestrator{
 		pidAliveFn:          func(pid int) bool { return false },
 		tmuxSessionExistsFn: func(name string) bool { return false },
@@ -498,10 +497,6 @@ func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing
 		createPRFn: func(title, body, base, head string) (int, error) {
 			gotTitle, gotBody, gotBase, gotHead = title, body, base, head
 			return 144, nil
-		},
-		amendHeadFn: func(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
-			amended = true
-			return nil
 		},
 	}
 
@@ -552,9 +547,6 @@ func TestReconcileRunningSessions_PushedBranchWithoutPR_AutoCreatesPR(t *testing
 			t.Fatalf("PR body leaks orchestration internals (%q): %q", leak, gotBody)
 		}
 	}
-	if amended {
-		t.Fatal("auto-created PR reconciliation must not rewrite the product branch for attribution")
-	}
 	if !s.IssueInProgress(108) {
 		t.Fatal("IssueInProgress(108) must remain true after auto-created PR")
 	}
@@ -582,7 +574,6 @@ func TestReconcileRunningSessions_OpenPR_DoesNotAmendProductCommit(t *testing.T)
 		}},
 	}
 
-	var amended bool
 	o := &Orchestrator{
 		pidAliveFn:          func(pid int) bool { return false },
 		tmuxSessionExistsFn: func(name string) bool { return false },
@@ -592,10 +583,6 @@ func TestReconcileRunningSessions_OpenPR_DoesNotAmendProductCommit(t *testing.T)
 				HeadRefName: "feat/mae-9-109-existing-pr",
 				Body:        "Refs #109\n",
 			}}, nil
-		},
-		amendHeadFn: func(worktreePath, branch string, attribution []state.BackendAttribution, now time.Time) error {
-			amended = true
-			return nil
 		},
 	}
 
@@ -609,9 +596,6 @@ func TestReconcileRunningSessions_OpenPR_DoesNotAmendProductCommit(t *testing.T)
 	}
 	if sess.PRNumber != 145 {
 		t.Fatalf("pr_number = %d, want 145", sess.PRNumber)
-	}
-	if amended {
-		t.Fatal("existing PR reconciliation must not rewrite the product branch for attribution")
 	}
 }
 
@@ -634,6 +618,35 @@ func TestAutoCreatedPRBody_NoOrchestrationInternals(t *testing.T) {
 		if strings.Contains(body, leak) {
 			t.Fatalf("PR body leaks orchestration internals (%q): %q", leak, body)
 		}
+	}
+}
+
+func TestCreatePR_NoAttributionPolicyRejectsForbiddenPublicText(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("No AI attribution anywhere in git/GitHub artifacts.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	called := false
+	o := &Orchestrator{
+		cfg: &config.Config{LocalPath: root},
+		createPRFn: func(title, body, base, head string) (int, error) {
+			called = true
+			return 974, nil
+		},
+	}
+	if _, err := o.createPR("policy regression", "Refs #974\n\nMaestro-Backend: sol openai gpt-5.6-sol\n", "main", "feat/policy"); err == nil {
+		t.Fatal("forbidden PR attribution was published")
+	}
+	if called {
+		t.Fatal("PR creation reached the public write after policy rejection")
+	}
+
+	if _, err := o.createPR("policy regression", "Refs #974\n", "main", "feat/policy"); err != nil {
+		t.Fatalf("clean PR text was rejected: %v", err)
+	}
+	if !called {
+		t.Fatal("clean PR text did not reach the public write")
 	}
 }
 

--- a/internal/orchestrator/pr_gate_progress_test.go
+++ b/internal/orchestrator/pr_gate_progress_test.go
@@ -244,11 +244,6 @@ func TestAutoMergePRs_PendingGateDoesNotInvokeAttributionAmend(t *testing.T) {
 			HeadSHA: currentHead, Verdict: "pending", Fingerprint: strings.Repeat("7", 16), Complete: true,
 		}, nil
 	}
-	amended := false
-	o.amendHeadFn = func(string, string, []state.BackendAttribution, time.Time) error {
-		amended = true
-		return errAmendDiverged
-	}
 	st := makeTestState([]github.PR{pr})
 	sess := st.Sessions["slot-0"]
 	sess.Attribution = []state.BackendAttribution{{Backend: "sol", StartedAt: time.Now().UTC()}}
@@ -261,9 +256,6 @@ func TestAutoMergePRs_PendingGateDoesNotInvokeAttributionAmend(t *testing.T) {
 	}
 	if len(*merged) != 0 {
 		t.Fatalf("pending PR unexpectedly merged: %v", *merged)
-	}
-	if amended {
-		t.Fatal("PR gate observation must not rewrite the product branch for attribution")
 	}
 }
 
@@ -279,11 +271,6 @@ func TestAutoMergePRs_PassingGateDoesNotInvokeAttributionAmend(t *testing.T) {
 	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
 		return github.ReviewGateVerdict{Passed: true, Streams: []github.ReviewStreamVerdict{{Name: "greptile", Passed: true}}}, nil
 	}
-	amended := false
-	o.amendHeadFn = func(string, string, []state.BackendAttribution, time.Time) error {
-		amended = true
-		return errAmendDiverged
-	}
 	st := makeTestState([]github.PR{pr})
 	sess := st.Sessions["slot-0"]
 	sess.Attribution = []state.BackendAttribution{{Backend: "sol", StartedAt: time.Now().UTC()}}
@@ -296,9 +283,6 @@ func TestAutoMergePRs_PassingGateDoesNotInvokeAttributionAmend(t *testing.T) {
 	}
 	if len(*merged) != 1 || (*merged)[0] != pr.Number {
 		t.Fatalf("passing PR was not merged normally: %v", *merged)
-	}
-	if amended {
-		t.Fatal("passing merge gate must not rewrite the product branch for attribution")
 	}
 }
 

--- a/internal/repopolicy/attribution.go
+++ b/internal/repopolicy/attribution.go
@@ -1,0 +1,111 @@
+package repopolicy
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+var conventionFiles = []string{"AGENTS.md", "CLAUDE.md", "CONTRIBUTING.md"}
+
+// ProhibitsPublicAIAttribution reports whether the repository's effective
+// convention file explicitly keeps AI/backend attribution out of public git or
+// GitHub artifacts. The precedence matches worker prompt assembly: AGENTS.md,
+// then CLAUDE.md, then CONTRIBUTING.md.
+func ProhibitsPublicAIAttribution(root string) (bool, error) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return false, nil
+	}
+
+	for _, name := range conventionFiles {
+		path := filepath.Join(root, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return false, fmt.Errorf("read repository policy %s: %w", name, err)
+		}
+		if strings.TrimSpace(string(data)) == "" {
+			continue
+		}
+		return textProhibitsPublicAIAttribution(string(data)), nil
+	}
+	return false, nil
+}
+
+func textProhibitsPublicAIAttribution(text string) bool {
+	text = strings.ToLower(strings.ReplaceAll(text, "‑", "-"))
+	paragraphs := strings.FieldsFunc(text, func(r rune) bool { return r == '\n' || r == '\r' })
+	for _, paragraph := range paragraphs {
+		line := strings.Join(strings.Fields(paragraph), " ")
+		if line == "" || !mentionsAttribution(line) {
+			continue
+		}
+		if explicitlyProhibits(line) {
+			return true
+		}
+	}
+	return false
+}
+
+func mentionsAttribution(line string) bool {
+	for _, marker := range []string{
+		"ai attribution", "agent attribution", "backend attribution", "model attribution",
+		"maestro-backend", "co-authored-by", "generated with",
+	} {
+		if strings.Contains(line, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func explicitlyProhibits(line string) bool {
+	for _, marker := range []string{
+		"do not", "don't", "must not", "never", "forbid", "prohibit",
+		"not allowed", "no ai attribution", "keep backend attribution internal",
+		"keep model attribution internal", "attribution-free", "attribution free",
+	} {
+		if strings.Contains(line, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsForbiddenPublicAttribution identifies attribution records that must
+// not be published when repository policy prohibits AI attribution. Human
+// co-author trailers are preserved; only known AI-agent co-authors are blocked.
+func ContainsForbiddenPublicAttribution(text string) bool {
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		lower := strings.ToLower(line)
+		switch {
+		case strings.HasPrefix(lower, "maestro-backend:"),
+			strings.HasPrefix(lower, "maestro-model:"),
+			strings.HasPrefix(lower, "maestro-agent:"),
+			strings.Contains(lower, "generated with claude"),
+			strings.Contains(lower, "generated with codex"),
+			strings.Contains(lower, "generated with chatgpt"),
+			strings.Contains(lower, "generated with gemini"):
+			return true
+		case strings.HasPrefix(lower, "co-authored-by:") && aiCoauthor(lower):
+			return true
+		}
+	}
+	return false
+}
+
+func aiCoauthor(line string) bool {
+	for _, marker := range []string{
+		"claude", "codex", "chatgpt", "openai", "anthropic", "gemini", "copilot", "maestro",
+	} {
+		if strings.Contains(line, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/repopolicy/attribution_test.go
+++ b/internal/repopolicy/attribution_test.go
@@ -1,0 +1,55 @@
+package repopolicy
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestProhibitsPublicAIAttribution_AGENTSIsAuthoritative(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("No AI attribution anywhere in git/GitHub artifacts.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "CLAUDE.md"), []byte("Preserve Maestro-Backend trailers.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	prohibited, err := ProhibitsPublicAIAttribution(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !prohibited {
+		t.Fatal("AGENTS.md no-attribution policy was not detected")
+	}
+}
+
+func TestProhibitsPublicAIAttribution_DoesNotInferProhibition(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "AGENTS.md"), []byte("Preserve the historical Maestro-Backend trailer.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	prohibited, err := ProhibitsPublicAIAttribution(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prohibited {
+		t.Fatal("positive attribution guidance was misread as a prohibition")
+	}
+}
+
+func TestContainsForbiddenPublicAttribution(t *testing.T) {
+	for _, text := range []string{
+		"subject\n\nMaestro-Backend: codex openai gpt-5.6\n",
+		"Co-authored-by: Claude <noreply@anthropic.com>\n",
+		"🤖 Generated with Claude Code\n",
+	} {
+		if !ContainsForbiddenPublicAttribution(text) {
+			t.Fatalf("forbidden attribution not detected in %q", text)
+		}
+	}
+	if ContainsForbiddenPublicAttribution("Co-authored-by: Ada Lovelace <ada@example.com>\n") {
+		t.Fatal("human co-author trailer must remain allowed")
+	}
+}

--- a/internal/worker/rebase_test.go
+++ b/internal/worker/rebase_test.go
@@ -130,6 +130,61 @@ func TestNormalizedGitPaths_TrimsDeduplicatesAndUsesSlash(t *testing.T) {
 	}
 }
 
+func TestRebaseWorktree_NoAttributionPolicyFailsClosedBeforeForcePush(t *testing.T) {
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	seed := filepath.Join(root, "seed")
+	worktree := filepath.Join(root, "worktree")
+	branch := "feat/no-attribution"
+
+	gitTest(t, root, "init", "--bare", origin)
+	gitTest(t, root, "clone", origin, seed)
+	gitTest(t, seed, "config", "user.email", "test@example.com")
+	gitTest(t, seed, "config", "user.name", "Test User")
+	writeTestFile(t, seed, "AGENTS.md", "No AI attribution anywhere in git/GitHub artifacts.\n")
+	writeTestFile(t, seed, "README.md", "base\n")
+	gitTest(t, seed, "add", "AGENTS.md", "README.md")
+	gitTest(t, seed, "commit", "-m", "initial")
+	gitTest(t, seed, "branch", "-M", "main")
+	gitTest(t, seed, "push", "-u", "origin", "main")
+	gitTest(t, seed, "checkout", "-b", branch)
+	writeTestFile(t, seed, "feature.txt", "implemented\n")
+	gitTest(t, seed, "add", "feature.txt")
+	gitTest(t, seed, "commit", "-m", "worker: implement feature")
+	gitTest(t, seed, "push", "-u", "origin", branch)
+
+	gitTest(t, root, "clone", origin, worktree)
+	gitTest(t, worktree, "config", "user.email", "test@example.com")
+	gitTest(t, worktree, "config", "user.name", "Test User")
+	gitTest(t, worktree, "checkout", branch)
+	remoteCleanHead := gitOutput(t, origin, "rev-parse", branch)
+
+	gitTest(t, worktree, "commit", "--amend", "-m", "worker: implement feature", "-m", "Maestro-Backend: sol openai gpt-5.6-sol")
+	if err := RebaseWorktree(worktree, branch, nil, nil); err == nil || !strings.Contains(err.Error(), "repository policy prohibits AI attribution") {
+		t.Fatalf("forbidden attribution force-push error = %v", err)
+	}
+	if got := gitOutput(t, origin, "rev-parse", branch); got != remoteCleanHead {
+		t.Fatalf("policy violation changed remote head: got %s want %s", got, remoteCleanHead)
+	}
+
+	// The worker strips the trailer. Finalization may force-push that clean head,
+	// but running it again must preserve the already accepted exact identity.
+	gitTest(t, worktree, "commit", "--amend", "-m", "worker: implement feature")
+	if err := RebaseWorktree(worktree, branch, nil, nil); err != nil {
+		t.Fatalf("clean force-push: %v", err)
+	}
+	acceptedHead := gitOutput(t, origin, "rev-parse", branch)
+	if msg := gitOutput(t, origin, "log", "-1", "--pretty=%B", branch); strings.Contains(msg, "Maestro-Backend:") {
+		t.Fatalf("clean force-push retained forbidden trailer:\n%s", msg)
+	}
+	if err := RebaseWorktree(worktree, branch, nil, nil); err != nil {
+		t.Fatalf("repeat clean finalization: %v", err)
+	}
+	if got := gitOutput(t, origin, "rev-parse", branch); got != acceptedHead {
+		t.Fatalf("repeat finalization invalidated exact head: got %s want %s", got, acceptedHead)
+	}
+}
+
 func gitTest(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	cmd := exec.Command("git", args...)
@@ -138,6 +193,17 @@ func gitTest(t *testing.T, dir string, args ...string) {
 	if err != nil {
 		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
 	}
+}
+
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func writeTestFile(t *testing.T, dir, rel, content string) {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/pipeline"
+	"github.com/befeast/maestro/internal/repopolicy"
 	"github.com/befeast/maestro/internal/state"
 	"github.com/befeast/maestro/internal/tmuxsession"
 )
@@ -509,11 +510,33 @@ func RebaseWorktree(worktreePath, branch string, autoResolveFiles, autoRestoreFi
 			return fmt.Errorf("rebase failed: %v; auto-resolve failed: %v", rebaseErr, resolveErr)
 		}
 	}
+	if err := validateAttributionPolicyBeforeForcePush(worktreePath); err != nil {
+		return err
+	}
 
 	if _, err := runGit(worktreePath, "push", "--force-with-lease", "origin", branch); err != nil {
 		return err
 	}
 
+	return nil
+}
+
+func validateAttributionPolicyBeforeForcePush(worktreePath string) error {
+	prohibited, err := repopolicy.ProhibitsPublicAIAttribution(worktreePath)
+	if err != nil {
+		return err
+	}
+	if !prohibited {
+		return nil
+	}
+
+	messages, err := runGit(worktreePath, "log", "--format=%B%x00", "origin/main..HEAD")
+	if err != nil {
+		return fmt.Errorf("inspect commits before force-push: %w", err)
+	}
+	if repopolicy.ContainsForbiddenPublicAttribution(messages) {
+		return fmt.Errorf("repository policy prohibits AI attribution; refusing force-push")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Refs #974

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds repository-policy enforcement for AI/backend attribution. The main changes are:

- Detects no-attribution policy from repository convention files.
- Blocks forbidden attribution in public PR title and body text.
- Makes historical attribution trailer amendment a no-op when policy forbids public attribution.
- Adds a pre-force-push worker check for forbidden attribution in branch commit messages.
- Updates orchestrator and worker tests for no-attribution, PR gate, and clean-head behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

Changes are narrowly scoped to attribution policy enforcement and removal of obsolete branch-rewrite hooks. Tests cover the main commit, PR text, and rebase/force-push paths. No blocking or non-blocking issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran targeted repopolicy tests and confirmed they passed with exit code 0 (proof 0).
- Ran targeted orchestrator tests and confirmed they passed with exit code 0 (proof 0).
- Ran targeted worker tests and confirmed they passed with exit code 0 (proof 0).
- Ran package-level tests and confirmed all involved components (internal/repopolicy, internal/orchestrator, internal/worker) passed with exit code 0 (proof 0).

<a href="https://app.greptile.com/trex/runs/14944302/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/repopolicy/attribution.go | Introduces repository policy detection and forbidden public attribution matching for trailers and known AI-generated/co-author markers. |
| internal/orchestrator/orchestrator.go | Removes production attribution amend hook plumbing and adds repository-policy checks before public PR creation and historical trailer amendments. |
| internal/worker/worker.go | Adds a fail-closed pre-force-push policy check that scans branch commit messages for forbidden public attribution. |
| internal/orchestrator/attribution_amend_test.go | Adds git-level coverage that no-attribution repository policy makes attribution amend finalization a no-op while preserving clean heads and checkpoint handling. |
| internal/worker/rebase_test.go | Adds integration-style rebase coverage proving no-attribution policy blocks dirty attribution force-pushes and preserves clean accepted heads. |

<sub>Reviews (1): Last reviewed commit: ["fix: honor repository no-attribution pol..."](https://github.com/befeast/maestro/commit/8af55876ca0a3aa1eb2fb7baf0d12dc6f736adfc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45306790)</sub>

<!-- /greptile_comment -->