### PR TITLE
P0: automatic outcome recovery must fence outcome-driven product repair dispatch (#1004)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -8525,15 +8525,7 @@ func (o *Orchestrator) revalidateSpawnRepairPR(s *state.State, target *state.Sup
 func (o *Orchestrator) automaticOutcomeRecoveryOwnsFailure(s *state.State) bool {
 	return o != nil && o.cfg != nil && o.cfg.Outcome.AutomaticRecoveryEnabled() &&
 		s != nil && s.OutcomeHealth != nil && s.OutcomeHealth.State == outcome.HealthFailing &&
-		activeOutcomeRecovery(s.OutcomeRecovery)
-}
-
-func activeOutcomeRecovery(recovery *outcome.RecoveryState) bool {
-	if recovery == nil {
-		return false
-	}
-	return recovery.Status == outcome.RecoveryStatusExecuting ||
-		recovery.Status == outcome.RecoveryStatusVerificationPending
+		s.OutcomeRecovery.OwnsActiveFailure(time.Now().UTC())
 }
 
 func activeIssueClaimForSession(s *state.State, issueNumber int, slot string) (state.IssueClaim, bool) {

--- a/internal/outcome/recovery.go
+++ b/internal/outcome/recovery.go
@@ -68,6 +68,36 @@ func (r RecoveryRunner) runCommand(ctx context.Context, command, dir string) (in
 	return recoveryExitCode(err), err
 }
 
+// OwnsActiveFailure reports whether this automatic-recovery lease/receipt is
+// still the sole actuator for the failing project outcome at time now.
+//
+// Ownership holds while the recovery is:
+//   - executing (a bounded command is running under the durable lease), or
+//   - verification-pending (the command finished exit 0 and the authoritative
+//     health check has not yet confirmed the fix), or
+//   - cooldown-bounded: a failed attempt whose retry cooldown has not yet
+//     elapsed. The project-scoped actuator will re-lease at NextEligibleAt, so
+//     the drift is still owned and an outcome-driven product repair must not
+//     race in during the cooldown window.
+//
+// A verified receipt (the outcome recovered), an uncertain receipt (no durable
+// receipt; health verification is authoritative and no cooldown fence exists),
+// or a failed attempt whose cooldown already elapsed do NOT own the failure —
+// genuine independent PR blockers remain repairable in those states.
+func (r *RecoveryState) OwnsActiveFailure(now time.Time) bool {
+	if r == nil {
+		return false
+	}
+	switch r.Status {
+	case RecoveryStatusExecuting, RecoveryStatusVerificationPending:
+		return true
+	case RecoveryStatusFailed:
+		return !r.NextEligibleAt.IsZero() && now.UTC().Before(r.NextEligibleAt)
+	default:
+		return false
+	}
+}
+
 func (r RecoveryRunner) now() time.Time {
 	if r.Now != nil {
 		return r.Now().UTC()

--- a/internal/outcome/recovery_test.go
+++ b/internal/outcome/recovery_test.go
@@ -28,3 +28,41 @@ func TestRecoveryRunnerTimeoutKillsDescendantProcessGroup(t *testing.T) {
 		t.Fatalf("stat marker: %v", err)
 	}
 }
+
+func TestRecoveryStateOwnsActiveFailure(t *testing.T) {
+	now := time.Date(2026, 7, 18, 8, 42, 0, 0, time.UTC)
+	cases := []struct {
+		name  string
+		state *RecoveryState
+		want  bool
+	}{
+		{name: "nil", state: nil, want: false},
+		{name: "executing", state: &RecoveryState{Status: RecoveryStatusExecuting}, want: true},
+		{name: "verification_pending", state: &RecoveryState{Status: RecoveryStatusVerificationPending}, want: true},
+		{name: "verified", state: &RecoveryState{Status: RecoveryStatusVerified}, want: false},
+		{name: "uncertain", state: &RecoveryState{Status: RecoveryStatusUncertain}, want: false},
+		{name: "failed_no_cooldown", state: &RecoveryState{Status: RecoveryStatusFailed}, want: false},
+		{
+			name:  "failed_cooldown_bounded",
+			state: &RecoveryState{Status: RecoveryStatusFailed, NextEligibleAt: now.Add(2 * time.Minute)},
+			want:  true,
+		},
+		{
+			name:  "failed_cooldown_elapsed",
+			state: &RecoveryState{Status: RecoveryStatusFailed, NextEligibleAt: now.Add(-2 * time.Minute)},
+			want:  false,
+		},
+		{
+			name:  "failed_cooldown_boundary_not_owned",
+			state: &RecoveryState{Status: RecoveryStatusFailed, NextEligibleAt: now},
+			want:  false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.state.OwnsActiveFailure(now); got != tc.want {
+				t.Fatalf("OwnsActiveFailure = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2876,12 +2876,10 @@ func (e *Engine) openPRNeedsRepair(st *state.State, stuckStates []state.Supervis
 
 func (e *Engine) automaticOutcomeRecoveryOwnsFailure(st *state.State) bool {
 	if e == nil || e.cfg == nil || !e.cfg.Outcome.AutomaticRecoveryEnabled() ||
-		st == nil || st.OutcomeHealth == nil || st.OutcomeHealth.State != outcome.HealthFailing ||
-		st.OutcomeRecovery == nil {
+		st == nil || st.OutcomeHealth == nil || st.OutcomeHealth.State != outcome.HealthFailing {
 		return false
 	}
-	return st.OutcomeRecovery.Status == outcome.RecoveryStatusExecuting ||
-		st.OutcomeRecovery.Status == outcome.RecoveryStatusVerificationPending
+	return st.OutcomeRecovery.OwnsActiveFailure(e.now())
 }
 
 // openPRReadyToMerge returns (true, reasons[]) when a session's open PR can


### PR DESCRIPTION
Implements #1004

## Changes
- Consolidate the automatic-recovery ownership predicate into a shared `RecoveryState.OwnsActiveFailure(now)` method, used by both the supervisor repair-eligibility gate (`openPRNeedsRepair`) and the dispatcher's spawn-repair revalidation (`revalidateSpawnRepairPR`).
- Extend ownership to the cooldown-bounded `failed` state so a delayed outcome-driven product repair cannot race in during a failed attempt's retry cooldown, when the project-scoped recovery actuator will re-lease at `NextEligibleAt`. Executing and verification-pending leases remain owned.
- Verified/uncertain receipts and elapsed-cooldown failures do not own the failure, so genuine independent PR blockers (current failed CI, merge conflict, actionable review finding) stay repairable in place.

## Testing
- `go test ./...` (full suite passes)
- `go build ./cmd/maestro/`
- Unit coverage for `OwnsActiveFailure` across all recovery statuses and the cooldown boundary; existing supervisor and dispatcher regressions (green draft + failing outcome + active recovery => no respawn; failed-CI/conflict/review paths still repairable; older approved outcome repair stales after recovery acquires a lease) continue to pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fences outcome-driven product repair while automatic recovery owns the active failure. The main changes are:

- Adds a shared recovery-ownership predicate.
- Covers executing, verification-pending, and cooldown-bounded failed attempts.
- Applies the predicate in supervisor eligibility and dispatcher revalidation.
- Tests every recovery status and the cooldown boundary.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the three requested recovery fencing commands against the change's parent revision and the updated change, recording verbose outputs in recovery fencing logs 01-before and 02-after.
- The verbose output confirms the specific cooldown checks passed: failed\_cooldown\_bounded, failed\_cooldown\_elapsed, and failed\_cooldown\_boundary\_not\_owned.
- Dispatcher output explicitly records refusal of the outcome-owned green-draft repair and identifies repair-7 as stale.
- Dispatcher and supervisor tests indicate there are inactive failed/uncertain recovery paths and that independent failed-CI paths remain repairable.
- A side-by-side comparison between the before and after logs was performed to validate the effect of the change on recovery fencing.

<a href="https://app.greptile.com/trex/runs/15275001/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/outcome/recovery.go | Adds the shared ownership predicate for active and cooldown-bounded recovery states. |
| internal/orchestrator/orchestrator.go | Uses the shared predicate when revalidating product repair dispatch. |
| internal/supervisor/supervisor.go | Uses the shared predicate when deciding whether an open pull request needs repair. |
| internal/outcome/recovery_test.go | Covers recovery statuses, cooldown timing, and the exact eligibility boundary. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-825-10..."](https://github.com/befeast/maestro/commit/1b24906b186489d35c4774570f68209c60912bdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46012893)</sub>

<!-- /greptile_comment -->