### PR TITLE
Execute approved worker stops immediately

### DIFF
--- a/internal/approver/executor.go
+++ b/internal/approver/executor.go
@@ -202,6 +202,12 @@ var ErrUnknownAction = errors.New("unknown approval action")
 // target field the executor needs (PR number, issue number, session).
 var ErrMissingTarget = errors.New("approval target is missing required fields")
 
+// ErrWorkerAlreadyStopped lets a worker controller report that the immutable
+// process instance named by a stop approval was already gone. Safety stops
+// treat this as a terminal no-op, never as a reason to act on a later process
+// that happens to reuse the slot.
+var ErrWorkerAlreadyStopped = errors.New("worker process is already stopped")
+
 // Execute drives one approval to its real-world side effect. The caller
 // is responsible for the state transition (Mark*) using the returned
 // Result. Execute itself does NOT touch state — keeping state mutation
@@ -1013,6 +1019,12 @@ func (e *Executor) executeWorkerControl(approval *state.Approval, verb string, s
 		err = e.Workers.RestartWorker(slot, sess)
 	}
 	if err != nil {
+		if stop && errors.Is(err, ErrWorkerAlreadyStopped) {
+			return Result{
+				Status:  state.ApprovalStatusExecutionSkipped,
+				Summary: fmt.Sprintf("%s skipped: worker process for slot %s was already stopped", verb, slot),
+			}
+		}
 		return Result{
 			Status:  state.ApprovalStatusExecutionFailed,
 			Summary: fmt.Sprintf("%s on slot %s: %v", verb, slot, err),

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/befeast/maestro/internal/approvalstore"
+	"github.com/befeast/maestro/internal/approver"
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/configwatch"
 	"github.com/befeast/maestro/internal/emergencystore"
@@ -398,7 +399,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 		seen[key] = true
 		name := server.UniqueFleetName(cfg.Repo, usedNames)
-		projects = append(projects, server.NewFleetProjectWithGitHubNamed(name, cfg))
+		project := server.NewFleetProjectWithGitHubNamed(name, cfg)
+		wireApprovalExecutor(&project)
+		projects = append(projects, project)
 		storeNames = append(storeNames, nc.name)
 		importCfgs = append(importCfgs, cfg)
 	}
@@ -607,6 +610,34 @@ func (d *Daemon) Run(ctx context.Context) error {
 		<-ctx.Done()
 		return nil
 	}
+}
+
+// wireApprovalExecutor gives a fleet project the same in-process approval
+// executor used by the supervisor, but bound to the state snapshot loaded by
+// the authenticated fleet request. Keeping one executor per project preserves
+// its per-approval concurrency fence while the FleetProject mutex serializes
+// the state pointer updates below.
+func wireApprovalExecutor(project *server.FleetProject) {
+	if project == nil {
+		return
+	}
+	cfg := project.Cfg()
+	executor := &approver.Executor{
+		Cfg:     cfg,
+		Workers: supervisor.NewWorkerController(cfg),
+	}
+	project.SetApprovalExecutor(func(st *state.State, approval state.Approval) server.ApprovalExecutionResult {
+		if st == nil {
+			return server.ApprovalExecutionResult{
+				Status:  state.ApprovalStatusExecutionFailed,
+				Summary: "stop_worker immediate executor received nil state",
+			}
+		}
+		executor.Sessions = approver.SessionLookupFunc(st.SessionAt)
+		executor.State = st
+		result := executor.Execute(&approval)
+		return server.ApprovalExecutionResult{Status: result.Status, Summary: result.Summary}
+	})
 }
 
 // namedConfig pairs a config-store project name with its loaded config. The

--- a/internal/daemon/watch.go
+++ b/internal/daemon/watch.go
@@ -131,6 +131,7 @@ func (d *Daemon) reconcileStore(flowParent context.Context, fp map[string]time.T
 		}
 		fleetName := server.UniqueFleetName(cfg.Repo, takenNames)
 		proj := server.NewFleetProjectWithGitHubNamed(fleetName, cfg)
+		wireApprovalExecutor(&proj)
 		if fleet != nil {
 			fleet.AddProject(proj)
 		}

