### PR TITLE
feat: scheduled-gate failure streaks as first-class supervisor events (counter + notify + intake)

### DIFF
--- a/internal/outcome/outcome.go
+++ b/internal/outcome/outcome.go
@@ -55,6 +55,11 @@ type Brief struct {
 	RecoveryIntervalSeconds int    `yaml:"recovery_interval_seconds" json:"recovery_interval_seconds,omitempty"`
 	RecoveryCooldownMinutes int    `yaml:"recovery_cooldown_minutes" json:"recovery_cooldown_minutes,omitempty"`
 	RecoveryTimeoutSeconds  int    `yaml:"recovery_timeout_seconds" json:"recovery_timeout_seconds,omitempty"`
+	// GateFailStreakThreshold is the number of consecutive same-fingerprint
+	// scheduled-gate failures at which Maestro emits a first-class supervisor
+	// event (notification + deduped repair intake). Zero uses the default (2); a
+	// negative value disables the escalation.
+	GateFailStreakThreshold int `yaml:"gate_fail_streak_threshold" json:"gate_fail_streak_threshold,omitempty"`
 }
 
 // Status is the concise outcome state exposed by CLI/API/dashboard surfaces.
@@ -88,6 +93,7 @@ type Status struct {
 	RecoveryConfigured      bool              `json:"recovery_configured,omitempty"`
 	RecoveryMode            string            `json:"recovery_mode,omitempty"`
 	Recovery                *RecoveryState    `json:"recovery,omitempty"`
+	GateStreaks             []GateStreak      `json:"gate_streaks,omitempty"`
 }
 
 // HealthCheckItem is the allow-listed, bounded part of structured checker
@@ -215,6 +221,24 @@ func (b Brief) EffectiveRecoveryTimeout() time.Duration {
 	return defaultRecoveryTimeout
 }
 
+// EffectiveGateFailStreakThreshold is the consecutive-failure count at which a
+// scheduled gate streak escalates. Zero uses the default; a negative value is
+// returned as-is so callers can treat it as disabled.
+func (b Brief) EffectiveGateFailStreakThreshold() int {
+	if b.GateFailStreakThreshold == 0 {
+		return DefaultGateFailStreakThreshold
+	}
+	return b.GateFailStreakThreshold
+}
+
+// GateFailStreakEnabled reports whether scheduled-gate failure-streak
+// escalation should run. It needs a health signal to observe gates and a
+// positive threshold.
+func (b Brief) GateFailStreakEnabled() bool {
+	b = b.Normalized()
+	return b.HasHealthSignal() && b.EffectiveGateFailStreakThreshold() > 0
+}
+
 func (b Brief) Configured() bool {
 	b = b.Normalized()
 	return b.DesiredOutcome != ""
@@ -331,6 +355,17 @@ func AttachRecovery(status Status, recovery *RecoveryState) Status {
 		copy.ExitCode = &code
 	}
 	status.Recovery = &copy
+	return status
+}
+
+// AttachGateStreaks exposes the persisted scheduled-gate failure-streak table
+// (counter, fingerprint, and last transition per gate) on a status without
+// mutating the caller's slice.
+func AttachGateStreaks(status Status, streaks []GateStreak) Status {
+	if len(streaks) == 0 {
+		return status
+	}
+	status.GateStreaks = append([]GateStreak(nil), streaks...)
 	return status
 }
 

