### PR TITLE
feat: ntfy notification transport + alert-class router (hands-off foundation)

### DIFF
--- a/cmd/maestro/emergency.go
+++ b/cmd/maestro/emergency.go
@@ -210,16 +210,22 @@ func emergencyConfigs(ef *emergencyFlags) []*config.Config {
 	return cfgs
 }
 
-// notifyEmergency sends the notify_red-grade alert from the first project with a
-// Telegram target. Best-effort: the switch is already written; a notification
-// failure only logs.
+// notifyEmergency sends the notify_red-grade alert from the first project that
+// configures a notification channel (Telegram target or the ntfy transport).
+// Best-effort: the switch is already written; a notification failure only logs.
 func notifyEmergency(ef *emergencyFlags, msg string) {
 	for _, cfg := range emergencyConfigs(ef) {
-		if cfg == nil || strings.TrimSpace(cfg.Telegram.Target) == "" {
+		if cfg == nil || (strings.TrimSpace(cfg.Telegram.Target) == "" && !cfg.Notify.Ntfy.Enabled()) {
 			continue
 		}
 		n := notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
+		n.WithNtfy(cfg.Notify.Ntfy.BaseURL, cfg.Notify.Ntfy.Topic, cfg.Notify.Ntfy.Token())
 		n.Sendf("%s", msg)
+		// Fan the notify_red-grade alert to ntfy (#1018). Keyed by message so a
+		// repeated identical emergency state does not re-notify.
+		if err := n.Alert(notify.AlertEmergency, "emergency", "maestro emergency", msg); err != nil {
+			log.Printf("[emergency] ntfy alert failed: %v", err)
+		}
 		return
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,41 @@ type TelegramConfig struct {
 	DigestMode  bool   `yaml:"digest_mode"`  // batch notifications per cycle instead of sending immediately
 }
 
+// NotifyConfig (#1018) carries lightweight push-notification transports that
+// live alongside the Telegram digest channel. The first transport is ntfy —
+// a plain HTTP POST push channel the supervisor/orchestrator/watchdog use to
+// emit alert-class notifications (gate-fail streaks, idle stalls, delivery
+// advances). Absent config = no ntfy fan-out; the Telegram path is unaffected.
+type NotifyConfig struct {
+	Ntfy NtfyConfig `yaml:"ntfy"`
+}
+
+// NtfyConfig configures the ntfy push transport. Topic is a per-project value
+// (fleet config supplies the default, a project overrides it). The auth token
+// is NEVER stored in config or repo: TokenEnv names an environment variable /
+// secret-store key the process reads at send time.
+type NtfyConfig struct {
+	BaseURL  string `yaml:"base_url"`  // e.g. https://ntfy.sh or a self-hosted base URL
+	Topic    string `yaml:"topic"`     // per-project topic (fleet default, project override)
+	TokenEnv string `yaml:"token_env"` // env var name holding the bearer token; the token itself is never stored here
+}
+
+// Enabled reports whether the ntfy transport has enough config to POST.
+func (c NtfyConfig) Enabled() bool {
+	return strings.TrimSpace(c.BaseURL) != "" && strings.TrimSpace(c.Topic) != ""
+}
+
+// Token resolves the ntfy bearer token from the configured env var. Returns ""
+// when TokenEnv is unset or the env var is unset/empty. Callers treat "" as
+// "unauthenticated ntfy" (public topics need no token).
+func (c NtfyConfig) Token() string {
+	env := strings.TrimSpace(c.TokenEnv)
+	if env == "" {
+		return ""
+	}
+	return strings.TrimSpace(os.Getenv(env))
+}
+
 // BackendDef defines a model backend CLI.
 type BackendDef struct {
 	Cmd        string    `yaml:"cmd"`
@@ -1926,6 +1961,7 @@ type Config struct {
 	MergeExhaustedNonCriticalReview *bool                         `yaml:"merge_exhausted_noncritical_review"` // #565: merge a green PR after review-feedback retries exhaust when only non-critical (P1/P2/P3) findings remain (no P0 on head). nil = default-on.
 	AutoRetryRebaseConflicts        bool                          `yaml:"auto_retry_rebase_conflicts"`        // retry PRs whose auto-rebase fails with conflicts
 	Telegram                        TelegramConfig                `yaml:"telegram"`
+	Notify                          NotifyConfig                  `yaml:"notify"` // #1018: ntfy push transport + alert-class routing
 	Versioning                      VersioningConfig              `yaml:"versioning"`
 	SelfDeploy                      SelfDeployConfig              `yaml:"self_deploy"` // #698: opt-in post-merge self-deploy of the maestro binary (default OFF)
 	GitHubProjects                  GitHubProjectsConfig          `yaml:"github_projects"`

--- a/internal/config/notify_config_test.go
+++ b/internal/config/notify_config_test.go
@@ -1,0 +1,67 @@
+package config
+
+import "testing"
+
+func TestNtfyConfig_Enabled(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  NtfyConfig
+		want bool
+	}{
+		{"empty", NtfyConfig{}, false},
+		{"base only", NtfyConfig{BaseURL: "https://ntfy.sh"}, false},
+		{"topic only", NtfyConfig{Topic: "proj"}, false},
+		{"base and topic", NtfyConfig{BaseURL: "https://ntfy.sh", Topic: "proj"}, true},
+		{"whitespace", NtfyConfig{BaseURL: "  ", Topic: "proj"}, false},
+	}
+	for _, c := range cases {
+		if got := c.cfg.Enabled(); got != c.want {
+			t.Errorf("%s: Enabled() = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestNtfyConfig_Token_FromEnv(t *testing.T) {
+	// Unset TokenEnv -> empty (public topic, no auth).
+	if got := (NtfyConfig{}).Token(); got != "" {
+		t.Errorf("Token() with no TokenEnv = %q, want empty", got)
+	}
+
+	// TokenEnv naming an unset variable -> empty.
+	if got := (NtfyConfig{TokenEnv: "MAESTRO_TEST_NTFY_UNSET"}).Token(); got != "" {
+		t.Errorf("Token() with unset env = %q, want empty", got)
+	}
+
+	// TokenEnv naming a populated variable -> the value, trimmed.
+	t.Setenv("MAESTRO_TEST_NTFY_TOKEN", "  tok-value  ")
+	if got := (NtfyConfig{TokenEnv: "MAESTRO_TEST_NTFY_TOKEN"}).Token(); got != "tok-value" {
+		t.Errorf("Token() = %q, want tok-value", got)
+	}
+}
+
+func TestNtfyConfig_ParsedFromYAML(t *testing.T) {
+	yaml := []byte(`
+repo: owner/name
+notify:
+  ntfy:
+    base_url: https://ntfy.example
+    topic: proj-alerts
+    token_env: MY_NTFY_TOKEN
+`)
+	cfg, err := parse(yaml)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.Notify.Ntfy.BaseURL != "https://ntfy.example" {
+		t.Errorf("BaseURL = %q", cfg.Notify.Ntfy.BaseURL)
+	}
+	if cfg.Notify.Ntfy.Topic != "proj-alerts" {
+		t.Errorf("Topic = %q", cfg.Notify.Ntfy.Topic)
+	}
+	if cfg.Notify.Ntfy.TokenEnv != "MY_NTFY_TOKEN" {
+		t.Errorf("TokenEnv = %q", cfg.Notify.Ntfy.TokenEnv)
+	}
+	if !cfg.Notify.Ntfy.Enabled() {
+		t.Errorf("Enabled() = false, want true for a fully configured ntfy block")
+	}
+}

--- a/internal/daemon/emergency.go
+++ b/internal/daemon/emergency.go
@@ -152,10 +152,15 @@ func emergencyNotifierFor(cfgs []*config.Config) *notify.Notifier {
 		if cfg == nil {
 			continue
 		}
-		if strings.TrimSpace(cfg.Telegram.Target) == "" {
+		// Prefer a project that configures notifications (Telegram target or the
+		// ntfy transport) so the notify_red-grade alert reaches an operator via
+		// at least one channel (#1018).
+		if strings.TrimSpace(cfg.Telegram.Target) == "" && !cfg.Notify.Ntfy.Enabled() {
 			continue
 		}
-		return notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
+		n := notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
+		n.WithNtfy(cfg.Notify.Ntfy.BaseURL, cfg.Notify.Ntfy.Topic, cfg.Notify.Ntfy.Token())
+		return n
 	}
 	return nil
 }

--- a/internal/notify/alert.go
+++ b/internal/notify/alert.go
@@ -1,0 +1,55 @@
+package notify
+
+// AlertClass is a small, closed enum of operator-alert categories the
+// supervisor, orchestrator, and watchdog emit (#1018). Each class maps to a
+// fixed ntfy priority + tag set via the router below, so callers name the
+// situation ("gate_fail_streak") rather than hand-picking a priority.
+type AlertClass string
+
+const (
+	// AlertGateFailStreak: a project's review/merge gate has failed N times in
+	// a row without advancing.
+	AlertGateFailStreak AlertClass = "gate_fail_streak"
+	// AlertIdleStall: no worker/feed progress for longer than the idle budget.
+	AlertIdleStall AlertClass = "idle_stall"
+	// AlertFutileRecovery: automated recovery kept retrying without effect.
+	AlertFutileRecovery AlertClass = "futile_recovery"
+	// AlertBackendCooldownExhausted: every backend is cooling down / quota-gated
+	// and dispatch has nothing to run.
+	AlertBackendCooldownExhausted AlertClass = "backend_cooldown_exhausted"
+	// AlertDeliveryAdvance: a positive event — the delivery/feed advanced.
+	AlertDeliveryAdvance AlertClass = "delivery_advance"
+	// AlertEmergency: notify_red-grade — emergency stop / supervisor degraded.
+	AlertEmergency AlertClass = "emergency"
+)
+
+// AlertRoute is the transport-shaping metadata a class maps to.
+type AlertRoute struct {
+	// Priority is the ntfy priority header value (1=min … 5=max/urgent).
+	Priority int
+	// Tags are ntfy tag shortcodes rendered as emoji/badges on the client.
+	Tags []string
+}
+
+// alertRoutes is the class→route table. A class absent here (never expected,
+// the enum is closed) falls back to defaultRoute via RouteFor.
+var alertRoutes = map[AlertClass]AlertRoute{
+	AlertGateFailStreak:           {Priority: 4, Tags: []string{"warning", "no_entry"}},
+	AlertIdleStall:                {Priority: 4, Tags: []string{"hourglass", "warning"}},
+	AlertFutileRecovery:           {Priority: 4, Tags: []string{"recycle", "warning"}},
+	AlertBackendCooldownExhausted: {Priority: 4, Tags: []string{"battery", "warning"}},
+	AlertDeliveryAdvance:          {Priority: 3, Tags: []string{"white_check_mark", "rocket"}},
+	AlertEmergency:                {Priority: 5, Tags: []string{"rotating_light", "sos"}},
+}
+
+// defaultRoute is used for an unknown class so an unmapped alert still sends at
+// a sane default priority rather than being dropped.
+var defaultRoute = AlertRoute{Priority: 3, Tags: []string{"bell"}}
+
+// RouteFor returns the priority + tags for an alert class.
+func RouteFor(class AlertClass) AlertRoute {
+	if r, ok := alertRoutes[class]; ok {
+		return r
+	}
+	return defaultRoute
+}

--- a/internal/notify/alert_test.go
+++ b/internal/notify/alert_test.go
@@ -1,0 +1,207 @@
+package notify
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// capturedPost records one ntfy POST for assertions.
+type capturedPost struct {
+	topic    string
+	title    string
+	priority string
+	tags     string
+	auth     string
+	body     string
+}
+
+// ntfyRecorder is an httptest server that captures every POST for a topic path.
+func ntfyRecorder(t *testing.T) (*httptest.Server, *[]capturedPost, *sync.Mutex) {
+	t.Helper()
+	var mu sync.Mutex
+	var posts []capturedPost
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		mu.Lock()
+		posts = append(posts, capturedPost{
+			topic:    strings.TrimPrefix(r.URL.Path, "/"),
+			title:    r.Header.Get("Title"),
+			priority: r.Header.Get("Priority"),
+			tags:     r.Header.Get("Tags"),
+			auth:     r.Header.Get("Authorization"),
+			body:     string(buf),
+		})
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &posts, &mu
+}
+
+func TestRouteFor_ClassToPriorityMapping(t *testing.T) {
+	cases := []struct {
+		class    AlertClass
+		priority int
+		wantTag  string
+	}{
+		{AlertGateFailStreak, 4, "warning"},
+		{AlertIdleStall, 4, "hourglass"},
+		{AlertFutileRecovery, 4, "recycle"},
+		{AlertBackendCooldownExhausted, 4, "battery"},
+		{AlertDeliveryAdvance, 3, "rocket"},
+		{AlertEmergency, 5, "rotating_light"},
+	}
+	for _, c := range cases {
+		r := RouteFor(c.class)
+		if r.Priority != c.priority {
+			t.Errorf("RouteFor(%s).Priority = %d, want %d", c.class, r.Priority, c.priority)
+		}
+		found := false
+		for _, tag := range r.Tags {
+			if tag == c.wantTag {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("RouteFor(%s).Tags = %v, want to contain %q", c.class, r.Tags, c.wantTag)
+		}
+	}
+}
+
+func TestRouteFor_UnknownClassFallsBackToDefault(t *testing.T) {
+	r := RouteFor(AlertClass("does_not_exist"))
+	if r.Priority != defaultRoute.Priority {
+		t.Errorf("unknown class priority = %d, want default %d", r.Priority, defaultRoute.Priority)
+	}
+}
+
+func TestAlert_SendsOnePostWithRoutedHeaders(t *testing.T) {
+	srv, posts, mu := ntfyRecorder(t)
+	n := (&Notifier{}).WithNtfy(srv.URL, "proj-alerts", "")
+
+	if err := n.Alert(AlertDeliveryAdvance, "proj:feed", "feed advanced", "issue #42 delivered"); err != nil {
+		t.Fatalf("Alert: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 1 {
+		t.Fatalf("got %d posts, want 1", len(*posts))
+	}
+	p := (*posts)[0]
+	if p.topic != "proj-alerts" {
+		t.Errorf("topic = %q, want proj-alerts", p.topic)
+	}
+	if p.title != "feed advanced" {
+		t.Errorf("title = %q", p.title)
+	}
+	if p.priority != strconv.Itoa(RouteFor(AlertDeliveryAdvance).Priority) {
+		t.Errorf("priority = %q, want %d", p.priority, RouteFor(AlertDeliveryAdvance).Priority)
+	}
+	if !strings.Contains(p.tags, "rocket") {
+		t.Errorf("tags = %q, want to contain rocket", p.tags)
+	}
+	if p.body != "issue #42 delivered" {
+		t.Errorf("body = %q", p.body)
+	}
+	if p.auth != "" {
+		t.Errorf("auth header set without a token: %q", p.auth)
+	}
+}
+
+func TestAlert_TokenSetsBearerHeader(t *testing.T) {
+	srv, posts, mu := ntfyRecorder(t)
+	n := (&Notifier{}).WithNtfy(srv.URL, "topic", "secret-from-env")
+
+	if err := n.Alert(AlertEmergency, "k", "t", "b"); err != nil {
+		t.Fatalf("Alert: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if got := (*posts)[0].auth; got != "Bearer secret-from-env" {
+		t.Errorf("auth = %q, want Bearer secret-from-env", got)
+	}
+}
+
+func TestAlert_DedupPerStateChange(t *testing.T) {
+	srv, posts, mu := ntfyRecorder(t)
+	n := (&Notifier{}).WithNtfy(srv.URL, "topic", "")
+
+	// Same (class,key,body) three times -> one POST.
+	for i := 0; i < 3; i++ {
+		if err := n.Alert(AlertGateFailStreak, "proj:gate", "gate failing", "3 consecutive failures"); err != nil {
+			t.Fatalf("Alert %d: %v", i, err)
+		}
+	}
+	mu.Lock()
+	after3 := len(*posts)
+	mu.Unlock()
+	if after3 != 1 {
+		t.Fatalf("repeated identical state produced %d posts, want 1", after3)
+	}
+
+	// State changes (body differs) -> a second POST.
+	if err := n.Alert(AlertGateFailStreak, "proj:gate", "gate failing", "5 consecutive failures"); err != nil {
+		t.Fatalf("Alert changed state: %v", err)
+	}
+	mu.Lock()
+	after4 := len(*posts)
+	mu.Unlock()
+	if after4 != 2 {
+		t.Fatalf("changed state produced total %d posts, want 2", after4)
+	}
+}
+
+func TestAlert_DifferentKeysAreIndependent(t *testing.T) {
+	srv, posts, mu := ntfyRecorder(t)
+	n := (&Notifier{}).WithNtfy(srv.URL, "topic", "")
+
+	// Two different projects, same class + same body: distinct dedup identities.
+	if err := n.Alert(AlertGateFailStreak, "projA:gate", "gate", "streak"); err != nil {
+		t.Fatalf("Alert A: %v", err)
+	}
+	if err := n.Alert(AlertGateFailStreak, "projB:gate", "gate", "streak"); err != nil {
+		t.Fatalf("Alert B: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 2 {
+		t.Errorf("distinct keys produced %d posts, want 2", len(*posts))
+	}
+}
+
+func TestAlert_NoNtfyConfig_IsNoOp(t *testing.T) {
+	n := &Notifier{} // no ntfy configured
+	if err := n.Alert(AlertEmergency, "k", "t", "b"); err != nil {
+		t.Errorf("Alert without ntfy config should return nil, got %v", err)
+	}
+}
+
+func TestAcceptance_DeliveryAdvanceAndGateFailEachOnePost(t *testing.T) {
+	// Mirrors the issue acceptance: with ntfy configured, a manufactured
+	// delivery_advance and a gate_fail_streak each produce exactly one POST;
+	// repeating the same state produces none.
+	srv, posts, mu := ntfyRecorder(t)
+	n := (&Notifier{}).WithNtfy(srv.URL, "proj", "")
+
+	_ = n.Alert(AlertDeliveryAdvance, "proj:feed", "advance", "delivered #1")
+	_ = n.Alert(AlertGateFailStreak, "proj:gate", "gate", "streak=3")
+	// Repeat identical states: no new POSTs.
+	_ = n.Alert(AlertDeliveryAdvance, "proj:feed", "advance", "delivered #1")
+	_ = n.Alert(AlertGateFailStreak, "proj:gate", "gate", "streak=3")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(*posts) != 2 {
+		t.Fatalf("got %d posts, want exactly 2 (one per class, repeats deduped)", len(*posts))
+	}
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -17,9 +18,34 @@ type Notifier struct {
 	Mode        string // "direct" (Telegram Bot API) or "openclaw" (OpenClaw relay)
 	OpenclawURL string
 
+	// ntfy push transport (#1018). When NtfyBaseURL+NtfyTopic are set, the
+	// alert-class router fans out to ntfy via a plain HTTP POST. NtfyToken is
+	// resolved from the environment by the caller — never stored in config.
+	NtfyBaseURL string
+	NtfyTopic   string
+	NtfyToken   string
+
 	mu         sync.Mutex
 	digestMode bool
 	buffer     []string
+	// alertState dedups (class,key) alerts: the last body sent per identity.
+	// An alert whose body equals the last-sent body is a no-op (no state
+	// change), so a supervisor cycle re-emitting the same condition sends once.
+	alertState map[string]string
+}
+
+// WithNtfy configures the ntfy push transport and returns the notifier for
+// chaining. base and topic empty leaves the transport disabled.
+func (n *Notifier) WithNtfy(base, topic, token string) *Notifier {
+	n.NtfyBaseURL = base
+	n.NtfyTopic = topic
+	n.NtfyToken = token
+	return n
+}
+
+// NtfyConfigured reports whether the ntfy transport can POST.
+func (n *Notifier) NtfyConfigured() bool {
+	return strings.TrimSpace(n.NtfyBaseURL) != "" && strings.TrimSpace(n.NtfyTopic) != ""
 }
 
 func New(openclawURL, target string) *Notifier {
@@ -148,4 +174,76 @@ func (n *Notifier) Sendf(format string, args ...any) {
 	if err := n.Send(fmt.Sprintf(format, args...)); err != nil {
 		log.Printf("[notify] failed to send: %v", err)
 	}
+}
+
+// Alert emits a classified operator alert (#1018). The class selects the ntfy
+// priority + tags; key is the dedup identity (e.g. "project:gate"); title and
+// body are the human-readable payload.
+//
+// Dedup is per-state-change: for a given (class,key) the alert fires once, then
+// stays silent until body differs from the last-sent body. This mirrors the
+// digest/notify contract so a supervisor loop re-detecting the same condition
+// every cycle produces one notification, not one per cycle.
+//
+// The alert fans out to the ntfy transport when configured; a nil-config ntfy
+// is a no-op. Returns the ntfy send error (nil when ntfy is not configured).
+func (n *Notifier) Alert(class AlertClass, key, title, body string) error {
+	stateKey := string(class) + "\x00" + key
+
+	n.mu.Lock()
+	if n.alertState == nil {
+		n.alertState = make(map[string]string)
+	}
+	if last, ok := n.alertState[stateKey]; ok && last == body {
+		n.mu.Unlock()
+		return nil // no state change since last send — dedup
+	}
+	n.alertState[stateKey] = body
+	n.mu.Unlock()
+
+	if !n.NtfyConfigured() {
+		return nil
+	}
+	route := RouteFor(class)
+	return n.sendNtfy(title, body, route)
+}
+
+// ResetAlertState clears the dedup memory (test/rotation helper).
+func (n *Notifier) ResetAlertState() {
+	n.mu.Lock()
+	n.alertState = nil
+	n.mu.Unlock()
+}
+
+func (n *Notifier) sendNtfy(title, body string, route AlertRoute) error {
+	base := strings.TrimRight(strings.TrimSpace(n.NtfyBaseURL), "/")
+	topic := strings.Trim(strings.TrimSpace(n.NtfyTopic), "/")
+	url := base + "/" + topic
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("ntfy request: %w", err)
+	}
+	if title != "" {
+		req.Header.Set("Title", title)
+	}
+	if route.Priority > 0 {
+		req.Header.Set("Priority", strconv.Itoa(route.Priority))
+	}
+	if len(route.Tags) > 0 {
+		req.Header.Set("Tags", strings.Join(route.Tags, ","))
+	}
+	if tok := strings.TrimSpace(n.NtfyToken); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	if err != nil {
+		return fmt.Errorf("ntfy post: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return fmt.Errorf("ntfy returned %d", resp.StatusCode)
+	}
+	return nil
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -202,6 +202,7 @@ type Orchestrator struct {
 // New creates a new Orchestrator
 func New(cfg *config.Config) *Orchestrator {
 	n := notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
+	n.WithNtfy(cfg.Notify.Ntfy.BaseURL, cfg.Notify.Ntfy.Topic, cfg.Notify.Ntfy.Token())
 	if cfg.Telegram.DigestMode {
 		n.SetDigestMode(true)
 		log.Printf("[orch] digest mode enabled — notifications will be batched per cycle")

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -26,6 +26,7 @@ import (
 	"github.com/befeast/maestro/internal/configstore"
 	"github.com/befeast/maestro/internal/emergencystore"
 	"github.com/befeast/maestro/internal/mirrorstore"
+	"github.com/befeast/maestro/internal/notify"
 	"github.com/befeast/maestro/internal/outcome"
 	"github.com/befeast/maestro/internal/progress"
 	"github.com/befeast/maestro/internal/server/web"
@@ -396,6 +397,9 @@ type EmergencySwitch interface {
 // satisfies it. nil disables the alert (the switch still flips).
 type EmergencyNotifier interface {
 	Sendf(format string, args ...any)
+	// Alert fans a classified alert to the ntfy transport when configured
+	// (#1018); a no-op when ntfy is not set up.
+	Alert(class notify.AlertClass, key, title, body string) error
 }
 
 // FleetProjectStore is the write side of the daemon's config store that the
@@ -2251,10 +2255,17 @@ func (s *FleetServer) handleFleetEmergency(w http.ResponseWriter, r *http.Reques
 	// sends exactly one alert — the daemon's watch loop only logs the per-flow
 	// journal confirmation.
 	if n := s.liveEmergencyNotifier(); n != nil {
+		var msg string
 		if st.Active() {
-			n.Sendf("%s", st.ActivationMessage())
+			msg = st.ActivationMessage()
 		} else {
-			n.Sendf("%s", emergencystore.ResumeMessage(emergencystore.State{Level: level}, st))
+			msg = emergencystore.ResumeMessage(emergencystore.State{Level: level}, st)
+		}
+		n.Sendf("%s", msg)
+		// Fan the notify_red-grade alert to ntfy (#1018); dedup keeps a repeated
+		// identical emergency state from re-notifying.
+		if err := n.Alert(notify.AlertEmergency, "emergency", "maestro emergency", msg); err != nil {
+			log.Printf("[fleet] ntfy emergency alert failed: %v", err)
 		}
 	}
 	writeJSON(w, http.StatusOK, emergencyStateToWire(st))

--- a/internal/server/fleet_emergency_test.go
+++ b/internal/server/fleet_emergency_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/befeast/maestro/internal/emergencystore"
+	"github.com/befeast/maestro/internal/notify"
 )
 
 // fakeEmergencySwitch is an in-memory EmergencySwitch for the endpoint tests.
@@ -31,7 +32,10 @@ func (f *fakeEmergencySwitch) Get(_ context.Context) (emergencystore.State, erro
 	return f.st, nil
 }
 
-type fakeEmergencyNotifier struct{ msgs []string }
+type fakeEmergencyNotifier struct {
+	msgs   []string
+	alerts []notify.AlertClass
+}
 
 func (f *fakeEmergencyNotifier) Sendf(format string, args ...any) {
 	f.msgs = append(f.msgs, format)
@@ -40,6 +44,11 @@ func (f *fakeEmergencyNotifier) Sendf(format string, args ...any) {
 			f.msgs[len(f.msgs)-1] = s
 		}
 	}
+}
+
+func (f *fakeEmergencyNotifier) Alert(class notify.AlertClass, _, _, _ string) error {
+	f.alerts = append(f.alerts, class)
+	return nil
 }
 
 // TestFleetAPIExposesEmergencyBlock pins #840: GET /api/v1/fleet always carries


### PR DESCRIPTION
Implements #1018

## Changes
- **ntfy transport** (`internal/notify`): plain HTTP POST push channel with `Title`/`Priority`/`Tags` headers and optional bearer auth.
- **Alert-class router** (`internal/notify/alert.go`): closed enum — `gate_fail_streak`, `idle_stall`, `futile_recovery`, `backend_cooldown_exhausted`, `delivery_advance`, `emergency` — each mapped to a fixed ntfy priority + tag set. `Notifier.Alert(class, key, title, body)` is one call usable from supervisor/orchestrator/watchdog.
- **Dedup per state change**: identical `(class, key)` alerts send once until the body changes; a re-detected condition notifies once, not per cycle.
- **Config**: new `notify.ntfy` block (`base_url`, `topic`, `token_env`). The auth token is referenced from the environment via `token_env` and never stored in config or repo.
- **Fan-out**: existing notify_red-grade emergency paths (dashboard red button, CLI emergency, orchestrator) gain the ntfy fan-out when configured.

## Testing
- `go test ./...`
- `go build ./cmd/maestro/`
- New unit tests: httptest transport (headers, body, topic, bearer), class→priority/tags mapping, dedup-per-state-change, and the acceptance scenario (one POST each for `delivery_advance` + `gate_fail_streak`, repeats deduped). Config `Enabled()`/`Token()`/YAML-parse tests.

No secrets or endpoint values appear in code, tests, or docs — config keys only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds ntfy alerts and routes emergency notifications through the new transport. The main changes are:

- ntfy configuration with environment-based bearer tokens.
- HTTP POST delivery with fixed alert priorities and tags.
- In-memory deduplication by alert class, key, and body.
- Emergency fan-out from CLI, dashboard, and orchestrator paths.
- Unit coverage for configuration, routing, transport headers, and deduplication.

<h3>Confidence Score: 4/5</h3>

Emergency delivery can be lost after a transient POST failure or when fleet channels are split across projects.

- Failed ntfy requests are marked as delivered, so later cycles do not retry.
- CLI emergency fan-out stops at the first project with any channel.
- Dashboard emergency fan-out cannot combine channels configured on separate projects.

internal/notify/notify.go, cmd/maestro/emergency.go, internal/daemon/emergency.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verification reproduced that a failed alert delivery did not trigger a retry: the first Alert call posted to /alerts returned 503, and the identical second call did not issue another request.
- Verification showed that with two projects, the first eligible transport received the POSTs, and swapping the project order changed which transport was used (Telegram versus ntfy).
- A focused integration test confirmed the mixed fleet fan-out was incomplete, delivering one Telegram request and zero ntfy requests.
- The after-state evidence shows POST /proj-alerts responses were 200 OK with defined deliveries and runtime metrics: observed\_count=2, attempted\_calls=4, deduplicated\_calls=2.

<a href="https://app.greptile.com/trex/runs/15233880/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/notify/notify.go | Adds ntfy delivery and deduplication, but failed deliveries are recorded as sent and cannot retry. |
| internal/notify/alert.go | Defines alert classes and their fixed ntfy priority and tag routes. |
| internal/config/config.go | Adds ntfy YAML configuration and environment-based token resolution. |
| cmd/maestro/emergency.go | Adds ntfy to CLI emergency alerts, but first-project selection can omit a configured channel. |
| internal/daemon/emergency.go | Builds the dashboard emergency notifier, but cannot combine channels from different projects. |
| internal/server/fleet.go | Extends dashboard emergency handling to invoke the classified ntfy alert path. |
| internal/orchestrator/orchestrator.go | Configures the orchestrator notifier with the project's ntfy settings. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/notify/notify.go:201
**Failed Sends Suppress Retries**

`Alert` records the body before `sendNtfy` succeeds. If the POST times out or returns an error, the next cycle treats the same alert as already delivered and suppresses every retry until the body changes.

### Issue 2 of 3
cmd/maestro/emergency.go:229
**First Project Drops Fleet Channels**

This return stops after the first project with either transport. If that project is Telegram-only and a later project supplies ntfy, the ntfy emergency alert is skipped; the inverse ordering skips Telegram.

### Issue 3 of 3
internal/daemon/emergency.go:163
**Mixed Fleet Fan-Out Is Incomplete**

The dashboard notifier comes from the first project with either channel. When Telegram and ntfy are configured on different projects, emergency actions use only the first project's transport and silently omit the other configured channel.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: ntfy notification transport + aler..."](https://github.com/befeast/maestro/commit/f18a54de19c53bb3c041d1d6b4c36efd43a6b055) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45932518)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->