### PR TITLE
P0: in-place respawn derives GitHub issue from slot suffix instead of canonical issue_number

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -960,7 +960,7 @@ func applySupervisorAttention(infos []sessionInfo, latest *state.SupervisorDecis
 			if !stuckTargetsSession(stuck, infos[i]) {
 				continue
 			}
-			if staleReviewFeedbackResolved(stuck, infos[i]) {
+			if staleSupervisorFindingResolved(stuck, infos[i]) {
 				continue
 			}
 			attention := supervisorStuckNeedsAttention(stuck)
@@ -979,6 +979,23 @@ func applySupervisorAttention(infos []sessionInfo, latest *state.SupervisorDecis
 			break
 		}
 	}
+}
+
+func staleSupervisorFindingResolved(stuck state.SupervisorStuckState, info sessionInfo) bool {
+	if staleReviewFeedbackResolved(stuck, info) {
+		return true
+	}
+	if stuck.Code != "dead_running_pid" {
+		return false
+	}
+	// Fleet derives PID and liveness from the current session projection. A
+	// supervisor decision recorded before an in-place respawn can still carry
+	// the dead predecessor's PID; never overwrite a coherent live tuple with
+	// that stale explanation.
+	if state.SessionStatus(info.Status) != state.StatusRunning {
+		return true
+	}
+	return info.Alive != nil && *info.Alive
 }
 
 func staleReviewFeedbackResolved(stuck state.SupervisorStuckState, info sessionInfo) bool {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -663,6 +663,43 @@ func TestApplySupervisorAttentionSessionTargetDoesNotFallback(t *testing.T) {
 	}
 }
 