--- a/internal/outcome/streak.go
+++ b/internal/outcome/streak.go
@@ -1,0 +1,248 @@
+package outcome
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DefaultGateFailStreakThreshold is the consecutive-failure count at which a
+// scheduled gate failure streak becomes a first-class supervisor event.
+const DefaultGateFailStreakThreshold = 2
+
+// maxTrackedGateStreaks bounds the number of retired (passed) gate records the
+// streak table retains for visibility, so a project that churns gate names over
+// time cannot grow the durable table without limit.
+const maxTrackedGateStreaks = 64
+
+// GateStreak is the durable per-gate consecutive-failure counter with a failure
+// fingerprint (gate name + reason class). A passing run or a fingerprint change
+// resets it, so it always describes exactly one uninterrupted failure run of a
+// single scheduled/candidate gate.
+type GateStreak struct {
+	Gate                string    `json:"gate"`
+	ReasonClass         string    `json:"reason_class,omitempty"`
+	Fingerprint         string    `json:"fingerprint,omitempty"`
+	ConsecutiveFailures int       `json:"consecutive_failures"`
+	FirstFailedAt       time.Time `json:"first_failed_at,omitempty"`
+	LastFailedAt        time.Time `json:"last_failed_at,omitempty"`
+	LastTransitionAt    time.Time `json:"last_transition_at,omitempty"`
+	LastRunLink         string    `json:"last_run_link,omitempty"`
+	// NotifiedFingerprint records the fingerprint whose streak already produced a
+	// gate_fail_streak notification. It dedupes the first-class event so a repeat
+	// same-fingerprint failure past the threshold never re-notifies.
+	NotifiedFingerprint string `json:"notified_fingerprint,omitempty"`
+	// IntakeFingerprint records the fingerprint whose streak already produced a
+	// deduped repair issue; IntakeIssue is that issue number (for visibility).
+	IntakeFingerprint string `json:"intake_fingerprint,omitempty"`
+	IntakeIssue       int    `json:"intake_issue,omitempty"`
+}
+
+// GateStreakEvent describes a same-fingerprint failure streak that reached the
+// escalation threshold and still has a pending notification and/or intake.
+type GateStreakEvent struct {
+	Gate                string
+	ReasonClass         string
+	Fingerprint         string
+	ConsecutiveFailures int
+	RunLink             string
+	FirstFailedAt       time.Time
+	LastFailedAt        time.Time
+	NotifyPending       bool
+	IntakePending       bool
+}
+
+// GateStreakFingerprint is the stable failure fingerprint for a gate: its name
+// plus the reason class of the failure. A different reason class is a different
+// fingerprint, so it starts a fresh streak instead of extending the old one.
+func GateStreakFingerprint(gate, reasonClass string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(gate) + "\x00" + strings.TrimSpace(reasonClass)))
+	return hex.EncodeToString(sum[:8])
+}
+
+type gateOutcome int
+
+const (
+	gateIndeterminate gateOutcome = iota
+	gatePass
+	gateFail
+)
+
+type gateObservation struct {
+	gate        string
+	status      gateOutcome
+	reasonClass string
+}
+
+// gateObservations derives the per-gate pass/fail observations from a health
+// check result. Structured checks yield one observation per named check; a bare
+// signal result yields a single gate keyed by the check signal.
+func gateObservations(result HealthCheckResult) []gateObservation {
+	if len(result.Checks) > 0 {
+		obs := make([]gateObservation, 0, len(result.Checks))
+		for _, check := range result.Checks {
+			name := strings.TrimSpace(check.Name)
+			if name == "" {
+				name = "structured-check"
+			}
+			status, reason := classifyGateStatus(check.Status)
+			obs = append(obs, gateObservation{gate: name, status: status, reasonClass: reason})
+		}
+		return obs
+	}
+	gate := strings.TrimSpace(result.Signal)
+	if gate == "" {
+		gate = "outcome"
+	}
+	switch normalizedHealthState(result.State) {
+	case HealthFailing:
+		return []gateObservation{{gate: gate, status: gateFail, reasonClass: "failing"}}
+	case HealthHealthy:
+		return []gateObservation{{gate: gate, status: gatePass}}
+	default:
+		// unknown/pending/unmonitored is neither a definitive pass nor fail, so it
+		// must not increment or reset a streak.
+		return nil
+	}
+}
+
+func classifyGateStatus(status string) (gateOutcome, string) {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "fail", "failing":
+		return gateFail, "fail"
+	case "error":
+		return gateFail, "error"
+	case "pass", "healthy":
+		return gatePass, ""
+	default:
+		// warning/unknown/pending/in_progress/queued: indeterminate.
+		return gateIndeterminate, ""
+	}
+}
+
+// RecordGateStreaks folds one scheduled health check result into the per-gate
+// streak table. It increments a same-fingerprint failure run, resets on a pass
+// or fingerprint change, and returns the streaks that have reached the
+// threshold with a still-pending notification or intake. Emission markers are
+// carried forward untouched: the caller sets them (via MarkGateStreak*) only
+// after the side effect succeeds, so a transient dispatch failure is retried on
+// the next scheduled run and a repeat failure never double-fires.
+func RecordGateStreaks(prev []GateStreak, result HealthCheckResult, threshold int, runLink string, now time.Time) ([]GateStreak, []GateStreakEvent) {
+	if threshold <= 0 {
+		threshold = DefaultGateFailStreakThreshold
+	}
+	now = now.UTC()
+	runLink = strings.TrimSpace(runLink)
+
+	byGate := make(map[string]GateStreak, len(prev))
+	for _, streak := range prev {
+		byGate[streak.Gate] = streak
+	}
+
+	for _, obs := range gateObservations(result) {
+		existing, had := byGate[obs.gate]
+		switch obs.status {
+		case gateFail:
+			fingerprint := GateStreakFingerprint(obs.gate, obs.reasonClass)
+			if had && existing.Fingerprint == fingerprint && existing.ConsecutiveFailures > 0 {
+				existing.ConsecutiveFailures++
+				existing.LastFailedAt = now
+				existing.LastRunLink = runLink
+				byGate[obs.gate] = existing
+				continue
+			}
+			byGate[obs.gate] = GateStreak{
+				Gate:                obs.gate,
+				ReasonClass:         obs.reasonClass,
+				Fingerprint:         fingerprint,
+				ConsecutiveFailures: 1,
+				FirstFailedAt:       now,
+				LastFailedAt:        now,
+				LastTransitionAt:    now,
+				LastRunLink:         runLink,
+			}
+		case gatePass:
+			if !had || existing.ConsecutiveFailures == 0 {
+				continue
+			}
+			byGate[obs.gate] = GateStreak{
+				Gate:             obs.gate,
+				LastTransitionAt: now,
+				LastFailedAt:     existing.LastFailedAt,
+			}
+		case gateIndeterminate:
+			// Carry the prior streak forward unchanged; an inconclusive run neither
+			// advances nor clears the failure run.
+		}
+	}
+
+	next := make([]GateStreak, 0, len(byGate))
+	for _, streak := range byGate {
+		next = append(next, streak)
+	}
+	sort.Slice(next, func(i, j int) bool { return next[i].Gate < next[j].Gate })
+	next = pruneGateStreaks(next)
+
+	var events []GateStreakEvent
+	for _, streak := range next {
+		if streak.ConsecutiveFailures < threshold || streak.Fingerprint == "" {
+			continue
+		}
+		notifyPending := streak.NotifiedFingerprint != streak.Fingerprint
+		intakePending := streak.IntakeFingerprint != streak.Fingerprint
+		if !notifyPending && !intakePending {
+			continue
+		}
+		events = append(events, GateStreakEvent{
+			Gate:                streak.Gate,
+			ReasonClass:         streak.ReasonClass,
+			Fingerprint:         streak.Fingerprint,
+			ConsecutiveFailures: streak.ConsecutiveFailures,
+			RunLink:             streak.LastRunLink,
+			FirstFailedAt:       streak.FirstFailedAt,
+			LastFailedAt:        streak.LastFailedAt,
+			NotifyPending:       notifyPending,
+			IntakePending:       intakePending,
+		})
+	}
+	return next, events
+}
+
+// pruneGateStreaks bounds the retired (passed) records the table keeps for
+// visibility. Active failure runs are always retained; only count==0 records
+// beyond the cap are dropped, oldest transition first.
+func pruneGateStreaks(streaks []GateStreak) []GateStreak {
+	if len(streaks) <= maxTrackedGateStreaks {
+		return streaks
+	}
+	retired := make([]int, 0, len(streaks))
+	for i, streak := range streaks {
+		if streak.ConsecutiveFailures == 0 {
+			retired = append(retired, i)
+		}
+	}
+	drop := len(streaks) - maxTrackedGateStreaks
+	if drop > len(retired) {
+		drop = len(retired)
+	}
+	if drop == 0 {
+		return streaks
+	}
+	sort.SliceStable(retired, func(i, j int) bool {
+		return streaks[retired[i]].LastTransitionAt.Before(streaks[retired[j]].LastTransitionAt)
+	})
+	dropped := make(map[int]struct{}, drop)
+	for _, idx := range retired[:drop] {
+		dropped[idx] = struct{}{}
+	}
+	kept := make([]GateStreak, 0, len(streaks)-drop)
+	for i, streak := range streaks {
+		if _, ok := dropped[i]; ok {
+			continue
+		}
+		kept = append(kept, streak)
+	}
+	return kept
+}