--- a/internal/server/approvals.go
+++ b/internal/server/approvals.go
@@ -72,7 +72,7 @@ func parseApprovalPath(prefix, urlPath string) (approvalRoute, bool) {
 // overrides any actor field in the request body — closing the bypass where
 // "approve IS the human-authorization step, and approve has no auth"
 // (write-path premortem failure mode #4).
-func applyApprovalDecision(w http.ResponseWriter, r *http.Request, readOnly bool, scope string, stateDir string, route approvalRoute, auth authChecker, store approvalstore.Binding) {
+func applyApprovalDecision(w http.ResponseWriter, r *http.Request, readOnly bool, scope string, stateDir string, route approvalRoute, auth authChecker, store approvalstore.Binding, execute ApprovalExecutor) {
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		return
@@ -173,7 +173,82 @@ func applyApprovalDecision(w http.ResponseWriter, r *http.Request, readOnly bool
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("save state: %v", err))
 		return
 	}
+
+	// A safety stop is different from every cadence-owned approval: once the
+	// authenticated operator has durably authorized it, execute that exact
+	// immutable target before returning. Leaving it in approved for the next
+	// supervisor poll is the containment gap this path exists to close.
+	if route.verb == "approve" && approval != nil && approval.Action == config.SupervisorActionStopWorker {
+		terminal, execErr := executeApprovedStopWorker(st, approval, actor, stateDir, store, execute)
+		if execErr != nil {
+			writeError(w, http.StatusInternalServerError, execErr.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, approvalDecisionResponse{OK: true, Approval: terminal})
+		return
+	}
 	writeJSON(w, http.StatusOK, approvalDecisionResponse{OK: true, Approval: approval})
+}
+
+// executeApprovedStopWorker runs the project-scoped safety callback only after
+// the approved transition has been saved, then records and persists a terminal
+// result before the HTTP request returns. The callback receives a detached
+// approval value so it cannot retarget the durable authorization in memory.
+func executeApprovedStopWorker(st *state.State, approval *state.Approval, actor, stateDir string, store approvalstore.Binding, execute ApprovalExecutor) (*state.Approval, error) {
+	result := ApprovalExecutionResult{
+		Status:  state.ApprovalStatusExecutionFailed,
+		Summary: "stop_worker immediate executor is unavailable for this project",
+	}
+	if execute != nil {
+		result = execute(st, immutableApprovalSnapshot(approval))
+	}
+
+	if result.Summary == "" {
+		result.Summary = fmt.Sprintf("stop_worker completed with status %s", result.Status)
+	}
+	now := time.Now().UTC()
+	var (
+		terminal *state.Approval
+		err      error
+	)
+	switch result.Status {
+	case state.ApprovalStatusExecuted:
+		terminal, err = st.MarkApprovalExecuted(approval.ID, now, actor, result.Summary)
+	case state.ApprovalStatusExecutionSkipped:
+		terminal, err = st.MarkApprovalExecutionSkipped(approval.ID, now, actor, result.Summary)
+	case state.ApprovalStatusExecutionFailed:
+		terminal, err = st.MarkApprovalExecutionFailed(approval.ID, now, actor, result.Summary)
+	default:
+		result.Status = state.ApprovalStatusExecutionFailed
+		result.Summary = fmt.Sprintf("stop_worker immediate executor returned non-terminal status %q", result.Status)
+		terminal, err = st.MarkApprovalExecutionFailed(approval.ID, now, actor, result.Summary)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("record stop_worker terminal result: %w", err)
+	}
+	if err := saveApprovalDecisionState(stateDir, st); err != nil {
+		return nil, fmt.Errorf("save stop_worker terminal result: %w", err)
+	}
+	store.StateDir = stateDir
+	if err := approvalstore.FinalizeExecution(store, approval.ID, terminal.Status, now, actor, result.Summary); err != nil {
+		return nil, fmt.Errorf("finalize stop_worker terminal result: %w", err)
+	}
+	return terminal, nil
+}
+
+func immutableApprovalSnapshot(approval *state.Approval) state.Approval {
+	if approval == nil {
+		return state.Approval{}
+	}
+	snapshot := *approval
+	if approval.Target != nil {
+		target := *approval.Target
+		target.Issues = append([]state.SupervisorIssueTarget(nil), approval.Target.Issues...)
+		snapshot.Target = &target
+	}
+	snapshot.Evidence = append([]string(nil), approval.Evidence...)
+	snapshot.Audit = append([]state.ApprovalAudit(nil), approval.Audit...)
+	return snapshot
 }
 
 // --- single-project server hookup -------------------------------------------
@@ -189,7 +264,7 @@ func (s *Server) handleApproval(w http.ResponseWriter, r *http.Request) {
 	if cfg != nil {
 		stateDir = cfg.StateDir
 	}
-	applyApprovalDecision(w, r, cfgServerReadOnly(cfg), "server", stateDir, route, s.auth, s.approvalBinding(cfg))
+	applyApprovalDecision(w, r, cfgServerReadOnly(cfg), "server", stateDir, route, s.auth, s.approvalBinding(cfg), nil)
 }
 
 func cfgServerReadOnly(cfg *config.Config) bool {
@@ -232,6 +307,10 @@ func (s *FleetServer) handleFleetApproval(w http.ResponseWriter, r *http.Request
 		writeError(w, http.StatusNotFound, fmt.Sprintf("unknown project %q", projectName))
 		return
 	}
+	if project.approvalMu != nil {
+		project.approvalMu.Lock()
+		defer project.approvalMu.Unlock()
+	}
 
 	// Project-scoped read-only: either the global flag or the project's own.
 	readOnly := s.readOnly
@@ -242,5 +321,5 @@ func (s *FleetServer) handleFleetApproval(w http.ResponseWriter, r *http.Request
 	if project.cfg != nil {
 		stateDir = project.cfg.StateDir
 	}
-	applyApprovalDecision(w, r, readOnly, fmt.Sprintf("fleet project %q", projectName), stateDir, route, auth, s.approvalBinding(project.cfg))
+	applyApprovalDecision(w, r, readOnly, fmt.Sprintf("fleet project %q", projectName), stateDir, route, auth, s.approvalBinding(project.cfg), project.approvalExecutor)
 }

--- a/internal/server/approvals_test.go
+++ b/internal/server/approvals_test.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -360,6 +362,101 @@ func TestHandleFleetApproval_Approve_HappyPath(t *testing.T) {
 	st, _ := state.Load(dir)
 	if st.Approvals[0].Status != state.ApprovalStatusApproved {
 		t.Fatalf("status = %q", st.Approvals[0].Status)
+	}
+}
+
+func TestHandleFleetApproval_ApproveStopExecutesBeforeReturn(t *testing.T) {
+	dir := t.TempDir()
+	projectName := "scribe-service"
+	cfg := &config.Config{Repo: "owner/scribe-service", StateDir: dir}
+	proj := NewFleetProject(projectName, "/tmp/scribe.yaml", "", cfg)
+	var calls int32
+	proj.SetApprovalExecutor(func(st *state.State, approval state.Approval) ApprovalExecutionResult {
+		atomic.AddInt32(&calls, 1)
+		if approval.Status != state.ApprovalStatusApproved {
+			t.Errorf("callback approval status = %q, want approved", approval.Status)
+		}
+		live, ok := st.FindApproval(approval.ID)
+		if !ok || live.Status != state.ApprovalStatusApproved {
+			t.Errorf("callback observed durable approval = %#v, want approved", live)
+		}
+		return ApprovalExecutionResult{Status: state.ApprovalStatusExecuted, Summary: "worker stopped"}
+	})
+	srv := NewFleet([]FleetProject{proj}, "127.0.0.1", 0, false)
+	a := enqueuedApproval(t, dir, config.SupervisorActionStopWorker, &state.SupervisorTarget{Session: "slot-1", Issue: 42})
+
+	url := fmt.Sprintf("/api/v1/fleet/approvals/%s/approve?project=%s", a.ID, projectName)
+	req := httptest.NewRequest(http.MethodPost, url, bytes.NewBufferString(`{"actor":"web"}`))
+	w := httptest.NewRecorder()
+	srv.handleFleetApproval(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", w.Code, w.Body.String())
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("callback calls = %d, want 1", got)
+	}
+	var resp approvalDecisionResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Approval == nil || resp.Approval.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("response approval = %#v, want terminal executed before return", resp.Approval)
+	}
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	terminal, ok := st.FindApproval(a.ID)
+	if !ok || terminal.Status != state.ApprovalStatusExecuted {
+		t.Fatalf("persisted approval = %#v, want terminal executed before return", terminal)
+	}
+}
+
+func TestHandleFleetApproval_ConcurrentDuplicateStopExecutesOnce(t *testing.T) {
+	dir := t.TempDir()
+	projectName := "scribe-service"
+	cfg := &config.Config{Repo: "owner/scribe-service", StateDir: dir}
+	proj := NewFleetProject(projectName, "/tmp/scribe.yaml", "", cfg)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls int32
+	proj.SetApprovalExecutor(func(_ *state.State, _ state.Approval) ApprovalExecutionResult {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			close(started)
+		}
+		<-release
+		return ApprovalExecutionResult{Status: state.ApprovalStatusExecuted, Summary: "worker stopped"}
+	})
+	srv := NewFleet([]FleetProject{proj}, "127.0.0.1", 0, false)
+	a := enqueuedApproval(t, dir, config.SupervisorActionStopWorker, &state.SupervisorTarget{Session: "slot-1", Issue: 42})
+	url := fmt.Sprintf("/api/v1/fleet/approvals/%s/approve?project=%s", a.ID, projectName)
+
+	responses := make(chan int, 2)
+	request := func() {
+		req := httptest.NewRequest(http.MethodPost, url, bytes.NewBufferString(`{"actor":"web"}`))
+		w := httptest.NewRecorder()
+		srv.handleFleetApproval(w, req)
+		responses <- w.Code
+	}
+	go request()
+	<-started
+	var secondStarted sync.WaitGroup
+	secondStarted.Add(1)
+	go func() {
+		secondStarted.Done()
+		request()
+	}()
+	secondStarted.Wait()
+	close(release)
+
+	codes := []int{<-responses, <-responses}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("callback calls = %d, want exactly 1", got)
+	}
+	if !((codes[0] == http.StatusOK && codes[1] == http.StatusConflict) ||
+		(codes[1] == http.StatusOK && codes[0] == http.StatusConflict)) {
+		t.Fatalf("response statuses = %v, want one 200 and one 409", codes)
 	}
 }
 

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -58,12 +58,38 @@ type FleetProject struct {
 	// safe actions for this project. Tests inject a fake via SetActionGH.
 	actionGH actionGitHubClient
 
+	// approvalExecutor is the project-scoped, in-process execution path for
+	// safety approvals that cannot wait for the next supervisor cadence. The
+	// daemon wires it to the live project's approver.Executor and worker
+	// controller. It is deliberately narrow: today only stop_worker is routed
+	// through it by handleFleetApproval.
+	approvalExecutor ApprovalExecutor
+
+	// approvalMu serializes approval decisions and their immediate execution
+	// for this project. FleetProject values are copied in snapshots, so this is
+	// a pointer shared by every copy rather than an embedded mutex.
+	approvalMu *sync.Mutex
+
 	// board is the GitHub Project board refresher state used by the
 	// /api/v1/fleet snapshot to surface the operator-glance WIP rollup
 	// (#529). nil disables board surfacing for the project. Wired by
 	// cmd/maestro via SetBoardClient when github_projects is enabled.
 	board *boardState
 }
