### PR TITLE
fix: fence outcome recovery from product repair

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -8115,7 +8115,7 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 		return false
 	}
 	if target.PR > 0 {
-		gate := o.revalidateSpawnRepairPR(target)
+		gate := o.revalidateSpawnRepairPR(s, target)
 		if !gate.actionable {
 			log.Printf("[orch] refusing repair dispatch for issue #%d / PR #%d on %s: %s", issue.Number, target.PR, slot, gate.reason)
 			if gate.stale {
@@ -8214,7 +8214,7 @@ func (o *Orchestrator) dispatchSpawnRepairWorker(s *state.State, issue github.Is
 // review finding is actionable; pending/green gates make an old repair intent
 // stale. Read errors and unknown states fail closed without consuming the
 // approval so a later healthy control-loop read can retry safely.
-func (o *Orchestrator) revalidateSpawnRepairPR(target *state.SupervisorTarget) spawnRepairGateDecision {
+func (o *Orchestrator) revalidateSpawnRepairPR(s *state.State, target *state.SupervisorTarget) spawnRepairGateDecision {
 	if target == nil || target.PR <= 0 {
 		return spawnRepairGateDecision{actionable: true, reason: "repair has no PR gate to revalidate"}
 	}
@@ -8299,6 +8299,9 @@ func (o *Orchestrator) revalidateSpawnRepairPR(target *state.SupervisorTarget) s
 			return spawnRepairGateDecision{stale: true, reason: "current PR is no longer open"}
 		}
 		if details.IsDraft {
+			if o.automaticOutcomeRecoveryOwnsFailure(s) {
+				return spawnRepairGateDecision{stale: true, reason: "automatic outcome recovery owns the failing project outcome; green draft repair is not independently actionable"}
+			}
 			return spawnRepairGateDecision{actionable: true, reason: "current PR remains an explicit draft/WIP continuation"}
 		}
 	}
@@ -8311,6 +8314,11 @@ func (o *Orchestrator) revalidateSpawnRepairPR(target *state.SupervisorTarget) s
 	default:
 		return spawnRepairGateDecision{reason: fmt.Sprintf("current PR check verdict %q is not authoritative", ci)}
 	}
+}
+
+func (o *Orchestrator) automaticOutcomeRecoveryOwnsFailure(s *state.State) bool {
+	return o != nil && o.cfg != nil && o.cfg.Outcome.AutomaticRecoveryEnabled() &&
+		s != nil && s.OutcomeHealth != nil && s.OutcomeHealth.State == outcome.HealthFailing
 }
 
 func activeIssueClaimForSession(s *state.State, issueNumber int, slot string) (state.IssueClaim, bool) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -8318,7 +8318,16 @@ func (o *Orchestrator) revalidateSpawnRepairPR(s *state.State, target *state.Sup
 
 func (o *Orchestrator) automaticOutcomeRecoveryOwnsFailure(s *state.State) bool {
 	return o != nil && o.cfg != nil && o.cfg.Outcome.AutomaticRecoveryEnabled() &&
-		s != nil && s.OutcomeHealth != nil && s.OutcomeHealth.State == outcome.HealthFailing
+		s != nil && s.OutcomeHealth != nil && s.OutcomeHealth.State == outcome.HealthFailing &&
+		activeOutcomeRecovery(s.OutcomeRecovery)
+}
+
+func activeOutcomeRecovery(recovery *outcome.RecoveryState) bool {
+	if recovery == nil {
+		return false
+	}
+	return recovery.Status == outcome.RecoveryStatusExecuting ||
+		recovery.Status == outcome.RecoveryStatusVerificationPending
 }
 
 func activeIssueClaimForSession(s *state.State, issueNumber int, slot string) (state.IssueClaim, bool) {

--- a/internal/orchestrator/repair_dispatch_gate_test.go
+++ b/internal/orchestrator/repair_dispatch_gate_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -255,6 +256,52 @@ func TestSpawnRepairDispatch_AutomaticOutcomeRecoveryStalesGreenDraftRepair(t *t
 	}
 	if got := approvalStatus(t, s, "repair-7"); got != state.ApprovalStatusStale {
 		t.Fatalf("repair approval = %q, want stale", got)
+	}
+}
+
+func TestSpawnRepairDispatch_ConfiguredButInactiveOutcomeRecoveryKeepsGreenDraftRepair(t *testing.T) {
+	for _, recovery := range []*outcome.RecoveryState{
+		nil,
+		{Status: outcome.RecoveryStatusFailed, AttemptID: "outcome-failed"},
+		{Status: outcome.RecoveryStatusUncertain, AttemptID: "outcome-uncertain"},
+	} {
+		t.Run(fmt.Sprintf("recovery_%v", recovery), func(t *testing.T) {
+			const head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			cfg := cfgWithBackends("codex", "codex")
+			cfg.Outcome = outcome.Brief{
+				DesiredOutcome:     "candidate feed follows main",
+				HealthcheckCommand: "check-outcome",
+				RecoveryMode:       outcome.RecoveryModeAutomatic,
+				RecoveryCommand:    "recover-outcome",
+			}
+			o, freshStarts, _ := newStartWorkersOrchestrator(cfg, []github.Issue{makeIssue(7, "continue explicit draft", "maestro-ready")})
+			o.hasOpenPRForIssueFn = func(int) (bool, error) { return true, nil }
+			o.ghPRHeadSHAFn = func(int) (string, error) { return head, nil }
+			o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+				return github.PRCheckRollup{HeadSHA: head, Verdict: "success", Complete: true}, nil
+			}
+			o.ghPRMergeStatusFn = func(int) (string, string, error) { return "MERGEABLE", "clean", nil }
+			o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+				return github.ReviewGateVerdict{Passed: true}, nil
+			}
+			o.ghPRDetailsFn = func(pr int) (github.PR, error) {
+				return github.PR{Number: pr, State: "OPEN", IsDraft: true, Body: "<!-- maestro:wip -->"}, nil
+			}
+			respawns := 0
+			o.respawnInPlaceFn = func(*config.Config, string, *state.Session, string, github.Issue, string, string) error {
+				respawns++
+				return nil
+			}
+
+			s := repairGateTestState(time.Now().UTC(), head)
+			s.OutcomeHealth = &outcome.HealthCheckResult{State: outcome.HealthFailing, CheckedAt: time.Now().UTC()}
+			s.OutcomeRecovery = recovery
+			o.startNewWorkers(s, 1)
+
+			if respawns != 1 || len(*freshStarts) != 0 {
+				t.Fatalf("inactive outcome recovery suppressed repair: respawns=%d fresh=%v", respawns, *freshStarts)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/repair_dispatch_gate_test.go
+++ b/internal/orchestrator/repair_dispatch_gate_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/outcome"
 	"github.com/befeast/maestro/internal/state"
 )
 
@@ -210,6 +211,79 @@ func TestSpawnRepairDispatch_CurrentGreenDraftAllowsExactInPlaceContinuation(t *
 
 	if respawns != 1 || len(*freshStarts) != 0 || len(s.Sessions) != 1 {
 		t.Fatalf("exact draft continuation mismatch: respawns=%d fresh=%v sessions=%d", respawns, *freshStarts, len(s.Sessions))
+	}
+	if got := approvalStatus(t, s, "repair-7"); got != state.ApprovalStatusSuperseded {
+		t.Fatalf("repair approval = %q, want consumed/superseded", got)
+	}
+}
+
+func TestSpawnRepairDispatch_AutomaticOutcomeRecoveryStalesGreenDraftRepair(t *testing.T) {
+	const head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	cfg := cfgWithBackends("codex", "codex")
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome:     "candidate feed follows main",
+		HealthcheckCommand: "check-outcome",
+		RecoveryMode:       outcome.RecoveryModeAutomatic,
+		RecoveryCommand:    "recover-outcome",
+	}
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, []github.Issue{makeIssue(7, "continue explicit draft", "maestro-ready")})
+	o.hasOpenPRForIssueFn = func(int) (bool, error) { return true, nil }
+	o.ghPRHeadSHAFn = func(int) (string, error) { return head, nil }
+	o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+		return github.PRCheckRollup{HeadSHA: head, Verdict: "success", Complete: true}, nil
+	}
+	o.ghPRMergeStatusFn = func(int) (string, string, error) { return "MERGEABLE", "clean", nil }
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return github.ReviewGateVerdict{Passed: true}, nil
+	}
+	o.ghPRDetailsFn = func(pr int) (github.PR, error) {
+		return github.PR{Number: pr, State: "OPEN", IsDraft: true, Body: "<!-- maestro:wip -->"}, nil
+	}
+	respawns := 0
+	o.respawnInPlaceFn = func(*config.Config, string, *state.Session, string, github.Issue, string, string) error {
+		respawns++
+		return nil
+	}
+
+	s := repairGateTestState(time.Now().UTC(), head)
+	s.OutcomeHealth = &outcome.HealthCheckResult{State: outcome.HealthFailing, CheckedAt: time.Now().UTC()}
+	s.OutcomeRecovery = &outcome.RecoveryState{Status: outcome.RecoveryStatusVerificationPending, AttemptID: "outcome-live"}
+	o.startNewWorkers(s, 1)
+
+	if respawns != 0 || len(*freshStarts) != 0 {
+		t.Fatalf("outcome-owned green draft repair dispatched: respawns=%d fresh=%v", respawns, *freshStarts)
+	}
+	if got := approvalStatus(t, s, "repair-7"); got != state.ApprovalStatusStale {
+		t.Fatalf("repair approval = %q, want stale", got)
+	}
+}
+
+func TestSpawnRepairDispatch_AutomaticOutcomeRecoveryStillAllowsFailedCIRepair(t *testing.T) {
+	const head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	cfg := cfgWithBackends("codex", "codex")
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome:     "candidate feed follows main",
+		HealthcheckCommand: "check-outcome",
+		RecoveryMode:       outcome.RecoveryModeAutomatic,
+		RecoveryCommand:    "recover-outcome",
+	}
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, []github.Issue{makeIssue(7, "repair failed PR", "maestro-ready")})
+	o.hasOpenPRForIssueFn = func(int) (bool, error) { return true, nil }
+	authorizeCurrentFailedRepairGate(o, 70)
+	respawns := 0
+	o.respawnInPlaceFn = func(_ *config.Config, _ string, sess *state.Session, _ string, _ github.Issue, _, _ string) error {
+		respawns++
+		sess.Status = state.StatusRunning
+		return nil
+	}
+
+	s := repairGateTestState(time.Now().UTC(), head)
+	s.OutcomeHealth = &outcome.HealthCheckResult{State: outcome.HealthFailing, CheckedAt: time.Now().UTC()}
+	s.OutcomeRecovery = &outcome.RecoveryState{Status: outcome.RecoveryStatusVerificationPending, AttemptID: "outcome-live"}
+	o.startNewWorkers(s, 1)
+
+	if respawns != 1 || len(*freshStarts) != 0 {
+		t.Fatalf("independent failed-CI repair was suppressed: respawns=%d fresh=%v", respawns, *freshStarts)
 	}
 	if got := approvalStatus(t, s, "repair-7"); got != state.ApprovalStatusSuperseded {
 		t.Fatalf("repair approval = %q, want consumed/superseded", got)

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2832,7 +2832,7 @@ func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.Supervis
 		case "retry_exhausted_open_pr":
 			return stuck.Severity == SeverityBlocked
 		case state.StuckNoOutcomeProgress:
-			if e.cfg != nil && e.cfg.Outcome.AutomaticRecoveryEnabled() {
+			if e.automaticOutcomeRecoveryOwnsFailure(st) {
 				return false
 			}
 			return e.outcomeStatus(st).HealthState == outcome.HealthFailing
@@ -2840,12 +2840,22 @@ func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.Supervis
 	}
 	if pr.IsDraft {
 		status := e.outcomeStatus(st)
-		if e.cfg != nil && e.cfg.Outcome.AutomaticRecoveryEnabled() && status.HealthState == outcome.HealthFailing && ciStatus == "success" {
+		if e.automaticOutcomeRecoveryOwnsFailure(st) && status.HealthState == outcome.HealthFailing && ciStatus == "success" {
 			return false
 		}
 		return true
 	}
 	return false
+}
+
+func (e *Engine) automaticOutcomeRecoveryOwnsFailure(st *state.State) bool {
+	if e == nil || e.cfg == nil || !e.cfg.Outcome.AutomaticRecoveryEnabled() ||
+		st == nil || st.OutcomeHealth == nil || st.OutcomeHealth.State != outcome.HealthFailing ||
+		st.OutcomeRecovery == nil {
+		return false
+	}
+	return st.OutcomeRecovery.Status == outcome.RecoveryStatusExecuting ||
+		st.OutcomeRecovery.Status == outcome.RecoveryStatusVerificationPending
 }
 
 // openPRReadyToMerge returns (true, reasons[]) when a session's open PR can

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2796,14 +2796,14 @@ func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.Supervis
 	// current-head guard, burns one supervisor call every cycle, and presents a
 	// false action in Fleet. Conflicts remain actionable above; failed CI and an
 	// unavailable/unknown CI read retain the existing fail-closed repair path.
+	ciStatus := ""
 	if ciReader, ok := e.reader.(prCIStatusReader); ok {
-		if ciStatus, err := ciReader.PRCIStatus(pr.Number); err == nil &&
-			strings.EqualFold(strings.TrimSpace(ciStatus), "pending") {
+		if current, err := ciReader.PRCIStatus(pr.Number); err == nil {
+			ciStatus = strings.ToLower(strings.TrimSpace(current))
+		}
+		if ciStatus == "pending" {
 			return false
 		}
-	}
-	if pr.IsDraft {
-		return true
 	}
 	for _, stuck := range stuckStates {
 		if stuck.Target != nil {
@@ -2832,8 +2832,18 @@ func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.Supervis
 		case "retry_exhausted_open_pr":
 			return stuck.Severity == SeverityBlocked
 		case state.StuckNoOutcomeProgress:
+			if e.cfg != nil && e.cfg.Outcome.AutomaticRecoveryEnabled() {
+				return false
+			}
 			return e.outcomeStatus(st).HealthState == outcome.HealthFailing
 		}
+	}
+	if pr.IsDraft {
+		status := e.outcomeStatus(st)
+		if e.cfg != nil && e.cfg.Outcome.AutomaticRecoveryEnabled() && status.HealthState == outcome.HealthFailing && ciStatus == "success" {
+			return false
+		}
+		return true
 	}
 	return false
 }

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -836,6 +836,50 @@ func TestDecide_AutomaticOutcomeRecoveryOwnsGreenDraftOutcomeDrift(t *testing.T)
 	}
 }
 
