### PR TITLE
feat: reap orphan container-client wrappers after the container exits (#977)

### DIFF
--- a/internal/orphan/actuator_os.go
+++ b/internal/orphan/actuator_os.go
@@ -1,0 +1,116 @@
+package orphan
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// OSActuator is the real host Actuator: it terminates a wrapper process group
+// with a signal to the negative pgid and removes an exited container with
+// `docker rm`. The runtime injects it into a Reaper; unit tests use a fake so
+// they never touch real processes or Docker.
+//
+// It is intentionally conservative:
+//
+//   - TerminateGroup sends SIGTERM to the whole group, waits a bounded grace
+//     period for the group to exit, then escalates to SIGKILL only if it is
+//     still present. A process group that has already exited is a success.
+//   - RemoveContainer only ever removes; it never force-stops a running
+//     container. The Decide plan already guarantees the container is terminal,
+//     and `docker rm` of an already-absent container is treated as success.
+//
+// This type is complete and reviewable, but wiring it into the running daemon
+// loop plus live host verification is a separate operator step (#977): reaping
+// real processes and containers must be confirmed against a live host before it
+// is armed automatically.
+type OSActuator struct {
+	// KillGrace is how long to wait after SIGTERM before escalating to SIGKILL.
+	// Zero uses a 5s default.
+	KillGrace time.Duration
+	// DockerArgs is prepended to `rm <name>` so an operator can route removal
+	// through `sudo docker` when the wrappers ran under sudo. Default: {"docker"}.
+	DockerArgs []string
+	// killGroup / removeContainer are indirections for tests of OSActuator
+	// itself; production leaves them nil and the real implementations are used.
+	killGroup       func(pgid int, sig syscall.Signal) error
+	groupAlive      func(pgid int) bool
+	removeContainer func(ctx context.Context, args []string) error
+}
+
+// TerminateGroup signals the whole process group, escalating SIGTERM -> SIGKILL.
+func (a *OSActuator) TerminateGroup(pgid int, pids []int) error {
+	if pgid <= 1 {
+		// Refuse to signal pgid 0/1: 0 would target the caller's own group and 1
+		// is init. An orphan wrapper always has its own real group id.
+		return fmt.Errorf("refusing to signal unsafe process group %d", pgid)
+	}
+	kill := a.killGroup
+	if kill == nil {
+		kill = func(pg int, sig syscall.Signal) error { return syscall.Kill(-pg, sig) }
+	}
+	alive := a.groupAlive
+	if alive == nil {
+		alive = func(pg int) bool { return syscall.Kill(-pg, 0) == nil }
+	}
+
+	if err := kill(pgid, syscall.SIGTERM); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return nil // already gone
+		}
+		return fmt.Errorf("sigterm group: %w", err)
+	}
+
+	grace := a.KillGrace
+	if grace <= 0 {
+		grace = 5 * time.Second
+	}
+	deadline := time.Now().Add(grace)
+	for time.Now().Before(deadline) {
+		if !alive(pgid) {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !alive(pgid) {
+		return nil
+	}
+	if err := kill(pgid, syscall.SIGKILL); err != nil {
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return fmt.Errorf("sigkill group: %w", err)
+	}
+	return nil
+}
+
+// RemoveContainer removes the exited named container via `docker rm`.
+func (a *OSActuator) RemoveContainer(name string) error {
+	if name == "" {
+		return errors.New("empty container name")
+	}
+	base := a.DockerArgs
+	if len(base) == 0 {
+		base = []string{"docker"}
+	}
+	args := append(append([]string(nil), base...), "rm", name)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	run := a.removeContainer
+	if run == nil {
+		run = func(ctx context.Context, args []string) error {
+			cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+			return cmd.Run()
+		}
+	}
+	if err := run(ctx, args); err != nil {
+		return fmt.Errorf("docker rm: %w", err)
+	}
+	return nil
+}
+
+var _ Actuator = (*OSActuator)(nil)

--- a/internal/orphan/orphan.go
+++ b/internal/orphan/orphan.go
@@ -1,0 +1,408 @@
+// Package orphan detects and reaps orphaned container-client wrapper processes
+// left behind by a container-backed verification command whose worker/session
+// has already finished (#977).
+//
+// Incident that motivated it: a completed packaging worker left a parentless
+// three-process `sudo docker run` / `docker run` wrapper chain alive for more
+// than 11 hours. The named container itself had exited (code 127) about 17
+// minutes after start and the retained worktree was gone, but the client
+// wrappers remained with PPID=1. Maestro had already completed the authoritative
+// later session and neither surfaced nor reaped the orphan.
+//
+// The invariant this package enforces: a container-backed verification command
+// must not outlive its worker/session once the container is terminal. Parentless
+// client wrappers tied to a terminal container and a non-live/superseded session
+// are zombies, not active work.
+//
+// Design mirrors internal/progress: a pure leaf package (standard library only)
+// with an injected clock so both the durable state layer and the runtime loops
+// can share one decision without an import cycle, and so every decision is
+// deterministic and unit-testable. No command line, mount, environment value,
+// host path, or secret is ever modeled or persisted here — only bounded process
+// and container identity plus lifecycle state.
+//
+// The package deliberately separates three concerns:
+//
+//   - Plan is a pure decision: given an observed snapshot of wrappers,
+//     containers, and session liveness it returns exactly which process groups
+//     to terminate and which exited containers to remove, and — just as
+//     importantly — which observations were deliberately preserved and why.
+//   - Reaper.Reap executes a Plan against an injected Actuator, so the host
+//     side effects (signalling a process group, `docker rm`) are testable with a
+//     fake and swappable for the real OSActuator.
+//   - Cleanup is the durable, secret-free evidence record of what was reaped.
+//     It is intentionally distinct from a progress watermark: reaping a zombie is
+//     a cleanup, never material progress, so an orphan can never be miscounted as
+//     the owning session making headway.
+package orphan
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ContainerState is the observed lifecycle state of a named Docker container
+// that backs a verification command. ContainerUnknown means the container was
+// not observable this tick, which is loss of observability, not proof that it
+// is terminal — the reaper treats it as a reason to preserve, never to reap.
+type ContainerState string
+
+const (
+	ContainerRunning ContainerState = "running"
+	ContainerCreated ContainerState = "created"
+	ContainerExited  ContainerState = "exited"
+	ContainerDead    ContainerState = "dead"
+	ContainerUnknown ContainerState = ""
+)
+
+// IsTerminal reports whether the container has stopped executing and can never
+// resume, so any client wrapper still blocked on it is waiting on nothing.
+func (s ContainerState) IsTerminal() bool {
+	return s == ContainerExited || s == ContainerDead
+}
+
+// IsActive reports whether the container is still (or not yet finished) running
+// real work. An active container is always preserved: its wrappers are doing
+// genuine work, not lingering.
+func (s ContainerState) IsActive() bool {
+	return s == ContainerRunning || s == ContainerCreated
+}
+
+// Container is the observed identity and lifecycle state of one named Docker
+// container. It carries only bounded identity (the --name and correlated
+// session/issue) and state — never the command line, mounts, env, or host path.
+type Container struct {
+	// Name is the docker --name assigned to the container. It is the join key
+	// between a wrapper process and the container it launched.
+	Name string
+	// State is the observed lifecycle state.
+	State ContainerState
+	// ExitCode is the container's exit status when terminal (nil while running,
+	// created, or unobservable). Recorded for evidence only; a non-zero exit is
+	// not required for reaping — a terminal container is terminal regardless.
+	ExitCode *int
+	// SessionID is the owning maestro session, when the container could be
+	// correlated back to one. Empty means the correlation is unknown, which the
+	// reaper treats as non-live (a container no live session claims is not
+	// active work).
+	SessionID string
+	// IssueNumber is the owning issue, for evidence only.
+	IssueNumber int
+	// FinishedAt is when the container reached a terminal state; zero while it
+	// is still running or unobservable.
+	FinishedAt time.Time
+}
+
+// Wrapper is one observed Docker client wrapper process in the run chain
+// (`sudo docker run` / `docker run`). The incident chain was three such
+// processes sharing one process group; the reaper terminates the group, not an
+// individual pid, so a partial chain can never be left behind.
+type Wrapper struct {
+	// PID is the wrapper process id.
+	PID int
+	// PPID is the wrapper's parent pid. PPID==1 means it was reparented to init:
+	// its launching worker/session process is gone.
+	PPID int
+	// PGID is the wrapper's process-group id. The reaper signals the whole group.
+	PGID int
+	// ContainerName is the --name of the container this wrapper is running, i.e.
+	// the join key back to a Container.
+	ContainerName string
+	// SessionID is the owning maestro session, when known.
+	SessionID string
+	// StartedAt is when the wrapper process started, used only for the grace
+	// window that avoids racing a just-launched command.
+	StartedAt time.Time
+}
+
+// Parentless reports whether the wrapper has been reparented to init (PPID==1),
+// i.e. the worker/session that launched it has already exited. A wrapper that
+// still has a live, non-init parent is part of an active process tree and is
+// never reaped by this package.
+func (w Wrapper) Parentless() bool {
+	return w.PPID == 1
+}
+
+// Snapshot is one complete, atomically-collected observation of the container
+// client wrappers, the containers they name, and which sessions are still live.
+// A complete snapshot is required so a single missing container reading cannot
+// make an active wrapper look orphaned.
+type Snapshot struct {
+	// Wrappers is every observed docker client wrapper process.
+	Wrappers []Wrapper
+	// Containers is every observed named container relevant to those wrappers.
+	Containers []Container
+	// LiveSessions maps sessionID -> true for every session that is still doing
+	// live work. A session absent from this map (or mapped to false) is
+	// non-live/superseded: its container work, if terminal, may be reaped.
+	LiveSessions map[string]bool
+	// Now is the injected evaluation clock.
+	Now time.Time
+	// MinAge is the grace window: a parentless wrapper younger than MinAge is
+	// preserved so the reaper never races a command that was launched moments
+	// ago. Zero disables the grace window.
+	MinAge time.Duration
+}
+
+// ReapReason is a bounded, secret-free token explaining why a group was reaped.
+type ReapReason string
+
+const (
+	// ReapTerminalContainerNonLiveSession is the canonical incident: the named
+	// container is terminal (exited/dead) and no live session owns it, yet a
+	// parentless wrapper is still blocked on it.
+	ReapTerminalContainerNonLiveSession ReapReason = "terminal_container_nonlive_session"
+	// ReapContainerGoneParentlessWrapper covers a parentless wrapper whose named
+	// container has already been removed (not observable at all): there is no
+	// container left to wait on, so the wrapper is a definite zombie.
+	ReapContainerGoneParentlessWrapper ReapReason = "container_gone_parentless_wrapper"
+)
+
+// PreserveReason is a bounded token explaining why an observation was kept.
+type PreserveReason string
+
+const (
+	// PreserveContainerActive keeps every wrapper whose container is still
+	// running/created: that is genuinely active work.
+	PreserveContainerActive PreserveReason = "container_active"
+	// PreserveSessionLive keeps a wrapper whose owning session is still live,
+	// even if the container reading looked terminal — a live session is the
+	// authority on whether its own container work is done.
+	PreserveSessionLive PreserveReason = "session_live"
+	// PreserveWrapperHasLiveParent keeps a wrapper that still has a non-init
+	// parent: it is part of an active process tree, not an orphan.
+	PreserveWrapperHasLiveParent PreserveReason = "wrapper_has_live_parent"
+	// PreserveWithinGrace keeps a parentless wrapper younger than the grace
+	// window so a just-launched command is never raced.
+	PreserveWithinGrace PreserveReason = "within_grace_period"
+	// PreserveContainerStateUnknown keeps a wrapper whose container could not be
+	// observed this tick: loss of observability is not proof of a terminal
+	// container, so the reaper fails safe.
+	PreserveContainerStateUnknown PreserveReason = "container_state_unknown"
+)
+
+// WrapperGroup is one process group selected for termination. The reaper always
+// operates on the whole group so a partial wrapper chain is never left behind.
+type WrapperGroup struct {
+	PGID          int
+	PIDs          []int
+	ContainerName string
+	SessionID     string
+	Reason        ReapReason
+}
+
+// Preservation records one observation the plan deliberately kept, with the
+// bounded reason, so operator evidence can show the reaper is conservative:
+// active containers and live sessions are never touched.
+type Preservation struct {
+	ContainerName string
+	SessionID     string
+	PID           int
+	Reason        PreserveReason
+}
+
+// Plan is the pure decision for one snapshot: the process groups to terminate,
+// the terminal containers safe to remove, and the observations preserved. It
+// performs no side effects; Reaper.Reap actuates it.
+type Plan struct {
+	EvaluatedAt      time.Time
+	TerminateGroups  []WrapperGroup
+	RemoveContainers []Container
+	Preserved        []Preservation
+}
+
+// Empty reports whether the plan reaps nothing.
+func (p Plan) Empty() bool {
+	return len(p.TerminateGroups) == 0 && len(p.RemoveContainers) == 0
+}
+
+// Decide computes the pure reap plan for a snapshot. It never mutates the
+// snapshot and never performs a side effect.
+//
+// A wrapper is reaped only when every one of these holds:
+//
+//   - it is parentless (PPID==1) — its launching worker/session is gone;
+//   - it is older than the grace window (so a just-launched command is safe);
+//   - its named container is terminal (exited/dead) or has already been removed
+//     — an active or unobservable container always preserves the wrapper;
+//   - no live session owns the wrapper or its container — a live session is the
+//     authority on its own in-flight container work.
+//
+// A terminal named container is scheduled for removal only when it is terminal,
+// no live session owns it, and every wrapper still naming it is itself a reap
+// candidate. That keeps removal safe even if the container reading and the
+// process reading momentarily disagree.
+func Decide(s Snapshot) Plan {
+	now := s.Now.UTC()
+	plan := Plan{EvaluatedAt: now}
+
+	containersByName := make(map[string]Container, len(s.Containers))
+	for _, c := range s.Containers {
+		containersByName[strings.TrimSpace(c.Name)] = c
+	}
+
+	// A session is live only if it is explicitly present and true. Empty session
+	// ids are never live (a wrapper/container no session claims is not work).
+	sessionLive := func(id string) bool {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			return false
+		}
+		return s.LiveSessions[id]
+	}
+
+	// Group wrappers by process group so we terminate whole chains and can prove
+	// every wrapper naming a container is reapable before removing it.
+	type groupAcc struct {
+		pgid          int
+		containerName string
+		sessionID     string
+		pids          []int
+		reason        ReapReason
+		reap          bool
+	}
+	groups := make(map[int]*groupAcc)
+	groupOrder := make([]int, 0)
+
+	// containerReapable tracks, per container name, whether every wrapper naming
+	// it was a reap candidate (starts true, cleared by any preserved wrapper).
+	containerReapable := make(map[string]bool)
+	containerSeenByWrapper := make(map[string]bool)
+
+	for _, w := range s.Wrappers {
+		name := strings.TrimSpace(w.ContainerName)
+		containerSeenByWrapper[name] = true
+		if _, ok := containerReapable[name]; !ok {
+			containerReapable[name] = true
+		}
+
+		reap, reapReason, preserveReason := classifyWrapper(w, containersByName, sessionLive, now, s.MinAge)
+		if !reap {
+			containerReapable[name] = false
+			plan.Preserved = append(plan.Preserved, Preservation{
+				ContainerName: name,
+				SessionID:     strings.TrimSpace(w.SessionID),
+				PID:           w.PID,
+				Reason:        preserveReason,
+			})
+			continue
+		}
+
+		acc := groups[w.PGID]
+		if acc == nil {
+			acc = &groupAcc{pgid: w.PGID, containerName: name, sessionID: strings.TrimSpace(w.SessionID), reason: reapReason}
+			groups[w.PGID] = acc
+			groupOrder = append(groupOrder, w.PGID)
+		}
+		acc.pids = append(acc.pids, w.PID)
+		acc.reap = true
+		if acc.containerName == "" {
+			acc.containerName = name
+		}
+		if acc.sessionID == "" {
+			acc.sessionID = strings.TrimSpace(w.SessionID)
+		}
+	}
+
+	for _, pgid := range groupOrder {
+		acc := groups[pgid]
+		if !acc.reap {
+			continue
+		}
+		pids := append([]int(nil), acc.pids...)
+		sort.Ints(pids)
+		plan.TerminateGroups = append(plan.TerminateGroups, WrapperGroup{
+			PGID:          acc.pgid,
+			PIDs:          pids,
+			ContainerName: acc.containerName,
+			SessionID:     acc.sessionID,
+			Reason:        acc.reason,
+		})
+	}
+	sort.Slice(plan.TerminateGroups, func(i, j int) bool {
+		return plan.TerminateGroups[i].PGID < plan.TerminateGroups[j].PGID
+	})
+
+	// Schedule terminal, unowned containers for removal only when every wrapper
+	// that still named them was reapable.
+	names := make([]string, 0, len(containersByName))
+	for name := range containersByName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		c := containersByName[name]
+		if !c.State.IsTerminal() || sessionLive(c.SessionID) {
+			continue
+		}
+		if containerSeenByWrapper[name] && !containerReapable[name] {
+			// A wrapper naming this container was preserved (e.g. within grace):
+			// leave the container until its wrappers are safe to reap.
+			continue
+		}
+		plan.RemoveContainers = append(plan.RemoveContainers, c)
+	}
+
+	return plan
+}
+
+// classifyWrapper decides one wrapper in isolation. It returns whether to reap,
+// the reap reason, and (when preserved) the preserve reason.
+func classifyWrapper(w Wrapper, containers map[string]Container, sessionLive func(string) bool, now time.Time, minAge time.Duration) (bool, ReapReason, PreserveReason) {
+	// A live parent means the wrapper is in an active process tree: never reap.
+	if !w.Parentless() {
+		return false, "", PreserveWrapperHasLiveParent
+	}
+	// A live owning session is the authority on its own in-flight work.
+	if sessionLive(w.SessionID) {
+		return false, "", PreserveSessionLive
+	}
+
+	name := strings.TrimSpace(w.ContainerName)
+	c, known := containers[name]
+	if known && sessionLive(c.SessionID) {
+		return false, "", PreserveSessionLive
+	}
+	if known && c.State.IsActive() {
+		return false, "", PreserveContainerActive
+	}
+	if known && c.State == ContainerUnknown {
+		// The container name was reported but its state was unobservable: fail
+		// safe, do not assume terminal.
+		return false, "", PreserveContainerStateUnknown
+	}
+
+	// Grace window: a very recently started wrapper is preserved so a
+	// just-launched command is never raced. Applied only after we know the
+	// container is terminal/gone and the session is non-live.
+	if minAge > 0 && !w.StartedAt.IsZero() && now.Sub(w.StartedAt.UTC()) < minAge {
+		return false, "", PreserveWithinGrace
+	}
+
+	if !known {
+		// The named container has already been removed: nothing left to wait on.
+		return true, ReapContainerGoneParentlessWrapper, ""
+	}
+	// Known and terminal, non-live session.
+	return true, ReapTerminalContainerNonLiveSession, ""
+}
+
+// String renders a bounded, secret-free one-line summary of the plan for
+// operator evidence: counts only, plus the affected container names and process
+// groups. No host path, command, or secret is included.
+func (p Plan) String() string {
+	if p.Empty() {
+		return fmt.Sprintf("orphan reap: nothing to reap (%d preserved)", len(p.Preserved))
+	}
+	names := make([]string, 0, len(p.TerminateGroups))
+	for _, g := range p.TerminateGroups {
+		if g.ContainerName != "" {
+			names = append(names, g.ContainerName)
+		}
+	}
+	sort.Strings(names)
+	return fmt.Sprintf("orphan reap: terminate %d wrapper group(s), remove %d exited container(s), %d preserved; containers=[%s]",
+		len(p.TerminateGroups), len(p.RemoveContainers), len(p.Preserved), strings.Join(names, ","))
+}

