### PR TITLE
fix: fail closed when PR head changes

### DIFF
--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -61,6 +61,14 @@ type GitHubClient interface {
 	UpdateBranch(prNumber int) error
 }
 
+type prHeadSHAReader interface {
+	PRHeadSHA(prNumber int) (string, error)
+}
+
+type prHeadBoundMerger interface {
+	MergePRAtHead(prNumber int, expectedHeadSHA string) error
+}
+
 // WorktreeRemover removes a git worktree. *worker.RemoveWorktree-shaped
 // callers satisfy this. Tests inject a fake.
 type WorktreeRemover interface {
@@ -431,6 +439,29 @@ func (e *Executor) executeMergePR(approval *state.Approval) Result {
 		return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("no GitHub client wired into executor")}
 	}
 	pr := approval.Target.PR
+	expectedHead := strings.TrimSpace(approval.Target.HeadSHA)
+	if expectedHead != "" {
+		headReader, ok := e.GH.(prHeadSHAReader)
+		if !ok {
+			return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("GitHub client cannot verify PR head SHA before merge")}
+		}
+		currentHead, err := headReader.PRHeadSHA(pr)
+		if err != nil {
+			return Result{
+				Status:  state.ApprovalStatusExecutionFailed,
+				Summary: fmt.Sprintf("verify head for PR #%d before merge: %v", pr, err),
+				Err:     fmt.Errorf("verify head for PR #%d: %w", pr, err),
+			}
+		}
+		if strings.TrimSpace(currentHead) != expectedHead {
+			return Result{
+				Status: state.ApprovalStatusExecutionSkipped,
+				Summary: fmt.Sprintf(
+					"PR #%d head changed after approval; expected %s, current %s — re-validate before merging",
+					pr, expectedHead, strings.TrimSpace(currentHead)),
+			}
+		}
+	}
 
 	// #547: a green PR that has fallen BEHIND main cannot merge under
 	// "branches must be up to date" protection — `gh pr merge` fails with
@@ -477,11 +508,24 @@ func (e *Executor) executeMergePR(approval *state.Approval) Result {
 		}
 	}
 
