### PR TITLE
P0: graceful drain can strand retained workers dead without retry or watchdog target

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -868,7 +868,11 @@ func (d *Daemon) Drain(ctx context.Context, timeout time.Duration) {
 			log.Printf("[daemon] drain: load state for flow %q (%s) failed: %v", names[i], dir, err)
 			continue
 		}
-		s.SetSpawnDrain(time.Now().UTC())
+		// Record that this drain is part of an actual daemon shutdown. The
+		// orchestrator uses this persisted cause marker to preserve only a
+		// shutdown-interrupted process loss across restart; a standalone
+		// `maestro drain` must not revive an unrelated crash (#967).
+		s.SetShutdownDrain(time.Now().UTC())
 		if err := state.Save(dir, s); err != nil {
 			log.Printf("[daemon] drain: set drain flag for flow %q (%s) failed: %v", names[i], dir, err)
 			continue

--- a/internal/daemon/daemon_drain_test.go
+++ b/internal/daemon/daemon_drain_test.go
@@ -44,6 +44,9 @@ func TestDrainSetsSpawnDrainAndReturnsWhenIdle(t *testing.T) {
 		if !s.DrainActive() {
 			t.Fatalf("flow %s: SpawnDrain not set after Drain", name)
 		}
+		if !s.ShutdownDrainActive() {
+			t.Fatalf("flow %s: daemon Drain did not persist shutdown-specific drain intent", name)
+		}
 	}
 }
 
@@ -82,8 +85,8 @@ func TestDrainWaitsForWorkersThenAbortsOnCancel(t *testing.T) {
 	}
 
 	// SpawnDrain was still requested in phase 1.