+
+// ApprovalExecutionResult is the terminal outcome returned by a project's
+// immediate safety-approval executor. The fleet handler owns the durable
+// approval transitions; the callback owns only the exact side effect and any
+// in-memory session mutation performed by the worker controller.
+type ApprovalExecutionResult struct {
+	Status  state.ApprovalStatus
+	Summary string
+}
+
+// ApprovalExecutor executes one immutable approved target against the state
+// snapshot that was durably transitioned to approved immediately beforehand.
+// Implementations must return a terminal approval status.
+type ApprovalExecutor func(st *state.State, approval state.Approval) ApprovalExecutionResult
 
 // SetActionGH wires the per-project GitHub client used by the safe-action
 // dispatcher. Call this on startup; nil leaves safe actions disabled for the
@@ -73,6 +99,15 @@ func (p *FleetProject) SetActionGH(gh actionGitHubClient) {
 		return
 	}
 	p.actionGH = gh
+}
+
+// SetApprovalExecutor wires the project-scoped immediate safety executor.
+// Call this during fleet construction before the project is served.
+func (p *FleetProject) SetApprovalExecutor(execute ApprovalExecutor) {
+	if p == nil {
+		return
+	}
+	p.approvalExecutor = execute
 }
 
 // Cfg exposes the loaded *config.Config so callers (cmd/maestro) that need