--- a/internal/outcome/streak_test.go
+++ b/internal/outcome/streak_test.go
@@ -1,0 +1,167 @@
+package outcome
+
+import (
+	"testing"
+	"time"
+)
+
+func failingCheck(name string) HealthCheckResult {
+	return HealthCheckResult{
+		CheckedAt: time.Now().UTC(),
+		State:     HealthFailing,
+		Checks:    []HealthCheckItem{{Name: name, Blocking: true, Status: "fail"}},
+	}
+}
+
+func passingCheck(name string) HealthCheckResult {
+	return HealthCheckResult{
+		CheckedAt: time.Now().UTC(),
+		State:     HealthHealthy,
+		Checks:    []HealthCheckItem{{Name: name, Blocking: true, Status: "pass"}},
+	}
+}
+
+// applyEmission mimics the caller marking a fingerprint after a successful
+// notification/intake so the pure model's dedup can be exercised end to end.
+func applyEmission(streaks []GateStreak, events []GateStreakEvent) []GateStreak {
+	for _, event := range events {
+		for i := range streaks {
+			if streaks[i].Gate == event.Gate && streaks[i].Fingerprint == event.Fingerprint {
+				if event.NotifyPending {
+					streaks[i].NotifiedFingerprint = event.Fingerprint
+				}
+				if event.IntakePending {
+					streaks[i].IntakeFingerprint = event.Fingerprint
+					streaks[i].IntakeIssue = 4242
+				}
+			}
+		}
+	}
+	return streaks
+}
+
+func TestRecordGateStreaks_ThresholdEmitsOnceThenDedupes(t *testing.T) {
+	now := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
+
+	// First failure: below threshold (default 2), no event.
+	streaks, events := RecordGateStreaks(nil, failingCheck("deb-idle-return-smoke"), 0, "https://runtime/health", now)
+	if len(events) != 0 {
+		t.Fatalf("first failure emitted %d events, want 0", len(events))
+	}
+	if streaks[0].ConsecutiveFailures != 1 {
+		t.Fatalf("count = %d, want 1", streaks[0].ConsecutiveFailures)
+	}
+
+	// Second consecutive same-gate failure crosses the threshold: exactly one
+	// event, pending both notify and intake, with gate name + run link.
+	streaks, events = RecordGateStreaks(streaks, failingCheck("deb-idle-return-smoke"), 0, "https://runtime/health", now.Add(time.Minute))
+	if len(events) != 1 {
+		t.Fatalf("second failure emitted %d events, want exactly 1", len(events))
+	}
+	ev := events[0]
+	if ev.Gate != "deb-idle-return-smoke" || ev.ConsecutiveFailures != 2 {
+		t.Fatalf("event = %+v, want gate deb-idle-return-smoke count 2", ev)
+	}
+	if !ev.NotifyPending || !ev.IntakePending {
+		t.Fatalf("event = %+v, want notify+intake pending", ev)
+	}
+	if ev.RunLink != "https://runtime/health" {
+		t.Fatalf("run link = %q, want the latest run link", ev.RunLink)
+	}
+	streaks = applyEmission(streaks, events)
+
+	// Third identical failure: streak keeps counting but must not re-fire.
+	streaks, events = RecordGateStreaks(streaks, failingCheck("deb-idle-return-smoke"), 0, "https://runtime/health", now.Add(2*time.Minute))
+	if len(events) != 0 {
+		t.Fatalf("third identical failure emitted %d events, want 0 (deduped)", len(events))
+	}
+	if streaks[0].ConsecutiveFailures != 3 {
+		t.Fatalf("count = %d, want 3", streaks[0].ConsecutiveFailures)
+	}
+	if streaks[0].IntakeIssue != 4242 {
+		t.Fatalf("intake issue = %d, want the deduped repair issue preserved", streaks[0].IntakeIssue)
+	}
+}
+
+func TestRecordGateStreaks_PassResetsStreak(t *testing.T) {
+	now := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
+	streaks, _ := RecordGateStreaks(nil, failingCheck("portability-package-smoke"), 0, "", now)
+	streaks, events := RecordGateStreaks(streaks, failingCheck("portability-package-smoke"), 0, "", now.Add(time.Minute))
+	if len(events) != 1 {
+		t.Fatalf("want one escalation before the pass, got %d", len(events))
+	}
+	streaks = applyEmission(streaks, events)
+
+	streaks, events = RecordGateStreaks(streaks, passingCheck("portability-package-smoke"), 0, "", now.Add(2*time.Minute))
+	if len(events) != 0 {
+		t.Fatalf("pass emitted %d events, want 0", len(events))
+	}
+	if streaks[0].ConsecutiveFailures != 0 || streaks[0].Fingerprint != "" {
+		t.Fatalf("pass did not reset streak: %+v", streaks[0])
+	}
+	if streaks[0].NotifiedFingerprint != "" || streaks[0].IntakeFingerprint != "" {
+		t.Fatalf("pass did not clear emission marks: %+v", streaks[0])
+	}
+
+	// A fresh failure run after the reset must escalate again.
+	streaks, _ = RecordGateStreaks(streaks, failingCheck("portability-package-smoke"), 0, "", now.Add(3*time.Minute))
+	streaks, events = RecordGateStreaks(streaks, failingCheck("portability-package-smoke"), 0, "", now.Add(4*time.Minute))
+	if len(events) != 1 {
+		t.Fatalf("post-reset streak did not re-escalate: %d events", len(events))
+	}
+}
+
+func TestRecordGateStreaks_DifferentGateStartsNewFingerprint(t *testing.T) {
+	now := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
+	streaks, _ := RecordGateStreaks(nil, failingCheck("gate-a"), 0, "", now)
+	streaks, events := RecordGateStreaks(streaks, failingCheck("gate-b"), 0, "", now.Add(time.Minute))
+	if len(events) != 0 {
+		t.Fatalf("distinct gate failures should each be a single-count streak, got %d events", len(events))
+	}
+	byGate := map[string]GateStreak{}
+	for _, s := range streaks {
+		byGate[s.Gate] = s
+	}
+	if byGate["gate-a"].ConsecutiveFailures != 1 || byGate["gate-b"].ConsecutiveFailures != 1 {
+		t.Fatalf("each gate should carry its own count-1 streak: %+v", streaks)
+	}
+	if byGate["gate-a"].Fingerprint == byGate["gate-b"].Fingerprint {
+		t.Fatalf("distinct gates must have distinct fingerprints")
+	}
+}
+
+func TestRecordGateStreaks_ReasonClassChangeStartsNewStreak(t *testing.T) {
+	now := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
+	failReason := func(status string) HealthCheckResult {
+		return HealthCheckResult{
+			CheckedAt: now,
+			State:     HealthFailing,
+			Checks:    []HealthCheckItem{{Name: "gate", Blocking: true, Status: status}},
+		}
+	}
+	streaks, _ := RecordGateStreaks(nil, failReason("fail"), 0, "", now)
+	streaks, events := RecordGateStreaks(streaks, failReason("error"), 0, "", now.Add(time.Minute))
+	if len(events) != 0 {
+		t.Fatalf("reason-class change should restart the streak at count 1, got %d events", len(events))
+	}
+	if streaks[0].ConsecutiveFailures != 1 || streaks[0].ReasonClass != "error" {
+		t.Fatalf("streak did not restart on reason change: %+v", streaks[0])
+	}
+}
+
+func TestRecordGateStreaks_IndeterminateDoesNotResetOrCount(t *testing.T) {
+	now := time.Date(2026, 7, 21, 9, 0, 0, 0, time.UTC)
+	pending := HealthCheckResult{
+		CheckedAt: now,
+		State:     HealthPending,
+		Checks:    []HealthCheckItem{{Name: "gate", Blocking: true, Status: "pending"}},
+	}
+	streaks, _ := RecordGateStreaks(nil, failingCheck("gate"), 0, "", now)
+	streaks, events := RecordGateStreaks(streaks, pending, 0, "", now.Add(time.Minute))
+	if len(events) != 0 {
+		t.Fatalf("pending run emitted %d events, want 0", len(events))
+	}
+	if streaks[0].ConsecutiveFailures != 1 {
+		t.Fatalf("pending run must not change the count: %+v", streaks[0])
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1244,7 +1244,8 @@ func outcomeStatusForState(cfg *config.Config, st *state.State) outcome.Status {
 	} else {
 		status = outcome.StatusFor(cfg.Outcome, st.DonePRCount(), st.LastMergeAt)
 	}
-	return outcome.AttachRecovery(status, st.OutcomeRecovery)
+	status = outcome.AttachRecovery(status, st.OutcomeRecovery)
+	return outcome.AttachGateStreaks(status, st.OutcomeGateStreaks)
 }
 
 func (s *Server) handleWorkers(w http.ResponseWriter, r *http.Request) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1258,19 +1258,25 @@ type ApprovalAudit struct {
 }
 
 type State struct {
-	Sessions            map[string]*Session                 `json:"sessions"`
-	Missions            map[int]*Mission                    `json:"missions,omitempty"` // parent issue number → mission
-	SupervisorDecisions []SupervisorDecision                `json:"supervisor_decisions,omitempty"`
-	Approvals           []Approval                          `json:"approvals,omitempty"`
-	LessonProposals     []LessonProposal                    `json:"lesson_proposals,omitempty"`
-	OutcomeHealth       *outcome.HealthCheckResult          `json:"outcome_health,omitempty"`
-	OutcomeRecovery     *outcome.RecoveryState              `json:"outcome_recovery,omitempty"`
-	BackendHealth       map[string]BackendHealth            `json:"backend_health,omitempty"`
-	ProviderModelHealth map[string]map[string]BackendHealth `json:"provider_model_health,omitempty"`
-	BackendQuotaUsage   map[string]*BackendQuotaUsage       `json:"backend_quota_usage,omitempty"`
-	ProjectStatusSync   map[int]ProjectStatusSync           `json:"project_status_sync,omitempty"`
-	NextSlot            int                                 `json:"next_slot"`
-	LastMergeAt         time.Time                           `json:"last_merge_at,omitempty"`
+	Sessions            map[string]*Session        `json:"sessions"`
+	Missions            map[int]*Mission           `json:"missions,omitempty"` // parent issue number → mission
+	SupervisorDecisions []SupervisorDecision       `json:"supervisor_decisions,omitempty"`
+	Approvals           []Approval                 `json:"approvals,omitempty"`
+	LessonProposals     []LessonProposal           `json:"lesson_proposals,omitempty"`
+	OutcomeHealth       *outcome.HealthCheckResult `json:"outcome_health,omitempty"`
+	OutcomeRecovery     *outcome.RecoveryState     `json:"outcome_recovery,omitempty"`
+	// OutcomeGateStreaks tracks per-gate consecutive scheduled-failure runs with
+	// a failure fingerprint (gate name + reason class). OutcomeGateStreakCheckedAt
+	// is the CheckedAt of the last health result already folded into the streaks,
+	// so each scheduled run increments a streak exactly once.
+	OutcomeGateStreaks         []outcome.GateStreak                `json:"outcome_gate_streaks,omitempty"`
+	OutcomeGateStreakCheckedAt time.Time                           `json:"outcome_gate_streak_checked_at,omitempty"`
+	BackendHealth              map[string]BackendHealth            `json:"backend_health,omitempty"`
+	ProviderModelHealth        map[string]map[string]BackendHealth `json:"provider_model_health,omitempty"`
+	BackendQuotaUsage          map[string]*BackendQuotaUsage       `json:"backend_quota_usage,omitempty"`
+	ProjectStatusSync          map[int]ProjectStatusSync           `json:"project_status_sync,omitempty"`
+	NextSlot                   int                                 `json:"next_slot"`
+	LastMergeAt                time.Time                           `json:"last_merge_at,omitempty"`
 
 	// RestartRequired is set by the running orchestrator when a config field that
 	// cannot be hot-applied (model.default, routing.*) changes during a reload. It is
@@ -1826,6 +1832,8 @@ func (s *State) copyFrom(src *State) {
 	s.Approvals = src.Approvals
 	s.LessonProposals = src.LessonProposals
 	s.OutcomeHealth = src.OutcomeHealth
+	s.OutcomeGateStreaks = src.OutcomeGateStreaks
+	s.OutcomeGateStreakCheckedAt = src.OutcomeGateStreakCheckedAt
 	s.ProjectStatusSync = src.ProjectStatusSync
 	s.BackendHealth = src.BackendHealth
 	s.ProviderModelHealth = src.ProviderModelHealth
@@ -1890,6 +1898,7 @@ func mergeStateSnapshots(base, current, ours *State) (*State, error) {
 	}
 	merged.OutcomeHealth = mergeOutcomeHealth(base.OutcomeHealth, current.OutcomeHealth, ours.OutcomeHealth)
 	merged.OutcomeRecovery = mergeOutcomeRecovery(base.OutcomeRecovery, current.OutcomeRecovery, ours.OutcomeRecovery)
+	merged.OutcomeGateStreaks, merged.OutcomeGateStreakCheckedAt = mergeOutcomeGateStreaks(current, ours)
 	merged.ProjectStatusSync = mergeProjectStatusSync(current.ProjectStatusSync, ours.ProjectStatusSync)
 	merged.SpecLintTracks = mergeSpecLintTracks(current.SpecLintTracks, ours.SpecLintTracks)
 	merged.PRGateSnapshots = mergePRGateSnapshots(current.PRGateSnapshots, ours.PRGateSnapshots)
@@ -2268,6 +2277,71 @@ func cloneOutcomeRecovery(value *outcome.RecoveryState) *outcome.RecoveryState {
 		clone.ExitCode = &code
 	}
 	return &clone
+}
+
+// mergeOutcomeGateStreaks keeps the streak table whose folded-run watermark is
+// newest. The table and its watermark advance together on every scheduled fold,
+// so the newer watermark carries the authoritative counters and emission marks.
+func mergeOutcomeGateStreaks(current, ours *State) ([]outcome.GateStreak, time.Time) {
+	winner := current
+	if winner == nil || (ours != nil && ours.OutcomeGateStreakCheckedAt.After(winner.OutcomeGateStreakCheckedAt)) {
+		winner = ours
+	}
+	if winner == nil {
+		return nil, time.Time{}
+	}
+	return append([]outcome.GateStreak(nil), winner.OutcomeGateStreaks...), winner.OutcomeGateStreakCheckedAt
+}
+
+// RecordOutcomeGateStreaks folds one scheduled health check result into the
+// per-gate streak table and returns the streaks that reached the escalation
+// threshold with a pending notification or intake. It records each distinct
+// scheduled run at most once: a result whose CheckedAt is not newer than the
+// last folded run is ignored, so overlapping evaluators never double-count.
+func (s *State) RecordOutcomeGateStreaks(result outcome.HealthCheckResult, threshold int, runLink string, now time.Time) []outcome.GateStreakEvent {
+	if s == nil {
+		return nil
+	}
+	if !result.CheckedAt.IsZero() && !result.CheckedAt.After(s.OutcomeGateStreakCheckedAt) {
+		return nil
+	}
+	next, events := outcome.RecordGateStreaks(s.OutcomeGateStreaks, result, threshold, runLink, now)
+	s.OutcomeGateStreaks = next
+	if !result.CheckedAt.IsZero() {
+		s.OutcomeGateStreakCheckedAt = result.CheckedAt.UTC()
+	}
+	return events
+}
+
+// MarkGateStreakNotified records that the gate_fail_streak notification for a
+// fingerprint has been sent, deduping repeat same-fingerprint escalations.
+func (s *State) MarkGateStreakNotified(gate, fingerprint string, now time.Time) {
+	if s == nil {
+		return
+	}
+	for i := range s.OutcomeGateStreaks {
+		if s.OutcomeGateStreaks[i].Gate == gate && s.OutcomeGateStreaks[i].Fingerprint == fingerprint {
+			s.OutcomeGateStreaks[i].NotifiedFingerprint = fingerprint
+			return
+		}
+	}
+}
+
+// MarkGateStreakIntaken records that the deduped repair issue for a fingerprint
+// has been filed, so a repeat same-fingerprint failure never re-files.
+func (s *State) MarkGateStreakIntaken(gate, fingerprint string, issue int, now time.Time) {
+	if s == nil {
+		return
+	}
+	for i := range s.OutcomeGateStreaks {
+		if s.OutcomeGateStreaks[i].Gate == gate && s.OutcomeGateStreaks[i].Fingerprint == fingerprint {
+			s.OutcomeGateStreaks[i].IntakeFingerprint = fingerprint
+			if issue > 0 {
+				s.OutcomeGateStreaks[i].IntakeIssue = issue
+			}
+			return
+		}
+	}
 }
 
 func unionKeys(maps ...map[string]*Session) []string {

--- a/internal/supervisor/material_progress_runtime.go
+++ b/internal/supervisor/material_progress_runtime.go
@@ -102,6 +102,9 @@ func RunMaterialProgressEvaluator(ctx context.Context, name string, getCfg func(
 			if _, err := EvaluateOutcomeRecoveryOnce(cfg, time.Now().UTC()); err != nil {
 				log.Printf("[%s] outcome recovery evaluation failed (will retry): %v", logPrefix, err)
 			}
+			if _, err := EvaluateGateFailureStreaksOnce(cfg, time.Now().UTC()); err != nil {
+				log.Printf("[%s] gate-fail-streak evaluation failed (will retry): %v", logPrefix, err)
+			}
 		}
 		if wait <= 0 {
 			wait = time.Second

--- a/internal/supervisor/outcome_streaks.go
+++ b/internal/supervisor/outcome_streaks.go
@@ -1,0 +1,191 @@
+package supervisor
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/outcome"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// gateFailStreakNotify and gateFailStreakIntake are the side-effecting dispatch
+// points for a first-class gate_fail_streak event. They are package variables so
+// tests can observe the deduped notification/intake without a Telegram relay or
+// live GitHub repo.
+var (
+	gateFailStreakNotify = defaultGateFailStreakNotify
+	gateFailStreakIntake = defaultGateFailStreakIntake
+)
+
+// EvaluateGateFailureStreaksOnce folds one scheduled outcome health result into
+// the per-gate consecutive-failure streak table and escalates a streak that
+// reached the configured threshold into a first-class supervisor event: a
+// gate_fail_streak notification plus one deduped repair issue. It reuses a
+// health result another evaluator already produced this interval so the shared
+// scheduled clock never double-reads the runtime.
+//
+// The returned bool is true only when a scheduled run was folded this call. A
+// call inside the interval with no fresh unfolded result is a cheap no-op.
+func EvaluateGateFailureStreaksOnce(cfg *config.Config, now time.Time) (bool, error) {
+	if cfg == nil {
+		return false, fmt.Errorf("gate-fail-streak evaluator: nil config")
+	}
+	brief := cfg.Outcome.Normalized()
+	if !brief.GateFailStreakEnabled() {
+		return false, nil
+	}
+	if strings.TrimSpace(cfg.StateDir) == "" {
+		return false, fmt.Errorf("gate-fail-streak evaluator: empty state_dir")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	} else {
+		now = now.UTC()
+	}
+
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		return false, fmt.Errorf("gate-fail-streak evaluator: load state: %w", err)
+	}
+	interval := brief.EffectiveRecoveryInterval()
+
+	// Prefer a scheduled health result the outcome-recovery evaluator already
+	// produced this interval; only read the runtime ourselves when none is
+	// available and the interval has elapsed. RecordOutcomeGateStreaks folds each
+	// distinct run (by CheckedAt) exactly once regardless of which evaluator read it.
+	var result outcome.HealthCheckResult
+	haveFresh := st.OutcomeHealth != nil && st.OutcomeHealth.CheckedAt.After(st.OutcomeGateStreakCheckedAt)
+	if haveFresh {
+		result = *st.OutcomeHealth
+	} else {
+		if !st.OutcomeGateStreakCheckedAt.IsZero() && now.Sub(st.OutcomeGateStreakCheckedAt) < interval {
+			return false, nil
+		}
+		result = checkOutcomeForRecovery(context.Background(), brief)
+	}
+
+	threshold := brief.EffectiveGateFailStreakThreshold()
+	runLink := gateFailStreakRunLink(brief)
+	var events []outcome.GateStreakEvent
+	if err := state.Update(cfg.StateDir, func(latest *state.State) error {
+		if !haveFresh {
+			setOutcomeHealthIfNewer(latest, result)
+		}
+		events = latest.RecordOutcomeGateStreaks(result, threshold, runLink, now)
+		return nil
+	}); err != nil {
+		return false, fmt.Errorf("gate-fail-streak evaluator: record streaks: %w", err)
+	}
+	if len(events) > 0 {
+		dispatchGateFailStreakEvents(cfg, events, now)
+	}
+	return true, nil
+}
+
+// dispatchGateFailStreakEvents performs the notification and repair intake for
+// each escalated streak, persisting a dedup mark only after the side effect
+// succeeds. A transient failure leaves the mark unset so the next scheduled run
+// retries; once a fingerprint is marked, a repeat same-fingerprint failure never
+// re-fires.
+func dispatchGateFailStreakEvents(cfg *config.Config, events []outcome.GateStreakEvent, now time.Time) {
+	for _, event := range events {
+		if event.NotifyPending {
+			if err := gateFailStreakNotify(cfg, event); err != nil {
+				log.Printf("[outcome/gate-streak] gate_fail_streak notify failed for gate %q (fingerprint=%s): %v", event.Gate, event.Fingerprint, err)
+			} else if err := state.Update(cfg.StateDir, func(latest *state.State) error {
+				latest.MarkGateStreakNotified(event.Gate, event.Fingerprint, now)
+				return nil
+			}); err != nil {
+				log.Printf("[outcome/gate-streak] persist notify mark failed for gate %q: %v", event.Gate, err)
+			}
+		}
+		if event.IntakePending {
+			issue, err := gateFailStreakIntake(cfg, event)
+			if err != nil {
+				log.Printf("[outcome/gate-streak] repair intake failed for gate %q (fingerprint=%s): %v", event.Gate, event.Fingerprint, err)
+				continue
+			}
+			if err := state.Update(cfg.StateDir, func(latest *state.State) error {
+				latest.MarkGateStreakIntaken(event.Gate, event.Fingerprint, issue, now)
+				return nil
+			}); err != nil {
+				log.Printf("[outcome/gate-streak] persist intake mark failed for gate %q: %v", event.Gate, err)
+			}
+		}
+	}
+}
+
+func defaultGateFailStreakNotify(cfg *config.Config, event outcome.GateStreakEvent) error {
+	if cfg == nil {
+		return nil
+	}
+	notifier := notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
+	return notifier.Send(gateFailStreakMessage(event))
+}
+
+func defaultGateFailStreakIntake(cfg *config.Config, event outcome.GateStreakEvent) (int, error) {
+	if cfg == nil || strings.TrimSpace(cfg.Repo) == "" {
+		return 0, fmt.Errorf("gate-fail-streak intake: no repo configured")
+	}
+	client := github.New(cfg.Repo)
+	title := fmt.Sprintf("gate failure streak: %s failing %d consecutive scheduled runs", event.Gate, event.ConsecutiveFailures)
+	return client.CreateIssue(title, gateFailStreakIssueBody(event), nil)
+}
+
+// gateFailStreakMessage is the first-class notification body: gate name, streak
+// count, reason class, and the latest run link. It carries no command text,
+// output, or host-side path.
+func gateFailStreakMessage(event outcome.GateStreakEvent) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "🔴 maestro: scheduled gate `%s` failed %d consecutive runs", event.Gate, event.ConsecutiveFailures)
+	if strings.TrimSpace(event.ReasonClass) != "" {
+		fmt.Fprintf(&b, " (reason: %s)", event.ReasonClass)
+	}
+	if link := strings.TrimSpace(event.RunLink); link != "" {
+		fmt.Fprintf(&b, "\nlatest run: %s", link)
+	}
+	return b.String()
+}
+
+// gateFailStreakIssueBody embeds a hidden fingerprint marker so the deduped
+// repair-issue path can recognize an existing streak issue. It records only
+// bounded, non-secret streak evidence.
+func gateFailStreakIssueBody(event outcome.GateStreakEvent) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "<!-- maestro:gate-fail-streak %s -->\n\n", event.Fingerprint)
+	fmt.Fprintf(&b, "Scheduled gate `%s` failed %d consecutive runs.\n\n", event.Gate, event.ConsecutiveFailures)
+	if strings.TrimSpace(event.ReasonClass) != "" {
+		fmt.Fprintf(&b, "- Reason class: `%s`\n", event.ReasonClass)
+	}
+	fmt.Fprintf(&b, "- Fingerprint: `%s`\n", event.Fingerprint)
+	fmt.Fprintf(&b, "- Consecutive failures: %d\n", event.ConsecutiveFailures)
+	if !event.FirstFailedAt.IsZero() {
+		fmt.Fprintf(&b, "- First failed: %s\n", event.FirstFailedAt.UTC().Format(time.RFC3339))
+	}
+	if !event.LastFailedAt.IsZero() {
+		fmt.Fprintf(&b, "- Latest failure: %s\n", event.LastFailedAt.UTC().Format(time.RFC3339))
+	}
+	if link := strings.TrimSpace(event.RunLink); link != "" {
+		fmt.Fprintf(&b, "- Latest run: %s\n", link)
+	}
+	b.WriteString("\nThe scheduled gate is failing repeatedly with the same fingerprint; investigate and repair the gate. This issue was opened automatically by Maestro's gate failure-streak escalation.\n")
+	return b.String()
+}
+
+// gateFailStreakRunLink is a non-secret pointer to the latest scheduled run's
+// runtime/healthcheck surface, used in the notification and repair issue.
+func gateFailStreakRunLink(brief outcome.Brief) string {
+	if link := strings.TrimSpace(brief.HealthcheckURL); link != "" {
+		return link
+	}
+	if link := strings.TrimSpace(brief.RuntimeURL); link != "" {
+		return link
+	}
+	return strings.TrimSpace(brief.RuntimeTarget)
+}