-	if err := e.GH.MergePR(pr); err != nil {
+	var mergeErr error
+	if expectedHead != "" {
+		headMerger, ok := e.GH.(prHeadBoundMerger)
+		if !ok {
+			return Result{Status: state.ApprovalStatusExecutionFailed, Err: errors.New("GitHub client cannot atomically bind merge to PR head SHA")}
+		}
+		mergeErr = headMerger.MergePRAtHead(pr, expectedHead)
+	} else {
+		// Backward compatibility for operator-authored and pre-upgrade approvals.
+		// Fresh supervisor approvals always carry HeadSHA and take the atomic
+		// path above; the next decision supersedes an older unstamped approval.
+		mergeErr = e.GH.MergePR(pr)
+	}
+	if mergeErr != nil {
 		return Result{
 			Status:  state.ApprovalStatusExecutionFailed,
-			Summary: fmt.Sprintf("merge PR #%d: %v", pr, err),
-			Err:     fmt.Errorf("merge PR #%d: %w", pr, err),
+			Summary: fmt.Sprintf("merge PR #%d: %v", pr, mergeErr),
+			Err:     fmt.Errorf("merge PR #%d: %w", pr, mergeErr),
 		}
 	}
 	return Result{

--- a/internal/approver/executor_test.go
+++ b/internal/approver/executor_test.go
@@ -22,6 +22,7 @@ import (
 // #547 paths set mergeable/mergeState explicitly.
 type fakeGH struct {
 	mergeCalls    []int
+	mergeHeads    []string
 	closeCalls    []closeCall
 	updateCalls   []int
 	labelCalls    []labelCall
@@ -43,7 +44,11 @@ type fakeGH struct {
 	mergeStatusErr error
 	// updateErr is returned by UpdateBranch.
 	updateErr error
+	headSHA   string
+	headErr   error
 }
+
+const testMergeHeadSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 type closeCall struct {
 	issue   int
@@ -63,6 +68,19 @@ type editBodyCall struct {
 func (f *fakeGH) MergePR(pr int) error {
 	f.mergeCalls = append(f.mergeCalls, pr)
 	return f.mergeErr
+}
+func (f *fakeGH) MergePRAtHead(pr int, headSHA string) error {
+	f.mergeHeads = append(f.mergeHeads, headSHA)
+	return f.MergePR(pr)
+}
+func (f *fakeGH) PRHeadSHA(int) (string, error) {
+	if f.headErr != nil {
+		return "", f.headErr
+	}
+	if f.headSHA != "" {
+		return f.headSHA, nil
+	}
+	return testMergeHeadSHA, nil
 }
 func (f *fakeGH) CloseIssue(issue int, comment string) error {
 	f.closeCalls = append(f.closeCalls, closeCall{issue: issue, comment: comment})
@@ -231,7 +249,7 @@ func TestExecute_ApplyLessonProposal_AppendsWorkerPromptAndMarksApplied(t *testi
 func TestExecute_MergePR_HappyPath(t *testing.T) {
 	gh := &fakeGH{}
 	ex := &Executor{GH: gh, Cfg: newCfg()}
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 99}, "merge me", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 99, HeadSHA: testMergeHeadSHA}, "merge me", "")
 
 	res := ex.Execute(a)
 	if res.Status != state.ApprovalStatusExecuted {
@@ -242,6 +260,26 @@ func TestExecute_MergePR_HappyPath(t *testing.T) {
 	}
 	if len(gh.mergeCalls) != 1 || gh.mergeCalls[0] != 99 {
 		t.Fatalf("mergeCalls = %v", gh.mergeCalls)
+	}
+	if len(gh.mergeHeads) != 1 || gh.mergeHeads[0] != testMergeHeadSHA {
+		t.Fatalf("mergeHeads = %v, want atomic merge at %s", gh.mergeHeads, testMergeHeadSHA)
+	}
+}
+
+func TestExecute_MergePR_ChangedHeadSkipsWithoutMerge(t *testing.T) {
+	gh := &fakeGH{headSHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}
+	ex := &Executor{GH: gh, Cfg: newCfg()}
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 99, HeadSHA: testMergeHeadSHA}, "merge me", "")
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionSkipped {
+		t.Fatalf("status = %q, want execution_skipped; res=%+v", res.Status, res)
+	}
+	if len(gh.mergeCalls) != 0 || len(gh.mergeHeads) != 0 {
+		t.Fatalf("changed head must not merge: calls=%v heads=%v", gh.mergeCalls, gh.mergeHeads)
+	}
+	if !strings.Contains(strings.ToLower(res.Summary), "head changed") {
+		t.Fatalf("summary = %q, want head-changed explanation", res.Summary)
 	}
 }
 
@@ -255,7 +293,7 @@ func TestExecute_MergePR_HappyPath(t *testing.T) {
 func TestExecute_MergePR_Behind_UpdatesBranchAndSkips(t *testing.T) {
 	gh := &fakeGH{mergeable: "MERGEABLE", mergeState: "behind"}
 	ex := &Executor{GH: gh, Cfg: newCfg()}
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 542}, "merge", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 542, HeadSHA: testMergeHeadSHA}, "merge", "")
 
 	res := ex.Execute(a)
 	if res.Status != state.ApprovalStatusExecutionSkipped {
@@ -283,7 +321,7 @@ func TestExecute_MergePR_Behind_UpdatesBranchAndSkips(t *testing.T) {
 func TestExecute_MergePR_Clean_Merges(t *testing.T) {
 	gh := &fakeGH{mergeable: "MERGEABLE", mergeState: "clean"}
 	ex := &Executor{GH: gh, Cfg: newCfg()}
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 100}, "merge", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 100, HeadSHA: testMergeHeadSHA}, "merge", "")
 
 	res := ex.Execute(a)
 	if res.Status != state.ApprovalStatusExecuted {
@@ -303,7 +341,7 @@ func TestExecute_MergePR_Clean_Merges(t *testing.T) {
 func TestExecute_MergePR_Conflicting_Fails(t *testing.T) {
 	gh := &fakeGH{mergeable: "CONFLICTING", mergeState: "dirty"}
 	ex := &Executor{GH: gh, Cfg: newCfg()}
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7, HeadSHA: testMergeHeadSHA}, "merge", "")
 
 	res := ex.Execute(a)
 	if res.Status != state.ApprovalStatusExecutionFailed || res.Err == nil {
@@ -326,7 +364,7 @@ func TestExecute_MergePR_Conflicting_Fails(t *testing.T) {
 func TestExecute_MergePR_BehindButConflicting_DoesNotUpdate(t *testing.T) {
 	gh := &fakeGH{mergeable: "CONFLICTING", mergeState: "behind"}
 	ex := &Executor{GH: gh, Cfg: newCfg()}
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 8}, "merge", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 8, HeadSHA: testMergeHeadSHA}, "merge", "")
 
 	res := ex.Execute(a)
 	if res.Status != state.ApprovalStatusExecutionFailed {
@@ -343,7 +381,7 @@ func TestExecute_MergePR_BehindButConflicting_DoesNotUpdate(t *testing.T) {
 func TestExecute_MergePR_Behind_UpdateBranchError_Fails(t *testing.T) {
 	gh := &fakeGH{mergeable: "MERGEABLE", mergeState: "behind", updateErr: errors.New("update boom")}
 	ex := &Executor{GH: gh, Cfg: newCfg()}
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 9}, "merge", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 9, HeadSHA: testMergeHeadSHA}, "merge", "")
 
 	res := ex.Execute(a)
 	if res.Status != state.ApprovalStatusExecutionFailed || res.Err == nil {
@@ -364,7 +402,7 @@ func TestExecute_MergePR_Behind_UpdateBranchError_Fails(t *testing.T) {
 func TestExecute_MergePR_StatusFetchError_StillMerges(t *testing.T) {
 	gh := &fakeGH{mergeStatusErr: errors.New("rate limited")}
 	ex := &Executor{GH: gh, Cfg: newCfg()}
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 11}, "merge", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 11, HeadSHA: testMergeHeadSHA}, "merge", "")
 
 	res := ex.Execute(a)
 	if res.Status != state.ApprovalStatusExecuted {

--- a/internal/approver/idempotent_test.go
+++ b/internal/approver/idempotent_test.go
@@ -38,6 +38,8 @@ func (b *blockingGH) MergePR(pr int) error {
 	}
 	return nil
 }
+func (b *blockingGH) MergePRAtHead(pr int, _ string) error { return b.MergePR(pr) }
+func (b *blockingGH) PRHeadSHA(int) (string, error)        { return testMergeHeadSHA, nil }
 func (b *blockingGH) CloseIssue(issue int, comment string) error {
 	atomic.AddInt32(&b.calls, 1)
 	return nil
@@ -73,7 +75,7 @@ func TestExecute_ConcurrentSameApproval_OnlyOneSideEffect(t *testing.T) {
 	gh := &blockingGH{gate: gate, released: released}
 	ex := &Executor{GH: gh, Cfg: newCfg()}
 
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7, HeadSHA: testMergeHeadSHA}, "merge", "")
 
 	results := make(chan Result, 2)
 	go func() { results <- ex.Execute(a) }()

--- a/internal/approver/repo_guard_test.go
+++ b/internal/approver/repo_guard_test.go
@@ -16,7 +16,7 @@ func TestExecute_CrossProjectMutation_Refused(t *testing.T) {
 	cfg := newCfg() // cfg.Repo = "owner/repo"
 	ex := &Executor{GH: gh, Cfg: cfg}
 
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7, HeadSHA: testMergeHeadSHA}, "merge", "")
 	a.Repo = "BeFeast/scribe-service" // mismatch
 
 	res := ex.Execute(a)
@@ -36,7 +36,7 @@ func TestExecute_RepoMatch_Proceeds(t *testing.T) {
 	cfg := newCfg()
 	ex := &Executor{GH: gh, Cfg: cfg}
 
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7, HeadSHA: testMergeHeadSHA}, "merge", "")
 	a.Repo = cfg.Repo // explicit match
 
 	res := ex.Execute(a)
@@ -54,7 +54,7 @@ func TestExecute_LegacyApprovalNoRepo_FallsThrough(t *testing.T) {
 	gh := &fakeGH{}
 	ex := &Executor{GH: gh, Cfg: newCfg()}
 
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7, HeadSHA: testMergeHeadSHA}, "merge", "")
 	// a.Repo intentionally left empty.
 
 	res := ex.Execute(a)
@@ -74,7 +74,7 @@ func TestExecute_NoCfgRepo_SkipsGuard(t *testing.T) {
 	cfg.Repo = ""
 	ex := &Executor{GH: gh, Cfg: cfg}
 
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7, HeadSHA: testMergeHeadSHA}, "merge", "")
 	a.Repo = "BeFeast/something" // irrelevant — cfg has nothing to compare against
 
 	res := ex.Execute(a)