-	if s, err := state.Load(cfg.StateDir); err != nil || !s.DrainActive() {
-		t.Fatalf("SpawnDrain not set during wait (err=%v)", err)
+	if s, err := state.Load(cfg.StateDir); err != nil || !s.ShutdownDrainActive() {
+		t.Fatalf("shutdown drain intent not set during wait (err=%v)", err)
 	}
 
 	// Second signal → ctx cancel → Drain aborts the wait.

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -163,6 +163,11 @@ func TestRunSkipsDuplicateFlowIdentity(t *testing.T) {
 	if flows != 1 {
 		t.Fatalf("flows = %d, want 1 (duplicate flow identity skipped)", flows)
 	}
+	// The single deduped flow's run loop is launched as a goroutine by
+	// startFlow, so it may not have incremented started yet when waitForFleet
+	// returns. Wait for it to reach 1; startFlow ran exactly once, so it can
+	// never exceed 1 (avoids a race where a 0 read spuriously fails).
+	waitFor(t, func() bool { return atomic.LoadInt64(&run.started) == 1 })
 	if got := atomic.LoadInt64(&run.started); got != 1 {
 		t.Fatalf("run loops started = %d, want 1", got)
 	}

--- a/internal/daemon/restart_checkpoint_test.go
+++ b/internal/daemon/restart_checkpoint_test.go
@@ -207,6 +207,47 @@ func TestCheckpointInFlightForRestart_YieldsToTerminalSession(t *testing.T) {
 	}
 }
 
+// A FinishedAt timestamp inside the drain window does not prove shutdown caused
+// the terminal transition. Ordinary failures and scheduled retries can also be
+// persisted while flows drain, so the shutdown checkpoint pass must continue to
+// accept only sessions that are still running rather than infer restart intent
+// from timestamp ordering.
+func TestCheckpointInFlightForRestart_DoesNotInferDeadDuringDrain(t *testing.T) {
+	stateDir := t.TempDir()
+	worktree := t.TempDir()
+	drainStart := time.Now().UTC().Add(-time.Minute)
+	finished := drainStart.Add(30 * time.Second)
+	retryAt := finished.Add(5 * time.Minute)
+
+	s := state.NewState()
+	s.SetSpawnDrain(drainStart)
+	s.Sessions["sup-320"] = &state.Session{
+		IssueNumber: 320,
+		Status:      state.StatusDead,
+		Worktree:    worktree,
+		FinishedAt:  &finished,
+		NextRetryAt: &retryAt,
+	}
+	if err := state.Save(stateDir, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	d := &Daemon{}
+	d.checkpointInFlightForRestart(time.Now().Add(time.Hour), []string{stateDir})
+
+	reloaded, err := state.Load(stateDir)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	got := reloaded.Sessions["sup-320"]
+	if got.RestartCheckpointAt != nil {
+		t.Fatalf("ordinary dead session received restart marker %v", got.RestartCheckpointAt)
+	}
+	if got.NextRetryAt == nil || !got.NextRetryAt.Equal(retryAt) {
+		t.Fatalf("ordinary retry policy changed: next_retry_at=%v, want %v", got.NextRetryAt, retryAt)
+	}
+}
+
 // A running session whose worktree no longer exists cannot be resumed in place,
 // so it is left unmarked for the normal reconcile/retry path.
 func TestCheckpointInFlightForRestart_SkipsMissingWorktree(t *testing.T) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3200,6 +3200,27 @@ func strSliceEqual(a, b []string) bool {
 	return true
 }
 
+// checkpointDrainDeathForRestart marks one explicit unexpected process-loss
+// transition as resumable while the session is still running. The caller must
+// invoke it before changing Status to Dead, and only the daemon's persisted
+// in-process shutdown drain qualifies: a generic operator drain can overlap an
+// ordinary crash and must not override its terminal or retry policy (#967).
+func checkpointDrainDeathForRestart(s *state.State, sess *state.Session, at time.Time) bool {
+	if s == nil || sess == nil || sess.Status != state.StatusRunning || !s.ShutdownDrainActive() {
+		return false
+	}
+	worktree := strings.TrimSpace(sess.Worktree)
+	if worktree == "" {
+		return false
+	}
+	if _, err := os.Stat(worktree); err != nil {
+		return false
+	}
+	stamp := at.UTC()
+	sess.RestartCheckpointAt = &stamp
+	return true
+}
+
 // reconcileRunningSessions self-heals stale "running" sessions.
 // If a session is marked running but either its PID is dead/missing OR its tmux session
 // is missing, the session is transitioned to a terminal state.
@@ -3567,24 +3588,20 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		// the first recovery when max_retries_per_issue is 1.
 		unexpectedRetryAllowed := strings.TrimSpace(sess.Worktree) != "" && o.canRetryIssue(s, sess)
 		o.updateTokensUsedFromWorkerLog(slotName, sess)
+		now := time.Now().UTC()
+		// #967: preserve recovery intent while this is still known to be the
+		// explicit process/tmux-gone path. Inferring the cause later from a dead
+		// session's FinishedAt would also revive ordinary provider failures and
+		// scheduled retries that happened during drain.
+		if checkpointDrainDeathForRestart(s, sess, now) {
+			log.Printf("[orch] reconcile: %s died during drain — retained worktree marked for exact in-place restart resume", slotName)
+		}
 		sess.Status = state.StatusDead
 		sess.PID = 0
 		sess.TmuxSession = ""
-		now := time.Now().UTC()
 		sess.FinishedAt = &now
 		state.MarkWorkerEnded(sess, now)
-		// #967: during graceful drain the daemon shutdown pass may run only
-		// after this flow has already persisted running->dead. Stamp the same
-		// resumable identity here while the cause is still known. Dead markers
-		// are held while drain remains active and consumed by the replacement
-		// daemon, preserving this exact slot/worktree without a new dispatch.
-		if s.DrainActive() && strings.TrimSpace(sess.Worktree) != "" {
-			if _, statErr := os.Stat(sess.Worktree); statErr == nil {
-				stamp := now
-				sess.RestartCheckpointAt = &stamp
-				log.Printf("[orch] reconcile: %s died during drain — retained worktree marked for exact in-place restart resume", slotName)
-			}
-		} else if unexpectedRetryAllowed {
+		if !s.DrainActive() && unexpectedRetryAllowed {
 			if _, statErr := os.Stat(sess.Worktree); statErr == nil {
 				// Unexpected process loss used to become an unscheduled dead
 				// session. Dead sessions are outside the material-progress watchdog,

--- a/internal/orchestrator/restart_resume_test.go
+++ b/internal/orchestrator/restart_resume_test.go
@@ -110,9 +110,10 @@ func TestReconcile_DrainDeathResumesDeadCheckpointAfterRestart(t *testing.T) {
 	resumeCount := 0
 	o := restartResumeOrchestrator(t, &resumeCount)
 
+	stateDir := t.TempDir()
 	worktree := t.TempDir()
 	s := state.NewState()
-	s.SetSpawnDrain(time.Now().UTC().Add(-time.Minute))
+	s.SetShutdownDrain(time.Now().UTC().Add(-time.Minute))
 	s.Sessions["sup-313"] = &state.Session{
 		IssueNumber: 313,
 		IssueTitle:  "dies during drain",
@@ -139,15 +140,50 @@ func TestReconcile_DrainDeathResumesDeadCheckpointAfterRestart(t *testing.T) {
 	if resumeCount != 0 {
 		t.Fatalf("old draining daemon resumed %d workers, want 0", resumeCount)
 	}
-	o.reconcileRunningSessions(s)
+	if err := state.Save(stateDir, s); err != nil {
+		t.Fatalf("persist drain-time death: %v", err)
+	}
+
+	// Cross the actual daemon restart boundary. The dead marker and canonical
+	// slot identity must survive persistence, and the retained-worktree claim
+	// must suppress a fresh ready-queue dispatch before restart reconcile runs.
+	post, err := state.Load(stateDir)
+	if err != nil {
+		t.Fatalf("reload drain-time death: %v", err)
+	}
+	sess = post.Sessions["sup-313"]
+	if sess.Status != state.StatusDead || sess.RestartCheckpointAt == nil {
+		t.Fatalf("persisted drain-time state = status %q marker %v, want dead with restart marker", sess.Status, sess.RestartCheckpointAt)
+	}
+	if sess.IssueNumber != 313 || sess.Branch != "feat/sup-313-313-drain" || sess.Worktree != worktree {
+		t.Fatalf("persisted session identity changed: issue=%d branch=%q worktree=%q", sess.IssueNumber, sess.Branch, sess.Worktree)
+	}
+	if !post.IssueInProgress(313) {
+		t.Fatal("persisted retained worktree must keep the issue claimed against duplicate dispatch")
+	}
+
+	o.reconcileRunningSessions(post)
 	if resumeCount != 0 {
 		t.Fatalf("old draining daemon replayed dead checkpoint %d times, want 0", resumeCount)
 	}
 
 	// New daemon clears the one-shot drain flag before its first cycle and
-	// consumes the dead marker exactly once on the same logical session.
-	s.ClearSpawnDrain(time.Now().UTC())
-	if !o.reconcileRunningSessions(s) {
+	// consumes the dead marker exactly once on the same logical session. Even if
+	// fresh dispatch were evaluated first, the retained claim must win.
+	post.ClearSpawnDrain(time.Now().UTC())
+	freshDispatches := 0
+	o.listOpenIssuesFn = func([]string) ([]github.Issue, error) {
+		return []github.Issue{makeIssue(313, "dies during drain")}, nil
+	}
+	o.workerStartFn = func(*config.Config, *state.State, string, github.Issue, string, string) (string, error) {
+		freshDispatches++
+		return "duplicate", nil
+	}
+	o.startNewWorkers(post, 1)
+	if freshDispatches != 0 {
+		t.Fatalf("fresh dispatch count = %d, want 0 while canonical dead checkpoint owns issue", freshDispatches)
+	}
+	if !o.reconcileRunningSessions(post) {
 		t.Fatal("replacement daemon did not resume dead checkpoint")
 	}
 	if resumeCount != 1 {
@@ -160,9 +196,113 @@ func TestReconcile_DrainDeathResumesDeadCheckpointAfterRestart(t *testing.T) {
 		t.Fatalf("session identity changed: issue=%d branch=%q worktree=%q", sess.IssueNumber, sess.Branch, sess.Worktree)
 	}
 
-	o.reconcileRunningSessions(s)
+	// Persist marker consumption too. A later daemon/cycle sees the live resumed
+	// runtime and cannot replay the checkpoint or dispatch another worker.
+	if err := state.Save(stateDir, post); err != nil {
+		t.Fatalf("persist resumed session: %v", err)
+	}
+	next, err := state.Load(stateDir)
+	if err != nil {
+		t.Fatalf("reload resumed session: %v", err)
+	}
+	o.reconcileRunningSessions(next)
 	if resumeCount != 1 {
 		t.Fatalf("dead checkpoint resumed %d times, want exactly once", resumeCount)
+	}
+}
+
+// A terminal failure recorded during the drain window is not proof that
+// shutdown caused it. In particular, a dead session with an ordinary retry
+// remains governed by its backoff; recovery must never infer restart intent
+// later from FinishedAt relative to SpawnDrainAt.
+func TestCheckpointDrainDeathForRestart_DoesNotInferOrdinaryTerminal(t *testing.T) {
+	worktree := t.TempDir()
+	drainStart := time.Now().UTC().Add(-time.Minute)
+	finished := drainStart.Add(30 * time.Second)
+	retryAt := finished.Add(5 * time.Minute)
+
+	s := state.NewState()
+	s.SetSpawnDrain(drainStart)
+	sess := &state.Session{
+		IssueNumber: 313,
+		Status:      state.StatusDead,
+		Worktree:    worktree,
+		FinishedAt:  &finished,
+		NextRetryAt: &retryAt,
+	}
+
+	if checkpointDrainDeathForRestart(s, sess, finished) {
+		t.Fatal("already-terminal failure must not be inferred to be restart-resumable")
+	}
+	if sess.RestartCheckpointAt != nil {
+		t.Fatalf("ordinary terminal failure received restart marker %v", sess.RestartCheckpointAt)
+	}
+	if sess.NextRetryAt == nil || !sess.NextRetryAt.Equal(retryAt) {
+		t.Fatalf("ordinary retry policy changed: next_retry_at=%v, want %v", sess.NextRetryAt, retryAt)
+	}
+}
+
+// A standalone operator drain only stops fresh dispatch; it does not prove an
+// unrelated process loss was caused by a daemon restart. The ordinary crash
+// must therefore remain dead and must not be replayed after a later restart.
+func TestReconcile_GenericDrainCrashDoesNotBecomeRestartCheckpoint(t *testing.T) {
+	resumeCount := 0
+	o := restartResumeOrchestrator(t, &resumeCount)
+	o.cfg.MaxRetriesPerIssue = 1
+	stateDir := t.TempDir()
+	worktree := t.TempDir()
+
+	s := state.NewState()
+	s.SetSpawnDrain(time.Now().UTC().Add(-time.Minute))
+	// Exhaust the ordinary retry budget so this process loss is terminal. The
+	// shutdown-resume marker must not silently override that policy.
+	s.Sessions["sup-776"] = &state.Session{
+		IssueNumber: 777,
+		Status:      state.StatusDead,
+	}
+	s.Sessions["sup-777"] = &state.Session{
+		IssueNumber: 777,
+		IssueTitle:  "ordinary crash during operator drain",
+		Status:      state.StatusRunning,
+		PID:         424242,
+		TmuxSession: "sup-777",
+		Branch:      "feat/sup-777-ordinary-crash",
+		Worktree:    worktree,
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("expected ordinary process loss to be reconciled")
+	}
+	sess := s.Sessions["sup-777"]
+	if sess.Status != state.StatusDead {
+		t.Fatalf("status = %q, want dead", sess.Status)
+	}
+	if sess.RestartCheckpointAt != nil {
+		t.Fatalf("generic drain crash received restart marker %v", sess.RestartCheckpointAt)
+	}
+	if resumeCount != 0 {
+		t.Fatalf("old daemon resumed %d workers, want 0", resumeCount)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatalf("retry-exhausted crash unexpectedly scheduled retry %v", sess.NextRetryAt)
+	}
+	if err := state.Save(stateDir, s); err != nil {
+		t.Fatalf("persist ordinary terminal crash: %v", err)
+	}
+
+	post, err := state.Load(stateDir)
+	if err != nil {
+		t.Fatalf("reload ordinary terminal crash: %v", err)
+	}
+	sess = post.Sessions["sup-777"]
+	if sess.Status != state.StatusDead || sess.RestartCheckpointAt != nil || sess.NextRetryAt != nil {
+		t.Fatalf("persisted ordinary crash = status %q marker %v retry %v, want terminal dead without restart policy", sess.Status, sess.RestartCheckpointAt, sess.NextRetryAt)
+	}
+
+	post.ClearSpawnDrain(time.Now().UTC())
+	o.reconcileRunningSessions(post)
+	if resumeCount != 0 {
+		t.Fatalf("ordinary crash resumed after restart %d times, want 0", resumeCount)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1340,9 +1340,12 @@ type State struct {
 	// workers but lets in-flight workers finish. It is set by `maestro
 	// drain` and cleared automatically when the orchestrator starts, so a
 	// drain never persists across a legitimate restart. SpawnDrainAt records
-	// when the drain was requested (UTC).
-	SpawnDrain   bool      `json:"spawn_drain,omitempty"`
-	SpawnDrainAt time.Time `json:"spawn_drain_at,omitempty"`
+	// when the drain was requested (UTC). ShutdownDrain distinguishes the
+	// daemon's in-process SIGTERM drain from a standalone operator drain: only
+	// the former makes a process loss restart-resumable (#967).
+	SpawnDrain    bool      `json:"spawn_drain,omitempty"`
+	SpawnDrainAt  time.Time `json:"spawn_drain_at,omitempty"`
+	ShutdownDrain bool      `json:"shutdown_drain,omitempty"`
 
 	// Paused is the first-class operator pause (#683): while it is set, the
 	// orchestrator skips issue selection entirely and spawns no new workers,
@@ -1881,6 +1884,7 @@ func (s *State) copyFrom(src *State) {
 	s.LastMergeAt = src.LastMergeAt
 	s.SpawnDrain = src.SpawnDrain
 	s.SpawnDrainAt = src.SpawnDrainAt
+	s.ShutdownDrain = src.ShutdownDrain
 	s.Paused = src.Paused
 	s.PausedAt = src.PausedAt
 	s.MaterialProgress = src.MaterialProgress
@@ -1993,10 +1997,12 @@ func mergeSpawnDrain(merged, current, ours *State) {
 	if ours.SpawnDrainAt.After(current.SpawnDrainAt) {
 		merged.SpawnDrain = ours.SpawnDrain
 		merged.SpawnDrainAt = ours.SpawnDrainAt
+		merged.ShutdownDrain = ours.ShutdownDrain
 		return
 	}
 	merged.SpawnDrain = current.SpawnDrain
 	merged.SpawnDrainAt = current.SpawnDrainAt
+	merged.ShutdownDrain = current.ShutdownDrain
 }
 
 // mergePaused resolves the pause flag (#683) latest-write-wins by PausedAt,
@@ -4019,6 +4025,20 @@ func (s *State) SetSpawnDrain(at time.Time) {
 		return
 	}
 	s.SpawnDrain = true
+	s.ShutdownDrain = false
+	s.SpawnDrainAt = normalizedTime(at)
+}
+
+// SetShutdownDrain requests the daemon's in-process graceful shutdown drain.
+// Unlike a standalone `maestro drain`, a worker process lost during this window
+// is presumed interrupted by the daemon restart and may carry restart intent
+// across its running-to-dead transition (#967).
+func (s *State) SetShutdownDrain(at time.Time) {
+	if s == nil {
+		return
+	}
+	s.SpawnDrain = true
+	s.ShutdownDrain = true
 	s.SpawnDrainAt = normalizedTime(at)
 }
 
@@ -4029,12 +4049,19 @@ func (s *State) ClearSpawnDrain(at time.Time) {
 		return
 	}
 	s.SpawnDrain = false
+	s.ShutdownDrain = false
 	s.SpawnDrainAt = normalizedTime(at)
 }
 
 // DrainActive reports whether a graceful drain is currently requested.
 func (s *State) DrainActive() bool {
 	return s != nil && s.SpawnDrain
+}
+
+// ShutdownDrainActive reports whether the active drain belongs to an in-process
+// daemon shutdown rather than a standalone operator drain.
+func (s *State) ShutdownDrainActive() bool {
+	return s != nil && s.SpawnDrain && s.ShutdownDrain
 }
 
 // SetPaused marks the project paused (#683): the orchestrator skips issue

--- a/internal/state/state_drain_test.go
+++ b/internal/state/state_drain_test.go
@@ -32,14 +32,29 @@ func TestSetAndClearSpawnDrain(t *testing.T) {
 	if !s.DrainActive() {
 		t.Fatal("DrainActive() false after SetSpawnDrain")
 	}
+	if s.ShutdownDrainActive() {
+		t.Fatal("standalone SetSpawnDrain must not claim daemon shutdown intent")
+	}
 	if !s.SpawnDrainAt.Equal(at) {
 		t.Fatalf("SpawnDrainAt = %v, want %v", s.SpawnDrainAt, at)
+	}
+
+	shutdownAt := at.Add(30 * time.Second)
+	s.SetShutdownDrain(shutdownAt)
+	if !s.ShutdownDrainActive() {
+		t.Fatal("ShutdownDrainActive() false after SetShutdownDrain")
+	}
+	if !s.SpawnDrainAt.Equal(shutdownAt) {
+		t.Fatalf("SpawnDrainAt = %v, want %v after shutdown drain", s.SpawnDrainAt, shutdownAt)
 	}
 
 	later := at.Add(time.Minute)
 	s.ClearSpawnDrain(later)
 	if s.DrainActive() {
 		t.Fatal("DrainActive() true after ClearSpawnDrain")
+	}
+	if s.ShutdownDrainActive() {
+		t.Fatal("ShutdownDrainActive() true after ClearSpawnDrain")
 	}
 	if !s.SpawnDrainAt.Equal(later) {
 		t.Fatalf("SpawnDrainAt = %v, want %v after clear", s.SpawnDrainAt, later)
@@ -67,6 +82,27 @@ func TestSpawnDrain_SurvivesSaveLoadRoundTrip(t *testing.T) {
 	}
 }
 
+func TestShutdownDrain_SurvivesSaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := NewState()
+	at := time.Date(2026, 7, 18, 0, 5, 0, 0, time.UTC)
+	s.SetShutdownDrain(at)
+	if err := Save(dir, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	reloaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if !reloaded.ShutdownDrainActive() {
+		t.Fatal("shutdown-specific drain intent lost across save/load")
+	}
+	if !reloaded.SpawnDrainAt.Equal(at) {
+		t.Fatalf("SpawnDrainAt = %v, want %v after round trip", reloaded.SpawnDrainAt, at)
+	}
+}
+
 // TestMergeSpawnDrain_LatestWriteWins covers the concurrent-save path: a drain
 // request must survive an orchestrator save that does not carry the flag (older
 // timestamp), and a fresh clear must not be undone by a stale set.
@@ -85,6 +121,21 @@ func TestMergeSpawnDrain_LatestWriteWins(t *testing.T) {
 		}
 		if !merged.DrainActive() {
 			t.Fatal("fresh drain request lost to stale concurrent save")
+		}
+	})
+
+	t.Run("fresh shutdown drain keeps its cause marker", func(t *testing.T) {
+		base := NewState()
+		current := NewState()
+		ours := NewState()
+		ours.SetShutdownDrain(t0.Add(time.Minute))
+
+		merged, err := mergeStateSnapshots(base, current, ours)
+		if err != nil {
+			t.Fatalf("merge: %v", err)
+		}
+		if !merged.ShutdownDrainActive() {
+			t.Fatal("fresh shutdown drain lost its persisted cause marker")
 		}
 	})
 


### PR DESCRIPTION
Refs #967

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds restart recovery for workers interrupted during graceful daemon shutdown. The main changes are:

- Persist a shutdown-specific drain marker in flow state.
- Checkpoint retained workers before marking them dead.
- Preserve checkpoint ownership across daemon restarts.
- Keep operator-drain failures under normal terminal and retry policy.
- Add drain, persistence, retry, and restart-boundary tests.

<h3>Confidence Score: 5/5</h3>

The shutdown and operator drain paths are separated.

No additional blocking issue qualified for this review.

No distinct unresolved failure remained in the selected scope.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the pre-change focused tests against pre-change production code and observed exit code 1 due to missing ShutdownDrainActive, SetShutdownDrain, and checkpointDrainDeathForRestart symbols.
- Ran the exact requested focused command documented in graceful-daemon-restart-02-after.log; all named tests passed, including both highest-risk reconciliation paths, with exit code 0.
- Captured a manifest documenting checksums, sizes, named outcomes, and exit codes for both executions to enable verification and traceability.

<a href="https://app.greptile.com/trex/runs/15299269/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/daemon/daemon.go | Marks daemon-initiated drains with shutdown-specific persisted state. |
| internal/orchestrator/orchestrator.go | Checkpoints retained workers during shutdown reconciliation and preserves ordinary retry behavior outside drains. |
| internal/state/state.go | Adds persistence, merging, and lifecycle methods for shutdown drain intent. |
| internal/orchestrator/restart_resume_test.go | Expands coverage for checkpoint persistence, duplicate-dispatch prevention, and operator-drain failures. |

<sub>Reviews (8): Last reviewed commit: ["test: wait for run loop start in duplica..."](https://github.com/befeast/maestro/commit/716931b9c5258b36138280062358a3d747f41b6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46014095)</sub>

<!-- /greptile_comment -->