+func TestDecide_ConfiguredButInactiveOutcomeRecoveryDoesNotOwnGreenDraft(t *testing.T) {
+	for _, recovery := range []*outcome.RecoveryState{
+		nil,
+		{Status: outcome.RecoveryStatusFailed, AttemptID: "outcome-failed"},
+		{Status: outcome.RecoveryStatusUncertain, AttemptID: "outcome-uncertain"},
+	} {
+		t.Run(fmt.Sprintf("recovery_%v", recovery), func(t *testing.T) {
+			cfg := testConfig(t)
+			cfg.ReviewGate = "none"
+			cfg.MaxParallel = 20
+			cfg.MaxLiveWorkers = 20
+			cfg.Outcome = outcome.Brief{
+				DesiredOutcome:     "candidate feed follows main",
+				HealthcheckCommand: "check-outcome",
+				RecoveryMode:       outcome.RecoveryModeAutomatic,
+				RecoveryCommand:    "recover-outcome",
+			}
+			reader := &fakeReader{
+				issues:     []github.Issue{{Number: 406, Title: "Flatpak continuation"}},
+				prs:        []github.PR{{Number: 388, HeadRefName: "feat/flatpak", Mergeable: "MERGEABLE", IsDraft: true}},
+				ciStatuses: map[int]string{388: "success"},
+			}
+			st := state.NewState()
+			st.Sessions["ok-player-302"] = &state.Session{
+				IssueNumber: 406,
+				Status:      state.StatusPROpen,
+				Branch:      "feat/flatpak",
+				PRNumber:    388,
+				StartedAt:   time.Now().UTC().Add(-10 * time.Minute),
+			}
+			st.OutcomeHealth = &outcome.HealthCheckResult{State: outcome.HealthFailing, CheckedAt: time.Now().UTC()}
+			st.OutcomeRecovery = recovery
+
+			decision, err := testEngine(cfg, reader).Decide(st)
+			if err != nil {
+				t.Fatalf("Decide: %v", err)
+			}
+			if decision.RecommendedAction != ActionSpawnRepairWorker {
+				t.Fatalf("action = %q, want spawn_repair_worker without active recovery ownership", decision.RecommendedAction)
+			}
+		})
+	}
+}
+
 func TestDecide_AutomaticOutcomeRecoveryDoesNotSuppressFailedCIRepair(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.ReviewGate = "none"

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -797,6 +797,81 @@ func TestDecide_DraftPRCurrentHeadCIFailed_RecommendsRepair(t *testing.T) {
 	}
 }
 