@@ -90,7 +90,7 @@ func TestExecute_LegacyApprovalNoRepo_EmitsDeprecationWarning(t *testing.T) {
 	gh := &fakeGH{}
 	ex := &Executor{GH: gh, Cfg: newCfg()}
 
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7, HeadSHA: testMergeHeadSHA}, "merge", "")
 	// a.Repo intentionally left empty — simulates a pre-#489 approval.
 
 	res := ex.Execute(a)
@@ -112,7 +112,7 @@ func TestExecute_RepoMatch_NoLegacyWarning(t *testing.T) {
 	cfg := newCfg()
 	ex := &Executor{GH: gh, Cfg: cfg}
 
-	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7}, "merge", "")
+	a := mkApproval(config.SupervisorActionMergePR, &state.SupervisorTarget{PR: 7, HeadSHA: testMergeHeadSHA}, "merge", "")
 	a.Repo = cfg.Repo
 
 	res := ex.Execute(a)

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2864,6 +2864,26 @@ func (c *Client) MergePR(prNumber int) error {
 	return nil
 }
 
+// MergePRAtHead squash-merges a PR only when its current head still matches
+// expectedHeadSHA. GitHub enforces the comparison atomically with the merge,
+// closing the force-push race between a gate/approval read and execution.
+func (c *Client) MergePRAtHead(prNumber int, expectedHeadSHA string) error {
+	expectedHeadSHA = strings.TrimSpace(expectedHeadSHA)
+	if expectedHeadSHA == "" {
+		return fmt.Errorf("merge PR %d: expected head SHA is required", prNumber)
+	}
+	out, err := ghCommand("pr", "merge",
+		fmt.Sprint(prNumber),
+		"--repo", c.Repo,
+		"--squash",
+		"--delete-branch",
+		"--match-head-commit", expectedHeadSHA).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("gh pr merge %d at head %s: %w\n%s", prNumber, expectedHeadSHA, err, out)
+	}
+	return nil
+}
+
 // MarkPRReady marks a draft pull request as ready for review (wraps
 // `gh pr ready`). `gh pr merge` on a draft fails with "still a draft", so
 // the orchestrator readies a green draft PR before merging it (#697).