@@ -102,6 +137,7 @@ func NewFleetProject(name, configPath, dashboardURL string, cfg *config.Config) 
 		ConfigPath:   strings.TrimSpace(configPath),
 		DashboardURL: fleetProjectScopedPath(trimmedName),
 		cfg:          cfg,
+		approvalMu:   &sync.Mutex{},
 	}
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -4406,28 +4406,35 @@ func commandBinary(cmd, fallback string) string {
 	return fields[0]
 }
 
-// newWorkerController wires worker.Stop + state transitions into the
+// NewWorkerController wires worker process control + state transitions into the
 // approver WorkerController interface (#567). The supervisor's
 // executeApprovedApprovals loop uses this to apply approved
 // restart_worker / stop_worker verbs from the fleet snapshot.
 //
 //   - stop_worker: terminate the worker, mark the session StatusDead,
-//     clear NextRetryAt so the orchestrator does NOT respawn.
+//     clear NextRetryAt so the orchestrator does NOT respawn, and preserve the
+//     worktree/branch/PR for later inspection or repair.
 //   - restart_worker: terminate the worker, mark StatusDead with
 //     NextRetryAt = now so respawnDueRetries picks it up on the next
 //     dispatcher cycle. worker.Stop removed the worktree, so the stale
 //     worktree/PR pointers are cleared (#874) — otherwise respawnDueRetries
 //     would choose RespawnInPlace against a directory that no longer exists.
