### PR TITLE
fix: operator attention ignores failed sessions superseded by a later authoritative session (#976)

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -4400,12 +4400,22 @@ func fleetSupersedingIssueSession(candidate sessionInfo, all []sessionInfo) (ses
 				return peer, true
 			}
 		case state.StatusDone:
-			// A terminal peer is authoritative only when it owns the issue's
-			// delivered PR and this attempt was explicitly reconciled as a
-			// duplicate. Do not hide a genuine failed follow-up merely because
-			// an older session for the issue once completed.
-			if peer.PRNumber > 0 && !peer.ReleasedForRedispatch &&
-				(candidate.WorkerOutcome == "duplicate_dispatch_reconciled" || fleetSessionStartedAfterCanonicalCompletion(candidate, peer)) {
+			// A canonical session that delivered the issue's PR and still owns
+			// it authoritatively supersedes a no-PR terminal sibling for the
+			// same issue — whether that sibling was an earlier predecessor
+			// attempt (failed A, failed B before the later done C) or a later
+			// duplicate that raced the merge. The old row is preserved in
+			// history/usage accounting but must not consume operator attention
+			// or become operator_state (#976).
+			//
+			// ReleasedForRedispatch is the discriminator that protects a
+			// genuine regression: when the issue is intentionally reopened for a
+			// real follow-up, the done session's dispatch claim is released, so
+			// it no longer hides the new attempt and the current session
+			// surfaces instead of a predecessor (#949). Selection stays
+			// deterministic and idempotent because it depends only on durable
+			// session fields, not on relative wall-clock ordering.
+			if peer.PRNumber > 0 && !peer.ReleasedForRedispatch {
 				return peer, true
 			}
 		}
@@ -4449,12 +4459,6 @@ func fleetPRSessionOwnerPrecedes(candidate, current sessionInfo) bool {
 		return state.SessionStatus(candidate.Status) == state.StatusQueued
 	}
 	return candidate.Slot < current.Slot
-}
-
-func fleetSessionStartedAfterCanonicalCompletion(candidate, canonical sessionInfo) bool {
-	started, startErr := time.Parse(time.RFC3339, strings.TrimSpace(candidate.StartedAt))
-	finished, finishErr := time.Parse(time.RFC3339, strings.TrimSpace(canonical.FinishedAt))
-	return startErr == nil && finishErr == nil && !started.Before(finished)
 }
 
 func backendDriftRestartControlAction(readOnly bool, endpoint, target string, workers, skipped []controlActionWorkerTarget) controlAction {

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -4041,10 +4041,16 @@ func TestFleetSupersedingIssueSessionUsesCanonicalMergedPRForReconciledDuplicate
 		t.Fatalf("superseding merged session = %+v, %v; want %s", got, ok, canonical.Slot)
 	}
 
+	// #976: a genuine failed predecessor (no reconciliation outcome) for a
+	// still-open issue is also superseded by the canonical done session that
+	// merged the issue's PR. The failed row stays in history/usage accounting
+	// but must not become operator_state. Genuine regressions are protected by
+	// ReleasedForRedispatch (see the reopened-follow-up test), not by treating
+	// every predecessor failure as current attention.
 	genuineFailure := duplicate
 	genuineFailure.WorkerOutcome = ""
-	if got, ok := fleetSupersedingIssueSession(genuineFailure, []sessionInfo{genuineFailure, canonical}); ok {
-		t.Fatalf("genuine failed follow-up incorrectly superseded: %+v", got)
+	if got, ok := fleetSupersedingIssueSession(genuineFailure, []sessionInfo{genuineFailure, canonical}); !ok || got.Slot != canonical.Slot {
+		t.Fatalf("failed predecessor not superseded by canonical done session = %+v, %v; want %s", got, ok, canonical.Slot)
 	}
 }
 
@@ -4062,10 +4068,14 @@ func TestFleetSupersedingIssueSessionUsesCanonicalMergedPRForLaterDuplicate(t *t
 		t.Fatalf("later duplicate superseding session = %+v, %v; want %s", got, ok, canonical.Slot)
 	}
 
+	// #976: an earlier predecessor failure (started before the canonical done
+	// session finished) is superseded too. Supersession no longer depends on
+	// relative wall-clock ordering between the failed row and the completion —
+	// only on the canonical done session still owning its delivered PR.
 	earlierFailure := duplicate
 	earlierFailure.StartedAt = "2026-07-17T13:20:00Z"
-	if got, ok := fleetSupersedingIssueSession(earlierFailure, []sessionInfo{earlierFailure, canonical}); ok {
-		t.Fatalf("earlier genuine failure incorrectly superseded: %+v", got)
+	if got, ok := fleetSupersedingIssueSession(earlierFailure, []sessionInfo{earlierFailure, canonical}); !ok || got.Slot != canonical.Slot {
+		t.Fatalf("earlier predecessor failure not superseded = %+v, %v; want %s", got, ok, canonical.Slot)
 	}
 }
 