--- a/internal/supervisor/policy_blocks_merge_test.go
+++ b/internal/supervisor/policy_blocks_merge_test.go
@@ -213,6 +213,48 @@ func TestDecide_OpenPR_RealPendingCheckRunBlocksCleanMergeState(t *testing.T) {
 	}
 }
 
+type headChangingReader struct {
+	*fakeReader
+	headSHA string
+	headErr error
+}
+
+func (r *headChangingReader) PRHeadSHA(int) (string, error) {
+	return r.headSHA, r.headErr
+}
+
+func TestDecide_OpenPR_HeadChangedAfterCheckRollup_StaysMonitor(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	checkedHead := strings.Repeat("a", 40)
+	reader := &headChangingReader{
+		fakeReader: &fakeReader{
+			prs:         []github.PR{{Number: 120, HeadRefName: "feat/force-pushed", Mergeable: "MERGEABLE"}},
+			mergeStates: map[int]string{120: "clean"},
+			checkRollups: map[int]github.PRCheckRollup{
+				120: {HeadSHA: checkedHead, Verdict: "success", Complete: true},
+			},
+		},
+		headSHA: strings.Repeat("b", 40),
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-2"] = &state.Session{
+		IssueNumber: 202,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/force-pushed",
+		PRNumber:    120,
+		StartedAt:   time.Now().UTC().Add(-time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want monitor_open_pr after PR head changed", decision.RecommendedAction)
+	}
+}
+
 // mergeable_state="blocked" means a required check is still failing;
 // stay on monitor_open_pr even if a legacy commit status would otherwise
 // have been pending-but-not-failure.

--- a/internal/supervisor/policy_blocks_merge_test.go
+++ b/internal/supervisor/policy_blocks_merge_test.go
@@ -177,6 +177,9 @@ func TestDecide_OpenPR_CIAggregateStaleButMergeStateClean_Merges(t *testing.T) {
 	if decision.RecommendedAction != ActionMergePR {
 		t.Fatalf("action = %q, want merge_pr (mergeable_state=clean must override stale aggregate CI=pending)", decision.RecommendedAction)
 	}
+	if decision.Target == nil || decision.Target.HeadSHA == "" {
+		t.Fatalf("target = %#v, want merge approval bound to checked head SHA", decision.Target)
+	}
 }
 
 func TestDecide_OpenPR_RealPendingCheckRunBlocksCleanMergeState(t *testing.T) {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -618,7 +618,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	cache := newResolutionCache(e.reader)
 	stuckStates := e.detectStuckStates(st, now, prs, nil, nil, nil, false, cache)
 
-	if slot, sess, pr, mergeReady, mergeReasons, ok := e.sessionWithOpenPR(st, prs, cache); ok {
+	if slot, sess, pr, mergeReady, mergeHeadSHA, mergeReasons, ok := e.sessionWithOpenPR(st, prs, cache); ok {
 		// #565: auto review-repair respawn. When a green+mergeable PR is
 		// settled retry_exhausted on review feedback AND Greptile flags
 		// ≥1 P0/P1 inline comment on its current head SHA, mint a
@@ -677,7 +677,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		if mergeReady {
 			summary := fmt.Sprintf("Merge PR #%d for issue #%d — checks green, mergeable, review gates passed.", pr.Number, sess.IssueNumber)
 			reasons := appendReasons(baseReasons, mergeReasons...)
-			target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}
+			target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, HeadSHA: mergeHeadSHA, Session: slot}
 			decision := e.decision(st, now, projectState, ActionMergePR,
 				summary,
 				RiskMutating, 0.9, target, PolicyRuleRuntimeState, reasons)
@@ -2689,7 +2689,7 @@ func sessionWithOpenPR(st *state.State, prs []github.PR) (string, *state.Session
 	return "", nil, github.PR{}, false
 }
 
-func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *resolutionCache) (string, *state.Session, github.PR, bool, []string, bool) {
+func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *resolutionCache) (string, *state.Session, github.PR, bool, string, []string, bool) {
 	branchToPR := make(map[string]github.PR, len(prs))
 	numberToPR := make(map[int]github.PR, len(prs))
 	for _, pr := range prs {
@@ -2707,6 +2707,7 @@ func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *reso
 	var bestSession *state.Session
 	var bestPR github.PR
 	var bestReady bool
+	var bestMergeHeadSHA string
 	var bestMergeReasons []string
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
@@ -2740,7 +2741,7 @@ func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *reso
 		// blocked draft) prevented a later CLEAN green PR from ever reaching the
 		// merge rule. One ready PR is the highest-priority action in sequential
 		// merge mode; attention states remain next, then passive PR gates.
-		ready, mergeReasons := e.openPRReadyToMerge(slot, sess, pr)
+		ready, mergeHeadSHA, mergeReasons := e.openPRReadyToMerge(slot, sess, pr)
 		rank := 2
 		if ready {
 			rank = 0
@@ -2753,7 +2754,7 @@ func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *reso
 		if bestSession == nil || rank < bestRank {
 			bestRank = rank
 			bestSlot, bestSession, bestPR = slot, sess, pr
-			bestReady, bestMergeReasons = ready, mergeReasons
+			bestReady, bestMergeHeadSHA, bestMergeReasons = ready, mergeHeadSHA, mergeReasons
 		}
 		if bestRank == 0 {
 			// sortedSessionNames provides the deterministic tie-break among
@@ -2762,9 +2763,9 @@ func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *reso
 		}
 	}
 	if bestSession != nil {
-		return bestSlot, bestSession, bestPR, bestReady, bestMergeReasons, true
+		return bestSlot, bestSession, bestPR, bestReady, bestMergeHeadSHA, bestMergeReasons, true
 	}
-	return "", nil, github.PR{}, false, nil, false
+	return "", nil, github.PR{}, false, "", nil, false
 }
 
 func runningSession(st *state.State) (string, *state.Session, bool) {
@@ -2833,7 +2834,7 @@ func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.Supervis
 			// instead of looping on spawn_repair_worker, which the executor
 			// refuses (not in the action registry) and wedges a green PR
 			// forever.
-			if ready, _ := e.openPRReadyToMerge(slot, sess, pr); ready {
+			if ready, _, _ := e.openPRReadyToMerge(slot, sess, pr); ready {
 				return false
 			}
 			return true
@@ -2875,12 +2876,12 @@ func (e *Engine) automaticOutcomeRecoveryOwnsFailure(st *state.State) bool {
 // Strict: an UNKNOWN mergeable, "pending" CI, or "unknown" review state
 // blocks the merge. We never speculate — a missing signal is treated as
 // "not ready" so we don't merge a PR whose state we couldn't read.
-func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.PR) (bool, []string) {
+func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.PR) (bool, string, []string) {
 	if sess == nil {
-		return false, nil
+		return false, "", nil
 	}
 	if pr.IsDraft {
-		return false, nil
+		return false, "", nil
 	}
 	// CI must be green. Production readers expose the current-head rollup so
 	// a real queued/in-progress check-run can never be confused with the
@@ -2891,7 +2892,7 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 	if rollupReader, ok := e.reader.(prCheckRollupReader); ok {
 		rollup, err := rollupReader.PRCheckRollup(pr.Number)
 		if err != nil || !rollup.Complete || strings.TrimSpace(rollup.HeadSHA) == "" {
-			return false, nil
+			return false, "", nil
 		}
 		rollupHeadSHA = strings.TrimSpace(rollup.HeadSHA)
 		ciStatus = rollup.Verdict
@@ -2899,12 +2900,12 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 	} else {
 		ciReader, ok := e.reader.(prCIStatusReader)
 		if !ok {
-			return false, nil
+			return false, "", nil
 		}
 		var err error
 		ciStatus, err = ciReader.PRCIStatus(pr.Number)
 		if err != nil {
-			return false, nil
+			return false, "", nil
 		}
 	}
 
@@ -2919,13 +2920,13 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 		}
 	}
 	if mergeable != "MERGEABLE" {
-		return false, nil
+		return false, "", nil
 	}
 
 	ciLower := strings.ToLower(strings.TrimSpace(ciStatus))
 	if ciLower != "success" {
 		if pendingCheckRuns {
-			return false, nil
+			return false, "", nil
 		}
 		// #425 (sup-98): the aggregate PRCIStatus can stick at "pending"
 		// long after every required check has gone green — the most common
@@ -2936,7 +2937,7 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 		// "blocked" / "behind" / "dirty" / "" / "unknown" all stay
 		// not-ready.
 		if !mergeStateAllowsMerge(e.reader, pr.Number) {
-			return false, nil
+			return false, "", nil
 		}
 	}
 
@@ -2947,13 +2948,13 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 	if greptileReader, ok := e.reader.(prGreptileReader); ok {
 		approved, pending, err := greptileReader.PRGreptileApproved(pr.Number)
 		if err != nil {
-			return false, nil
+			return false, "", nil
 		}
 		if pending {
-			return false, nil
+			return false, "", nil
 		}
 		if !approved {
-			return false, nil
+			return false, "", nil
 		}
 	}
 
@@ -2963,11 +2964,11 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 	if rollupHeadSHA != "" {
 		headReader, ok := e.reader.(prHeadSHAReader)
 		if !ok {
-			return false, nil
+			return false, "", nil
 		}
 		currentHead, err := headReader.PRHeadSHA(pr.Number)
 		if err != nil || strings.TrimSpace(currentHead) != rollupHeadSHA {
-			return false, nil
+			return false, "", nil
 		}
 	}
 
@@ -2987,7 +2988,7 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 	if _, ok := e.reader.(prGreptileReader); ok {
 		reasons = append(reasons, fmt.Sprintf("PR #%d Greptile review approved", pr.Number))
 	}
-	return true, reasons
+	return true, rollupHeadSHA, reasons
 }
 
 // monitorOpenPRReasons returns a short list of human-readable reasons

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -116,6 +116,10 @@ type prCheckRollupReader interface {
 	PRCheckRollup(prNumber int) (github.PRCheckRollup, error)
 }
 
+type prHeadSHAReader interface {
+	PRHeadSHA(prNumber int) (string, error)
+}
+
 type prGreptileReader interface {
 	PRGreptileApproved(prNumber int) (approved bool, pending bool, err error)
 }
@@ -2878,30 +2882,18 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 	if pr.IsDraft {
 		return false, nil
 	}
-	// #543: GitHub LIST endpoint never populates `mergeable`; fetch via
-	// single-PR endpoint when reader supports it. Without this every
-	// PR.Mergeable read here was "" → "UNKNOWN" → merge_pr never
-	// recommended.
-	mergeable := strings.ToUpper(strings.TrimSpace(pr.Mergeable))
-	if mr, ok := e.reader.(prMergeableReader); ok {
-		if fresh, err := mr.PRMergeable(pr.Number); err == nil {
-			mergeable = strings.ToUpper(strings.TrimSpace(fresh))
-		}
-	}
-	if mergeable != "MERGEABLE" {
-		return false, nil
-	}
-
 	// CI must be green. Production readers expose the current-head rollup so
 	// a real queued/in-progress check-run can never be confused with the
 	// legacy commit-status-only pending state handled by #425.
 	ciStatus := ""
 	pendingCheckRuns := false
+	rollupHeadSHA := ""
 	if rollupReader, ok := e.reader.(prCheckRollupReader); ok {
 		rollup, err := rollupReader.PRCheckRollup(pr.Number)
-		if err != nil || !rollup.Complete {
+		if err != nil || !rollup.Complete || strings.TrimSpace(rollup.HeadSHA) == "" {
 			return false, nil
 		}
+		rollupHeadSHA = strings.TrimSpace(rollup.HeadSHA)
 		ciStatus = rollup.Verdict
 		pendingCheckRuns = rollup.PendingCheckRuns
 	} else {
@@ -2915,6 +2907,21 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 			return false, nil
 		}
 	}
+
+	// #543: GitHub LIST endpoint never populates `mergeable`; fetch via
+	// single-PR endpoint when reader supports it. Read it after the rollup so
+	// the final head identity check below proves every gate was observed for
+	// one unchanged PR head.
+	mergeable := strings.ToUpper(strings.TrimSpace(pr.Mergeable))
+	if mr, ok := e.reader.(prMergeableReader); ok {
+		if fresh, err := mr.PRMergeable(pr.Number); err == nil {
+			mergeable = strings.ToUpper(strings.TrimSpace(fresh))
+		}
+	}
+	if mergeable != "MERGEABLE" {
+		return false, nil
+	}
+
 	ciLower := strings.ToLower(strings.TrimSpace(ciStatus))
 	if ciLower != "success" {
 		if pendingCheckRuns {
@@ -2946,6 +2953,20 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 			return false, nil
 		}
 		if !approved {
+			return false, nil
+		}
+	}
+
+	// A force-push or repair commit can land between the rollup read and the
+	// merge decision. Production readers expose PRHeadSHA; fail closed unless
+	// the current head still matches the exact head whose checks were read.
+	if rollupHeadSHA != "" {
+		headReader, ok := e.reader.(prHeadSHAReader)
+		if !ok {
+			return false, nil
+		}
+		currentHead, err := headReader.PRHeadSHA(pr.Number)
+		if err != nil || strings.TrimSpace(currentHead) != rollupHeadSHA {
 			return false, nil
 		}
 	}

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -139,9 +139,23 @@ func (f *fakeReader) PRCIStatus(prNumber int) (string, error) {
 
 func (f *fakeReader) PRCheckRollup(prNumber int) (github.PRCheckRollup, error) {
 	if rollup, ok := f.checkRollups[prNumber]; ok {
+		if rollup.HeadSHA == "" {
+			rollup.HeadSHA = strings.Repeat("f", 40)
+		}
 		return rollup, nil
 	}
-	return github.PRCheckRollup{Verdict: f.ciStatuses[prNumber], Complete: true}, nil
+	return github.PRCheckRollup{
+		HeadSHA:  strings.Repeat("f", 40),
+		Verdict:  f.ciStatuses[prNumber],
+		Complete: true,
+	}, nil
+}
+
+func (f *fakeReader) PRHeadSHA(prNumber int) (string, error) {
+	if rollup, ok := f.checkRollups[prNumber]; ok && rollup.HeadSHA != "" {
+		return rollup.HeadSHA, nil
+	}
+	return strings.Repeat("f", 40), nil
 }
 
 func (f *fakeReader) PRMergeable(prNumber int) (string, error) {
@@ -234,7 +248,7 @@ func enableDynamicWave(cfg *config.Config) {
 	cfg.Supervisor.DynamicWave.Enabled = &enabled
 }
 
-func testEngine(cfg *config.Config, reader *fakeReader) *Engine {
+func testEngine(cfg *config.Config, reader Reader) *Engine {
 	eng := NewEngine(cfg, reader)
 	eng.now = func() time.Time { return time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC) }
 	eng.pidAlive = func(pid int) bool { return true }

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1217,7 +1217,7 @@ func TestSessionWithOpenPR_SkipsSettledSessionsBeforeRemoteResolution(t *testing
 		PRNumber:    202,
 	}
 
-	_, _, _, found, _, _ := eng.sessionWithOpenPR(st, nil, newResolutionCache(eng.reader))
+	_, _, _, found, _, _, _ := eng.sessionWithOpenPR(st, nil, newResolutionCache(eng.reader))
 
 	if found {
 		t.Fatal("settled session was selected as an open-PR candidate")


### PR DESCRIPTION
## Summary

- fail closed when a PR head changes after its current-head check rollup is read
- order mergeability and review reads between the rollup and a final head identity check
- stamp the verified head SHA onto `merge_pr` decisions and approval identity
- re-check the head at execution and atomically merge with `--match-head-commit`
- add supervisor and approver regressions for force-push/rebase races

## Validation

- `go test ./internal/github ./internal/supervisor`
- `go test ./internal/approver`
- `go test ./...`
- `go build ./cmd/maestro/`
- `git diff --check`

Follow-up to #1011. Completes #1009 acceptance for head mismatch.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes merge decisions fail closed when a PR head changes. The main changes are:

- Adds a supervisor head check after reading CI, mergeability, and review gates.
- Carries the verified check-rollup head SHA into merge approvals.
- Uses `gh pr merge --match-head-commit` for head-bound merge execution.
- Adds tests for changed-head races and updates test fakes for head-aware merge paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is focused, keeps legacy unstamped approvals on the existing path, and adds tests for the head-change race.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification.
- T-Rex noted that local artifact references were not uploaded with the verification.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Reorders merge readiness reads around the check rollup and final head identity check, then stores the verified head SHA on merge approvals. |
| internal/approver/executor.go | Adds pre-merge head verification and switches stamped approvals to an atomic head-bound merge path. |
| internal/github/github.go | Adds `MergePRAtHead` using `gh pr merge --match-head-commit`. |
| internal/supervisor/policy_blocks_merge_test.go | Adds regression coverage for a PR head changing between check rollup reads and merge decisions. |

<sub>Reviews (2): Last reviewed commit: ["fix: bind merge approvals to checked hea..."](https://github.com/befeast/maestro/commit/cd8470b5d505af6340b2a55c4c8173a02899ce0b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45316828)</sub>

<!-- /greptile_comment -->