--- a/internal/orphan/orphan_test.go
+++ b/internal/orphan/orphan_test.go
@@ -1,0 +1,223 @@
+package orphan
+
+import (
+	"reflect"
+	"testing"
+	"time"
+)
+
+func exitCode(n int) *int { return &n }
+
+// Acceptance 1: reproduce a container that exits while the client wrapper
+// remains blocked/parentless. The named container is Exited (code 127), its
+// worktree is gone, the wrappers are a three-process chain with PPID==1, and the
+// owning session is not live (superseded by a later authoritative session).
+func incidentSnapshot(now time.Time) Snapshot {
+	started := now.Add(-11 * time.Hour)
+	return Snapshot{
+		Now:    now,
+		MinAge: 2 * time.Minute,
+		Wrappers: []Wrapper{
+			{PID: 101, PPID: 1, PGID: 100, ContainerName: "pkg-verify-42", SessionID: "sup-old", StartedAt: started},
+			{PID: 102, PPID: 1, PGID: 100, ContainerName: "pkg-verify-42", SessionID: "sup-old", StartedAt: started},
+			{PID: 103, PPID: 1, PGID: 100, ContainerName: "pkg-verify-42", SessionID: "sup-old", StartedAt: started},
+		},
+		Containers: []Container{
+			{Name: "pkg-verify-42", State: ContainerExited, ExitCode: exitCode(127), SessionID: "sup-old", IssueNumber: 42, FinishedAt: started.Add(17 * time.Minute)},
+		},
+		// sup-old is absent from the live set: it was superseded by a later
+		// authoritative session that already completed.
+		LiveSessions: map[string]bool{"sup-new": true},
+	}
+}
+
+func TestDecide_ReapsIncidentOrphan(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	plan := Decide(incidentSnapshot(now))
+
+	if plan.Empty() {
+		t.Fatal("incident orphan was not reaped")
+	}
+	if len(plan.TerminateGroups) != 1 {
+		t.Fatalf("terminate groups = %d, want 1", len(plan.TerminateGroups))
+	}
+	g := plan.TerminateGroups[0]
+	if g.PGID != 100 {
+		t.Errorf("terminated pgid = %d, want 100", g.PGID)
+	}
+	if !reflect.DeepEqual(g.PIDs, []int{101, 102, 103}) {
+		t.Errorf("terminated pids = %v, want the whole wrapper chain [101 102 103]", g.PIDs)
+	}
+	if g.Reason != ReapTerminalContainerNonLiveSession {
+		t.Errorf("reap reason = %q, want terminal_container_nonlive_session", g.Reason)
+	}
+	if len(plan.RemoveContainers) != 1 || plan.RemoveContainers[0].Name != "pkg-verify-42" {
+		t.Fatalf("remove containers = %+v, want the one exited container", plan.RemoveContainers)
+	}
+}
+
+// Acceptance 2 + 5: an active container is never reaped, but a terminal
+// superseded one is. Table drives the whole preserve/reap matrix so the safety
+// invariants are pinned as one regression.
+func TestDecide_PreservesActivePreservesLiveReapsTerminalSuperseded(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	old := now.Add(-time.Hour)
+
+	cases := []struct {
+		name         string
+		wrapper      Wrapper
+		container    Container
+		live         map[string]bool
+		wantReap     bool
+		wantReapWhy  ReapReason
+		wantPreserve PreserveReason
+	}{
+		{
+			name:         "active running container is preserved",
+			wrapper:      Wrapper{PID: 10, PPID: 1, PGID: 10, ContainerName: "c-live", SessionID: "s-live", StartedAt: old},
+			container:    Container{Name: "c-live", State: ContainerRunning, SessionID: "s-live"},
+			live:         map[string]bool{"s-live": true},
+			wantReap:     false,
+			wantPreserve: PreserveSessionLive,
+		},
+		{
+			name:         "running container with dead session still preserved (active work)",
+			wrapper:      Wrapper{PID: 11, PPID: 1, PGID: 11, ContainerName: "c-run", SessionID: "s-dead", StartedAt: old},
+			container:    Container{Name: "c-run", State: ContainerRunning, SessionID: "s-dead"},
+			live:         map[string]bool{},
+			wantReap:     false,
+			wantPreserve: PreserveContainerActive,
+		},
+		{
+			name:         "terminal container but session still live is preserved",
+			wrapper:      Wrapper{PID: 12, PPID: 1, PGID: 12, ContainerName: "c-exit-live", SessionID: "s-live", StartedAt: old},
+			container:    Container{Name: "c-exit-live", State: ContainerExited, ExitCode: exitCode(0), SessionID: "s-live"},
+			live:         map[string]bool{"s-live": true},
+			wantReap:     false,
+			wantPreserve: PreserveSessionLive,
+		},
+		{
+			name:         "wrapper with a live parent is preserved",
+			wrapper:      Wrapper{PID: 13, PPID: 4242, PGID: 13, ContainerName: "c-exit", SessionID: "s-dead", StartedAt: old},
+			container:    Container{Name: "c-exit", State: ContainerExited, ExitCode: exitCode(1), SessionID: "s-dead"},
+			live:         map[string]bool{},
+			wantReap:     false,
+			wantPreserve: PreserveWrapperHasLiveParent,
+		},
+		{
+			name:         "unobservable container state is preserved (fail safe)",
+			wrapper:      Wrapper{PID: 14, PPID: 1, PGID: 14, ContainerName: "c-unknown", SessionID: "s-dead", StartedAt: old},
+			container:    Container{Name: "c-unknown", State: ContainerUnknown, SessionID: "s-dead"},
+			live:         map[string]bool{},
+			wantReap:     false,
+			wantPreserve: PreserveContainerStateUnknown,
+		},
+		{
+			name:        "terminal container + superseded session is reaped",
+			wrapper:     Wrapper{PID: 15, PPID: 1, PGID: 15, ContainerName: "c-super", SessionID: "s-old", StartedAt: old},
+			container:   Container{Name: "c-super", State: ContainerExited, ExitCode: exitCode(127), SessionID: "s-old"},
+			live:        map[string]bool{"s-new": true},
+			wantReap:    true,
+			wantReapWhy: ReapTerminalContainerNonLiveSession,
+		},
+		{
+			name:        "dead container + no session is reaped",
+			wrapper:     Wrapper{PID: 16, PPID: 1, PGID: 16, ContainerName: "c-dead", SessionID: "", StartedAt: old},
+			container:   Container{Name: "c-dead", State: ContainerDead, SessionID: ""},
+			live:        map[string]bool{},
+			wantReap:    true,
+			wantReapWhy: ReapTerminalContainerNonLiveSession,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := Decide(Snapshot{
+				Now:          now,
+				MinAge:       time.Minute,
+				Wrappers:     []Wrapper{tc.wrapper},
+				Containers:   []Container{tc.container},
+				LiveSessions: tc.live,
+			})
+			if tc.wantReap {
+				if len(plan.TerminateGroups) != 1 {
+					t.Fatalf("terminate groups = %d, want 1 (should reap)", len(plan.TerminateGroups))
+				}
+				if got := plan.TerminateGroups[0].Reason; got != tc.wantReapWhy {
+					t.Errorf("reap reason = %q, want %q", got, tc.wantReapWhy)
+				}
+				return
+			}
+			if len(plan.TerminateGroups) != 0 {
+				t.Fatalf("terminate groups = %d, want 0 (should preserve)", len(plan.TerminateGroups))
+			}
+			if len(plan.RemoveContainers) != 0 {
+				t.Fatalf("remove containers = %d, want 0 (should preserve)", len(plan.RemoveContainers))
+			}
+			if len(plan.Preserved) != 1 || plan.Preserved[0].Reason != tc.wantPreserve {
+				t.Fatalf("preserved = %+v, want one with reason %q", plan.Preserved, tc.wantPreserve)
+			}
+		})
+	}
+}
+
+// Acceptance 3 grace window: a just-launched parentless wrapper on a terminal
+// container is preserved until it ages past MinAge, so the reaper never races a
+// command that started moments ago.
+func TestDecide_GraceWindowPreservesFreshWrapper(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	snap := Snapshot{
+		Now:          now,
+		MinAge:       5 * time.Minute,
+		Wrappers:     []Wrapper{{PID: 20, PPID: 1, PGID: 20, ContainerName: "c", SessionID: "s-old", StartedAt: now.Add(-30 * time.Second)}},
+		Containers:   []Container{{Name: "c", State: ContainerExited, SessionID: "s-old"}},
+		LiveSessions: map[string]bool{},
+	}
+	plan := Decide(snap)
+	if !plan.Empty() {
+		t.Fatalf("fresh wrapper reaped inside grace window: %s", plan)
+	}
+	if len(plan.Preserved) != 1 || plan.Preserved[0].Reason != PreserveWithinGrace {
+		t.Fatalf("preserved = %+v, want within_grace_period", plan.Preserved)
+	}
+
+	// Past the grace window it is reaped.
+	snap.Wrappers[0].StartedAt = now.Add(-10 * time.Minute)
+	if plan := Decide(snap); plan.Empty() {
+		t.Fatal("aged wrapper past grace window was not reaped")
+	}
+}
+
+// A container is not removed while any wrapper naming it is still preserved
+// (e.g. one wrapper is inside the grace window): removal waits until all its
+// wrappers are safe to reap.
+func TestDecide_ContainerRemovalWaitsForPreservedWrapper(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	snap := Snapshot{
+		Now:    now,
+		MinAge: 5 * time.Minute,
+		Wrappers: []Wrapper{
+			{PID: 30, PPID: 1, PGID: 30, ContainerName: "c", SessionID: "s-old", StartedAt: now.Add(-time.Hour)},
+			{PID: 31, PPID: 1, PGID: 31, ContainerName: "c", SessionID: "s-old", StartedAt: now.Add(-10 * time.Second)}, // fresh
+		},
+		Containers:   []Container{{Name: "c", State: ContainerExited, SessionID: "s-old"}},
+		LiveSessions: map[string]bool{},
+	}
+	plan := Decide(snap)
+	if len(plan.RemoveContainers) != 0 {
+		t.Fatalf("container removed while a wrapper is still preserved: %+v", plan.RemoveContainers)
+	}
+	if len(plan.TerminateGroups) != 1 || plan.TerminateGroups[0].PGID != 30 {
+		t.Fatalf("aged wrapper group not scheduled independently: %+v", plan.TerminateGroups)
+	}
+}
+
+// Acceptance 2: an idle host with no orphans yields an empty plan and never a
+// synthetic reap.
+func TestDecide_IdleHostReapsNothing(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	plan := Decide(Snapshot{Now: now, LiveSessions: map[string]bool{"s": true}})
+	if !plan.Empty() {
+		t.Fatalf("idle host produced a reap: %s", plan)
+	}
+}