@@ -4081,6 +4091,41 @@ func TestFleetSupersedingIssueSessionDoesNotUseReleasedDoneSessionForReopenedFol
 
 	if got, ok := fleetSupersedingIssueSession(followUp, []sessionInfo{followUp, oldCompleted}); ok {
 		t.Fatalf("released terminal session incorrectly hid reopened follow-up: %+v", got)
+	}
+}
+
+// TestFleetSupersedingIssueSessionSuppressesPredecessorFailuresBehindLaterDone
+// pins the #976 regression: an issue accumulated two failed implementation
+// sessions, then a later canonical session merged its PR and reached done while
+// the issue intentionally stayed open/blocked for installed-runtime QA. Neither
+// failed predecessor may become operator_state; the canonical done session
+// wins. Selection is order-independent and idempotent across the full session
+// set (both predecessors present at once).
+func TestFleetSupersedingIssueSessionSuppressesPredecessorFailuresBehindLaterDone(t *testing.T) {
+	failedA := sessionInfo{
+		Slot: "ok-player-410", IssueNumber: 512, Status: string(state.StatusFailed),
+		NeedsAttention: true, StartedAt: "2026-07-19T08:00:00Z",
+	}
+	failedB := sessionInfo{
+		Slot: "ok-player-418", IssueNumber: 512, Status: string(state.StatusDead),
+		NeedsAttention: true, StartedAt: "2026-07-19T10:30:00Z",
+	}
+	doneC := sessionInfo{
+		Slot: "ok-player-431", IssueNumber: 512, Status: string(state.StatusDone),
+		PRNumber: 540, FinishedAt: "2026-07-19T13:15:00Z",
+	}
+	all := []sessionInfo{failedA, failedB, doneC}
+
+	if got, ok := fleetSupersedingIssueSession(failedA, all); !ok || got.Slot != doneC.Slot {
+		t.Fatalf("failed A superseding session = %+v, %v; want %s", got, ok, doneC.Slot)
+	}
+	if got, ok := fleetSupersedingIssueSession(failedB, all); !ok || got.Slot != doneC.Slot {
+		t.Fatalf("failed B superseding session = %+v, %v; want %s", got, ok, doneC.Slot)
+	}
+	// The canonical done session itself is never a suppression candidate: it is
+	// not flagged as needing attention, so it remains the surfaced state.
+	if _, ok := fleetSupersedingIssueSession(doneC, all); ok {
+		t.Fatalf("canonical done session must not be superseded")
 	}
 }
 


### PR DESCRIPTION
Refs #976

## Changes
- `fleetSupersedingIssueSession` (operator-attention / `operator_state` selection): a canonical `done` session that delivered the issue's PR and still owns it now supersedes every no-PR terminal (`failed`/`dead`/`conflict_failed`/`retry_exhausted`) sibling for the same issue — earlier failed predecessors (failed A, failed B before a later done C) as well as later duplicates that raced the merge. Previously only siblings that started after completion or were reconciled as `duplicate_dispatch_reconciled` were suppressed, so predecessors A/B could still become `operator_state`.
- `ReleasedForRedispatch` remains the single discriminator that steps the done session aside for a genuine reopened follow-up, so a real regression surfaces the current session rather than a predecessor. Selection depends only on durable session fields (no relative wall-clock ordering), so it is deterministic and idempotent across reconciliation cycles and restarts.
- Removed the now-unused `fleetSessionStartedAfterCanonicalCompletion` helper.
- Display/reconciliation truth only: no worktree deletion, no change to dispatch leases, no loss of history/usage/attribution records.

## Testing
- `go build ./cmd/maestro/`
- `go test ./...` (green; added a predecessor-failures-behind-later-done regression test and updated two sibling assertions to the new invariant)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects operator-attention selection for issues with superseded failed sessions. The main changes are:

- Treats an authoritative completed session with a retained PR claim as superseding terminal no-PR siblings.
- Uses `ReleasedForRedispatch` to preserve attention for genuine reopened follow-ups.
- Removes timestamp-based supersession logic.
- Adds tests for predecessor failures, later duplicates, and reopened follow-ups.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before the change, the old logic failed to supersede no-PR predecessor failures behind a canonical done session with a delivered PR, but after the change the focused regression tests passed: TestFleetSupersedingIssueSessionUsesCanonicalMergedPRForReconciledDuplicate, TestFleetSupersedingIssueSessionUsesCanonicalMergedPRForLaterDuplicate, TestFleetSupersedingIssueSessionSuppressesPredecessorFailuresBehindLaterDone, and TestFleetSupersedingIssueSessionDoesNotUseReleasedDoneSessionForReopenedFollowUp.
- The Maestro command compiled successfully after the focused regression passed.
- Three log artifacts were produced to document the test results and validation outputs.

<a href="https://app.greptile.com/trex/runs/15283769/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Updates completed-session supersession and removes the obsolete timestamp comparison helper. |
| internal/server/fleet_test.go | Adds and updates tests for failed predecessors, duplicate attempts, and redispatched follow-ups. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-827-97..."](https://github.com/befeast/maestro/commit/c4ec0e6fd196ea3fd04e63d9faa71e6c4ba02f14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46013931)</sub>

<!-- /greptile_comment -->