-func newWorkerController(cfg *config.Config) approver.WorkerControllerFuncs {
+func NewWorkerController(cfg *config.Config) approver.WorkerControllerFuncs {
 	return approver.WorkerControllerFuncs{
 		Stop: func(slot string, sess *state.Session) error {
-			if err := worker.Stop(cfg, slot, sess); err != nil {
+			alreadyStopped := sess == nil || sess.PID <= 0 || !worker.IsAlive(sess.PID)
+			if err := worker.StopProcess(slot, sess); err != nil {
 				return err
 			}
 			now := time.Now().UTC()
-			sess.Status = state.StatusDead
-			sess.FinishedAt = &now
-			sess.NextRetryAt = nil
+			if sess != nil {
+				sess.Status = state.StatusDead
+				sess.FinishedAt = &now
+				sess.NextRetryAt = nil
+			}
+			if alreadyStopped {
+				return approver.ErrWorkerAlreadyStopped
+			}
 			return nil
 		},
 		Restart: func(slot string, sess *state.Session) error {
@@ -4587,7 +4594,7 @@ func executeApprovedApprovals(cfg *config.Config, st *state.State, reader Reader
 		Worktrees: approver.WorktreeRemoverFunc(worker.RemoveWorktree),
 		Cfg:       cfg,
 		Sessions:  approver.SessionLookupFunc(st.SessionAt),
-		Workers:   newWorkerController(cfg),
+		Workers:   NewWorkerController(cfg),
 		State:     st,
 	}
 	for _, a := range approvals {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -6,11 +6,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
+	"github.com/befeast/maestro/internal/approver"
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/outcome"
@@ -61,6 +64,131 @@ type fakeLLM struct {
 	prompt string
 	calls  int
 	err    error
+}
+
+func startApprovalStopSleeper(t *testing.T) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleeper: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	return cmd
+}
+
+func requireApprovalStopProcessAlive(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	time.Sleep(50 * time.Millisecond)
+	var status syscall.WaitStatus
+	waited, err := syscall.Wait4(cmd.Process.Pid, &status, syscall.WNOHANG, nil)
+	if err != nil {
+		t.Fatalf("check replacement pid %d: %v", cmd.Process.Pid, err)
+	}
+	if waited != 0 {
+		t.Fatalf("replacement pid %d was killed; wait status=%v", cmd.Process.Pid, status)
+	}
+}
+
+func TestExecuteStopWorker_StaleOrReusedSlotDoesNotKillReplacementPID(t *testing.T) {
+	t.Run("stale snapshot is skipped", func(t *testing.T) {
+		cmd := startApprovalStopSleeper(t)
+		cfg := &config.Config{Repo: "owner/repo"}
+		target := &state.SupervisorTarget{Session: "slot-1", Issue: 42}
+		st := state.NewState()
+		st.Sessions["slot-1"] = &state.Session{IssueNumber: 42, PID: 1, Status: state.StatusDead}
+		approval := &state.Approval{
+			ID:              "stop-stale",
+			Repo:            cfg.Repo,
+			Action:          config.SupervisorActionStopWorker,
+			Target:          target,
+			TargetStateHash: st.ApprovalTargetStateHash(target),
+			Status:          state.ApprovalStatusApproved,
+		}
+		st.Sessions["slot-1"] = &state.Session{
+			IssueNumber: 42,
+			PID:         cmd.Process.Pid,
+			Status:      state.StatusRunning,
+			StartedAt:   time.Now().UTC(),
+		}
+		executor := &approver.Executor{
+			Cfg:      cfg,
+			Sessions: approver.SessionLookupFunc(st.SessionAt),
+			Workers:  NewWorkerController(cfg),
+			State:    st,
+		}
+
+		result := executor.Execute(approval)
+		if result.Status != state.ApprovalStatusExecutionSkipped {
+			t.Fatalf("status = %q, want execution_skipped; result=%+v", result.Status, result)
+		}
+		requireApprovalStopProcessAlive(t, cmd)
+	})
+
+	t.Run("reused slot fails closed", func(t *testing.T) {
+		cmd := startApprovalStopSleeper(t)
+		cfg := &config.Config{Repo: "owner/repo"}
+		st := state.NewState()
+		st.Sessions["slot-1"] = &state.Session{
+			IssueNumber: 99,
+			PID:         cmd.Process.Pid,
+			Status:      state.StatusRunning,
+			StartedAt:   time.Now().UTC(),
+		}
+		approval := &state.Approval{
+			ID:     "stop-reused",
+			Repo:   cfg.Repo,
+			Action: config.SupervisorActionStopWorker,
+			Target: &state.SupervisorTarget{Session: "slot-1", Issue: 42},
+			Status: state.ApprovalStatusApproved,
+		}
+		executor := &approver.Executor{
+			Cfg:      cfg,
+			Sessions: approver.SessionLookupFunc(st.SessionAt),
+			Workers:  NewWorkerController(cfg),
+			State:    st,
+		}
+
+		result := executor.Execute(approval)
+		if result.Status != state.ApprovalStatusExecutionFailed {
+			t.Fatalf("status = %q, want execution_failed; result=%+v", result.Status, result)
+		}
+		requireApprovalStopProcessAlive(t, cmd)
+	})
+}
+
+func TestNewWorkerController_StopPreservesWorktreeBranchAndPR(t *testing.T) {
+	cmd := startApprovalStopSleeper(t)
+	sess := &state.Session{
+		IssueNumber: 42,
+		Worktree:    "/srv/worktrees/slot-1",
+		Branch:      "maestro/issue-42",
+		PID:         cmd.Process.Pid,
+		Status:      state.StatusRunning,
+		PRNumber:    1008,
+	}
+	controller := NewWorkerController(&config.Config{Repo: "owner/repo"})
+	stopDone := make(chan error, 1)
+	go func() {
+		stopDone <- controller.StopWorker("slot-1", sess)
+	}()
+	_ = cmd.Wait()
+	select {
+	case err := <-stopDone:
+		if err != nil {
+			t.Fatalf("StopWorker: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("StopWorker did not return after terminating the worker")
+	}
+	if sess.Status != state.StatusDead || sess.FinishedAt == nil || sess.NextRetryAt != nil {
+		t.Fatalf("session lifecycle after stop = status:%q finished:%v retry:%v", sess.Status, sess.FinishedAt, sess.NextRetryAt)
+	}
+	if sess.Worktree != "/srv/worktrees/slot-1" || sess.Branch != "maestro/issue-42" || sess.PRNumber != 1008 {
+		t.Fatalf("stop destroyed durable work pointers: worktree=%q branch=%q pr=%d", sess.Worktree, sess.Branch, sess.PRNumber)
+	}
 }
 
 func (f *fakeLLM) Complete(prompt string) (string, error) {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -374,8 +374,10 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 	return nil
 }
 
-// Stop kills a worker and removes its worktree
-func Stop(cfg *config.Config, slotName string, sess *state.Session) error {
+// StopProcess terminates only the worker runtime for a slot. It deliberately
+// preserves the worktree, branch, and PR so a safety stop cannot destroy the
+// worker's durable output; cleanup remains a separate, explicit operation.
+func StopProcess(slotName string, sess *state.Session) error {
 	// Try to kill the tmux session first (covers tmux-spawned workers)
 	tmuxName := TmuxSessionName(slotName)
 	if out, err := tmuxsession.KillSession(tmuxName); err != nil {
@@ -386,8 +388,19 @@ func Stop(cfg *config.Config, slotName string, sess *state.Session) error {
 	// processes still parented to the pane shell; worker grandchildren that
 	// reparent away (notably headless Chrome + its crashpad handler) survive a
 	// plain pane-PID kill, so signal the recorded PID's full descendant tree.
-	if sess.PID > 0 && IsAlive(sess.PID) {
+	if sess != nil && sess.PID > 0 && IsAlive(sess.PID) {
 		KillProcessTree(sess.PID)
+	}
+	return nil
+}
+
+// Stop kills a worker and removes its worktree.
+func Stop(cfg *config.Config, slotName string, sess *state.Session) error {
+	if err := StopProcess(slotName, sess); err != nil {
+		return err
+	}
+	if sess == nil {
+		return nil
 	}
 
 	// Run before_remove hook


### PR DESCRIPTION
## Summary

- execute approved `stop_worker` actions synchronously through the live project executor before the fleet response returns
- serialize duplicate fleet approval requests and fence stale or reused slots so replacement PIDs are never terminated
- stop only the worker process while preserving its worktree, branch, and PR for inspection or repair
- wire the executor for startup projects and config-store hot-adds

## Root cause

The fleet approval endpoint only persisted `pending -> approved` and waited for the next supervisor cadence to execute the stop. That left a containment window, allowed duplicate callers to race, and reused the destructive worker cleanup path that removed durable work.

## Impact

An authenticated fleet stop approval now returns only after a terminal result is persisted. Stale or already-stopped targets fail closed without touching a replacement worker, and successful stops retain durable work pointers.

## Validation

- `umask 077; go test ./...`
- `go build ./cmd/maestro/`

Refs #1008

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes approved worker stops execute immediately through the fleet approval flow. The main changes are:

- Executes approved `stop_worker` actions before the fleet response returns.
- Serializes duplicate fleet approval requests for each project.
- Adds stale-target and reused-slot fences so replacement workers are not stopped.
- Splits worker process termination from worktree cleanup so stopped workers keep their branch, worktree, and PR metadata.
- Wires immediate approval execution for daemon startup projects and config-store hot-adds.

<h3>Confidence Score: 4/5</h3>

One contained blocking issue remains in fleet serving mode.

Daemon-created projects are wired correctly, but `serve --fleet` project construction still passes a nil executor into the immediate stop path, breaking `stop_worker` approvals in that mode.

`internal/server/approvals.go` and fleet project construction paths need attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the requested verification, but its local artifact references were not uploaded.
- The subsequent validation confirmed test success, build success, and the Go environment, and noted that stale local files caused earlier captures and were removed before the clean run.

<a href="https://app.greptile.com/trex/runs/14952768/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/approvals.go | Executes approved fleet `stop_worker` actions before returning, but non-daemon fleet construction still leaves the executor nil and finalizes stops as failed. |
| internal/server/fleet.go | Adds the fleet project approval executor callback and shared mutex used to serialize project approval decisions. |
| internal/daemon/daemon.go | Wires daemon-created fleet projects to an immediate approval executor for `stop_worker` approvals. |
| internal/supervisor/supervisor.go | Exports the worker controller and changes `stop_worker` to stop only the process while preserving durable work pointers. |
| internal/worker/worker.go | Splits process termination from destructive worktree cleanup so safety stops can preserve worker output. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/server/approvals.go:181-182
**Fleet serve stops fail**
This immediate path also runs for fleet projects created by `serve --fleet` / `FleetProjectsFromConfigs`; those constructors only wire GitHub clients, while `wireApprovalExecutor` is daemon-only. In that mode `project.approvalExecutor` is nil at line 324, so approving any `stop_worker` is persisted as approved and then immediately finalized as `execution_failed` with the unavailable-executor summary instead of stopping the worker.

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-801-10..."](https://github.com/befeast/maestro/commit/eae89cf8a19f1497b1e46860279959419a4157ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45322703)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->