### PR TITLE
P0: blocked scheduled retry remains false operator attention forever (#1013)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2486,8 +2486,8 @@ func (o *Orchestrator) retireStaleRetry(s *state.State, slotName string, sess *s
 			continue
 		}
 		log.Printf("[orch] worker %s retry invalidated: PR #%d for issue #%d is merged — marking code_landed instead of respawning", slotName, prNumber, sess.IssueNumber)
-		sess.NextRetryAt = nil
-		sess.RetryHoldReason = ""
+		// markCodeLanded clears NextRetryAt and the issue-guard hold at the
+		// shared code_landed sink (#1013), so the retry cannot outlive the merge.
 		o.markCodeLanded(sess, prNumber)
 		if o.notifier != nil {
 			o.notifier.Sendf("🧟 maestro: cancelled scheduled retry for issue #%d (%s) — PR #%d already merged", sess.IssueNumber, sess.IssueTitle, prNumber)
@@ -6061,6 +6061,13 @@ func (o *Orchestrator) markCodeLanded(sess *state.Session, prNumber int) {
 	if prNumber > 0 {
 		sess.PRNumber = prNumber
 	}
+	// #1013: a code_landed transition is terminal reconciliation — the PR
+	// merged, so any scheduled retry (including one deliberately held behind a
+	// current issue-guard label) is settled and must not survive. Clear it at
+	// this shared sink so the invariant holds for every merge-detection path,
+	// not only the retireStaleRetry pre-check that also clears it explicitly.
+	sess.NextRetryAt = nil
+	sess.RetryHoldReason = ""
 	sess.DeploymentFinishedAt = nil
 	o.syncProject(sess.IssueNumber, codeLandedProjectStatus(o.cfg.Outcome.RequiresDeploy))
 	sess.Status = state.StatusCodeLanded

--- a/internal/orchestrator/zombie_respawn_test.go
+++ b/internal/orchestrator/zombie_respawn_test.go
@@ -191,6 +191,45 @@ func TestRespawnDueRetries_PROpenDuringCIRetryThenMerged_NoRespawn(t *testing.T)
 	}
 }
 
+// #1013: markCodeLanded is the shared sink for every merge-detection path
+// (retireStaleRetry, reconcile branch-merge, outcome verification, …). A
+// canonical retry deliberately held behind a current issue-guard label carries
+// NextRetryAt + RetryHoldReason; when any of those paths observes the merge the
+// hold must not outlive it, regardless of which caller reached the sink and
+// whether that caller pre-cleared the fields. Pin the invariant to the sink so
+// a future merge path added without an explicit clear cannot resurrect the
+// "false operator attention forever" state.
+func TestMarkCodeLanded_ClearsHeldRetry(t *testing.T) {
+	o := &Orchestrator{cfg: &config.Config{Repo: "owner/repo"}}
+
+	pastTime := time.Now().UTC().Add(-1 * time.Second)
+	sess := &state.Session{
+		IssueNumber:     406,
+		IssueTitle:      "held retry that merged out-of-band",
+		Status:          state.StatusDead,
+		RetryCount:      3,
+		NextRetryAt:     &pastTime,
+		RetryHoldReason: "issue #406 has a current excluded label",
+		Branch:          "feat/ok-player-302-406-test",
+		PRNumber:        388,
+	}
+
+	o.markCodeLanded(sess, 388)
+
+	if sess.Status != state.StatusCodeLanded {
+		t.Fatalf("status = %q, want %q", sess.Status, state.StatusCodeLanded)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatal("NextRetryAt must be cleared at the code_landed sink")
+	}
+	if sess.RetryHoldReason != "" {
+		t.Fatalf("issue-guard hold must be cleared at the code_landed sink: %q", sess.RetryHoldReason)
+	}
+	if sess.PRNumber != 388 {
+		t.Fatalf("PRNumber = %d, want 388 (canonical PR preserved)", sess.PRNumber)
+	}
+}
+
 func TestRespawnDueRetries_GitHubReadErrorFailsOpen(t *testing.T) {
 	respawned := false
 	o := zombieRetryOrchestrator(t, &respawned)


### PR DESCRIPTION
Refs #1013

Maestro auto-created this pull request for pushed branch feat/sup-824-1013-p0-blocked-scheduled-retry-remains-false because no open pull request was found for it.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR clears stale scheduled-retry state when a session reaches `code_landed`. The main changes are:

- Moves retry-time and hold-reason cleanup into the shared code-landed transition.
- Updates stale-retry retirement to use the shared cleanup.
- Adds a test for code landing while a retry is held by an issue guard.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed go test for internal/orchestrator focusing on TestMarkCodeLanded\_ClearsHeldRetry and TestRespawnDueRetries\_\*; the run completed with exit code 0 and all listed tests passed.

<a href="https://app.greptile.com/trex/runs/15271272/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Centralizes cleanup of scheduled-retry fields in the terminal code-landed transition. |
| internal/orchestrator/zombie_respawn_test.go | Adds a focused test that verifies a held retry is cleared when code lands. |

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-824-10..."](https://github.com/befeast/maestro/commit/a1a1f85c5a117c847a3438c27374ab0a9d970843) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46011901)</sub>

<!-- /greptile_comment -->