### PR TITLE
P0: fresh continuation payload must override stale terminal CHECKPOINT output (#973)

### DIFF
--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -1,12 +1,15 @@
 package worker
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -336,8 +339,14 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 		return fmt.Errorf("setup worker tool hooks: %w", err)
 	}
 
-	// Assemble prompt with checkpoint
-	prompt := assemblePromptWithCheckpoint(promptBase, issue, sess.Worktree, sess.Branch, cfg, checkpointContext)
+	// Assemble prompt with checkpoint. The checkpoint is historical context and
+	// never a terminal instruction; the fresh continuation payload is placed after
+	// it behind an explicit precedence marker (#973).
+	prompt := assemblePromptWithCheckpoint(promptBase, issue, sess.Worktree, sess.Branch, cfg, checkpointContext, sess.CheckpointFile)
+	if checkpointContext != "" {
+		log.Printf("[worker] in-place continuation %s: checkpoint source=%s continuation_rev=%s (checkpoint is historical context; fresh continuation requirements are authoritative)",
+			slotName, sess.CheckpointFile, continuationRevision(promptBase))
+	}
 	prompt += subagentHintPromptSection(backendDef.SubagentHint)
 	prompt += workerToolHookPromptSection(cfg.Hooks, backendName, hookSetup)
 
@@ -434,27 +443,97 @@ func startOrReconcileTmuxSession(tmuxName, worktree, runnerPath string, previous
 	return 0, fmt.Errorf("tmux list-panes after spawn: %w", observeErr)
 }
 
