### PR TITLE
fix: block merge while check runs are pending

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2235,10 +2235,11 @@ func (c *Client) MergedPRNumberForBranch(branch string) (int, error) {
 // and closed status/conclusion fields only; it never carries descriptions,
 // URLs, output, annotations, paths, or credentials (#887/#940).
 type PRCheckRollup struct {
-	HeadSHA     string
-	Verdict     string
-	Fingerprint string
-	Complete    bool
+	HeadSHA          string
+	Verdict          string
+	Fingerprint      string
+	Complete         bool
+	PendingCheckRuns bool
 }
 
 // PRCheckRollup returns the current head, normalized aggregate verdict, and a
@@ -2259,14 +2260,27 @@ func (c *Client) PRCheckRollup(prNumber int) (PRCheckRollup, error) {
 		return PRCheckRollup{HeadSHA: sha, Verdict: "unknown"}, fmt.Errorf("get checks for PR %d: check-runs: %v; statuses: %v", prNumber, checksErr, statusErr)
 	}
 	rollup := PRCheckRollup{
-		HeadSHA:  sha,
-		Verdict:  ciStatusFromREST(checks, combined),
-		Complete: checksErr == nil && statusErr == nil,
+		HeadSHA:          sha,
+		Verdict:          ciStatusFromREST(checks, combined),
+		Complete:         checksErr == nil && statusErr == nil,
+		PendingCheckRuns: hasPendingCheckRuns(checks),
 	}
 	if rollup.Complete {
 		rollup.Fingerprint = ciCheckRollupFingerprint(checks, combined)
 	}
 	return rollup, nil
+}
+
+func hasPendingCheckRuns(checks []greptileCheckRun) bool {
+	for _, check := range checks {
+		status := strings.ToLower(strings.TrimSpace(check.Status))
+		conclusion := strings.ToLower(strings.TrimSpace(check.Conclusion))
+		if status == "queued" || status == "in_progress" || status == "waiting" || status == "requested" ||
+			(status != "completed" && conclusion == "") {
+			return true
+		}
+	}
+	return false
 }
 
 // PRCIStatus returns "success", "failure", "pending", or "unknown".

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -284,6 +284,30 @@ func TestCIStatusFromREST(t *testing.T) {
 	}
 }
 