+func TestDecide_AutomaticOutcomeRecoveryOwnsGreenDraftOutcomeDrift(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	cfg.MaxParallel = 20
+	cfg.MaxLiveWorkers = 20
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome:     "candidate feed follows main",
+		HealthcheckCommand: "check-outcome",
+		RecoveryMode:       outcome.RecoveryModeAutomatic,
+		RecoveryCommand:    "recover-outcome",
+	}
+	reader := &fakeReader{
+		issues:     []github.Issue{{Number: 406, Title: "Flatpak continuation"}},
+		prs:        []github.PR{{Number: 388, HeadRefName: "feat/flatpak", Mergeable: "MERGEABLE", IsDraft: true}},
+		ciStatuses: map[int]string{388: "success"},
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-302"] = &state.Session{
+		IssueNumber: 406,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/flatpak",
+		PRNumber:    388,
+		StartedAt:   time.Now().UTC().Add(-10 * time.Minute),
+	}
+	st.OutcomeHealth = &outcome.HealthCheckResult{State: outcome.HealthFailing, CheckedAt: time.Now().UTC()}
+	st.OutcomeRecovery = &outcome.RecoveryState{Status: outcome.RecoveryStatusVerificationPending, AttemptID: "outcome-live"}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want monitor_open_pr while automatic outcome recovery owns drift", decision.RecommendedAction)
+	}
+	if decision.Target == nil || decision.Target.PR != 388 || decision.Target.Session != "ok-player-302" {
+		t.Fatalf("target = %#v, want canonical PR #388 / ok-player-302", decision.Target)
+	}
+}
+
+func TestDecide_AutomaticOutcomeRecoveryDoesNotSuppressFailedCIRepair(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	cfg.MaxParallel = 20
+	cfg.MaxLiveWorkers = 20
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome:     "candidate feed follows main",
+		HealthcheckCommand: "check-outcome",
+		RecoveryMode:       outcome.RecoveryModeAutomatic,
+		RecoveryCommand:    "recover-outcome",
+	}
+	reader := &fakeReader{
+		issues:     []github.Issue{{Number: 407, Title: "Flatpak red"}},
+		prs:        []github.PR{{Number: 389, HeadRefName: "feat/flatpak-red", Mergeable: "MERGEABLE", IsDraft: true}},
+		ciStatuses: map[int]string{389: "failure"},
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-303"] = &state.Session{
+		IssueNumber: 407,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/flatpak-red",
+		PRNumber:    389,
+		StartedAt:   time.Now().UTC().Add(-10 * time.Minute),
+	}
+	st.OutcomeHealth = &outcome.HealthCheckResult{State: outcome.HealthFailing, CheckedAt: time.Now().UTC()}
+	st.OutcomeRecovery = &outcome.RecoveryState{Status: outcome.RecoveryStatusVerificationPending, AttemptID: "outcome-live"}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnRepairWorker {
+		t.Fatalf("action = %q, want spawn_repair_worker for independent failed CI", decision.RecommendedAction)
+	}
+}
+
 func TestDecide_ConflictingDraftPRWithCIPending_RecommendsConflictRepair(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.ReviewGate = "none"


### PR DESCRIPTION
Implements #1004.

## Root cause

Automatic project outcome recovery and issue/PR repair dispatch were evaluated independently. When a project outcome failed because delivery lagged, a green draft PR could still be classified as actionable product repair. The already-approved repair intent could then race the bounded outcome recovery command and spend a worker on unrelated product changes.

## Changes

- Treat a green draft PR as monitored while automatic outcome recovery owns the current failing outcome.
- Revalidate an approved repair intent against the same ownership rule immediately before dispatch and stale it if delivery recovery now owns the failure.
- Preserve repairs for independent failed CI, conflicts, and actionable review findings.
- Add supervisor and orchestrator regression coverage for both suppression and allowed failed-CI repair.

## Validation

- `umask 022; go test ./...`
- `go build ./cmd/maestro/`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents product repair from racing active automatic outcome recovery. The main changes are:

- Rechecks repair dispatch against active outcome recovery ownership before spending a worker.
- Treats green draft PRs as monitored while automatic outcome recovery owns the failing outcome.
- Keeps repair dispatch available for failed CI, conflicts, and blocking review findings.
- Adds tests for suppressed green draft repair and allowed failed-CI repair paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrowly scoped and applies the same ownership rule in both supervisor decisions and orchestrator dispatch revalidation. Tests cover the suppressed green draft path, inactive recovery path, and independent failed-CI repair path. No issues were identified in the changed code.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a full Go test across the repository and confirmed all tests passed with EXIT\_CODE 0.
- Built the Maestro command binary using go build ./cmd/maestro/ and confirmed the build completed with EXIT\_CODE 0.
- Ran git diff --check to validate code changes and confirmed no issues were reported (EXIT\_CODE 0).

<a href="https://app.greptile.com/trex/runs/14948085/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Revalidates repair dispatch against active automatic outcome recovery ownership before allowing green draft PR repairs. |
| internal/orchestrator/repair_dispatch_gate_test.go | Adds tests for staling green draft repairs during active outcome recovery while preserving inactive and failed-CI repair paths. |
| internal/supervisor/supervisor.go | Updates open PR repair classification so active automatic outcome recovery monitors green draft outcome drift instead of spawning product repair. |
| internal/supervisor/supervisor_test.go | Adds supervisor decision tests for active outcome recovery suppression and failed-CI allowance. |

<sub>Reviews (1): Last reviewed commit: ["fix: require active outcome recovery own..."](https://github.com/befeast/maestro/commit/72785a515ed9d92423db5f7d90b0df9229e55812) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45314042)</sub>

<!-- /greptile_comment -->