### PR TITLE
P0: docs-only code_landed must not settle a bug issue — return it to dispatch eligibility

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -905,7 +905,42 @@ type SupervisorConfig struct {
 	// the approval-gated edit_issue_body verb.
 	SpecGroom SupervisorSpecGroomConfig `yaml:"spec_groom" json:"spec_groom,omitempty"`
 
+	// NonFunctionalPaths lists extra doublestar globs whose EXCLUSIVE change in a
+	// merged PR must not settle a bug issue (#1020): a docs-only QA record is a
+	// record delivery, not a fix, so the session is released for fresh dispatch
+	// instead of silencing the issue. docs/** is always included; this field only
+	// extends the set (for example a project-specific records/ or qa/ tree).
+	NonFunctionalPaths []string `yaml:"non_functional_paths" json:"non_functional_paths,omitempty"`
+
 	excludedLabelsSet bool
+}
+
+// defaultNonFunctionalPaths mirrors pipeline.DefaultNonFunctionalPaths. It is
+// duplicated here to keep the config package free of a dependency on pipeline
+// (pipeline imports config, so the reverse edge would be an import cycle).
+var defaultNonFunctionalPaths = []string{"docs/**"}
+
+// EffectiveNonFunctionalPaths returns the non-functional path globs used to
+// classify a merged PR as a documentation/record delivery (#1020): the docs/**
+// default unioned with any project-configured extensions, de-duplicated with
+// input order preserved (defaults first).
+func (c SupervisorConfig) EffectiveNonFunctionalPaths() []string {
+	seen := make(map[string]struct{}, len(defaultNonFunctionalPaths)+len(c.NonFunctionalPaths))
+	out := make([]string, 0, len(defaultNonFunctionalPaths)+len(c.NonFunctionalPaths))
+	for _, group := range [][]string{defaultNonFunctionalPaths, c.NonFunctionalPaths} {
+		for _, p := range group {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			if _, ok := seen[p]; ok {
+				continue
+			}
+			seen[p] = struct{}{}
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // SupervisorSpecGroomConfig gates the spec-lint + grooming capability (#851).

--- a/internal/config/nonfunctional_paths_test.go
+++ b/internal/config/nonfunctional_paths_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestEffectiveNonFunctionalPaths(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "default is docs only",
+			in:   nil,
+			want: []string{"docs/**"},
+		},
+		{
+			name: "project extensions union with default, docs first",
+			in:   []string{"qa/**", "records/**"},
+			want: []string{"docs/**", "qa/**", "records/**"},
+		},
+		{
+			name: "blank and duplicate entries are dropped",
+			in:   []string{"  ", "docs/**", "qa/**", "qa/**"},
+			want: []string{"docs/**", "qa/**"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := SupervisorConfig{NonFunctionalPaths: tc.in}.EffectiveNonFunctionalPaths()
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("EffectiveNonFunctionalPaths() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/code_landed_test.go
+++ b/internal/orchestrator/code_landed_test.go
@@ -1,0 +1,198 @@
+package orchestrator
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/outcome"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func codeLandedTestOrchestrator(labels []string, changed []string, changedErr error) *Orchestrator {
+	cfg := &config.Config{Repo: "owner/repo"}
+	ghLabels := make([]struct {
+		Name string `json:"name"`
+	}, 0, len(labels))
+	for _, l := range labels {
+		ghLabels = append(ghLabels, struct {
+			Name string `json:"name"`
+		}{Name: l})
+	}
+	return &Orchestrator{
+		cfg:      cfg,
+		notifier: &notify.Notifier{},
+		getIssueFn: func(number int) (github.Issue, error) {
+			return github.Issue{Number: number, Labels: ghLabels}, nil
+		},
+		ghPRChangedFilesFn: func(prNumber int) ([]string, error) {
+			return changed, changedErr
+		},
+	}
+}
+
+func TestClassifyMergedCodeLanded_DocsOnlyBugReleased(t *testing.T) {
+	o := codeLandedTestOrchestrator([]string{"bug"}, []string{"docs/qa/ok-player-486.md"}, nil)
+	s := state.NewState()
+	sess := &state.Session{IssueNumber: 486, Status: state.StatusCodeLanded, PRNumber: 900}
+	s.Sessions["slot-a"] = sess
+
+	if got := o.classifyMergedCodeLandedDelivery(s, sess); got != codeLandedRecordOnly {
+		t.Fatalf("classify = %v, want codeLandedRecordOnly", got)
+	}
+	if !sess.ReleasedForRedispatch {
+		t.Fatalf("docs-only bug session must be released for redispatch")
+	}
+	if sess.WorkerOutcome != state.WorkerOutcomeRecordOnlyDelivery {
+		t.Fatalf("WorkerOutcome = %q, want %q", sess.WorkerOutcome, state.WorkerOutcomeRecordOnlyDelivery)
+	}
+	if s.IssueInProgress(486) {
+		t.Fatalf("released docs-only session must not keep issue #486 in progress")
+	}
+}
+
+func TestClassifyMergedCodeLanded_FunctionalBugSettles(t *testing.T) {
+	o := codeLandedTestOrchestrator([]string{"bug"}, []string{"docs/note.md", "internal/state/state.go"}, nil)
+	s := state.NewState()
+	sess := &state.Session{IssueNumber: 487, Status: state.StatusCodeLanded, PRNumber: 901}
+	s.Sessions["slot-b"] = sess
+
+	if got := o.classifyMergedCodeLandedDelivery(s, sess); got != codeLandedSettle {
+		t.Fatalf("classify = %v, want codeLandedSettle", got)
+	}
+	if sess.ReleasedForRedispatch {
+		t.Fatalf("a real code fix must settle, not release")
+	}
+	if !s.IssueInProgress(487) {
+		t.Fatalf("a settling code_landed session must keep its issue claim")
+	}
+}
+
+func TestClassifyMergedCodeLanded_NonBugDocsSettles(t *testing.T) {
+	o := codeLandedTestOrchestrator([]string{"enhancement"}, []string{"docs/guide.md"}, nil)
+	s := state.NewState()
+	sess := &state.Session{IssueNumber: 488, Status: state.StatusCodeLanded, PRNumber: 902}
+	s.Sessions["slot-c"] = sess
+
+	if got := o.classifyMergedCodeLandedDelivery(s, sess); got != codeLandedSettle {
+		t.Fatalf("classify = %v, want codeLandedSettle (only bug issues are guarded)", got)
+	}
+	if sess.ReleasedForRedispatch {
+		t.Fatalf("a non-bug docs delivery must settle as today")
+	}
+}
+
+func TestClassifyMergedCodeLanded_ChangedFilesErrorSettles(t *testing.T) {
+	// A changed-files read failure must fall through to the legacy settle path,
+	// not hold — otherwise a transient forge blip would strand every normal PR.
+	o := codeLandedTestOrchestrator([]string{"bug"}, nil, fmt.Errorf("boom"))
+	s := state.NewState()
+	sess := &state.Session{IssueNumber: 489, Status: state.StatusCodeLanded, PRNumber: 903}
+	s.Sessions["slot-d"] = sess
+
+	if got := o.classifyMergedCodeLandedDelivery(s, sess); got != codeLandedSettle {
+		t.Fatalf("classify = %v, want codeLandedSettle on changed-files read error", got)
+	}
+	if sess.ReleasedForRedispatch {
+		t.Fatalf("a changed-files read error must not release the session")
+	}
+}
+
+func TestClassifyMergedCodeLanded_DocsOnlyIssueReadErrorHolds(t *testing.T) {
+	// The diff is confirmed non-functional, but the issue read (needed to check
+	// the bug label) failed: hold and retry rather than settle a possible
+	// docs-only bug delivery on incomplete evidence.
+	o := codeLandedTestOrchestrator([]string{"bug"}, []string{"docs/qa/rec.md"}, nil)
+	o.getIssueFn = func(number int) (github.Issue, error) {
+		return github.Issue{}, fmt.Errorf("issue read boom")
+	}
+	s := state.NewState()
+	sess := &state.Session{IssueNumber: 489, Status: state.StatusCodeLanded, PRNumber: 903}
+	s.Sessions["slot-d"] = sess
+
+	if got := o.classifyMergedCodeLandedDelivery(s, sess); got != codeLandedHold {
+		t.Fatalf("classify = %v, want codeLandedHold when a docs-only PR's issue read fails", got)
+	}
+	if sess.ReleasedForRedispatch {
+		t.Fatalf("an issue read error must not release the session")
+	}
+}
+
+func TestReconcileIneffectiveCodeLanded_ArmsThenConvicts(t *testing.T) {
+	o := codeLandedTestOrchestrator([]string{"bug"}, []string{"internal/state/state.go"}, nil)
+	s := state.NewState()
+	sess := &state.Session{IssueNumber: 490, Status: state.StatusCodeLanded, PRNumber: 904}
+	s.Sessions["slot-e"] = sess
+
+	failing := outcome.HealthCheckResult{
+		State:  outcome.HealthFailing,
+		Signal: "healthcheck_command",
+		Checks: []outcome.HealthCheckItem{{Name: "ok-player-boots", Blocking: true, Status: outcome.HealthFailing}},
+	}
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+
+	// First observation arms the deadline; must not convict yet.
+	if o.reconcileIneffectiveCodeLanded(s, sess, failing, t0) {
+		t.Fatalf("first failing observation must arm, not convict")
+	}
+	if sess.CodeLandedVerifyDeadline == nil || sess.OutcomeFailureFingerprint == "" {
+		t.Fatalf("deadline and fingerprint must be armed on first observation")
+	}
+	if sess.ReleasedForRedispatch {
+		t.Fatalf("must not release before the deadline elapses")
+	}
+
+	// Same fingerprint, still before deadline: keep holding.
+	if o.reconcileIneffectiveCodeLanded(s, sess, failing, t0.Add(time.Minute)) {
+		t.Fatalf("must not convict before the verification deadline")
+	}
+
+	// Same fingerprint, past deadline: ineffective -> released.
+	past := t0.Add(o.codeLandedVerifyGrace() + time.Minute)
+	if !o.reconcileIneffectiveCodeLanded(s, sess, failing, past) {
+		t.Fatalf("same failing fingerprint past the deadline must convict")
+	}
+	if !sess.ReleasedForRedispatch || sess.WorkerOutcome != state.WorkerOutcomeCodeLandedIneffective {
+		t.Fatalf("convicted session must be released as code_landed_ineffective, got released=%v outcome=%q",
+			sess.ReleasedForRedispatch, sess.WorkerOutcome)
+	}
+	if s.IssueInProgress(490) {
+		t.Fatalf("released ineffective session must not keep issue #490 in progress")
+	}
+}
+
+func TestReconcileIneffectiveCodeLanded_ChangedFingerprintReArms(t *testing.T) {
+	o := codeLandedTestOrchestrator([]string{"bug"}, nil, nil)
+	s := state.NewState()
+	sess := &state.Session{IssueNumber: 491, Status: state.StatusCodeLanded, PRNumber: 905}
+	s.Sessions["slot-f"] = sess
+
+	first := outcome.HealthCheckResult{
+		State:  outcome.HealthFailing,
+		Checks: []outcome.HealthCheckItem{{Name: "check-a", Blocking: true, Status: outcome.HealthFailing}},
+	}
+	second := outcome.HealthCheckResult{
+		State:  outcome.HealthFailing,
+		Checks: []outcome.HealthCheckItem{{Name: "check-b", Blocking: true, Status: outcome.HealthFailing}},
+	}
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+
+	o.reconcileIneffectiveCodeLanded(s, sess, first, t0)
+	firstDeadline := *sess.CodeLandedVerifyDeadline
+
+	// A different failure past the first deadline must RE-ARM, not convict:
+	// a new red check is not evidence the merged fix was ineffective.
+	past := t0.Add(o.codeLandedVerifyGrace() + time.Minute)
+	if o.reconcileIneffectiveCodeLanded(s, sess, second, past) {
+		t.Fatalf("a changed fingerprint must re-arm, not convict")
+	}
+	if sess.ReleasedForRedispatch {
+		t.Fatalf("changed fingerprint must not release the session")
+	}
+	if !sess.CodeLandedVerifyDeadline.After(firstDeadline) {
+		t.Fatalf("changed fingerprint must push the deadline forward")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1703,7 +1703,9 @@ func (o *Orchestrator) projectBoardSweepDue(now time.Time) bool {
 //   - running               => In Progress
 //   - queued / pr_open      => In Review
 //   - code_landed           => Deploying or Live Verification (depending on
-//     whether the outcome contract requires deploy)
+//     whether the outcome contract requires deploy), unless
+//     ReleasedForRedispatch (#1020) which maps to Todo so an issue whose merge
+//     did not fix it (docs-only / ineffective) stays runnable
 //   - done                  => Done
 //   - retry_exhausted /
 //     conflict_failed       => Blocked
@@ -1721,6 +1723,14 @@ func projectStatusForSession(sess *state.Session, requiresDeploy bool) (github.P
 	case state.StatusQueued, state.StatusPROpen:
 		return github.ProjectStatusInReview, true
 	case state.StatusCodeLanded:
+		// #1020: a code_landed session released for redispatch (docs-only /
+		// record-only delivery, or an ineffective fix whose blocking outcome
+		// check never recovered) did not settle its issue. Mirror it as runnable
+		// Todo, not Deploying/Live Verification, so the dynamic wave re-dispatches
+		// instead of leaving the issue stranded behind an ineffective merge.
+		if sess.ReleasedForRedispatch {
+			return github.ProjectStatusTodo, true
+		}
 		return codeLandedProjectStatusForSession(sess, requiresDeploy), true
 	case state.StatusDone:
 		return github.ProjectStatusDone, true
@@ -6316,7 +6326,11 @@ func (o *Orchestrator) reconcileCodeLandedSessions(s *state.State) {
 	codeLanded := make([]*state.Session, 0)
 	for _, slotName := range sortedStateSessionNames(s) {
 		sess := s.Sessions[slotName]
-		if sess != nil && sess.Status == state.StatusCodeLanded {
+		// #1020: a code_landed session already released for redispatch (docs-only
+		// record delivery or an ineffective fix) is terminal for reconciliation —
+		// it no longer owns its issue and must never be settled toward done, or a
+		// later cycle would re-close the issue the release just re-opened.
+		if sess != nil && sess.Status == state.StatusCodeLanded && !sess.ReleasedForRedispatch {
 			codeLanded = append(codeLanded, sess)
 		}
 	}
@@ -6347,6 +6361,15 @@ func (o *Orchestrator) reconcileCodeLandedSessions(s *state.State) {
 		checkedAt := time.Now().UTC()
 		sess.LastTerminalReconcileAt = &checkedAt
 		o.ensureMergedPRGateSnapshot(s, sess, checkedAt)
+		// #1020: before settling, inspect the merged diff. A bug issue whose PR
+		// changed only non-functional (docs/record) paths is a record delivery,
+		// not a fix: release it for fresh dispatch instead of silencing the issue.
+		switch o.classifyMergedCodeLandedDelivery(s, sess) {
+		case codeLandedRecordOnly:
+			continue // released for redispatch; must not settle the issue
+		case codeLandedHold:
+			continue // transient classification read error; retry next cycle
+		}
 		if !o.reconcileCodeLandedDelivery(s, sess) {
 			o.syncProject(sess.IssueNumber, github.ProjectStatusLiveVerify)
 			continue
@@ -6366,7 +6389,15 @@ func (o *Orchestrator) reconcileCodeLandedSessions(s *state.State) {
 		s.OutcomeHealth = &result
 		if result.State != outcome.HealthHealthy {
 			log.Printf("[orch] code_landed reconcile held: outcome verifier is %s: %s", result.State, result.Summary)
+			now := time.Now().UTC()
 			for _, sess := range ready {
+				// #1020 independent guard: a real code fix that merged but left the
+				// blocking outcome check failing with the SAME fingerprint past the
+				// verification deadline is ineffective — release it for redispatch
+				// instead of holding the issue in live-verification indefinitely.
+				if o.reconcileIneffectiveCodeLanded(s, sess, result, now) {
+					continue
+				}
 				o.syncProject(sess.IssueNumber, github.ProjectStatusLiveVerify)
 			}
 			return
@@ -6385,6 +6416,134 @@ func (o *Orchestrator) reconcileCodeLandedSessions(s *state.State) {
 				fmt.Sprintf("issue #%d resolved (verified merge) — repair worker moot", sess.IssueNumber))
 		}
 	}
+}
+
+// codeLandedVerifyGraceDefault is how long a code_landed session may keep
+// failing its blocking outcome check before the merge is judged ineffective
+// (#1020). It must exceed one terminalReconcileInterval so the same failure
+// fingerprint is observed on at least two independent cycles before conviction.
+const codeLandedVerifyGraceDefault = 30 * time.Minute
+
+func (o *Orchestrator) codeLandedVerifyGrace() time.Duration {
+	return codeLandedVerifyGraceDefault
+}
+
+// codeLandedClassification is the verdict of inspecting a merged code_landed PR
+// before it settles its issue (#1020).
+type codeLandedClassification int
+
+const (
+	codeLandedSettle     codeLandedClassification = iota // proceed to the normal settle path
+	codeLandedRecordOnly                                 // released as a docs/record delivery
+	codeLandedHold                                       // transient read error; retry next cycle
+)
+
+// classifyMergedCodeLandedDelivery inspects a merged code_landed session before
+// it settles its issue. For a bug-labelled issue whose merged PR changed only
+// non-functional (docs/record) paths, it releases the session for fresh
+// dispatch and returns codeLandedRecordOnly — the merge delivered evidence, not
+// a fix, so the issue must stay dispatchable rather than being silenced. A
+// transient GitHub read failure returns codeLandedHold so the caller retries
+// next cycle instead of settling on incomplete evidence. Every other case
+// (non-bug issue, or any functional path in the diff) returns codeLandedSettle.
+func (o *Orchestrator) classifyMergedCodeLandedDelivery(s *state.State, sess *state.Session) codeLandedClassification {
+	if sess == nil || sess.IssueNumber <= 0 || sess.PRNumber <= 0 || sess.ReleasedForRedispatch {
+		return codeLandedSettle
+	}
+	// Cheapest discriminator first: the changed-file set. A merged PR that
+	// touches any functional path is a fix and settles exactly as today. Only a
+	// fully non-functional diff is worth the extra issue read below, so a normal
+	// code PR (and any changed-files read failure) falls straight through to
+	// settle without ever calling getIssue — preserving the legacy close path.
+	files, err := o.prChangedFiles(sess.PRNumber)
+	if err != nil {
+		log.Printf("[orch] code_landed classify: changed-files lookup for PR #%d failed; settling on the legacy path: %v", sess.PRNumber, err)
+		return codeLandedSettle
+	}
+	if !pipeline.AllPathsNonFunctional(o.cfg.Supervisor.EffectiveNonFunctionalPaths(), files) {
+		return codeLandedSettle
+	}
+	// The diff is entirely non-functional. Only bug-labelled issues are guarded:
+	// a docs/enhancement issue may legitimately be closed by a docs-only PR.
+	issue, err := o.getIssue(sess.IssueNumber)
+	if err != nil {
+		log.Printf("[orch] code_landed classify: issue #%d lookup failed for a non-functional PR #%d; holding (will retry next cycle): %v", sess.IssueNumber, sess.PRNumber, err)
+		return codeLandedHold
+	}
+	if !github.HasLabel(issue, []string{"bug"}) {
+		return codeLandedSettle
+	}
+	o.releaseCodeLandedForRedispatch(s, sess, state.WorkerOutcomeRecordOnlyDelivery,
+		fmt.Sprintf("bug issue #%d merged PR #%d changed only non-functional paths (%s) — record delivery, not a fix",
+			sess.IssueNumber, sess.PRNumber, summarizeChangedPaths(files)))
+	if o.notifier != nil {
+		o.notifier.Sendf("♻️ maestro: PR #%d for bug issue #%d changed only documentation/record paths — released for fresh dispatch instead of settling the issue", sess.PRNumber, sess.IssueNumber)
+	}
+	return codeLandedRecordOnly
+}
+
+// reconcileIneffectiveCodeLanded is the independent #1020 guard: a code_landed
+// session whose real code change merged but whose blocking outcome check stayed
+// failing with the SAME fingerprint past the verification deadline is released
+// for fresh dispatch. Deterministic and logged. The deadline is armed the first
+// time a given failure fingerprint is observed; a changed fingerprint re-arms
+// (a new, different failure is not evidence the merged fix was ineffective).
+// Returns true only when it released the session.
+func (o *Orchestrator) reconcileIneffectiveCodeLanded(s *state.State, sess *state.Session, result outcome.HealthCheckResult, now time.Time) bool {
+	if sess == nil || sess.ReleasedForRedispatch {
+		return false
+	}
+	fp := state.OutcomeFailureFingerprint(result)
+	if fp == "" {
+		return false // pending/unknown/healthy: not a definite failure, keep holding
+	}
+	if sess.CodeLandedVerifyDeadline == nil || sess.OutcomeFailureFingerprint != fp {
+		deadline := now.Add(o.codeLandedVerifyGrace())
+		sess.CodeLandedVerifyDeadline = &deadline
+		sess.OutcomeFailureFingerprint = fp
+		log.Printf("[orch] issue #%d code_landed but blocking outcome check is failing (%s); verification deadline armed until %s",
+			sess.IssueNumber, fp, deadline.Format(time.RFC3339))
+		return false
+	}
+	if !state.CodeLandedIneffective(sess, result, now) {
+		return false
+	}
+	o.releaseCodeLandedForRedispatch(s, sess, state.WorkerOutcomeCodeLandedIneffective,
+		fmt.Sprintf("issue #%d code_landed via PR #%d but the blocking outcome check stayed failing with the same fingerprint (%s) past the verification deadline",
+			sess.IssueNumber, sess.PRNumber, fp))
+	if o.notifier != nil {
+		o.notifier.Sendf("♻️ maestro: PR #%d for issue #%d merged but the blocking outcome check never recovered — released for fresh dispatch (code_landed_ineffective)", sess.PRNumber, sess.IssueNumber)
+	}
+	return true
+}
+
+// releaseCodeLandedForRedispatch marks a code_landed session terminal-but-
+// released: it keeps its status and history (the PR really did merge) while
+// ReleasedForRedispatch drops its issue claim (state.sessionIssueClaim) and
+// maps the board to runnable Todo (projectStatusForSession), so the dynamic
+// wave dispatches a fresh worker within one cycle. State is persisted eagerly
+// so a crash before end-of-tick cannot resurrect the settled-but-ineffective
+// claim.
+func (o *Orchestrator) releaseCodeLandedForRedispatch(s *state.State, sess *state.Session, workerOutcome, reason string) {
+	sess.ReleasedForRedispatch = true
+	sess.WorkerOutcome = workerOutcome
+	o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
+	log.Printf("[orch] %s: %s — released for redispatch", workerOutcome, reason)
+	if strings.TrimSpace(o.cfg.StateDir) != "" {
+		if err := state.Save(o.cfg.StateDir, s); err != nil {
+			log.Printf("[orch] release for redispatch: state save failed for issue #%d: %v", sess.IssueNumber, err)
+		}
+	}
+}
+
+// summarizeChangedPaths renders a bounded, operator-facing list of changed
+// paths for a log line.
+func summarizeChangedPaths(files []string) string {
+	const max = 3
+	if len(files) <= max {
+		return strings.Join(files, ", ")
+	}
+	return fmt.Sprintf("%s, … (+%d more)", strings.Join(files[:max], ", "), len(files)-max)
 }
 
 // reconcileCodeLandedDelivery returns true only when no approval-gated

--- a/internal/pipeline/nonfunctional.go
+++ b/internal/pipeline/nonfunctional.go
@@ -1,0 +1,50 @@
+package pipeline
+
+// Non-functional change classification (#1020). A merged PR that touches only
+// non-functional paths (documentation, QA records) must not be treated as a
+// fix that settles a bug issue. The helpers here are deterministic and
+// side-effect free; they reuse the doublestar-style glob matcher from
+// MatchesVisualPath so path semantics stay identical across the codebase.
+
+// DefaultNonFunctionalPaths lists the glob patterns whose exclusive change in a
+// merged PR is a documentation/record delivery rather than a code fix. Projects
+// may extend this set via supervisor.non_functional_paths; docs/** is always
+// included.
+var DefaultNonFunctionalPaths = []string{"docs/**"}
+
+// MatchesPathGlob reports whether a repo-relative file path matches a single
+// doublestar-style glob pattern. It is a semantic alias for MatchesVisualPath
+// so callers classifying non-functional paths do not read as visual-evidence
+// logic.
+func MatchesPathGlob(pattern, file string) bool {
+	return MatchesVisualPath(pattern, file)
+}
+
+// AllPathsNonFunctional reports whether every changed path matches at least one
+// of the supplied non-functional globs. An empty changedFiles set returns false:
+// "no diff" is not evidence of a documentation-only delivery and must never
+// release an issue on its own. An empty patterns set falls back to
+// DefaultNonFunctionalPaths so a caller that forgot to configure the set still
+// gets the docs/** default rather than classifying everything as non-functional.
+func AllPathsNonFunctional(patterns, changedFiles []string) bool {
+	if len(changedFiles) == 0 {
+		return false
+	}
+	globs := patterns
+	if len(globs) == 0 {
+		globs = DefaultNonFunctionalPaths
+	}
+	for _, file := range changedFiles {
+		matched := false
+		for _, pattern := range globs {
+			if MatchesPathGlob(pattern, file) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/pipeline/nonfunctional_test.go
+++ b/internal/pipeline/nonfunctional_test.go
@@ -1,0 +1,71 @@
+package pipeline
+
+import "testing"
+
+func TestAllPathsNonFunctional(t *testing.T) {
+	cases := []struct {
+		name     string
+		patterns []string
+		files    []string
+		want     bool
+	}{
+		{
+			name:  "empty diff is never non-functional",
+			files: nil,
+			want:  false,
+		},
+		{
+			name:  "docs-only default matches",
+			files: []string{"docs/qa/ok-player-486.md"},
+			want:  true,
+		},
+		{
+			name:  "nested docs-only default matches",
+			files: []string{"docs/a/b/c/record.md", "docs/index.md"},
+			want:  true,
+		},
+		{
+			name:  "any code path fails the classification",
+			files: []string{"docs/qa/record.md", "internal/state/state.go"},
+			want:  false,
+		},
+		{
+			name:  "single code path fails",
+			files: []string{"cmd/maestro/main.go"},
+			want:  false,
+		},
+		{
+			name:     "project-extended set matches records dir",
+			patterns: []string{"docs/**", "qa/**"},
+			files:    []string{"qa/session-486.json", "docs/note.md"},
+			want:     true,
+		},
+		{
+			name:     "extended set still rejects unlisted code",
+			patterns: []string{"docs/**", "qa/**"},
+			files:    []string{"qa/session-486.json", "internal/orchestrator/orchestrator.go"},
+			want:     false,
+		},
+		{
+			name:  "top-level doc file is not under docs/",
+			files: []string{"README.md"},
+			want:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := AllPathsNonFunctional(tc.patterns, tc.files); got != tc.want {
+				t.Fatalf("AllPathsNonFunctional(%v, %v) = %v, want %v", tc.patterns, tc.files, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchesPathGlobDelegates(t *testing.T) {
+	if !MatchesPathGlob("docs/**", "docs/a/b.md") {
+		t.Fatalf("expected docs/** to match nested docs path")
+	}
+	if MatchesPathGlob("docs/**", "internal/x.go") {
+		t.Fatalf("expected docs/** not to match a code path")
+	}
+}

--- a/internal/state/code_landed.go
+++ b/internal/state/code_landed.go
@@ -1,0 +1,75 @@
+package state
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/outcome"
+)
+
+// Worker outcomes that mark a code_landed session as a delivery which did NOT
+// settle its issue (#1020). Both keep the session terminal for history while
+// ReleasedForRedispatch drops its issue claim so a fresh worker is dispatched.
+const (
+	// WorkerOutcomeRecordOnlyDelivery: the merged PR changed only non-functional
+	// (documentation/record) paths, so it delivered evidence, not a fix.
+	WorkerOutcomeRecordOnlyDelivery = "record_only_delivery"
+	// WorkerOutcomeCodeLandedIneffective: the merged PR was a real code change,
+	// but the blocking outcome check the issue targeted stayed failing with the
+	// same fingerprint past the post-merge verification deadline.
+	WorkerOutcomeCodeLandedIneffective = "code_landed_ineffective"
+)
+
+// OutcomeFailureFingerprint returns a stable identity for a FAILING outcome
+// health result, or "" when the result is not a definite failure. The
+// fingerprint intentionally derives only from durable, low-cardinality fields —
+// the failing blocking-check names+statuses, else the signal+exit code — so a
+// transient re-run of the same failure produces the same value while free-form
+// summary/detail text (timestamps, hostnames) never perturbs it. This is what
+// lets the ineffective-code_landed guard tell "the same red check is still red"
+// apart from "a new, different failure appeared".
+func OutcomeFailureFingerprint(result outcome.HealthCheckResult) string {
+	if !strings.EqualFold(strings.TrimSpace(result.State), outcome.HealthFailing) {
+		return ""
+	}
+	var blocking []string
+	for _, c := range result.Checks {
+		if !c.Blocking {
+			continue
+		}
+		if strings.EqualFold(strings.TrimSpace(c.Status), outcome.HealthHealthy) {
+			continue
+		}
+		name := strings.ToLower(strings.TrimSpace(c.Name))
+		status := strings.ToLower(strings.TrimSpace(c.Status))
+		blocking = append(blocking, name+"="+status)
+	}
+	if len(blocking) > 0 {
+		sort.Strings(blocking)
+		return "checks:" + strings.Join(blocking, ",")
+	}
+	signal := strings.ToLower(strings.TrimSpace(result.Signal))
+	if signal == "" {
+		signal = "outcome"
+	}
+	return "signal:" + signal + ":exit:" + strconv.Itoa(result.ExitCode)
+}
+
+// CodeLandedIneffective reports whether a code_landed session's post-merge
+// verification has definitively failed: the session is still holding its issue
+// (not already released), its verification deadline has elapsed, and the
+// blocking outcome check is STILL failing with the exact fingerprint recorded
+// when the deadline was armed. Deterministic and side-effect free so the
+// orchestrator wiring and unit tests share one definition.
+func CodeLandedIneffective(sess *Session, current outcome.HealthCheckResult, now time.Time) bool {
+	if sess == nil || sess.Status != StatusCodeLanded || sess.ReleasedForRedispatch {
+		return false
+	}
+	if sess.CodeLandedVerifyDeadline == nil || now.Before(*sess.CodeLandedVerifyDeadline) {
+		return false
+	}
+	fp := OutcomeFailureFingerprint(current)
+	return fp != "" && fp == sess.OutcomeFailureFingerprint
+}

--- a/internal/state/code_landed_test.go
+++ b/internal/state/code_landed_test.go
@@ -1,0 +1,141 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/outcome"
+)
+
+func failingOutcome(checkName string) outcome.HealthCheckResult {
+	return outcome.HealthCheckResult{
+		State:  outcome.HealthFailing,
+		Signal: "healthcheck_command",
+		Checks: []outcome.HealthCheckItem{
+			{Name: checkName, Blocking: true, Status: outcome.HealthFailing},
+		},
+	}
+}
+
+func TestOutcomeFailureFingerprint(t *testing.T) {
+	// Non-failing results have no fingerprint.
+	for _, st := range []string{outcome.HealthHealthy, outcome.HealthPending, outcome.HealthUnknown} {
+		if fp := OutcomeFailureFingerprint(outcome.HealthCheckResult{State: st}); fp != "" {
+			t.Fatalf("state %q: expected empty fingerprint, got %q", st, fp)
+		}
+	}
+
+	// Same failing blocking check => same fingerprint regardless of summary noise.
+	a := failingOutcome("ok-player-boots")
+	a.Summary = "run at 2026-07-20T01:02:03Z on host-a"
+	b := failingOutcome("ok-player-boots")
+	b.Summary = "run at 2026-07-21T09:09:09Z on host-b"
+	if OutcomeFailureFingerprint(a) == "" {
+		t.Fatalf("expected non-empty fingerprint for failing check")
+	}
+	if OutcomeFailureFingerprint(a) != OutcomeFailureFingerprint(b) {
+		t.Fatalf("same blocking check should fingerprint identically: %q vs %q",
+			OutcomeFailureFingerprint(a), OutcomeFailureFingerprint(b))
+	}
+
+	// A different failing check yields a different fingerprint.
+	if OutcomeFailureFingerprint(a) == OutcomeFailureFingerprint(failingOutcome("some-other-check")) {
+		t.Fatalf("different blocking checks must not share a fingerprint")
+	}
+
+	// Falls back to signal+exit code when no structured blocking checks exist.
+	sig := outcome.HealthCheckResult{State: outcome.HealthFailing, Signal: "healthcheck_url", ExitCode: 7}
+	if got := OutcomeFailureFingerprint(sig); got != "signal:healthcheck_url:exit:7" {
+		t.Fatalf("signal fallback fingerprint = %q", got)
+	}
+}
+
+func TestCodeLandedIneffective(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	past := now.Add(-time.Minute)
+	future := now.Add(time.Minute)
+	failing := failingOutcome("ok-player-boots")
+	fp := OutcomeFailureFingerprint(failing)
+
+	base := func() *Session {
+		return &Session{
+			Status:                    StatusCodeLanded,
+			CodeLandedVerifyDeadline:  &past,
+			OutcomeFailureFingerprint: fp,
+		}
+	}
+
+	t.Run("deadline passed with matching fingerprint is ineffective", func(t *testing.T) {
+		if !CodeLandedIneffective(base(), failing, now) {
+			t.Fatalf("expected ineffective when deadline passed and fingerprint matches")
+		}
+	})
+
+	t.Run("deadline in future holds", func(t *testing.T) {
+		sess := base()
+		sess.CodeLandedVerifyDeadline = &future
+		if CodeLandedIneffective(sess, failing, now) {
+			t.Fatalf("must not convict before the verification deadline")
+		}
+	})
+
+	t.Run("unarmed deadline holds", func(t *testing.T) {
+		sess := base()
+		sess.CodeLandedVerifyDeadline = nil
+		if CodeLandedIneffective(sess, failing, now) {
+			t.Fatalf("must not convict before a deadline is armed")
+		}
+	})
+
+	t.Run("changed fingerprint holds", func(t *testing.T) {
+		if CodeLandedIneffective(base(), failingOutcome("a-new-different-failure"), now) {
+			t.Fatalf("a different failure fingerprint must re-arm, not convict")
+		}
+	})
+
+	t.Run("healthy outcome holds", func(t *testing.T) {
+		if CodeLandedIneffective(base(), outcome.HealthCheckResult{State: outcome.HealthHealthy}, now) {
+			t.Fatalf("a recovered outcome must not be judged ineffective")
+		}
+	})
+
+	t.Run("already released does not re-trigger", func(t *testing.T) {
+		sess := base()
+		sess.ReleasedForRedispatch = true
+		if CodeLandedIneffective(sess, failing, now) {
+			t.Fatalf("an already-released session must not re-trigger")
+		}
+	})
+
+	t.Run("non code_landed status holds", func(t *testing.T) {
+		sess := base()
+		sess.Status = StatusDone
+		if CodeLandedIneffective(sess, failing, now) {
+			t.Fatalf("only code_landed sessions are subject to the guard")
+		}
+	})
+}
+
+func TestCodeLandedReleasedDropsIssueClaim(t *testing.T) {
+	s := NewState()
+	s.Sessions["slot-a"] = &Session{
+		IssueNumber: 486,
+		Status:      StatusCodeLanded,
+		PRNumber:    900,
+	}
+
+	if !s.IssueInProgress(486) {
+		t.Fatalf("a fresh code_landed session must claim its issue")
+	}
+
+	// Release it as a record-only delivery (docs-only merge).
+	s.Sessions["slot-a"].ReleasedForRedispatch = true
+	s.Sessions["slot-a"].WorkerOutcome = WorkerOutcomeRecordOnlyDelivery
+
+	if s.IssueInProgress(486) {
+		t.Fatalf("a released code_landed session must not keep the issue claimed")
+	}
+	if s.IssueDone(486) {
+		t.Fatalf("a released code_landed session must not report the issue done")
+	}
+}

--- a/internal/state/issue_claim.go
+++ b/internal/state/issue_claim.go
@@ -274,10 +274,23 @@ func sessionIssueClaim(slot string, sess *Session) (IssueClaim, bool) {
 		Status:      string(sess.Status),
 	}
 	switch sess.Status {
-	case StatusRunning, StatusQueued, StatusCodeLanded:
+	case StatusRunning, StatusQueued:
 		claim.Kind = IssueClaimImplementation
 		claim.Reason = fmt.Sprintf("issue #%d already has active session %s (%s)", sess.IssueNumber, slot, sess.Status)
 		return claim, true
+	case StatusCodeLanded:
+		// #1020: a code_landed session normally holds an implementation claim
+		// until post-merge verification settles the issue. But when that session
+		// is released for redispatch — because its merged PR delivered only
+		// non-functional (docs/record) changes, or its blocking outcome check
+		// stayed red past the verification deadline — the merge did NOT fix the
+		// issue. The claim must drop so the dynamic wave re-dispatches a fresh
+		// worker instead of silencing the issue behind an ineffective merge.
+		if !sess.ReleasedForRedispatch {
+			claim.Kind = IssueClaimImplementation
+			claim.Reason = fmt.Sprintf("issue #%d already has active session %s (%s)", sess.IssueNumber, slot, sess.Status)
+			return claim, true
+		}
 	case StatusPROpen:
 		claim.Kind = IssueClaimOpenPRMaintenance
 		claim.Reason = fmt.Sprintf("issue #%d is maintained by session %s for PR #%d", sess.IssueNumber, slot, sess.PRNumber)

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -262,6 +262,8 @@ type Session struct {
 	CheckpointFile              string            `json:"checkpoint_file,omitempty"`                // path to CHECKPOINT.md saved at soft token threshold
 	RestartCheckpointAt         *time.Time        `json:"restart_checkpoint_at,omitempty"`          // #877: set when the daemon deliberately checkpoints this still-running worker on shutdown (self-deploy/restart), because KillMode reaps the worker's cgroup once the daemon exits. A non-nil value tells the next daemon's reconcile to resume the SAME logical session in place exactly once — preserving the dirty worktree — instead of a false running->dead transition. Cleared as soon as the resume is attempted so it can never loop.
 	DeploymentFinishedAt        *time.Time        `json:"deployment_finished_at,omitempty"`         // set when the post-merge deploy hook succeeds
+	CodeLandedVerifyDeadline    *time.Time        `json:"code_landed_verify_deadline,omitempty"`    // #1020: when a code_landed session was first observed failing its blocking outcome check; past this the fix is judged ineffective if the SAME fingerprint persists
+	OutcomeFailureFingerprint   string            `json:"outcome_failure_fingerprint,omitempty"`    // #1020: stable identity of the blocking outcome failure captured when the deadline was armed; a changed fingerprint re-arms rather than convicting
 
 	// #705: opt-in verify.visual outcome for this session's PR. Set once by
 	// the orchestrator's merge flow: "not_required" (no UI paths touched),


### PR DESCRIPTION
Implements #1020

## Problem
A `code_landed` session permanently silenced its issue even when the merged PR fixed nothing. `IssueInProgress` counts `StatusCodeLanded`, so a bug issue whose worker merged a docs-only record stayed "already in progress" forever while post-merge verification kept failing, and the orchestrator never re-dispatched it. No code inspected the merged diff, so a docs-only merge and a real fix were indistinguishable.

## Changes
- **Path classification** (`internal/pipeline`): `AllPathsNonFunctional` + `DefaultNonFunctionalPaths` (`docs/**`), reusing the existing doublestar matcher.
- **Config** (`internal/config`): `supervisor.non_functional_paths` extends the default set; `EffectiveNonFunctionalPaths()` returns the union (docs always included).
- **State**: a `code_landed` session `ReleasedForRedispatch` no longer holds an implementation claim, so `IssueInProgress` returns false and the issue is dispatchable again. Adds deterministic `OutcomeFailureFingerprint` and `CodeLandedIneffective` helpers plus `record_only_delivery` / `code_landed_ineffective` worker outcomes.
- **Orchestrator**: before settling a merged `code_landed` session, classify the diff — a bug issue whose PR changed only non-functional paths is released as a record-only delivery (board mirrors runnable Todo) instead of settling. Independent guard: a session whose blocking outcome check stays failing with the same fingerprint past a verification deadline is released as `code_landed_ineffective`. A settled session and a real code fix behave exactly as today; changed-files read errors fall through to the legacy settle path.
- Closed/outcome-health semantics (#899/#970) are untouched.

## Testing
- `go test ./...`
- `go build ./cmd/maestro/`
- New unit tests: path classification, effective-paths union, outcome fingerprint, ineffective-deadline arm/convict/re-arm, docs-only release drops the issue claim, and orchestrator classification (docs-only bug released, functional bug settles, non-bug settles, read-error handling).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes ineffective bug deliveries eligible for redispatch. The main changes are:

- Classification of docs-only and configured non-functional diffs.
- Release of record-only and persistently failing merged sessions.
- Updated issue claims and project-board status for released sessions.
- Persisted verification deadlines and failure fingerprints.
- Tests for configuration, classification, state, and reconciliation.

<h3>Confidence Score: 4/5</h3>

The ineffective-merge attribution needs a fix before merging.

A repository-wide failing check can release unrelated merged sessions. Docs-only classification and released-session claim handling are otherwise consistent with the intended flow.

internal/orchestrator/orchestrator.go. The new state dependency does not introduce an import cycle.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced the shared-failure verification where two unrelated sessions with distinct merged code\_landed issues 1001 and 2002 share a fingerprint, exercising the real orchestrator and state reconciliation logic, and observed that after the grace period the unrelated issue B was ReleasedForRedispatch true with workerOutcome code\_landed\_ineffective due to the unchanged fingerprint.
- Before the API surface was added, the focused tests copied onto the parent revision failed to compile because the new classification, release, fingerprint, deadline, and path APIs did not exist.
- After the API surface was added, the same focused scope passed, with runtime logs showing that docs-only bug issue #486 was released for redispatch and issue #491's failure fingerprint was re-armed, and validation logs captured exact commands, working directory, outputs, and exit statuses for focused tests, full suite, and build.

<a href="https://app.greptile.com/trex/runs/15235512/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds merged-delivery classification and redispatch reconciliation, but attributes a shared outcome failure to every ready session. |
| internal/pipeline/nonfunctional.go | Adds deterministic classification of changed paths using the existing glob matcher. |
| internal/config/config.go | Adds configurable non-functional paths while retaining and deduplicating the default docs pattern. |
| internal/state/code_landed.go | Adds failure fingerprinting and deadline checks for ineffective merged sessions. |
| internal/state/issue_claim.go | Drops the implementation claim when a merged session is explicitly released for redispatch. |
| internal/state/state.go | Adds backward-compatible persisted fields for verification deadlines and fingerprints. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:6434
**Shared Failure Releases Unrelated Sessions**

The same repository-wide outcome result is applied to every ready `code_landed` session without linking the failing check to that session. If a check remains red because of issue A while an unrelated fix for issue B merges, B receives the same fingerprint and is released after 30 minutes even when its fix worked, causing duplicate dispatch instead of settlement.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-810-10..."](https://github.com/befeast/maestro/commit/a6e6922c99c531ad917abb172e972d2befc35d1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45934286)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->