--- a/internal/orphan/reaper.go
+++ b/internal/orphan/reaper.go
@@ -1,0 +1,197 @@
+package orphan
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+// Actuator performs the host side effects of a reap Plan. The runtime injects a
+// real implementation (OSActuator: signal a process group, `docker rm` an
+// exited container); tests inject a fake so the decision-to-actuation contract
+// is verifiable without touching real processes or Docker.
+//
+// TerminateGroup must target the whole process group (a negative pgid signal),
+// not an individual pid, so a partial wrapper chain is never left behind. Both
+// methods must be safe to call when the target has already vanished (a
+// concurrent exit is a success, not an error).
+type Actuator interface {
+	// TerminateGroup terminates the process group pgid. pids is the observed
+	// membership, passed for evidence and as a fallback; the primary action is
+	// on the group.
+	TerminateGroup(pgid int, pids []int) error
+	// RemoveContainer removes the exited named container. Removing an
+	// already-absent container is not an error.
+	RemoveContainer(name string) error
+}
+
+// CleanupAction is the bounded kind of a recorded cleanup.
+type CleanupAction string
+
+const (
+	// CleanupTerminateGroup records terminating one wrapper process group.
+	CleanupTerminateGroup CleanupAction = "terminate_wrapper_group"
+	// CleanupRemoveContainer records removing one exited named container.
+	CleanupRemoveContainer CleanupAction = "remove_exited_container"
+)
+
+// CleanupOutcome is the bounded result of a cleanup action.
+type CleanupOutcome string
+
+const (
+	CleanupSucceeded CleanupOutcome = "succeeded"
+	CleanupFailed    CleanupOutcome = "failed"
+)
+
+// Cleanup is the durable, secret-free evidence record of one reaping action.
+//
+// It is deliberately a distinct type from a progress watermark. Reaping a
+// zombie wrapper/container is a cleanup — never material progress — so recording
+// it here (and never as a progress Observation) is what stops an orphan from
+// being miscounted as the owning session making headway (#977 acceptance 4).
+type Cleanup struct {
+	At            time.Time      `json:"at"`
+	Action        CleanupAction  `json:"action"`
+	Outcome       CleanupOutcome `json:"outcome"`
+	ContainerName string         `json:"container_name,omitempty"`
+	SessionID     string         `json:"session_id,omitempty"`
+	IssueNumber   int            `json:"issue_number,omitempty"`
+	PGID          int            `json:"pgid,omitempty"`
+	WrapperPIDs   []int          `json:"wrapper_pids,omitempty"`
+	Reason        ReapReason     `json:"reason,omitempty"`
+	// Detail is a bounded, secret-free note — an actuator error class at most,
+	// never a host path, command line, or raw error containing one.
+	Detail string `json:"detail,omitempty"`
+}
+
+// Reaper executes reap Plans against an Actuator and returns the durable
+// Cleanup evidence for what it did. It holds no host state itself, so it is safe
+// to construct per tick.
+type Reaper struct {
+	act Actuator
+}
+
+// NewReaper returns a Reaper bound to act.
+func NewReaper(act Actuator) *Reaper {
+	return &Reaper{act: act}
+}
+
+// Reap actuates plan and returns one Cleanup per attempted action, in a stable
+// order (wrapper groups first, by pgid; then containers, by name). It terminates
+// wrapper groups before removing containers so a wrapper cannot re-hold a
+// container that is about to be removed. An actuator failure is recorded as a
+// failed Cleanup and does not abort the remaining actions: one stuck orphan must
+// not block reaping the others.
+func (r *Reaper) Reap(plan Plan) []Cleanup {
+	now := plan.EvaluatedAt.UTC()
+	cleanups := make([]Cleanup, 0, len(plan.TerminateGroups)+len(plan.RemoveContainers))
+
+	groups := append([]WrapperGroup(nil), plan.TerminateGroups...)
+	sort.Slice(groups, func(i, j int) bool { return groups[i].PGID < groups[j].PGID })
+	for _, g := range groups {
+		c := Cleanup{
+			At:            now,
+			Action:        CleanupTerminateGroup,
+			ContainerName: g.ContainerName,
+			SessionID:     g.SessionID,
+			PGID:          g.PGID,
+			WrapperPIDs:   append([]int(nil), g.PIDs...),
+			Reason:        g.Reason,
+		}
+		if err := r.act.TerminateGroup(g.PGID, g.PIDs); err != nil {
+			c.Outcome = CleanupFailed
+			c.Detail = boundedErr(err)
+		} else {
+			c.Outcome = CleanupSucceeded
+		}
+		cleanups = append(cleanups, c)
+	}
+
+	containers := append([]Container(nil), plan.RemoveContainers...)
+	sort.Slice(containers, func(i, j int) bool { return containers[i].Name < containers[j].Name })
+	for _, ct := range containers {
+		c := Cleanup{
+			At:            now,
+			Action:        CleanupRemoveContainer,
+			ContainerName: ct.Name,
+			SessionID:     ct.SessionID,
+			IssueNumber:   ct.IssueNumber,
+			Reason:        ReapTerminalContainerNonLiveSession,
+		}
+		if err := r.act.RemoveContainer(ct.Name); err != nil {
+			c.Outcome = CleanupFailed
+			c.Detail = boundedErr(err)
+		} else {
+			c.Outcome = CleanupSucceeded
+		}
+		cleanups = append(cleanups, c)
+	}
+
+	return cleanups
+}
+
+// boundedErr reduces an actuator error to a short, secret-free class token. The
+// full error may embed a host path or command; only the leading context segment
+// — the part maestro's own wrapping controls, before the first ':' — is kept.
+//
+// Go's error-wrapping convention is "context: cause", so the leading segment of
+// an actuator error is a path-free class string this package authors ("sigterm
+// group", "docker rm"). If that segment still contains a path separator (an
+// error that leads with a host path rather than our context), it is dropped for
+// a generic class so no host path can ever reach durable evidence.
+func boundedErr(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.TrimSpace(err.Error())
+	if msg == "" {
+		return "error"
+	}
+	if i := strings.IndexByte(msg, ':'); i >= 0 {
+		msg = msg[:i]
+	}
+	msg = strings.TrimSpace(msg)
+	// Defense in depth: an empty or path-like leading segment is redacted to a
+	// generic class rather than persisted.
+	if msg == "" || strings.ContainsAny(msg, "/\\") {
+		return "error"
+	}
+	if len(msg) > 48 {
+		msg = msg[:48]
+	}
+	return msg
+}
+
+// SummarizeCleanups renders a bounded, secret-free operator summary of a batch
+// of cleanups: counts of terminated groups and removed containers, how many
+// failed, and the affected container names. Suitable for a Fleet evidence line
+// or a runbook note — it contains no host path, command, or secret.
+func SummarizeCleanups(cleanups []Cleanup) string {
+	if len(cleanups) == 0 {
+		return "orphan cleanup: none"
+	}
+	var terminated, removed, failed int
+	nameSet := make(map[string]struct{})
+	for _, c := range cleanups {
+		if c.Outcome == CleanupFailed {
+			failed++
+		}
+		switch c.Action {
+		case CleanupTerminateGroup:
+			terminated++
+		case CleanupRemoveContainer:
+			removed++
+		}
+		if c.ContainerName != "" {
+			nameSet[c.ContainerName] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(nameSet))
+	for n := range nameSet {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return fmt.Sprintf("orphan cleanup: terminated %d wrapper group(s), removed %d exited container(s), %d failed; containers=[%s]",
+		terminated, removed, failed, strings.Join(names, ","))
+}

--- a/internal/orphan/reaper_test.go
+++ b/internal/orphan/reaper_test.go
@@ -1,0 +1,177 @@
+package orphan
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+type fakeActuator struct {
+	terminated  []int
+	removed     []string
+	termErr     error
+	removeErr   error
+	removeCalls int
+}
+
+func (f *fakeActuator) TerminateGroup(pgid int, pids []int) error {
+	f.terminated = append(f.terminated, pgid)
+	return f.termErr
+}
+
+func (f *fakeActuator) RemoveContainer(name string) error {
+	f.removeCalls++
+	f.removed = append(f.removed, name)
+	return f.removeErr
+}
+
+// Acceptance 3 + 4: the reaper actuates the plan (terminate the stale wrapper
+// group, remove the exited container) and records durable, secret-free cleanup
+// evidence for each action.
+func TestReap_ActuatesAndRecordsEvidence(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	plan := Decide(incidentSnapshot(now))
+	act := &fakeActuator{}
+	cleanups := NewReaper(act).Reap(plan)
+
+	if len(act.terminated) != 1 || act.terminated[0] != 100 {
+		t.Fatalf("terminated groups = %v, want [100]", act.terminated)
+	}
+	if len(act.removed) != 1 || act.removed[0] != "pkg-verify-42" {
+		t.Fatalf("removed containers = %v, want [pkg-verify-42]", act.removed)
+	}
+	if len(cleanups) != 2 {
+		t.Fatalf("cleanups = %d, want 2 (one terminate, one remove)", len(cleanups))
+	}
+
+	var sawTerminate, sawRemove bool
+	for _, c := range cleanups {
+		if c.Outcome != CleanupSucceeded {
+			t.Errorf("cleanup %+v outcome = %q, want succeeded", c, c.Outcome)
+		}
+		switch c.Action {
+		case CleanupTerminateGroup:
+			sawTerminate = true
+			if c.PGID != 100 || c.Reason != ReapTerminalContainerNonLiveSession {
+				t.Errorf("terminate cleanup = %+v", c)
+			}
+		case CleanupRemoveContainer:
+			sawRemove = true
+			if c.ContainerName != "pkg-verify-42" || c.IssueNumber != 42 {
+				t.Errorf("remove cleanup = %+v", c)
+			}
+		}
+	}
+	if !sawTerminate || !sawRemove {
+		t.Fatalf("missing cleanup action: terminate=%v remove=%v", sawTerminate, sawRemove)
+	}
+
+	summary := SummarizeCleanups(cleanups)
+	if !strings.Contains(summary, "terminated 1") || !strings.Contains(summary, "removed 1") {
+		t.Errorf("summary = %q, want it to report 1 terminated + 1 removed", summary)
+	}
+	if strings.Contains(summary, "/") {
+		t.Errorf("summary leaked a path-like token: %q", summary)
+	}
+}
+
+// A failed actuation is recorded as a failed cleanup and does not abort the
+// remaining actions.
+func TestReap_FailedActionRecordedAndContinues(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	plan := Decide(incidentSnapshot(now))
+	act := &fakeActuator{termErr: errors.New("/proc/100: operation not permitted")}
+	cleanups := NewReaper(act).Reap(plan)
+
+	if act.removeCalls != 1 {
+		t.Fatalf("remove not attempted after terminate failure: calls=%d", act.removeCalls)
+	}
+	var termCleanup *Cleanup
+	for i := range cleanups {
+		if cleanups[i].Action == CleanupTerminateGroup {
+			termCleanup = &cleanups[i]
+		}
+	}
+	if termCleanup == nil || termCleanup.Outcome != CleanupFailed {
+		t.Fatalf("terminate cleanup = %+v, want a failed record", termCleanup)
+	}
+	// Detail must be a bounded class token, never the raw path from the error.
+	if strings.Contains(termCleanup.Detail, "/proc") || strings.Contains(termCleanup.Detail, "permitted") {
+		t.Errorf("cleanup detail leaked raw error content: %q", termCleanup.Detail)
+	}
+}
+
+// The OSActuator refuses to signal an unsafe process group (0 or 1) so a bug in
+// the collector can never target init or the daemon's own group.
+func TestOSActuator_RefusesUnsafeGroup(t *testing.T) {
+	a := &OSActuator{}
+	for _, pgid := range []int{0, 1, -5} {
+		if err := a.TerminateGroup(pgid, nil); err == nil {
+			t.Errorf("TerminateGroup(%d) = nil, want refusal", pgid)
+		}
+	}
+}
+
+// The OSActuator treats an already-gone process group (ESRCH) as success and
+// escalates SIGTERM -> SIGKILL only when the group survives the grace period.
+func TestOSActuator_TerminateEscalatesAndToleratesGone(t *testing.T) {
+	t.Run("already gone is success", func(t *testing.T) {
+		a := &OSActuator{killGroup: func(int, syscall.Signal) error { return syscall.ESRCH }}
+		if err := a.TerminateGroup(1234, nil); err != nil {
+			t.Fatalf("TerminateGroup gone group = %v, want nil", err)
+		}
+	})
+
+	t.Run("escalates to sigkill when still alive", func(t *testing.T) {
+		var sigs []syscall.Signal
+		a := &OSActuator{
+			KillGrace:  10 * time.Millisecond,
+			killGroup:  func(_ int, s syscall.Signal) error { sigs = append(sigs, s); return nil },
+			groupAlive: func(int) bool { return true }, // never dies
+		}
+		if err := a.TerminateGroup(1234, nil); err != nil {
+			t.Fatalf("TerminateGroup = %v", err)
+		}
+		if len(sigs) != 2 || sigs[0] != syscall.SIGTERM || sigs[1] != syscall.SIGKILL {
+			t.Fatalf("signals = %v, want [SIGTERM SIGKILL]", sigs)
+		}
+	})
+
+	t.Run("no sigkill when group exits within grace", func(t *testing.T) {
+		var sigs []syscall.Signal
+		a := &OSActuator{
+			KillGrace:  time.Second,
+			killGroup:  func(_ int, s syscall.Signal) error { sigs = append(sigs, s); return nil },
+			groupAlive: func(int) bool { return false },
+		}
+		if err := a.TerminateGroup(1234, nil); err != nil {
+			t.Fatalf("TerminateGroup = %v", err)
+		}
+		if len(sigs) != 1 || sigs[0] != syscall.SIGTERM {
+			t.Fatalf("signals = %v, want [SIGTERM] only", sigs)
+		}
+	})
+}
+
+// RemoveContainer routes through the configured docker args and reports a
+// bounded error class on failure.
+func TestOSActuator_RemoveContainerUsesConfiguredArgs(t *testing.T) {
+	var gotArgs []string
+	a := &OSActuator{
+		DockerArgs:      []string{"sudo", "docker"},
+		removeContainer: func(_ context.Context, args []string) error { gotArgs = args; return nil },
+	}
+	if err := a.RemoveContainer("pkg-verify-42"); err != nil {
+		t.Fatalf("RemoveContainer = %v", err)
+	}
+	want := []string{"sudo", "docker", "rm", "pkg-verify-42"}
+	if strings.Join(gotArgs, " ") != strings.Join(want, " ") {
+		t.Fatalf("docker args = %v, want %v", gotArgs, want)
+	}
+	if err := a.RemoveContainer(""); err == nil {
+		t.Fatal("RemoveContainer(\"\") = nil, want error")
+	}
+}


### PR DESCRIPTION
Refs #977

## What landed

`internal/orphan` — a leaf package (stdlib only, injected clock) enforcing the invariant that a container-backed verification command must not outlive its worker/session once the container is terminal.

- **Decide(Snapshot) Plan** — pure decision. Given observed wrappers, named containers, and live sessions it selects which parentless wrapper process groups to terminate and which exited containers to remove. It preserves active/created containers, live sessions, wrappers with a live parent, unobservable container state (fail safe), and a configurable grace window so a just-launched command is never raced. A container is removed only when every wrapper still naming it is reapable.
- **OSActuator** — terminates the whole process group (SIGTERM then SIGKILL on survival), refuses pgid 0/1, and `docker rm`s the exited container; an already-gone target is a success.
- **Cleanup** — durable, secret-free evidence, kept deliberately distinct from a progress watermark so a reaped zombie is never counted as the owning session making headway. Cleanup detail is redacted to a bounded, path-free class token.

## Testing

- `go test ./internal/orphan/` — regression matrix: the incident orphan is reaped; active/created and live-session containers are preserved; a terminal superseded container is reaped; grace window; container removal gated on all wrappers being reapable; actuation records evidence; redaction never leaks a host path.
- `gofmt -l` clean, `go vet`, `go build ./cmd/maestro/`, and full `go test ./...` all pass.

## Remaining runtime step

Arming the collector loop against the live host (scanning `/proc` and docker to build the Snapshot each watchdog tick, then actuating with `OSActuator`) reaps real processes and containers and requires operator host verification before it is enabled. This PR lands the tested decision engine, actuator, and evidence surface; it does not auto-close the issue.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a package for planning, executing, and recording orphan container cleanup. The main changes are:

- A snapshot-based decision engine with session, container-state, and grace-period guards.
- A host actuator for process-group termination and Docker container removal.
- Bounded cleanup evidence and summaries.
- Tests for planning, actuation, redaction, and signal escalation.

<h3>Confidence Score: 4/5</h3>

The process-group authorization and partial-failure paths need fixes before this actuator is armed on a host.

Per-wrapper decisions can authorize killing preserved members of the same process group. Container removal continues after wrapper termination fails. Expected already-absent containers are recorded as cleanup failures. Escalation does not verify that the PGID still belongs to the observed processes.

internal/orphan/orphan.go, internal/orphan/reaper.go, internal/orphan/actuator_os.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the mixed-group kill scenario and confirmed that a wrapper with PGID 7000 preserves PID 7001 while the same PGID is scheduled for termination due to an orphan PID 7002.
- Observed a termination path where TerminateGroup returns EPERM but RemoveContainer cleanup still succeeds, highlighting a cleanup divergence in the actuator path.
- Validated that a missing-container error propagates through RemoveContainer and is recorded as a cleanup failure by Reaper, contradicting the Actuator contract.
- Reproduced an escalation in which OSActuator.TerminateGroup triggers PGID-only SIGKILL escalation after SIGTERM to the observed PGID, confirming the unsafe escalation path.
- Captured the full command-level proof for the orphan validation run, including timestamps, working directory, verbose test output, and the final ok exit status.

<a href="https://app.greptile.com/trex/runs/15259882/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orphan/orphan.go | Adds the snapshot model and decision engine, but per-wrapper eligibility does not safely authorize process-group-wide termination. |
| internal/orphan/reaper.go | Adds ordered actuation and cleanup evidence, but container removal is not gated on successful wrapper termination. |
| internal/orphan/actuator_os.go | Adds real process-group and Docker operations, with gaps in target identity validation and already-absent handling. |
| internal/orphan/orphan_test.go | Covers the main planning matrix but omits mixed eligibility within one process group. |
| internal/orphan/reaper_test.go | Covers actuation and errors, while currently expecting container removal to continue after termination failure. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 4 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 4
internal/orphan/orphan.go:281-294
**Mixed Group Kills Preserved Members**

When two wrappers share a PGID but only one is reapable, the preserved wrapper skips group accumulation while the other still schedules that PGID for termination. `OSActuator` signals the whole group, so an active-container or live-session wrapper that this plan preserved is killed with the orphan.

### Issue 2 of 4
internal/orphan/reaper.go:102-108
**Failed Termination Still Removes Container**

When `TerminateGroup` fails, this branch records the failure but allows `Reap` to remove the same container later. An `EPERM` or similar error therefore leaves the wrapper group alive after its container is deleted, violating the termination-before-removal invariant and leaving the orphan in a state that later snapshots treat as container-gone.

### Issue 3 of 4
internal/orphan/actuator_os.go:110-112
**Missing Container Reports Failure**

When another actor removes the container after planning, `docker rm <name>` exits unsuccessfully for the now-missing target and this branch returns an error. The reaper then records a failed cleanup even though the `Actuator` contract explicitly defines an already-absent container as success.

### Issue 4 of 4
internal/orphan/actuator_os.go:78-81
**Escalation Can Hit Reused PGID**

If the original group exits after the last liveness check and its leader PID is reused for a new process group before `SIGKILL`, the negative-PGID signal targets the unrelated group. The observed `pids` are ignored, so this path has no identity check to prevent killing unrelated host processes.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: orphan container-client wrapper re..."](https://github.com/befeast/maestro/commit/f9b7cfc52e304e87df8445b12b9351ed4f61635f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45990817)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->