### PR TITLE
feat: watchdog reaps orphan container-client wrappers after the container exits (#977)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2768,6 +2768,14 @@ func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once boo
 	// (+ crashpad) processes and their temp dirs behind; clean them on startup.
 	worker.SweepStaleVisualQA()
 
+	// Reap orphan container-client wrappers left by a previous run (#977): a
+	// `docker run` verification wrapper whose owning worker died can outlive it
+	// as a parentless (PPID=1) zombie once its named container exits. A unit
+	// restart cannot reparent it back, so clear terminal-container orphans on
+	// startup alongside the visual-QA sweep. The watchdog interval catches ones
+	// that appear while the daemon keeps running.
+	worker.ReapOrphanContainerWrappers(nil)
+
 	// One-time startup sequence before the first poll cycle. The provider-
 	// credential scrub (#888) runs in BOTH the long-running daemon and a
 	// `run --once` reconcile; the daemon-restart reconciliation steps are

--- a/internal/supervisor/material_progress_runtime.go
+++ b/internal/supervisor/material_progress_runtime.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/worker"
 )
 
 // materialProgressConfigRefreshCap bounds how long a live config edit can take
@@ -104,6 +105,18 @@ func RunMaterialProgressEvaluator(ctx context.Context, name string, getCfg func(
 			}
 			if _, err := EvaluateGateFailureStreaksOnce(cfg, time.Now().UTC()); err != nil {
 				log.Printf("[%s] gate-fail-streak evaluation failed (will retry): %v", logPrefix, err)
+			}
+			// #977: reap orphan container-client wrappers on the watchdog
+			// interval. A `docker run` verification wrapper whose owning worker
+			// died lingers parentless (PPID=1) after its named container exits;
+			// it is a zombie, not active work, and must not be counted as
+			// progress. Host-global and idempotent — a non-empty report is
+			// logged for operator evidence; liveSessions is nil because the
+			// parentless-wrapper + terminal-container signal already spares any
+			// genuinely active verification command.
+			if report := worker.ReapOrphanContainerWrappers(nil); !report.Empty() {
+				log.Printf("[%s] reaped orphan container-client wrappers: killed=%v removed_containers=%v",
+					logPrefix, report.KilledWrappers, report.RemovedContainers)
 			}
 		}
 		if wait <= 0 {

--- a/internal/worker/container_reap.go
+++ b/internal/worker/container_reap.go
@@ -1,0 +1,309 @@
+package worker
+
+import (
+	"context"
+	"log"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Orphan container-client wrapper reaping (#977).
+//
+// A container-backed verification command (e.g. `sudo docker run --name X ...`)
+// spawns a client wrapper chain that blocks until the named container exits. If
+// the owning worker/session dies while a wrapper is still blocked, the container
+// can go terminal (exited) while the wrapper is reparented to init (PPID=1) and
+// lingers indefinitely — the 11-hour zombie that motivated this. Maestro may
+// have already completed the authoritative later session, so the orphan is not
+// active work and must not be counted as progress.
+//
+// Invariant: a container-backed verification command must not outlive its
+// worker/session once the container is terminal. A parentless wrapper tied to a
+// terminal container and a non-live/superseded session is a zombie, not work.
+
+// ContainerState is a snapshot of one docker container as reported by
+// `docker ps -a`. Session is the owning maestro session, correlated from a
+// container label when the operator's verification command sets one; it is empty
+// when no correlation is available, in which case the parentless-wrapper +
+// terminal-container signal alone governs reaping.
+type ContainerState struct {
+	ID      string
+	Name    string
+	Running bool
+	Session string
+}
+
+// WrapperProc is a docker-client wrapper process (the `sudo docker run` /
+// `docker run` chain) blocked on a named container. PPID==1 means the wrapper
+// was reparented to init because its owning worker exited — the strongest
+// host-global signal that the owning session is no longer live.
+type WrapperProc struct {
+	PID       int
+	PPID      int
+	Container string // container name parsed from the wrapper argv
+}
+
+// OrphanCleanupPlan is the pure decision output: wrapper PIDs whose process
+// group must be terminated, and terminal container names safe to remove.
+type OrphanCleanupPlan struct {
+	KillPIDs         []int
+	RemoveContainers []string
+}
+
+// OrphanCleanupReport is the durable operator-evidence record of one reap pass.
+// It is what the watchdog logs and returns; the orphan it clears is never folded
+// back into the material-progress watermark.
+type OrphanCleanupReport struct {
+	KilledWrappers    []int
+	RemovedContainers []string
+}
+
+// Empty reports whether the pass reaped nothing (the overwhelming common case on
+// a host with no leftover docker verification wrappers).
+func (r OrphanCleanupReport) Empty() bool {
+	return len(r.KilledWrappers) == 0 && len(r.RemovedContainers) == 0
+}
+
+// selectOrphanContainerReaps decides which wrapper process groups to terminate
+// and which exited containers to remove, given a container snapshot, the live
+// wrapper processes, and the set of genuinely live session identifiers.
+//
+// It is conservative by construction. A wrapper is reaped only when ALL hold:
+//   - it is parentless (PPID==1): its owning worker/session is gone;
+//   - it references a container that exists and is terminal (not running);
+//   - that container's owning session is not live.
+//
+// A running container, a live owning session, or a wrapper still attached to a
+// live parent (PPID!=1) is always preserved — a genuinely active verification
+// command is never reaped. A container is removed only when maestro reaped an
+// orphan wrapper that referenced it (proving maestro launched it) and no
+// preserved wrapper still holds it; unrelated host containers are never touched.
+func selectOrphanContainerReaps(containers []ContainerState, wrappers []WrapperProc, liveSessions map[string]bool) OrphanCleanupPlan {
+	byName := make(map[string]ContainerState, len(containers))
+	for _, c := range containers {
+		if c.Name != "" {
+			byName[c.Name] = c
+		}
+	}
+	sessionLive := func(s string) bool { return s != "" && liveSessions[s] }
+
+	var plan OrphanCleanupPlan
+	killed := make(map[int]bool)
+	reapedContainer := make(map[string]bool)
+	preservedContainer := make(map[string]bool)
+
+	for _, w := range wrappers {
+		c, known := byName[w.Container]
+		if !known {
+			continue
+		}
+		reapable := w.PPID == 1 && !c.Running && !sessionLive(c.Session)
+		if reapable {
+			if w.PID > 1 && !killed[w.PID] {
+				plan.KillPIDs = append(plan.KillPIDs, w.PID)
+				killed[w.PID] = true
+			}
+			reapedContainer[c.Name] = true
+		} else {
+			// A running/live/live-parented wrapper still holds this container.
+			preservedContainer[c.Name] = true
+		}
+	}
+
+	// Iterate containers (not the map) so removal order is deterministic.
+	for _, c := range containers {
+		if reapedContainer[c.Name] && !preservedContainer[c.Name] {
+			plan.RemoveContainers = append(plan.RemoveContainers, c.Name)
+		}
+	}
+	return plan
+}
+
+// isDockerRunWrapper reports whether a NUL-joined-then-space-collapsed cmdline is
+// a `docker run` / `sudo docker run` client wrapper. It matches the docker
+// binary by basename so an absolute path (`/usr/bin/docker`) still counts, and
+// requires the `run` subcommand to appear after it.
+func isDockerRunWrapper(cmdline string) bool {
+	sawDocker, sawRun := false, false
+	for _, f := range strings.Fields(cmdline) {
+		base := f
+		if idx := strings.LastIndexByte(base, '/'); idx >= 0 {
+			base = base[idx+1:]
+		}
+		if base == "docker" {
+			sawDocker = true
+			continue
+		}
+		if sawDocker && f == "run" {
+			sawRun = true
+		}
+	}
+	return sawDocker && sawRun
+}
+
+// parseWrapperContainer extracts the `--name` container from a docker-run
+// wrapper cmdline. It returns ok=false for any process that is not a docker-run
+// wrapper or does not name a container (an anonymous container cannot be
+// correlated to a snapshot entry and is left alone).
+func parseWrapperContainer(cmdline string) (string, bool) {
+	if !isDockerRunWrapper(cmdline) {
+		return "", false
+	}
+	fields := strings.Fields(cmdline)
+	for i, f := range fields {
+		if f == "--name" && i+1 < len(fields) {
+			return fields[i+1], true
+		}
+		if strings.HasPrefix(f, "--name=") {
+			if name := strings.TrimPrefix(f, "--name="); name != "" {
+				return name, true
+			}
+		}
+	}
+	return "", false
+}
+
+// collectDockerWrappers builds the WrapperProc set from a /proc snapshot,
+// reading each candidate's live PPID so a wrapper that has since been reparented
+// to init is correctly recognised as parentless.
+func collectDockerWrappers(procs []procInfo) []WrapperProc {
+	var wrappers []WrapperProc
+	for _, p := range procs {
+		name, ok := parseWrapperContainer(p.Cmdline)
+		if !ok {
+			continue
+		}
+		ppid, ok := readPPID(p.PID)
+		if !ok {
+			continue
+		}
+		wrappers = append(wrappers, WrapperProc{PID: p.PID, PPID: ppid, Container: name})
+	}
+	return wrappers
+}
+
+// reaperDeps injects the side-effecting operations so the sweep is unit-testable
+// without a real docker daemon or /proc.
+type reaperDeps struct {
+	listContainers  func() ([]ContainerState, error)
+	killGroup       func(pid int)
+	removeContainer func(name string) error
+}
+
+// sweepOrphanContainerWrappers applies the pure decision to the current
+// container snapshot: it terminates each orphan wrapper's whole process group,
+// removes the exited containers, and returns a report for operator evidence.
+func sweepOrphanContainerWrappers(wrappers []WrapperProc, deps reaperDeps, liveSessions map[string]bool) (OrphanCleanupReport, error) {
+	containers, err := deps.listContainers()
+	if err != nil {
+		return OrphanCleanupReport{}, err
+	}
+	plan := selectOrphanContainerReaps(containers, wrappers, liveSessions)
+
+	var report OrphanCleanupReport
+	for _, pid := range plan.KillPIDs {
+		log.Printf("[sweep] reaping orphan container-client wrapper pid=%d (owning worker gone, container terminal)", pid)
+		deps.killGroup(pid)
+		report.KilledWrappers = append(report.KilledWrappers, pid)
+	}
+	for _, name := range plan.RemoveContainers {
+		if err := deps.removeContainer(name); err != nil {
+			log.Printf("[sweep] remove exited orphan container %s: %v", name, err)
+			continue
+		}
+		log.Printf("[sweep] removed exited orphan container %s", name)
+		report.RemovedContainers = append(report.RemovedContainers, name)
+	}
+	return report, nil
+}
+
+// ReapOrphanContainerWrappers scans the host for parentless docker-client
+// wrapper chains whose named container has gone terminal, terminates those
+// wrapper process groups, and removes the exited containers. liveSessions may be
+// nil: the parentless-wrapper + terminal-container signal is sufficient on its
+// own, and a genuinely active verification command (running container, or a
+// wrapper still attached to a live parent) is never reaped either way.
+//
+// It is a no-op off Linux or when the docker CLI is unavailable, and returns
+// early before shelling out to docker when the host has no docker-run wrappers
+// at all — the common case. Safe to call repeatedly on the watchdog interval: it
+// is idempotent and never touches a running container or a live wrapper.
+func ReapOrphanContainerWrappers(liveSessions map[string]bool) OrphanCleanupReport {
+	if runtime.GOOS != "linux" {
+		return OrphanCleanupReport{}
+	}
+	dockerBin, err := exec.LookPath("docker")
+	if err != nil {
+		return OrphanCleanupReport{} // no docker on this host → nothing to reap
+	}
+	wrappers := collectDockerWrappers(scanProcs())
+	if len(wrappers) == 0 {
+		return OrphanCleanupReport{}
+	}
+	deps := reaperDeps{
+		listContainers:  func() ([]ContainerState, error) { return listDockerContainers(dockerBin) },
+		killGroup:       KillProcessTree,
+		removeContainer: func(name string) error { return removeDockerContainer(dockerBin, name) },
+	}
+	report, err := sweepOrphanContainerWrappers(wrappers, deps, liveSessions)
+	if err != nil {
+		log.Printf("[sweep] orphan container reap: %v", err)
+	}
+	return report
+}
+
+// listDockerContainers snapshots every container (running and exited) with the
+// fields the reaper correlates on. It runs docker without sudo: maestro's daemon
+// user is expected to have docker access, and shelling out through sudo from a
+// watchdog would be an unbounded privilege surface.
+func listDockerContainers(dockerBin string) ([]ContainerState, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, dockerBin, "ps", "-a", "--no-trunc",
+		"--format", "{{.Names}}\t{{.State}}\t{{.ID}}\t{{.Label \"maestro.session\"}}").Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseDockerContainers(string(out)), nil
+}
+
+// parseDockerContainers parses the tab-delimited `docker ps -a` output produced
+// by listDockerContainers. A container is Running only when docker reports its
+// state as "running"; every other state (exited, dead, created, paused) is
+// treated as terminal-or-not-eligible and, for exited, safe to reap.
+func parseDockerContainers(out string) []ContainerState {
+	var cs []ContainerState
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 2 {
+			continue
+		}
+		c := ContainerState{
+			Name:    strings.TrimSpace(fields[0]),
+			Running: strings.EqualFold(strings.TrimSpace(fields[1]), "running"),
+		}
+		if len(fields) >= 3 {
+			c.ID = strings.TrimSpace(fields[2])
+		}
+		if len(fields) >= 4 {
+			c.Session = strings.TrimSpace(fields[3])
+		}
+		if c.Name != "" {
+			cs = append(cs, c)
+		}
+	}
+	return cs
+}
+
+// removeDockerContainer force-removes an exited named container.
+func removeDockerContainer(dockerBin, name string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	return exec.CommandContext(ctx, dockerBin, "rm", "-f", name).Run()
+}

--- a/internal/worker/container_reap_test.go
+++ b/internal/worker/container_reap_test.go
@@ -1,0 +1,223 @@
+package worker
+
+import (
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestIsDockerRunWrapper(t *testing.T) {
+	cases := []struct {
+		cmdline string
+		want    bool
+	}{
+		{"sudo docker run --name verify-x alpine true", true},
+		{"docker run --name verify-x alpine true", true},
+		{"/usr/bin/docker run --rm alpine", true},
+		{"sudo /usr/bin/docker run --name c img", true},
+		{"docker ps -a", false},
+		{"docker rm -f c", false},
+		{"dockerd --experimental", false},
+		{"my-docker-runner run x", false}, // basename is not exactly "docker"
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isDockerRunWrapper(tc.cmdline); got != tc.want {
+			t.Errorf("isDockerRunWrapper(%q) = %v, want %v", tc.cmdline, got, tc.want)
+		}
+	}
+}
+
+func TestParseWrapperContainer(t *testing.T) {
+	cases := []struct {
+		cmdline  string
+		wantName string
+		wantOK   bool
+	}{
+		{"sudo docker run --name verify-826 alpine true", "verify-826", true},
+		{"docker run --name=verify-826 alpine true", "verify-826", true},
+		{"docker run --rm alpine true", "", false}, // anonymous container
+		{"docker run --name", "", false},           // dangling flag
+		{"docker ps -a", "", false},                // not a run wrapper
+	}
+	for _, tc := range cases {
+		name, ok := parseWrapperContainer(tc.cmdline)
+		if name != tc.wantName || ok != tc.wantOK {
+			t.Errorf("parseWrapperContainer(%q) = (%q,%v), want (%q,%v)",
+				tc.cmdline, name, ok, tc.wantName, tc.wantOK)
+		}
+	}
+}
+
+func TestParseDockerContainers(t *testing.T) {
+	out := "verify-826\tExited\tabc123\tsess-old\n" +
+		"active-verify\trunning\tdef456\tsess-live\n" +
+		"\t\t\t\n" + // blank/garbage line ignored
+		"leftover\tdead\tghi789\t\n"
+	got := parseDockerContainers(out)
+	want := []ContainerState{
+		{Name: "verify-826", Running: false, ID: "abc123", Session: "sess-old"},
+		{Name: "active-verify", Running: true, ID: "def456", Session: "sess-live"},
+		{Name: "leftover", Running: false, ID: "ghi789", Session: ""},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseDockerContainers mismatch:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+// TestSelectOrphanContainerReaps is the acceptance-5 regression: a genuinely
+// active container is never reaped, while a terminal container backing a
+// superseded/parentless wrapper is.
+func TestSelectOrphanContainerReaps(t *testing.T) {
+	containers := []ContainerState{
+		{Name: "verify-826", Running: false, Session: "sess-old"}, // terminal, superseded
+		{Name: "active-verify", Running: true, Session: "sess-live"},
+		{Name: "quiet-live", Running: false, Session: "sess-live2"}, // terminal but session still live
+	}
+	wrappers := []WrapperProc{
+		{PID: 100, PPID: 1, Container: "verify-826"},       // orphan → reap
+		{PID: 200, PPID: 4321, Container: "active-verify"}, // live parent + running container → keep
+		{PID: 300, PPID: 1, Container: "quiet-live"},       // parentless but session live → keep
+	}
+	liveSessions := map[string]bool{"sess-live": true, "sess-live2": true}
+
+	plan := selectOrphanContainerReaps(containers, wrappers, liveSessions)
+
+	if !reflect.DeepEqual(plan.KillPIDs, []int{100}) {
+		t.Errorf("KillPIDs = %v, want [100]", plan.KillPIDs)
+	}
+	if !reflect.DeepEqual(plan.RemoveContainers, []string{"verify-826"}) {
+		t.Errorf("RemoveContainers = %v, want [verify-826]", plan.RemoveContainers)
+	}
+}
+
+// TestSelectOrphanContainerReaps_IncidentChain reproduces the incident: a
+// three-process `sudo docker run` wrapper chain, all reparented to init, whose
+// named container exited 127. No session correlation is available (empty
+// Session, nil liveSessions) so the parentless + terminal signal alone reaps it.
+func TestSelectOrphanContainerReaps_IncidentChain(t *testing.T) {
+	containers := []ContainerState{
+		{Name: "pkg-verify", Running: false, Session: ""},
+	}
+	wrappers := []WrapperProc{
+		{PID: 111, PPID: 1, Container: "pkg-verify"},
+		{PID: 112, PPID: 1, Container: "pkg-verify"},
+		{PID: 113, PPID: 1, Container: "pkg-verify"},
+	}
+	plan := selectOrphanContainerReaps(containers, wrappers, nil)
+
+	sort.Ints(plan.KillPIDs)
+	if !reflect.DeepEqual(plan.KillPIDs, []int{111, 112, 113}) {
+		t.Errorf("KillPIDs = %v, want [111 112 113]", plan.KillPIDs)
+	}
+	if !reflect.DeepEqual(plan.RemoveContainers, []string{"pkg-verify"}) {
+		t.Errorf("RemoveContainers = %v, want [pkg-verify]", plan.RemoveContainers)
+	}
+}
+
+// A terminal container is not removed while any preserved (still-live) wrapper
+// references it — even if another parentless wrapper for the same container is
+// reaped.
+func TestSelectOrphanContainerReaps_PreservedWrapperBlocksRemoval(t *testing.T) {
+	containers := []ContainerState{{Name: "shared", Running: false, Session: ""}}
+	wrappers := []WrapperProc{
+		{PID: 100, PPID: 1, Container: "shared"},   // orphan
+		{PID: 200, PPID: 999, Container: "shared"}, // live parent → preserve container
+	}
+	plan := selectOrphanContainerReaps(containers, wrappers, nil)
+
+	if !reflect.DeepEqual(plan.KillPIDs, []int{100}) {
+		t.Errorf("KillPIDs = %v, want [100]", plan.KillPIDs)
+	}
+	if len(plan.RemoveContainers) != 0 {
+		t.Errorf("RemoveContainers = %v, want none (live wrapper still holds it)", plan.RemoveContainers)
+	}
+}
+
+// A parentless wrapper referencing an unknown/absent container is left alone: we
+// cannot positively confirm the container is terminal, so we never guess.
+func TestSelectOrphanContainerReaps_UnknownContainerLeftAlone(t *testing.T) {
+	wrappers := []WrapperProc{{PID: 100, PPID: 1, Container: "ghost"}}
+	plan := selectOrphanContainerReaps(nil, wrappers, nil)
+	if len(plan.KillPIDs) != 0 || len(plan.RemoveContainers) != 0 {
+		t.Errorf("expected no action for absent container, got %+v", plan)
+	}
+}
+
+// A wrapper for a container maestro did not launch (no reap) never causes a
+// removal — unrelated exited host containers are untouched.
+func TestSelectOrphanContainerReaps_UnrelatedExitedContainerUntouched(t *testing.T) {
+	containers := []ContainerState{{Name: "someone-elses", Running: false, Session: ""}}
+	plan := selectOrphanContainerReaps(containers, nil, nil)
+	if len(plan.RemoveContainers) != 0 {
+		t.Errorf("RemoveContainers = %v, want none (no maestro wrapper reaped)", plan.RemoveContainers)
+	}
+}
+
+func TestSweepOrphanContainerWrappers(t *testing.T) {
+	containers := []ContainerState{
+		{Name: "verify-826", Running: false, Session: ""},
+		{Name: "active", Running: true, Session: ""},
+	}
+	wrappers := []WrapperProc{
+		{PID: 100, PPID: 1, Container: "verify-826"},
+		{PID: 200, PPID: 5, Container: "active"},
+	}
+	var killed []int
+	var removed []string
+	deps := reaperDeps{
+		listContainers:  func() ([]ContainerState, error) { return containers, nil },
+		killGroup:       func(pid int) { killed = append(killed, pid) },
+		removeContainer: func(name string) error { removed = append(removed, name); return nil },
+	}
+
+	report, err := sweepOrphanContainerWrappers(wrappers, deps, nil)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if !reflect.DeepEqual(killed, []int{100}) {
+		t.Errorf("killed = %v, want [100]", killed)
+	}
+	if !reflect.DeepEqual(removed, []string{"verify-826"}) {
+		t.Errorf("removed = %v, want [verify-826]", removed)
+	}
+	if !reflect.DeepEqual(report.KilledWrappers, []int{100}) || !reflect.DeepEqual(report.RemovedContainers, []string{"verify-826"}) {
+		t.Errorf("report = %+v, want killed [100] removed [verify-826]", report)
+	}
+	if report.Empty() {
+		t.Error("report.Empty() = true, want false")
+	}
+}
+
+// A container-removal failure must not be recorded as removed evidence, and must
+// not abort the pass.
+func TestSweepOrphanContainerWrappers_RemoveError(t *testing.T) {
+	deps := reaperDeps{
+		listContainers: func() ([]ContainerState, error) {
+			return []ContainerState{{Name: "verify-826", Running: false}}, nil
+		},
+		killGroup:       func(pid int) {},
+		removeContainer: func(name string) error { return errors.New("busy") },
+	}
+	report, err := sweepOrphanContainerWrappers(
+		[]WrapperProc{{PID: 100, PPID: 1, Container: "verify-826"}}, deps, nil)
+	if err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if len(report.RemovedContainers) != 0 {
+		t.Errorf("RemovedContainers = %v, want none on remove error", report.RemovedContainers)
+	}
+	if !reflect.DeepEqual(report.KilledWrappers, []int{100}) {
+		t.Errorf("KilledWrappers = %v, want [100]", report.KilledWrappers)
+	}
+}
+
+func TestSweepOrphanContainerWrappers_ListError(t *testing.T) {
+	deps := reaperDeps{
+		listContainers: func() ([]ContainerState, error) { return nil, errors.New("docker down") },
+	}
+	if _, err := sweepOrphanContainerWrappers([]WrapperProc{{PID: 1, PPID: 1, Container: "x"}}, deps, nil); err == nil {
+		t.Fatal("expected error when container listing fails")
+	}
+}


### PR DESCRIPTION
Implements #977

## Changes
- New `internal/worker/container_reap.go`: a host-global, idempotent reaper for parentless `docker run` client wrappers whose named container has gone terminal.
  - Correlates wrapper/container identity with the owning session (via a `maestro.session` container label when present).
  - Reaps a wrapper only when it is parentless (PPID=1), its container is terminal, and the owning session is not live. Running containers, live sessions, and live-parented wrappers are always preserved.
  - Removes the exited container only when maestro reaped a wrapper for it and no preserved wrapper still holds it; unrelated host containers are untouched.
  - Records the cleanup in an `OrphanCleanupReport` for operator evidence.
- Wired into orchestrator startup (alongside the visual-QA sweep) and the material-progress watchdog interval. The reaped orphan is never folded into the progress watermark.

## Testing
- `go test ./...` (green)
- `go build ./cmd/maestro/`
- Unit regressions cover: active container preserved, terminal superseded wrapper reaped, the three-process parentless incident chain, preserved-wrapper-blocks-removal, unknown/unrelated containers left alone, and sweep error paths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds automatic cleanup for orphaned Docker client wrappers. The main changes are:

- A host-global wrapper and container reaper.
- Startup cleanup in the orchestrator.
- Periodic cleanup in the material-progress watchdog.

<h3>Confidence Score: 4/5</h3>

The destructive cleanup path can remove non-terminal or unrelated containers and can signal a reused PID.

Docker states other than `running` are treated as terminal. Cleanup does not require positive Maestro ownership. Process identity is not revalidated before signaling.

internal/worker/container_reap.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the non-terminal container cleanup behavior by running a focused Go test that exercised the production parser, reaper selector, and sweep path for paused, restarting, and created containers, and observed that each non-terminal state produced a cleanup plan containing the parentless wrapper PID and container name, with every sweep invoking both the process-group kill callback and the container-removal callback and reporting the wrapper killed and the container removed.
- Verified the cleanup without Maestro ownership proof by running the production parser and sweep with a parentless docker-run wrapper and an unrecognized terminal session; the plan picked PID 42420 and operator-wrapper, and the sweep's callbacks killed PID 42420 and removed operator-wrapper, and the focused Go test passed.
- Verified stale PID handling by using the focused Go harness modeling PID reuse during the Docker query; the listContainers step changed occupant of PID 4242 before killGroup saw the same PID, and the production sweep test passed, confirming the order is listContainers, killGroup, then removeContainer with no identity-validation hook.
- Verified end-to-end readiness by running the focused suite and seeing all named reaper tests pass, the integration package test commands return exit code 0, and the daemon build succeed.

<a href="https://app.greptile.com/trex/runs/15272634/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/container_reap.go | Adds host discovery and destructive cleanup, but its state, ownership, and PID identity checks are too broad. |
| internal/supervisor/material_progress_runtime.go | Runs the host-global cleanup periodically from each material-progress evaluator. |
| internal/orchestrator/orchestrator.go | Runs the cleanup during orchestrator startup before normal reconciliation. |
| internal/worker/container_reap_test.go | Covers intended cleanup behavior but omits non-terminal Docker states, unrelated wrappers, and PID identity changes. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/worker/container_reap.go:101
**Non-Terminal Containers Are Removed**

`Running` is false for every Docker state except `running`, so parentless wrappers for `paused`, `restarting`, or `created` containers pass this gate. The sweep then runs `docker rm -f`, destroying a container that has not reached a terminal state.

### Issue 2 of 3
internal/worker/container_reap.go:101
**Cleanup Lacks Maestro Ownership Proof**

This predicate accepts any host process parsed as a parentless `docker run --name` wrapper when the matching container is not running. It does not require a Maestro label or known session, so an unrelated operator-owned wrapper can be killed and its exited container force-removed.

### Issue 3 of 3
internal/worker/container_reap.go:207-209
**Stale PID Can Kill Replacement**

The PID comes from an earlier `/proc` snapshot and is not revalidated after the Docker query. If the wrapper exits and Linux reuses its PID during that window, `KillProcessTree` signals the unrelated replacement process and its children.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-826-97..."](https://github.com/befeast/maestro/commit/a0277bc252d107bcbbe169c4b75eb5df6694d9c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46012812)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->