+func TestAllSessionInfosSuppressesDeadPIDFindingAfterRespawn(t *testing.T) {
+	now := time.Now().UTC()
+	pid := os.Getpid()
+	st := state.NewState()
+	st.Sessions["project-273"] = &state.Session{
+		IssueNumber: 345,
+		IssueTitle:  "flatpak beta retry",
+		Status:      state.StatusRunning,
+		PID:         pid,
+		StartedAt:   now,
+		PRNumber:    388,
+	}
+	st.RecordSupervisorDecision(state.SupervisorDecision{
+		ID:        "before-respawn",
+		CreatedAt: now.Add(-time.Minute),
+		StuckStates: []state.SupervisorStuckState{{
+			Code:              "dead_running_pid",
+			Severity:          "blocked",
+			Summary:           "Worker project-273 is marked running, but PID 481040 is not alive.",
+			RecommendedAction: "Run a Maestro reconciliation cycle.",
+			Target:            &state.SupervisorTarget{Issue: 345, PR: 388, Session: "project-273"},
+		}},
+	}, state.DefaultSupervisorDecisionLimit)
+
+	infos := allSessionInfos(&config.Config{Repo: "BeFeast/ok-player"}, st)
+	if len(infos) != 1 {
+		t.Fatalf("session projections = %d, want 1", len(infos))
+	}
+	got := infos[0]
+	if got.Status != string(state.StatusRunning) || got.PID != pid || got.Alive == nil || !*got.Alive {
+		t.Fatalf("runtime tuple = status:%q pid:%d alive:%v, want coherent live replacement", got.Status, got.PID, got.Alive)
+	}
+	if !contains(got.StatusReason, "alive") || contains(got.StatusReason, "481040") || contains(got.StatusReason, "not alive") || got.NextAction != "" || got.NeedsAttention {
+		t.Fatalf("stale predecessor finding leaked into live projection: reason=%q next=%q attention=%v", got.StatusReason, got.NextAction, got.NeedsAttention)
+	}
+}
+
 func TestApplySupervisorAttentionSuppressesResolvedStaleReviewFeedback(t *testing.T) {
 	infos := []sessionInfo{
 		{

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -169,6 +169,8 @@ func TestNewWorkerController_StopPreservesWorktreeBranchAndPR(t *testing.T) {
 		Status:      state.StatusRunning,
 		PRNumber:    1008,
 	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = sess
 	controller := NewWorkerController(&config.Config{Repo: "owner/repo"})
 	stopDone := make(chan error, 1)
 	go func() {
@@ -188,6 +190,9 @@ func TestNewWorkerController_StopPreservesWorktreeBranchAndPR(t *testing.T) {
 	}
 	if sess.Worktree != "/srv/worktrees/slot-1" || sess.Branch != "maestro/issue-42" || sess.PRNumber != 1008 {
 		t.Fatalf("stop destroyed durable work pointers: worktree=%q branch=%q pr=%d", sess.Worktree, sess.Branch, sess.PRNumber)
+	}
+	if claim, ok := st.IssueClaimFor(42); !ok || claim.Kind != state.IssueClaimOpenPRMaintenance || claim.Session != "slot-1" {
+		t.Fatalf("stopped open-PR session lost its dispatch lease: claim=%+v ok=%v", claim, ok)
 	}
 }
 

--- a/internal/worker/canonical_issue.go
+++ b/internal/worker/canonical_issue.go
@@ -1,0 +1,112 @@
+package worker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+const canonicalIssueMarkerFormat = "<!-- maestro:canonical-issue-number=%d -->"
+
+const canonicalIssueReminderFormat = "Runtime identifier suffixes are not issue numbers. Continue only issue **#%d**."
+
+// assertCanonicalIssue fails closed when the issue about to be rendered into a
+// worker prompt does not match the session's persisted canonical issue_number.
+//
+// #959: an in-place respawn for an open-PR session composed the worker task from
+// the numeric slot suffix (e.g. slot "ok-player-273") instead of the session's
+// canonical issue_number (345), so every respawn ran `gh issue view 273` and
+// burned tokens on the wrong issue. The slot suffix is a monotonic slot counter
+// unrelated to the GitHub issue number; the two diverge whenever the slot index
+// and the issue number differ. Every launch/respawn path already sources the
+// issue via getIssue(sess.IssueNumber), so a mismatch here means a caller
+// derived the number from the slot name — refuse to launch (and preserve the
+// existing worktree/PR) rather than prompt a worker for the wrong issue.
+func assertCanonicalIssue(slotName string, sess *state.Session, issue github.Issue) error {
+	if sess == nil {
+		return fmt.Errorf("refusing to launch worker %s: session record is missing", slotName)
+	}
+	if sess.IssueNumber <= 0 {
+		return fmt.Errorf("refusing to launch worker %s: session canonical issue_number is invalid (%d)", slotName, sess.IssueNumber)
+	}
+	if issue.Number <= 0 {
+		return fmt.Errorf("refusing to launch worker %s: rendered issue number is invalid (%d)", slotName, issue.Number)
+	}
+	if issue.Number != sess.IssueNumber {
+		return fmt.Errorf(
+			"refusing to launch worker %s: rendered issue #%d does not match session canonical issue #%d",
+			slotName, issue.Number, sess.IssueNumber,
+		)
+	}
+	return nil
+}
+
+// withCanonicalIssueBinding puts the persisted GitHub identity ahead of every
+// other prompt section. Slot, worktree, and tmux names contain a monotonic
+// numeric suffix that is unrelated to the GitHub issue number; spelling that
+// out at the top prevents an agent from treating the runtime suffix as task
+// identity when it decides which `gh issue` command to run.
+func withCanonicalIssueBinding(prompt, repo string, issue github.Issue) string {
+	repo = strings.TrimSpace(repo)
+	identity := fmt.Sprintf("issue #%d", issue.Number)
+	if repo != "" {
+		identity = fmt.Sprintf("%s#%d", repo, issue.Number)
+	}
+	title := strings.TrimSpace(issue.Title)
+	if title != "" {
+		identity += ": " + title
+	}
+
+	return fmt.Sprintf(`%s
+## Canonical GitHub Issue Binding
+
+This worker launch is bound to **%s**. Use issue **#%d** for every GitHub issue lookup, issue command, issue comment, and PR-body issue reference.
+
+Session, slot, branch, worktree, log, and tmux names are runtime identifiers. Their numeric suffixes are never GitHub issue numbers; do not derive an issue number from them.
+
+---
+
+%s
+
+---
+
+## Canonical Issue Reminder
+
+%s`,
+		fmt.Sprintf(canonicalIssueMarkerFormat, issue.Number),
+		identity,
+		issue.Number,
+		prompt,
+		fmt.Sprintf(canonicalIssueReminderFormat, issue.Number),
+	)
+}
+
+// assertCanonicalPrompt verifies the final rendered prompt retained the exact
+// canonical issue binding before any worker process is launched.
+func assertCanonicalPrompt(slotName string, expectedIssue int, prompt string) error {
+	if expectedIssue <= 0 {
+		return fmt.Errorf("refusing to launch worker %s: expected canonical issue number is invalid (%d)", slotName, expectedIssue)
+	}
+	marker := fmt.Sprintf(canonicalIssueMarkerFormat, expectedIssue)
+	if !strings.HasPrefix(prompt, marker+"\n") {
+		return fmt.Errorf("refusing to launch worker %s: rendered prompt does not match canonical issue #%d", slotName, expectedIssue)
+	}
+	reminder := fmt.Sprintf(canonicalIssueReminderFormat, expectedIssue)
+	if !strings.HasSuffix(prompt, reminder) {
+		return fmt.Errorf("refusing to launch worker %s: rendered prompt lost its final canonical issue #%d reminder", slotName, expectedIssue)
+	}
+	// Continuation/checkpoint text is carried forward from a previous worker
+	// and can contain the exact bad command that caused #959. Reject that
+	// command when it targets the runtime slot suffix instead of the canonical
+	// issue, even though the surrounding prompt has a correct binding.
+	slotSuffix := parseSlotNumber(slotName)
+	if slotSuffix > 0 && slotSuffix != expectedIssue {
+		wrongView := fmt.Sprintf("gh issue view %d", slotSuffix)
+		if strings.Contains(strings.ToLower(prompt), wrongView) {
+			return fmt.Errorf("refusing to launch worker %s: rendered prompt contains a slot-suffix issue command instead of canonical issue #%d", slotName, expectedIssue)
+		}
+	}
+	return nil
+}

--- a/internal/worker/canonical_issue_test.go
+++ b/internal/worker/canonical_issue_test.go
@@ -1,0 +1,105 @@
+package worker
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// #959: the numeric slot suffix (a monotonic slot counter) is unrelated to the
+// canonical GitHub issue number. assertCanonicalIssue must fail closed when a
+// caller hands the launch path an issue whose number was derived from the slot
+// name instead of the session's persisted issue_number.
+func TestAssertCanonicalIssue_SlotSuffixDiffersFromCanonical(t *testing.T) {
+	// slot "ok-player-273", canonical issue #345 — the incident shape.
+	sess := &state.Session{IssueNumber: 345}
+
+	if err := assertCanonicalIssue("ok-player-273", sess, github.Issue{Number: 345}); err != nil {
+		t.Fatalf("canonical issue #345 must launch: %v", err)
+	}
+
+	err := assertCanonicalIssue("ok-player-273", sess, github.Issue{Number: 273})
+	if err == nil {
+		t.Fatal("issue #273 derived from the slot suffix must be refused")
+	}
+	if !strings.Contains(err.Error(), "345") || !strings.Contains(err.Error(), "273") {
+		t.Fatalf("error must name both the rendered and canonical issue: %q", err)
+	}
+}
+
+func TestAssertCanonicalIssue_MissingRecordFailsClosed(t *testing.T) {
+	if err := assertCanonicalIssue("slot-1", nil, github.Issue{Number: 5}); err == nil {
+		t.Fatal("nil session must fail closed")
+	}
+	if err := assertCanonicalIssue("slot-1", &state.Session{IssueNumber: 0}, github.Issue{Number: 5}); err == nil {
+		t.Fatal("unset canonical issue must fail closed")
+	}
+}
+
+// Acceptance: respawning a fixture session named `project-273` with
+// issue_number=345 produces a prompt for issue #345 only; no command or prompt
+// references issue #273.
+func TestRespawnPrompt_SourcesCanonicalIssueNotSlotSuffix(t *testing.T) {
+	cfg := &config.Config{Repo: "BeFeast/ok-player"}
+	// The canonical issue the session record points at — NOT the slot suffix.
+	issue := github.Issue{
+		Number: 345,
+		Title:  "flatpak beta retry",
+		Body:   "Retry the flatpak beta publish.",
+	}
+
+	prompt := assemblePromptWithCheckpoint(
+		"Before editing, run `gh issue view {{ISSUE_NUMBER}} --repo {{REPO}}` and read {{ISSUE_TITLE}}.\n\n{{ISSUE_BODY}}",
+		issue,
+		"/tmp/worktrees/project-273",
+		"feat/ok-player-345-flatpak-beta-retry",
+		cfg,
+		"checkpoint context",
+		"CHECKPOINT.md",
+	)
+	prompt = withCanonicalIssueBinding(prompt, cfg.Repo, issue)
+
+	for _, want := range []string{
+		"<!-- maestro:canonical-issue-number=345 -->",
+		"Use issue **#345** for every GitHub issue lookup",
+		"Runtime identifier suffixes are not issue numbers. Continue only issue **#345**.",
+		"gh issue view 345 --repo BeFeast/ok-player",
+		"flatpak beta retry",
+		"Retry the flatpak beta publish.",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt must contain canonical issue content %q\nprompt:\n%s", want, prompt)
+		}
+	}
+	if err := assertCanonicalPrompt("project-273", 345, prompt); err != nil {
+		t.Fatalf("canonical prompt validation failed: %v", err)
+	}
+	// The slot suffix 273 must never appear as an issue reference or a
+	// `gh issue view 273` command.
+	for _, forbidden := range []string{"#273", "issue 273", "view 273", "issue #273"} {
+		if strings.Contains(prompt, forbidden) {
+			t.Fatalf("prompt must not reference slot suffix via %q\nprompt:\n%s", forbidden, prompt)
+		}
+	}
+}
+
+func TestAssertCanonicalPromptRejectsDifferentRenderedIssue(t *testing.T) {
+	prompt := withCanonicalIssueBinding("base", "BeFeast/ok-player", github.Issue{Number: 273, Title: "wrong"})
+	if err := assertCanonicalPrompt("project-273", 345, prompt); err == nil {
+		t.Fatal("prompt rendered for slot suffix issue #273 must not launch canonical issue #345")
+	}
+}
+
+func TestAssertCanonicalPromptRejectsSlotSuffixIssueCommandFromCheckpoint(t *testing.T) {
+	prompt := withCanonicalIssueBinding(
+		"Previous output: I'll inspect the issue now.\n`gh issue view 273 --repo BeFeast/ok-player`",
+		"BeFeast/ok-player",
+		github.Issue{Number: 345, Title: "flatpak beta retry"},
+	)
+	if err := assertCanonicalPrompt("project-273", 345, prompt); err == nil {
+		t.Fatal("slot-suffix issue command carried in checkpoint context must fail closed")
+	}
+}

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -284,6 +284,13 @@ func SaveCheckpoint(sess *state.Session) (string, error) {
 // with checkpoint context included in the prompt. Unlike Respawn, this preserves
 // the existing worktree with all committed and staged code.
 func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+	// #959: assert the rendered issue matches the session's canonical
+	// issue_number before killing the current worker, so a slot-suffix-derived
+	// number can never respawn a mis-scoped worker in the preserved worktree.
+	if err := assertCanonicalIssue(slotName, sess, issue); err != nil {
+		return err
+	}
+
 	// Kill tmux session + process subtree (but do NOT remove worktree). Reaping
 	// the whole descendant tree — not just the recorded pane PID — ensures
 	// worker grandchildren that reparented away (e.g. headless Chrome) do not
@@ -349,6 +356,10 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 	}
 	prompt += subagentHintPromptSection(backendDef.SubagentHint)
 	prompt += workerToolHookPromptSection(cfg.Hooks, backendName, hookSetup)
+	prompt = withCanonicalIssueBinding(prompt, cfg.Repo, issue)
+	if err := assertCanonicalPrompt(slotName, sess.IssueNumber, prompt); err != nil {
+		return err
+	}
 
 	// Write prompt to file
 	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -143,6 +143,10 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 	prompt := assemblePrompt(promptBase, issue, worktreePath, branchName, cfg)
 	prompt += subagentHintPromptSection(backendDef.SubagentHint)
 	prompt += workerToolHookPromptSection(cfg.Hooks, backendName, hookSetup)
+	prompt = withCanonicalIssueBinding(prompt, cfg.Repo, issue)
+	if err := assertCanonicalPrompt(slotName, issue.Number, prompt); err != nil {
+		return "", err
+	}
 
 	// Write prompt to file
 	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))
@@ -217,6 +221,12 @@ func Start(cfg *config.Config, s *state.State, repo string, issue github.Issue, 
 // Respawn cleans up a dead worker and restarts it in the same slot with a fresh worktree.
 // The session is updated in place with new PID, worktree, branch, and timestamps.
 func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo string, issue github.Issue, promptBase string, backendName string) error {
+	// #959: assert the rendered issue matches the session's canonical
+	// issue_number before tearing anything down, so a slot-suffix-derived number
+	// can never launch a mis-scoped worker.
+	if err := assertCanonicalIssue(slotName, sess, issue); err != nil {
+		return err
+	}
 	// Validate the replacement backend before killing the old session or
 	// removing its worktree.
 	if backendName == "" {
@@ -295,6 +305,10 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 	prompt := assemblePrompt(promptBase, issue, worktreePath, branchName, cfg)
 	prompt += subagentHintPromptSection(backendDef.SubagentHint)
 	prompt += workerToolHookPromptSection(cfg.Hooks, backendName, hookSetup)
+	prompt = withCanonicalIssueBinding(prompt, cfg.Repo, issue)
+	if err := assertCanonicalPrompt(slotName, sess.IssueNumber, prompt); err != nil {
+		return err
+	}
 
 	// Write prompt to file
 	promptFile := filepath.Join(cfg.StateDir, fmt.Sprintf("%s-prompt.md", slotName))


### PR DESCRIPTION
Refs #959

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR binds worker launches and respawns to the session’s canonical GitHub issue number. The main changes are:

- Adds canonical issue markers and reminders to worker prompts.
- Validates issue identity before respawn teardown.
- Validates final prompts before launching replacement workers.
- Suppresses stale dead-PID findings after a successful in-place respawn.
- Adds coverage for canonical issue handling and supervisor state projection.

<h3>Confidence Score: 5/5</h3>

No additional blocking issue qualifies for this follow-up review.

The remaining identified behaviors are already covered by the existing review threads. No distinct incomplete fix, unsafe fix, or missing paired case was found.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before any changes, slot project-273 had no binding marker or reminder and gh issue view 273 was retained without rejection.
- The generated continuation included the #345 marker, a reminder, and the canonical command, with no incorrect command present.
- After generation, the carried-forward gh issue view 273 and the issue object numbered 273 were explicitly rejected prior to worker replacement.

<a href="https://app.greptile.com/trex/runs/15278872/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/canonical_issue.go | Adds canonical issue validation, prompt binding, and slot-suffix command detection. |
| internal/worker/checkpoint.go | Adds canonical issue checks to in-place respawns. |
| internal/worker/worker.go | Adds canonical prompt binding and validation to worker start and respawn paths. |
| internal/server/server.go | Suppresses obsolete dead-PID findings when the current session projection is coherent. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-833-95..."](https://github.com/befeast/maestro/commit/92614114b2b211eb8395607675078f46bdf452e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46021501)</sub>

<!-- /greptile_comment -->