+func TestHasPendingCheckRuns(t *testing.T) {
+	tests := []struct {
+		name   string
+		checks []greptileCheckRun
+		want   bool
+	}{
+		{name: "none"},
+		{name: "queued", checks: []greptileCheckRun{{Status: "queued"}}, want: true},
+		{name: "in progress", checks: []greptileCheckRun{{Status: "in_progress"}}, want: true},
+		{name: "waiting", checks: []greptileCheckRun{{Status: "waiting"}}, want: true},
+		{name: "requested", checks: []greptileCheckRun{{Status: "requested"}}, want: true},
+		{name: "unknown nonterminal", checks: []greptileCheckRun{{Status: "pending"}}, want: true},
+		{name: "success", checks: []greptileCheckRun{{Status: "completed", Conclusion: "success"}}},
+		{name: "failure", checks: []greptileCheckRun{{Status: "completed", Conclusion: "failure"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasPendingCheckRuns(tt.checks); got != tt.want {
+				t.Fatalf("hasPendingCheckRuns() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseCheckRunsKeepsLatestAttemptPerAppAndName(t *testing.T) {
 	checks, err := parseCheckRuns([]byte(`{
 		"check_runs": [

--- a/internal/supervisor/policy_blocks_merge_test.go
+++ b/internal/supervisor/policy_blocks_merge_test.go
@@ -157,6 +157,9 @@ func TestDecide_OpenPR_CIAggregateStaleButMergeStateClean_Merges(t *testing.T) {
 		prs:         []github.PR{{Number: 115, HeadRefName: "feat/auth", Mergeable: "MERGEABLE"}},
 		ciStatuses:  map[int]string{115: "pending"},
 		mergeStates: map[int]string{115: "clean"},
+		checkRollups: map[int]github.PRCheckRollup{
+			115: {Verdict: "pending", Complete: true},
+		},
 	}
 	st := state.NewState()
 	st.Sessions["scribe-1"] = &state.Session{
@@ -173,6 +176,40 @@ func TestDecide_OpenPR_CIAggregateStaleButMergeStateClean_Merges(t *testing.T) {
 	}
 	if decision.RecommendedAction != ActionMergePR {
 		t.Fatalf("action = %q, want merge_pr (mergeable_state=clean must override stale aggregate CI=pending)", decision.RecommendedAction)
+	}
+}
+
+func TestDecide_OpenPR_RealPendingCheckRunBlocksCleanMergeState(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:         []github.PR{{Number: 119, HeadRefName: "feat/new-pr", Mergeable: "MERGEABLE"}},
+		ciStatuses:  map[int]string{119: "pending"},
+		mergeStates: map[int]string{119: "clean"},
+		checkRollups: map[int]github.PRCheckRollup{
+			119: {
+				HeadSHA:          strings.Repeat("a", 40),
+				Verdict:          "pending",
+				Complete:         true,
+				PendingCheckRuns: true,
+			},
+		},
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-1"] = &state.Session{
+		IssueNumber: 201,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/new-pr",
+		PRNumber:    119,
+		StartedAt:   time.Now().UTC().Add(-time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want monitor_open_pr while current-head check-runs are pending", decision.RecommendedAction)
 	}
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -112,6 +112,10 @@ type prCIStatusReader interface {
 	PRCIStatus(prNumber int) (string, error)
 }
 
+type prCheckRollupReader interface {
+	PRCheckRollup(prNumber int) (github.PRCheckRollup, error)
+}
+
 type prGreptileReader interface {
 	PRGreptileApproved(prNumber int) (approved bool, pending bool, err error)
 }
@@ -2888,18 +2892,34 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 		return false, nil
 	}
 
-	// CI must be green. PRCIStatus is an optional reader interface; when
-	// the reader does not implement it we conservatively refuse to merge.
-	ciReader, ok := e.reader.(prCIStatusReader)
-	if !ok {
-		return false, nil
-	}
-	ciStatus, err := ciReader.PRCIStatus(pr.Number)
-	if err != nil {
-		return false, nil
+	// CI must be green. Production readers expose the current-head rollup so
+	// a real queued/in-progress check-run can never be confused with the
+	// legacy commit-status-only pending state handled by #425.
+	ciStatus := ""
+	pendingCheckRuns := false
+	if rollupReader, ok := e.reader.(prCheckRollupReader); ok {
+		rollup, err := rollupReader.PRCheckRollup(pr.Number)
+		if err != nil || !rollup.Complete {
+			return false, nil
+		}
+		ciStatus = rollup.Verdict
+		pendingCheckRuns = rollup.PendingCheckRuns
+	} else {
+		ciReader, ok := e.reader.(prCIStatusReader)
+		if !ok {
+			return false, nil
+		}
+		var err error
+		ciStatus, err = ciReader.PRCIStatus(pr.Number)
+		if err != nil {
+			return false, nil
+		}
 	}
 	ciLower := strings.ToLower(strings.TrimSpace(ciStatus))
 	if ciLower != "success" {
+		if pendingCheckRuns {
+			return false, nil
+		}
 		// #425 (sup-98): the aggregate PRCIStatus can stick at "pending"
 		// long after every required check has gone green — the most common
 		// cause is a legacy commit-status (used by some review bots) that

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -25,6 +25,7 @@ type fakeReader struct {
 	closedIssues         map[int]bool
 	mergedPRs            map[int]bool
 	ciStatuses           map[int]string
+	checkRollups         map[int]github.PRCheckRollup
 	greptileOK           map[int]bool
 	greptilePend         map[int]bool
 	reviewVerdicts       map[int]github.ReviewGateVerdict
@@ -134,6 +135,13 @@ func (f *fakeReader) CommentIssue(issueNumber int, body string) error {
 
 func (f *fakeReader) PRCIStatus(prNumber int) (string, error) {
 	return f.ciStatuses[prNumber], nil
+}
+
+func (f *fakeReader) PRCheckRollup(prNumber int) (github.PRCheckRollup, error) {
+	if rollup, ok := f.checkRollups[prNumber]; ok {
+		return rollup, nil
+	}
+	return github.PRCheckRollup{Verdict: f.ciStatuses[prNumber], Complete: true}, nil
 }
 
 func (f *fakeReader) PRMergeable(prNumber int) (string, error) {


### PR DESCRIPTION
Implements #1009.

## Root cause

The deterministic merge guard allowed GitHub `mergeState=CLEAN/UNSTABLE` to override aggregate `CI=pending` without distinguishing why CI was pending. That override is valid for a stuck legacy commit status after all check-runs finish, but unsafe while current-head check-runs are actually queued or in progress. A newly opened OK Player PR reproduced the race live: Fedora jobs were running while the guardrail selected `merge_pr`.

## Changes

- Add a bounded `PendingCheckRuns` fact to the current-head check rollup.
- Make the production supervisor consume one complete rollup read for merge classification.
- Block deterministic merge whenever a check-run is queued, in progress, waiting, requested, or otherwise non-terminal.
- Preserve the legacy-status-only pending override when every observed check-run is terminal.
- Add opposite-path GitHub and supervisor regressions.

## Validation

- `go test ./internal/github ./internal/supervisor`
- `umask 022; go test ./...`
- `go build ./cmd/maestro/`
- `git diff --check`

Refs #940 and #969.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates merge readiness so pending check runs block deterministic merges. The main changes are:

- Adds `PendingCheckRuns` to the GitHub PR check rollup.
- Detects queued, in-progress, waiting, requested, and other non-terminal check runs on the current head.
- Uses the complete rollup in supervisor merge classification before applying merge-state overrides.
- Keeps the legacy pending-status override when all observed check runs are terminal.
- Adds tests for both the blocking path and the preserved stale-status path.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is narrow and keeps the existing legacy pending-status behavior while blocking active check runs. Tests cover the fixed race and the preserved opposite path. No correctness or security issues were found in the changed files.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran targeted changed-package tests using the Go internal supervisor, and they completed with exit status 0.
- Ran the full Go test suite across the repository, and it completed with exit status 0.
- Built the Maestro command as part of the workflow, and the build exited with status 0.
- Ran a git diff check as part of validation, and it completed with exit status 0.

<a href="https://app.greptile.com/trex/runs/14949161/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/github/github.go | Adds `PendingCheckRuns` to PR check rollups and derives it from non-terminal current-head check runs. |
| internal/github/github_test.go | Adds tests for pending check-run classification across active and terminal states. |
| internal/supervisor/policy_blocks_merge_test.go | Adds tests for blocking real pending check runs while preserving stale legacy-status merge behavior. |
| internal/supervisor/supervisor.go | Updates merge readiness to use complete PR check rollups before allowing merge-state overrides. |
| internal/supervisor/supervisor_test.go | Extends the fake reader with `PRCheckRollup` support for supervisor tests. |

<sub>Reviews (1): Last reviewed commit: ["fix: block merge while check runs are pe..."](https://github.com/befeast/maestro/commit/da166dc7f96deb14d28dd8554b3a64a8fed37334) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45316282)</sub>

<!-- /greptile_comment -->