### PR TITLE
P0: pending post-merge CI must not trigger outcome failure cooldown

### DIFF
--- a/internal/outcome/checker.go
+++ b/internal/outcome/checker.go
@@ -103,6 +103,18 @@ func (c Checker) checkCommand(ctx context.Context, command, dir, signal string) 
 
 	output, exitCode, err := c.runCommand(ctx, command, dir)
 	checks, projectedDetail, projectedSummary, declaredHealthy := projectStructuredHealth(output)
+	if state, summary := blockingStructuredHealthState(checks); state != "" {
+		if summary != "" {
+			summary = fmt.Sprintf("%s: %s", signal, summary)
+		} else if state == HealthPending {
+			summary = fmt.Sprintf("%s pending", signal)
+		} else {
+			summary = fmt.Sprintf("%s reported unhealthy", signal)
+		}
+		result := c.result(start, signal, state, summary, projectedDetail, exitCode)
+		result.Checks = checks
+		return result
+	}
 	if err != nil {
 		summary := fmt.Sprintf("%s failed", signal)
 		if ctx.Err() == context.DeadlineExceeded {
@@ -249,9 +261,33 @@ func projectHealthCheckName(value string) string {
 
 func projectHealthCheckStatus(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "pass", "fail", "warning", "unknown", "error", "healthy", "failing":
+	case "pass", "fail", "warning", "unknown", "error", "healthy", "failing", "pending", "in_progress", "queued":
 		return strings.ToLower(strings.TrimSpace(value))
+	case "in-progress":
+		return "in_progress"
 	default:
 		return "unknown"
 	}
+}
+
+func blockingStructuredHealthState(checks []HealthCheckItem) (state, summary string) {
+	for _, check := range checks {
+		if !check.Blocking {
+			continue
+		}
+		switch check.Status {
+		case "fail", "failing", "error":
+			return HealthFailing, check.Name + " reported " + check.Status
+		}
+	}
+	for _, check := range checks {
+		if !check.Blocking {
+			continue
+		}
+		switch check.Status {
+		case "pending", "in_progress", "queued":
+			return HealthPending, check.Name + " reported " + check.Status
+		}
+	}
+	return "", ""
 }

--- a/internal/outcome/outcome.go
+++ b/internal/outcome/outcome.go
@@ -11,6 +11,7 @@ const (
 	HealthUnmonitored   = "unmonitored"
 	HealthUnknown       = "unknown"
 	HealthHealthy       = "healthy"
+	HealthPending       = "pending"
 	HealthFailing       = "failing"
 
 	RecoveryModeDisabled  = "disabled"
@@ -294,6 +295,8 @@ func StatusFor(brief Brief, mergedPRs int, lastMergeAt time.Time, checks ...Heal
 			switch status.HealthState {
 			case HealthHealthy:
 				status.NextAction = "Runtime outcome health is passing; continue normal supervisor policy."
+			case HealthPending:
+				status.NextAction = "Required outcome checks are still pending; continue normal supervisor policy while they complete."
 			case HealthFailing:
 				status.NextAction = "Fix runtime/deploy health before dispatching more issue work."
 			default:
@@ -351,6 +354,8 @@ func normalizedHealthState(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case HealthHealthy:
 		return HealthHealthy
+	case HealthPending:
+		return HealthPending
 	case HealthFailing:
 		return HealthFailing
 	case HealthUnknown:

--- a/internal/outcome/outcome_test.go
+++ b/internal/outcome/outcome_test.go
@@ -122,6 +122,34 @@ func TestStatusForUsesFreshHealthCheck(t *testing.T) {
 	}
 }
 
+func TestStatusForPersistsPendingHealthCheck(t *testing.T) {
+	checkedAt := time.Date(2026, 7, 18, 12, 15, 56, 0, time.UTC)
+	status := StatusFor(Brief{
+		DesiredOutcome:     "Merged main passes required CI",
+		HealthcheckCommand: "check-main-ci",
+	}, 1, checkedAt.Add(-time.Minute), HealthCheckResult{
+		CheckedAt: checkedAt,
+		Signal:    "healthcheck_command",
+		State:     HealthPending,
+		Summary:   "source-main-ci reported pending",
+		Checks: []HealthCheckItem{{
+			Name:     "source-main-ci",
+			Blocking: true,
+			Status:   "pending",
+		}},
+	})
+
+	if status.HealthState != HealthPending {
+		t.Fatalf("HealthState = %q, want %q", status.HealthState, HealthPending)
+	}
+	if len(status.Checks) != 1 || status.Checks[0].Status != "pending" {
+		t.Fatalf("Checks = %+v, want persisted pending check", status.Checks)
+	}
+	if strings.Contains(status.NextAction, "before dispatching") {
+		t.Fatalf("NextAction = %q, pending must not block dispatch", status.NextAction)
+	}
+}
+
 func TestStatusForIgnoresHealthCheckBeforeLastMerge(t *testing.T) {
 	lastMerge := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
 	status := StatusFor(Brief{
@@ -217,5 +245,44 @@ func TestCheckerHonorsStructuredUnhealthyWhenCommandExitsZero(t *testing.T) {
 	}.Check(context.Background(), Brief{DesiredOutcome: "candidate is fresh", HealthcheckCommand: "check"})
 	if result.State != HealthFailing || result.ExitCode != 0 || len(result.Checks) != 1 {
 		t.Fatalf("structured unhealthy result=%+v", result)
+	}
+}
+
+func TestCheckerTreatsBlockingStructuredPendingAsTransitional(t *testing.T) {
+	result := Checker{
+		RunCommand: func(context.Context, string, string) ([]byte, int, error) {
+			return []byte(`{"healthy":false,"checks":[{"name":"source-main-ci","blocking":true,"status":"in_progress"}]}`), 1, context.DeadlineExceeded
+		},
+	}.Check(context.Background(), Brief{DesiredOutcome: "main is healthy", HealthcheckCommand: "check"})
+
+	if result.State != HealthPending || result.ExitCode != 1 {
+		t.Fatalf("structured pending result=%+v, want pending", result)
+	}
+	if len(result.Checks) != 1 || result.Checks[0].Status != "in_progress" {
+		t.Fatalf("Checks = %+v, want projected in-progress check", result.Checks)
+	}
+}
+
+func TestCheckerTreatsBlockingStructuredFailureAsFailing(t *testing.T) {
+	result := Checker{
+		RunCommand: func(context.Context, string, string) ([]byte, int, error) {
+			return []byte(`{"healthy":true,"checks":[{"name":"source-main-ci","blocking":true,"status":"error"},{"name":"deploy","blocking":true,"status":"queued"}]}`), 0, nil
+		},
+	}.Check(context.Background(), Brief{DesiredOutcome: "main is healthy", HealthcheckCommand: "check"})
+
+	if result.State != HealthFailing {
+		t.Fatalf("State = %q, want %q: %+v", result.State, HealthFailing, result)
+	}
+}
+
+func TestCheckerTreatsConcludedStructuredSuccessAsHealthy(t *testing.T) {
+	result := Checker{
+		RunCommand: func(context.Context, string, string) ([]byte, int, error) {
+			return []byte(`{"healthy":true,"checks":[{"name":"source-main-ci","blocking":true,"status":"pass"}]}`), 0, nil
+		},
+	}.Check(context.Background(), Brief{DesiredOutcome: "main is healthy", HealthcheckCommand: "check"})
+
+	if result.State != HealthHealthy {
+		t.Fatalf("State = %q, want %q: %+v", result.State, HealthHealthy, result)
 	}
 }

--- a/internal/supervisor/outcome_recovery_test.go
+++ b/internal/supervisor/outcome_recovery_test.go
@@ -102,6 +102,47 @@ func TestEvaluateOutcomeRecoveryOnce_NonFailingHealthNeverRunsCommand(t *testing
 	}
 }
 
+func TestEvaluateOutcomeRecoveryOnce_PendingPersistsWithoutRecoveryCooldown(t *testing.T) {
+	cfg := recoveryTestConfig(t)
+	t0 := time.Date(2026, 7, 18, 12, 15, 56, 0, time.UTC)
+	if err := state.Save(cfg.StateDir, state.NewState()); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	originalCheck, originalRun := checkOutcomeForRecovery, runOutcomeRecovery
+	t.Cleanup(func() { checkOutcomeForRecovery, runOutcomeRecovery = originalCheck, originalRun })
+	checkOutcomeForRecovery = func(_ context.Context, _ outcome.Brief) outcome.HealthCheckResult {
+		return outcome.HealthCheckResult{
+			CheckedAt: t0,
+			Signal:    "healthcheck_command",
+			State:     outcome.HealthPending,
+			Summary:   "source-main-ci reported in_progress",
+		}
+	}
+	runCalls := 0
+	runOutcomeRecovery = func(_ context.Context, _ outcome.Brief) outcome.RecoveryExecution {
+		runCalls++
+		return outcome.RecoveryExecution{}
+	}
+
+	if evaluated, err := EvaluateOutcomeRecoveryOnce(cfg, t0); err != nil || !evaluated {
+		t.Fatalf("evaluation: evaluated=%t err=%v", evaluated, err)
+	}
+	loaded, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if runCalls != 0 {
+		t.Fatalf("pending health launched recovery %d time(s)", runCalls)
+	}
+	if loaded.OutcomeHealth == nil || loaded.OutcomeHealth.State != outcome.HealthPending {
+		t.Fatalf("stored outcome health = %+v, want pending", loaded.OutcomeHealth)
+	}
+	if loaded.OutcomeRecovery != nil {
+		t.Fatalf("pending health entered recovery/cooldown: %+v", loaded.OutcomeRecovery)
+	}
+}
+
 func TestEvaluateOutcomeRecoveryOnce_LeasesRunsOnceAndVerifies(t *testing.T) {
 	cfg := recoveryTestConfig(t)
 	t0 := time.Date(2026, 7, 18, 8, 0, 0, 0, time.UTC)

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1782,6 +1782,51 @@ func TestDecide_HealthyOutcomeAllowsIssueWorkAfterMerges(t *testing.T) {
 	}
 }
 
+func TestDecide_PendingOutcomeAllowsUnrelatedIssueWorkAfterMerge(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome:     "Merged main passes required CI",
+		HealthcheckCommand: "check-main-ci",
+	}
+	reader := &fakeReader{issues: []github.Issue{testIssue(312, "next independent iteration", "maestro-ready")}}
+	now := time.Date(2026, 7, 18, 12, 15, 56, 0, time.UTC)
+	st := state.NewState()
+	st.LastMergeAt = now.Add(-time.Minute)
+	st.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: now,
+		Signal:    "healthcheck_command",
+		State:     outcome.HealthPending,
+		Summary:   "source-main-ci reported in_progress",
+	}
+	st.Sessions["done-421"] = &state.Session{
+		IssueNumber: 421,
+		IssueTitle:  "merged work",
+		Status:      state.StatusDone,
+		PRNumber:    421,
+		StartedAt:   now.Add(-time.Hour),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.Target == nil || decision.Target.Issue != 312 {
+		t.Fatalf("target = %#v, want unrelated ready issue 312", decision.Target)
+	}
+	if decision.Outcome == nil || decision.Outcome.HealthState != outcome.HealthPending {
+		t.Fatalf("Outcome = %+v, want persisted pending outcome", decision.Outcome)
+	}
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == state.StuckNoOutcomeProgress {
+			t.Fatalf("pending outcome suppressed material progress: %+v", stuck)
+		}
+	}
+}
+
 func TestDecide_EmptyStateNoAction(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{}


### PR DESCRIPTION
Refs #1014

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `pending` outcome health state for post-merge checks. The main changes are:

- Structured health checks now treat blocking `pending`, `in_progress`, and `queued` statuses as transitional.
- Pending outcome health is persisted and shown separately from failing health.
- Supervisor and recovery tests cover pending checks without recovery cooldown or issue-work blocking.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is focused and covered by targeted tests across outcome status, checker behavior, automatic recovery, and supervisor decisions. No blocking logic or security issues were found.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A Go test run for pending outcome checks was executed and the proof log capturing the command, working directory, timestamps, verbose output, and exit code was saved.
- The proof confirms that the outcome checker for pending structured health passed and that the supervisor recovery/decision tests passed with no recovery cooldown and no suppression of unrelated issue work.

<a href="https://app.greptile.com/trex/runs/14952062/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/outcome/checker.go | Adds structured pending status recognition and prioritizes blocking structured check states before command exit handling; no issues found. |
| internal/outcome/outcome.go | Introduces the pending health state in outcome status normalization and next-action messaging; no issues found. |
| internal/outcome/outcome_test.go | Covers pending health persistence and structured pending/failure/success checker behavior; no issues found. |
| internal/supervisor/outcome_recovery_test.go | Adds coverage that pending outcome health persists without launching recovery or entering cooldown; no issues found. |
| internal/supervisor/supervisor_test.go | Adds decision coverage confirming pending outcome health does not suppress unrelated ready issue work; no issues found. |

<sub>Reviews (2): Last reviewed commit: ["outcome: keep pending checks transitiona..."](https://github.com/befeast/maestro/commit/4b1eb3f5b5079604f61f2c55cbd94cf6345dc05c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45321362)</sub>

<!-- /greptile_comment -->