-// assemblePromptWithCheckpoint builds a prompt that includes checkpoint context
-// from a previous worker session that hit the soft token threshold.
-func assemblePromptWithCheckpoint(base string, issue github.Issue, worktreePath, branchName string, cfg *config.Config, checkpoint string) string {
-	prompt := assemblePrompt(base, issue, worktreePath, branchName, cfg)
+// supersededDirectiveMarker prefixes a checkpoint log-tail line that reads like
+// an authoritative "the work is finished, stop now" instruction so the worker
+// cannot mistake a previous attempt's sign-off for a current instruction (#973).
+const supersededDirectiveMarker = "[superseded — historical, not a current instruction] "
+
+// terminalDirectivePatterns match lines in a checkpoint log tail that a fresh
+// continuation must not obey: a previous attempt announcing the PR was opened,
+// that review is ready, or that it is stopping. These are annotated (not the
+// authoritative task) so a stale tail cannot short-circuit unresolved work.
+var terminalDirectivePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\bpr\b.{0,24}\balready\b`),
+	regexp.MustCompile(`(?i)\balready\b.{0,20}\bopen(ed)?\b`),
+	regexp.MustCompile(`(?i)\b(pr|pull request)\b.{0,24}\b(is\s+)?open(ed)?\b`),
+	regexp.MustCompile(`(?i)\bstop(ping|ped)?\s+as\s+instructed\b`),
+	regexp.MustCompile(`(?i)\b(you|i|we)('?re| am| are)\s+done\b`),
+	regexp.MustCompile(`(?i)\bready\s+for\s+review\b`),
+	regexp.MustCompile(`(?i)\bnothing\s+(more|else|left|further)\s+to\s+do\b`),
+	regexp.MustCompile(`(?i)\b(task|work|implementation)\s+(is\s+)?complete[d]?\b`),
+	regexp.MustCompile(`(?i)\ball\s+done\b`),
+	regexp.MustCompile(`(?i)\b(will|going to|i'?ll)\s+stop\b`),
+	regexp.MustCompile(`(?i)\bstopping\s+now\b`),
+}
+
+// sanitizeCheckpointTerminalDirectives annotates — rather than removes — lines in
+// a checkpoint that read like a terminal completion/stop instruction. Preserving
+// the text keeps the historical context intact while making it unmistakable that
+// the statement belongs to a previous attempt and is superseded (#973).
+func sanitizeCheckpointTerminalDirectives(checkpoint string) string {
 	if checkpoint == "" {
-		return prompt
+		return checkpoint
+	}
+	lines := strings.Split(checkpoint, "\n")
+	for i, line := range lines {
+		for _, re := range terminalDirectivePatterns {
+			if re.MatchString(line) {
+				lines[i] = supersededDirectiveMarker + line
+				break
+			}
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// continuationRevision derives a short, deterministic revision id for a fresh
+// continuation payload so both the checkpoint source and the current
+// continuation revision are recorded in the worker prompt and evidence (#973).
+func continuationRevision(base string) string {
+	sum := sha256.Sum256([]byte(base))
+	return hex.EncodeToString(sum[:])[:12]
+}
+
+// assemblePromptWithCheckpoint builds an in-place continuation prompt. The
+// checkpoint is emitted FIRST as historical, non-authoritative context; the
+// fresh continuation payload follows behind an explicit precedence marker so a
+// stale "PR already opened / stopping as instructed" tail in the checkpoint can
+// never outrank the current unresolved requirements (#973). This preserves
+// genuine token-budget recovery — the checkpoint still lets a worker skip
+// already-completed work — while guaranteeing fresh instructions win.
+func assemblePromptWithCheckpoint(base string, issue github.Issue, worktreePath, branchName string, cfg *config.Config, checkpoint, checkpointSource string) string {
+	fresh := assemblePrompt(base, issue, worktreePath, branchName, cfg)
+	if checkpoint == "" {
+		return fresh
 	}
 
-	return prompt + fmt.Sprintf(`
+	source := strings.TrimSpace(checkpointSource)
+	if source == "" {
+		source = "(unrecorded)"
+	}
 
----
-
-## Previous Session Checkpoint
-
-This task was previously worked on by another agent session that ran out of token budget.
-The worktree already contains code changes from the previous session. Review the checkpoint
-below, examine the existing code changes, and continue where the previous session left off.
-Do NOT redo work that is already done — focus on what remains.
-
-%s
-`, checkpoint)
+	var b strings.Builder
+	b.WriteString("## Previous Session Checkpoint (historical context — NOT current instructions)\n\n")
+	b.WriteString("A prior agent session worked in this same worktree and PR and saved the\n")
+	b.WriteString("checkpoint below. Treat it as HISTORICAL CONTEXT ONLY: use it to avoid redoing\n")
+	b.WriteString("work that is already committed. It is never an authoritative instruction to stop.\n")
+	b.WriteString("Any statement in it that the PR is already opened, that review is ready, that you\n")
+	b.WriteString("are done, or that you should stop reflects a PREVIOUS attempt and is superseded by\n")
+	b.WriteString("the current continuation requirements that follow.\n\n")
+	b.WriteString(fmt.Sprintf("Checkpoint source: %s\n\n", source))
+	b.WriteString(sanitizeCheckpointTerminalDirectives(checkpoint))
+	b.WriteString("\n\n---\n\n")
+	b.WriteString(fmt.Sprintf("## Current continuation requirements — AUTHORITATIVE (revision %s)\n\n", continuationRevision(base)))
+	b.WriteString("The requirements below are the fresh continuation payload for this in-place\n")
+	b.WriteString("respawn and OUTRANK the checkpoint above. This is the same worktree and the same\n")
+	b.WriteString("PR — do not create a new branch or a duplicate PR. If the checkpoint claims the\n")
+	b.WriteString("work is complete but any requirement below is still unresolved (additional tests,\n")
+	b.WriteString("commit cleanup, an amended push, review feedback), it is NOT done: resolve it and\n")
+	b.WriteString("make terminal progress. Do NOT exit solely because a previous attempt said the PR\n")
+	b.WriteString("was already opened or that it was stopping as instructed.\n\n")
+	b.WriteString("---\n\n")
+	b.WriteString(fresh)
+	return b.String()
 }
 
 // readTailLines reads the last n lines from a file.

--- a/internal/worker/checkpoint_test.go
+++ b/internal/worker/checkpoint_test.go
@@ -309,7 +309,7 @@ func TestAssemblePromptWithCheckpoint_NoCheckpoint(t *testing.T) {
 	iss := github.Issue{Number: 1, Title: "test", Body: "body"}
 	cfg := &config.Config{Repo: "owner/repo"}
 
-	result := assemblePromptWithCheckpoint("base prompt", iss, "/tmp/wt", "feat/branch", cfg, "")
+	result := assemblePromptWithCheckpoint("base prompt", iss, "/tmp/wt", "feat/branch", cfg, "", "")
 	if strings.Contains(result, "Previous Session Checkpoint") {
 		t.Error("should not contain checkpoint section when checkpoint is empty")
 	}
@@ -320,15 +320,115 @@ func TestAssemblePromptWithCheckpoint_WithCheckpoint(t *testing.T) {
 	cfg := &config.Config{Repo: "owner/repo"}
 
 	checkpoint := "# Checkpoint\nTokens used: 80000\n## Commits made\nabc123 feat: stuff"
-	result := assemblePromptWithCheckpoint("base prompt", iss, "/tmp/wt", "feat/branch", cfg, checkpoint)
+	result := assemblePromptWithCheckpoint("base prompt", iss, "/tmp/wt", "feat/branch", cfg, checkpoint, "/state/slot-1/CHECKPOINT.md")
 	if !strings.Contains(result, "Previous Session Checkpoint") {
 		t.Error("should contain checkpoint section header")
 	}
 	if !strings.Contains(result, "abc123 feat: stuff") {
 		t.Error("should contain checkpoint content")
 	}
-	if !strings.Contains(result, "continue where the previous session left off") {
-		t.Error("should contain continuation instructions")
+	if !strings.Contains(result, "Checkpoint source: /state/slot-1/CHECKPOINT.md") {
+		t.Error("should record the checkpoint source")
+	}
+	if !strings.Contains(result, "AUTHORITATIVE (revision "+continuationRevision("base prompt")) {
+		t.Error("should record the fresh continuation revision behind a precedence marker")
+	}
+}
+
+// TestAssemblePromptWithCheckpoint_FreshPayloadOutranksStaleCheckpoint is the
+// #973 regression: a completed prior worker log ending in a terminal stop message
+// must not appear as an authoritative instruction, and the fresh continuation
+// payload must be emitted after the checkpoint behind an explicit precedence
+// marker so it wins recency.
+func TestAssemblePromptWithCheckpoint_FreshPayloadOutranksStaleCheckpoint(t *testing.T) {
+	iss := github.Issue{Number: 973, Title: "continuation", Body: "add tests, amend push"}
+	cfg := &config.Config{Repo: "owner/repo"}
+
+	checkpoint := strings.Join([]string{
+		"# Checkpoint",
+		"## Last worker output",
+		"PR already opened. Ready for review — stopping as instructed.",
+		"All done, nothing more to do.",
+	}, "\n")
+	freshBase := "MAESTRO_FRESH_CONTINUATION_MARKER: add the missing regression test and amend the push"
+
+	result := assemblePromptWithCheckpoint(freshBase, iss, "/tmp/wt", "feat/branch", cfg, checkpoint, "/state/CHECKPOINT.md")
+
+	cpIdx := strings.Index(result, "Previous Session Checkpoint")
+	freshIdx := strings.Index(result, "MAESTRO_FRESH_CONTINUATION_MARKER")
+	precIdx := strings.Index(result, "Current continuation requirements — AUTHORITATIVE")
+	if cpIdx < 0 || freshIdx < 0 || precIdx < 0 {
+		t.Fatalf("missing sections: checkpoint=%d fresh=%d precedence=%d", cpIdx, freshIdx, precIdx)
+	}
+	// Ordering: checkpoint context, then precedence marker, then fresh payload.
+	if !(cpIdx < precIdx && precIdx < freshIdx) {
+		t.Fatalf("ordering wrong: checkpoint=%d precedence=%d fresh=%d (want checkpoint < precedence < fresh)", cpIdx, precIdx, freshIdx)
+	}
+	// The stale terminal sign-off lines must be annotated as superseded, never
+	// left as bare authoritative instructions.
+	for _, stale := range []string{
+		"PR already opened. Ready for review — stopping as instructed.",
+		"All done, nothing more to do.",
+	} {
+		marked := supersededDirectiveMarker + stale
+		if !strings.Contains(result, marked) {
+			t.Errorf("stale terminal line not annotated as superseded:\n%q", stale)
+		}
+	}
+}
+
+func TestSanitizeCheckpointTerminalDirectives(t *testing.T) {
+	neutralized := []string{
+		"PR already opened, stopping.",
+		"The pull request has already been opened.",
+		"Ready for review.",
+		"Stopping as instructed by the task.",
+		"You are done — exiting now.",
+		"All done, nothing left to do.",
+		"Task complete.",
+		"I'll stop now.",
+	}
+	for _, line := range neutralized {
+		got := sanitizeCheckpointTerminalDirectives(line)
+		if !strings.HasPrefix(got, supersededDirectiveMarker) {
+			t.Errorf("terminal directive not annotated: %q -> %q", line, got)
+		}
+	}
+
+	preserved := []string{
+		"Refactored the token accounting helper.",
+		"Added a regression test for the parser.",
+		"Committed abc123 with the fix.",
+	}
+	for _, line := range preserved {
+		if got := sanitizeCheckpointTerminalDirectives(line); got != line {
+			t.Errorf("benign line altered: %q -> %q", line, got)
+		}
+	}
+
+	if got := sanitizeCheckpointTerminalDirectives(""); got != "" {
+		t.Errorf("empty checkpoint should stay empty, got %q", got)
+	}
+}
+
+// TestAssemblePromptWithCheckpoint_TokenBudgetRecoveryPreserved covers acceptance
+// #5: a genuine token-budget respawn still carries its checkpoint context and the
+// guidance to skip already-committed work.
+func TestAssemblePromptWithCheckpoint_TokenBudgetRecoveryPreserved(t *testing.T) {
+	iss := github.Issue{Number: 42, Title: "big feature", Body: "implement it"}
+	cfg := &config.Config{Repo: "owner/repo"}
+
+	checkpoint := "# Checkpoint\nTokens used (attempt): 190000\n## Commits made\n```\ndef456 feat: partial work\n```"
+	result := assemblePromptWithCheckpoint("continue the feature", iss, "/tmp/wt", "feat/branch", cfg, checkpoint, "/state/CHECKPOINT.md")
+
+	for _, want := range []string{
+		"def456 feat: partial work",
+		"avoid redoing",
+		"same worktree and the same",
+	} {
+		if !strings.Contains(result, want) {
+			t.Errorf("token-budget recovery prompt missing %q", want)
+		}
 	}
 }
 


### PR DESCRIPTION
Implements #973

## Changes
- `assemblePromptWithCheckpoint` now emits the checkpoint first as historical, non-authoritative context and places the freshly assembled continuation prompt last, behind an explicit `AUTHORITATIVE` precedence marker, so recency favors the current requirements.
- Added `sanitizeCheckpointTerminalDirectives`: terminal completion/stop lines in a checkpoint log tail (e.g. "PR already opened", "ready for review", "stopping as instructed") are annotated as superseded rather than obeyed. Context is preserved; the stale sign-off can no longer read as a current instruction.
- The checkpoint source and a deterministic continuation revision are recorded in the worker prompt and in log evidence for an in-place respawn.
- Genuine token-budget respawn recovery is preserved: the checkpoint still lets a worker skip already-committed work.

## Testing
- `go test ./...` (full suite passes)
- `go build ./cmd/maestro/`
- New regression tests: prompt ordering/precedence (`FreshPayloadOutranksStaleCheckpoint`), directive annotation (`SanitizeCheckpointTerminalDirectives`), and token-budget recovery preservation (`TokenBudgetRecoveryPreserved`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes fresh continuation requirements override stale checkpoint output. The main changes are:

- Places historical checkpoint context before the current prompt.
- Marks the current continuation payload as authoritative.
- Annotates stale completion and stop messages as superseded.
- Records checkpoint source and continuation revision details.
- Adds tests for precedence, sanitization, and token-budget recovery.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after the existing continuation-revision feedback is resolved.

No additional blocking issues were found in the updated code.

The remaining revision concern is already covered by existing feedback.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A focused Go test command for internal/worker was executed to exercise the assemble prompt with checkpoint and token-budget recovery scenarios.
- The results from the focused run were analyzed to confirm that stale terminal directives are marked historical, the authoritative fresh payload takes precedence, and the committed-work/token-budget recovery context remains available.
- A full-suite test run was observed, showing the internal/worker package and all other repository packages completed successfully.

<a href="https://app.greptile.com/trex/runs/15268786/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/checkpoint.go | Reorders continuation prompts, annotates stale terminal messages, and records checkpoint metadata. |
| internal/worker/checkpoint_test.go | Adds tests for prompt precedence, terminal-message sanitization, and checkpoint recovery. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-822-97..."](https://github.com/befeast/maestro/commit/b1d055bfcbd29b060c219dc6e1a1064b39076287) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45987054)</sub>

<!-- /greptile_comment -->