--- a/internal/supervisor/outcome_streaks_test.go
+++ b/internal/supervisor/outcome_streaks_test.go
@@ -1,0 +1,206 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/outcome"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func streakTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	return &config.Config{
+		Repo:     "BeFeast/example",
+		StateDir: t.TempDir(),
+		Outcome: outcome.Brief{
+			DesiredOutcome:          "candidate feed follows main",
+			HealthcheckCommand:      "./check-outcome.sh",
+			HealthcheckURL:          "https://runtime/health",
+			RecoveryIntervalSeconds: 60,
+		},
+	}
+}
+
+type streakNotification struct {
+	gate  string
+	count int
+	link  string
+}
+
+// installStreakDispatchStubs replaces the notify/intake side effects with
+// in-memory recorders and returns pointers to the captured events.
+func installStreakDispatchStubs(t *testing.T) (*[]streakNotification, *[]string, *int) {
+	t.Helper()
+	originalNotify, originalIntake := gateFailStreakNotify, gateFailStreakIntake
+	t.Cleanup(func() { gateFailStreakNotify, gateFailStreakIntake = originalNotify, originalIntake })
+
+	notifications := &[]streakNotification{}
+	intakeFingerprints := &[]string{}
+	issueSeq := new(int)
+	*issueSeq = 900
+
+	gateFailStreakNotify = func(_ *config.Config, event outcome.GateStreakEvent) error {
+		*notifications = append(*notifications, streakNotification{gate: event.Gate, count: event.ConsecutiveFailures, link: event.RunLink})
+		return nil
+	}
+	gateFailStreakIntake = func(_ *config.Config, event outcome.GateStreakEvent) (int, error) {
+		*intakeFingerprints = append(*intakeFingerprints, event.Fingerprint)
+		*issueSeq++
+		return *issueSeq, nil
+	}
+	return notifications, intakeFingerprints, issueSeq
+}
+
+func stubScheduledCheck(t *testing.T, result *outcome.HealthCheckResult) {
+	t.Helper()
+	original := checkOutcomeForRecovery
+	t.Cleanup(func() { checkOutcomeForRecovery = original })
+	checkOutcomeForRecovery = func(_ context.Context, _ outcome.Brief) outcome.HealthCheckResult {
+		return *result
+	}
+}
+
+func failingScheduledResult(gate string, at time.Time) outcome.HealthCheckResult {
+	return outcome.HealthCheckResult{
+		CheckedAt: at,
+		Signal:    "healthcheck_command",
+		State:     outcome.HealthFailing,
+		Checks:    []outcome.HealthCheckItem{{Name: gate, Blocking: true, Status: "fail"}},
+	}
+}
+
+func TestEvaluateGateFailureStreaksOnce_ReplayEmitsOnceAndDedupes(t *testing.T) {
+	cfg := streakTestConfig(t)
+	if err := state.Save(cfg.StateDir, state.NewState()); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	notifications, intakes, _ := installStreakDispatchStubs(t)
+
+	t0 := time.Date(2026, 7, 21, 8, 0, 0, 0, time.UTC)
+	current := failingScheduledResult("deb-idle-return-smoke", t0)
+	stubScheduledCheck(t, &current)
+
+	// Scheduled run #1: first failure, below threshold — no escalation.
+	if _, err := EvaluateGateFailureStreaksOnce(cfg, t0); err != nil {
+		t.Fatalf("run 1: %v", err)
+	}
+	if len(*notifications) != 0 || len(*intakes) != 0 {
+		t.Fatalf("first failure escalated early: notifications=%v intakes=%v", *notifications, *intakes)
+	}
+
+	// Scheduled run #2: second consecutive same-gate failure crosses N=2.
+	current = failingScheduledResult("deb-idle-return-smoke", t0.Add(time.Minute))
+	if _, err := EvaluateGateFailureStreaksOnce(cfg, t0.Add(time.Minute)); err != nil {
+		t.Fatalf("run 2: %v", err)
+	}
+	if len(*notifications) != 1 {
+		t.Fatalf("want exactly one notification, got %d: %v", len(*notifications), *notifications)
+	}
+	if got := (*notifications)[0]; got.gate != "deb-idle-return-smoke" || got.count != 2 || got.link != "https://runtime/health" {
+		t.Fatalf("notification = %+v, want gate+count+run link", got)
+	}
+	if len(*intakes) != 1 {
+		t.Fatalf("want exactly one deduped repair issue, got %d", len(*intakes))
+	}
+
+	// Scheduled run #3: identical failure — no duplicate notification or issue.
+	current = failingScheduledResult("deb-idle-return-smoke", t0.Add(2*time.Minute))
+	if _, err := EvaluateGateFailureStreaksOnce(cfg, t0.Add(2*time.Minute)); err != nil {
+		t.Fatalf("run 3: %v", err)
+	}
+	if len(*notifications) != 1 || len(*intakes) != 1 {
+		t.Fatalf("third identical failure duplicated escalation: notifications=%d intakes=%d", len(*notifications), len(*intakes))
+	}
+
+	loaded, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if len(loaded.OutcomeGateStreaks) != 1 {
+		t.Fatalf("want one tracked gate streak, got %+v", loaded.OutcomeGateStreaks)
+	}
+	streak := loaded.OutcomeGateStreaks[0]
+	if streak.ConsecutiveFailures != 3 {
+		t.Fatalf("streak count = %d, want 3", streak.ConsecutiveFailures)
+	}
+	if streak.IntakeIssue != 901 {
+		t.Fatalf("intake issue = %d, want the single filed repair issue 901", streak.IntakeIssue)
+	}
+	if streak.LastTransitionAt.IsZero() {
+		t.Fatalf("last transition should be visible in state")
+	}
+}
+
+func TestEvaluateGateFailureStreaksOnce_PassResetsAndDifferentGateReEscalates(t *testing.T) {
+	cfg := streakTestConfig(t)
+	if err := state.Save(cfg.StateDir, state.NewState()); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	notifications, intakes, _ := installStreakDispatchStubs(t)
+
+	t0 := time.Date(2026, 7, 21, 8, 0, 0, 0, time.UTC)
+	var current outcome.HealthCheckResult
+	stubScheduledCheck(t, &current)
+
+	current = failingScheduledResult("gate-a", t0)
+	if _, err := EvaluateGateFailureStreaksOnce(cfg, t0); err != nil {
+		t.Fatalf("run 1: %v", err)
+	}
+	current = failingScheduledResult("gate-a", t0.Add(time.Minute))
+	if _, err := EvaluateGateFailureStreaksOnce(cfg, t0.Add(time.Minute)); err != nil {
+		t.Fatalf("run 2: %v", err)
+	}
+	if len(*notifications) != 1 {
+		t.Fatalf("want one escalation for gate-a, got %d", len(*notifications))
+	}
+
+	// A pass resets the streak.
+	current = outcome.HealthCheckResult{
+		CheckedAt: t0.Add(2 * time.Minute),
+		State:     outcome.HealthHealthy,
+		Checks:    []outcome.HealthCheckItem{{Name: "gate-a", Blocking: true, Status: "pass"}},
+	}
+	if _, err := EvaluateGateFailureStreaksOnce(cfg, t0.Add(2*time.Minute)); err != nil {
+		t.Fatalf("pass run: %v", err)
+	}
+	if len(*notifications) != 1 {
+		t.Fatalf("pass should not notify: %d", len(*notifications))
+	}
+
+	// A different failing gate is a new fingerprint and escalates on its own.
+	current = failingScheduledResult("gate-b", t0.Add(3*time.Minute))
+	if _, err := EvaluateGateFailureStreaksOnce(cfg, t0.Add(3*time.Minute)); err != nil {
+		t.Fatalf("gate-b run 1: %v", err)
+	}
+	current = failingScheduledResult("gate-b", t0.Add(4*time.Minute))
+	if _, err := EvaluateGateFailureStreaksOnce(cfg, t0.Add(4*time.Minute)); err != nil {
+		t.Fatalf("gate-b run 2: %v", err)
+	}
+	if len(*notifications) != 2 || len(*intakes) != 2 {
+		t.Fatalf("different failing gate did not re-escalate: notifications=%d intakes=%d", len(*notifications), len(*intakes))
+	}
+	if (*notifications)[1].gate != "gate-b" {
+		t.Fatalf("second escalation gate = %q, want gate-b", (*notifications)[1].gate)
+	}
+}
+
+func TestEvaluateGateFailureStreaksOnce_DisabledWithoutHealthSignal(t *testing.T) {
+	cfg := &config.Config{
+		Repo:     "BeFeast/example",
+		StateDir: t.TempDir(),
+		Outcome:  outcome.Brief{DesiredOutcome: "candidate feed follows main"},
+	}
+	if err := state.Save(cfg.StateDir, state.NewState()); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	evaluated, err := EvaluateGateFailureStreaksOnce(cfg, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if evaluated {
+		t.Fatalf("gate-streak evaluator should be a no-op without a health signal")
+	}
+}


### PR DESCRIPTION
Implements #1021

## Changes
- **Per-gate streak model** (`internal/outcome/streak.go`): `GateStreak` tracks a consecutive-failure counter with a failure fingerprint (gate name + reason class). `RecordGateStreaks` folds one scheduled health result — incrementing a same-fingerprint run, resetting on a pass or fingerprint change — and returns the streaks that reached the threshold (default 2, `outcome.gate_fail_streak_threshold`) with a still-pending notification/intake.
- **Durable state** (`internal/state`): `OutcomeGateStreaks` + `OutcomeGateStreakCheckedAt` persisted, merged, and cloned. `RecordOutcomeGateStreaks` folds each distinct scheduled run exactly once (dedup by CheckedAt); `MarkGateStreakNotified`/`MarkGateStreakIntaken` record dedup marks only after the side effect succeeds.
- **Scheduled evaluator** (`internal/supervisor/outcome_streaks.go`): `EvaluateGateFailureStreaksOnce` runs on the shared outcome clock (reusing a health result the recovery evaluator already produced), emits a `gate_fail_streak` notification (gate name, count, latest run link), and files one deduped repair issue with a hidden fingerprint marker. Wired into `RunMaterialProgressEvaluator`.
- **Fleet API**: streak counter, fingerprint, and last transition are exposed in the outcome block via `AttachGateStreaks`.

## Testing
- `go test ./...`
- `go build ./cmd/maestro/`
- Added unit coverage for the pure model (threshold-once-then-dedupe, pass reset, distinct-gate/reason fingerprints, indeterminate runs) and an end-to-end evaluator replay: 2 consecutive same-gate failures → exactly one notification + one deduped repair issue; a 3rd identical failure produces no duplicate; a pass resets and a different gate re-escalates.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds scheduled gate failure streaks as supervisor events. The main changes are:

- Tracks consecutive failures by gate and reason.
- Persists streak counters and delivery markers.
- Sends notifications and opens repair issues at a configurable threshold.
- Exposes gate streaks through the outcome API.
- Adds model and evaluator tests for escalation, deduplication, and reset behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after the existing review findings are addressed.

No additional blocking issue met the subsequent-review selection requirements.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the targeted scheduled gate-failure evaluator replay.
- Verified escalation and deduplication for repeated same-gate failures, plus pass-reset and different-gate re-escalation behavior.
- Ran the gate-failure streak tests and confirmed the targeted tests passed, with the Go test run reporting PASS.

<a href="https://app.greptile.com/trex/runs/15236637/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/outcome/outcome.go | Adds streak threshold configuration and gate streaks to outcome status. |
| internal/outcome/streak.go | Implements gate observation, failure streak tracking, fingerprinting, escalation, and retention. |
| internal/state/state.go | Persists, merges, records, and marks gate streak state. |
| internal/supervisor/outcome_streaks.go | Evaluates scheduled results and dispatches streak notifications and repair intake. |
| internal/supervisor/material_progress_runtime.go | Runs the gate streak evaluator from the shared supervisor loop. |
| internal/server/server.go | Attaches persisted gate streaks to the outcome API response. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-813-10..."](https://github.com/befeast/maestro/commit/f59d2c8e91711f67900e6efb0383c042cb6a6357) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45933714)</sub>

<!-- /greptile_comment -->