### PR TITLE
P0: closed no-delivery session remains dead behind project outcome gate

### DIFF
--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -5977,9 +5977,9 @@ func TestCheckSessions_ClosedNoDeliveryIssueBecomesDoneWhenProjectOutcomeFails(t
 	}
 	s.Sessions["pan-10"] = &state.Session{
 		IssueNumber: 100,
-		IssueTitle:  "failed worker",
-		Status:      state.StatusFailed,
-		Branch:      "feat/pan-10-100-failed",
+		IssueTitle:  "dead worker",
+		Status:      state.StatusDead,
+		Branch:      "feat/pan-10-100-dead",
 		Worktree:    worktree,
 		FinishedAt:  &now,
 	}
@@ -5990,7 +5990,7 @@ func TestCheckSessions_ClosedNoDeliveryIssueBecomesDoneWhenProjectOutcomeFails(t
 	if sess.Status != state.StatusDone {
 		t.Fatalf("status = %q, want %q: no merged revision is owned by this closed issue", sess.Status, state.StatusDone)
 	}
-	if sess.Branch != "feat/pan-10-100-failed" {
+	if sess.Branch != "feat/pan-10-100-dead" {
 		t.Fatalf("branch = %q, want retained branch unchanged", sess.Branch)
 	}
 	if sess.Worktree != worktree {


### PR DESCRIPTION
Refs #970

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the orchestrator test for closed sessions without an owned delivery. The main changes are:

- Uses a dead session instead of a failed session in the test fixture.
- Verifies that the dead session transitions to done when the project outcome fails.
- Updates the retained branch expectation to match the dead-session fixture.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused closed-session reconciliation regression test before the fixture change to establish a baseline.
- Observed the closed dead session transitioned to done and retained its branch and worktree despite failing project outcome health.
- Ran the same test after the fixture change and confirmed the command exited with code 0.
- Verified the post-change test output explicitly showed dead -\> done despite health failure.
- Compared the before and after results across both proofs to confirm the fixture change achieved the intended state transition.

<a href="https://app.greptile.com/trex/runs/15288232/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator_test.go | Updates the lifecycle test fixture and branch assertion to cover a closed dead session with no owned delivery. |

<sub>Reviews (3): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-828-97..."](https://github.com/befeast/maestro/commit/454fae67210fb7993135583d19cc25a1afc656f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46018879)</sub>

<!-- /greptile_comment -->