### PR TITLE
P0: real pending check-runs must block deterministic merge despite CLEAN merge state

### DIFF
--- a/internal/supervisor/policy_blocks_merge_test.go
+++ b/internal/supervisor/policy_blocks_merge_test.go
@@ -158,7 +158,14 @@ func TestDecide_OpenPR_CIAggregateStaleButMergeStateClean_Merges(t *testing.T) {
 		ciStatuses:  map[int]string{115: "pending"},
 		mergeStates: map[int]string{115: "clean"},
 		checkRollups: map[int]github.PRCheckRollup{
-			115: {Verdict: "pending", Complete: true},
+			115: {
+				Verdict:  "pending",
+				Complete: true,
+				Signals: []github.PRCheckSignal{
+					{Source: "check_run", Name: "Fedora 43", Status: "completed", Conclusion: "success"},
+					{Source: "commit_status", Name: "legacy/review", Status: "pending"},
+				},
+			},
 		},
 	}
 	st := state.NewState()
@@ -182,19 +189,23 @@ func TestDecide_OpenPR_CIAggregateStaleButMergeStateClean_Merges(t *testing.T) {
 	}
 }
 
-func TestDecide_OpenPR_RealPendingCheckRunBlocksCleanMergeState(t *testing.T) {
+func TestDecide_OpenPR420_RealPendingCheckRunBlocksCleanMergeState(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.ReviewGate = "none"
 	reader := &fakeReader{
-		prs:         []github.PR{{Number: 119, HeadRefName: "feat/new-pr", Mergeable: "MERGEABLE"}},
-		ciStatuses:  map[int]string{119: "pending"},
-		mergeStates: map[int]string{119: "clean"},
+		prs:         []github.PR{{Number: 420, HeadRefName: "ok-player/fedora", Mergeable: "MERGEABLE"}},
+		ciStatuses:  map[int]string{420: "pending"},
+		mergeStates: map[int]string{420: "clean"},
 		checkRollups: map[int]github.PRCheckRollup{
-			119: {
+			420: {
 				HeadSHA:          strings.Repeat("a", 40),
 				Verdict:          "pending",
 				Complete:         true,
 				PendingCheckRuns: true,
+				Signals: []github.PRCheckSignal{
+					{Source: "check_run", Name: "Fedora 43", Status: "in_progress"},
+					{Source: "check_run", Name: "Fedora 44", Status: "queued"},
+				},
 			},
 		},
 	}
@@ -202,8 +213,8 @@ func TestDecide_OpenPR_RealPendingCheckRunBlocksCleanMergeState(t *testing.T) {
 	st.Sessions["ok-player-1"] = &state.Session{
 		IssueNumber: 201,
 		Status:      state.StatusPROpen,
-		Branch:      "feat/new-pr",
-		PRNumber:    119,
+		Branch:      "ok-player/fedora",
+		PRNumber:    420,
 		StartedAt:   time.Now().UTC().Add(-time.Minute),
 	}
 
@@ -213,6 +224,146 @@ func TestDecide_OpenPR_RealPendingCheckRunBlocksCleanMergeState(t *testing.T) {
 	}
 	if decision.RecommendedAction != ActionMonitorOpenPR {
 		t.Fatalf("action = %q, want monitor_open_pr while current-head check-runs are pending", decision.RecommendedAction)
+	}
+}
+
+func TestDecide_OpenPR_LegacyPendingDoesNotMaskTerminalFailedCheckRun(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:         []github.PR{{Number: 123, HeadRefName: "feat/failed-check", Mergeable: "MERGEABLE"}},
+		mergeStates: map[int]string{123: "clean"},
+		checkRollups: map[int]github.PRCheckRollup{
+			123: {
+				Verdict:  "pending",
+				Complete: true,
+				Signals: []github.PRCheckSignal{
+					{Source: "check_run", Name: "build", Status: "completed", Conclusion: "failure"},
+					{Source: "commit_status", Name: "legacy/review", Status: "pending"},
+				},
+			},
+		},
+	}
+	st := state.NewState()
+	st.Sessions["failed-check-1"] = &state.Session{
+		IssueNumber: 206,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/failed-check",
+		PRNumber:    123,
+		StartedAt:   time.Now().UTC().Add(-time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want monitor_open_pr when a terminal check-run failed", decision.RecommendedAction)
+	}
+}
+
+func TestDecide_OpenPR_PendingRollupWithoutLegacyPendingSignalBlocksCleanMergeState(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:         []github.PR{{Number: 124, HeadRefName: "feat/unproven-pending", Mergeable: "MERGEABLE"}},
+		mergeStates: map[int]string{124: "clean"},
+		checkRollups: map[int]github.PRCheckRollup{
+			124: {
+				Verdict:  "pending",
+				Complete: true,
+				Signals: []github.PRCheckSignal{
+					{Source: "check_run", Name: "build", Status: "completed", Conclusion: "success"},
+				},
+			},
+		},
+	}
+	st := state.NewState()
+	st.Sessions["unproven-pending-1"] = &state.Session{
+		IssueNumber: 207,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/unproven-pending",
+		PRNumber:    124,
+		StartedAt:   time.Now().UTC().Add(-time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want monitor_open_pr without a legacy pending status signal", decision.RecommendedAction)
+	}
+}
+
+type aggregateOnlyReader struct {
+	Reader
+	ciStatus   string
+	mergeState string
+}
+
+func (r *aggregateOnlyReader) PRCIStatus(int) (string, error) {
+	return r.ciStatus, nil
+}
+
+func (r *aggregateOnlyReader) PRMergeStatus(int) (string, string, error) {
+	return "MERGEABLE", r.mergeState, nil
+}
+
+func TestDecide_OpenPR_CheckRollupUnavailableBlocksCleanMergeState(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	base := &fakeReader{
+		prs: []github.PR{{Number: 121, HeadRefName: "feat/no-rollup", Mergeable: "MERGEABLE"}},
+	}
+	reader := &aggregateOnlyReader{
+		Reader:     base,
+		ciStatus:   "pending",
+		mergeState: "clean",
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-3"] = &state.Session{
+		IssueNumber: 204,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/no-rollup",
+		PRNumber:    121,
+		StartedAt:   time.Now().UTC().Add(-time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want monitor_open_pr when current-head check rollup is unavailable", decision.RecommendedAction)
+	}
+}
+
+func TestDecide_OpenPR_PartialCheckRollupBlocksCleanMergeState(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.ReviewGate = "none"
+	reader := &fakeReader{
+		prs:         []github.PR{{Number: 122, HeadRefName: "feat/partial-rollup", Mergeable: "MERGEABLE"}},
+		mergeStates: map[int]string{122: "clean"},
+		checkRollups: map[int]github.PRCheckRollup{
+			122: {Verdict: "pending", Complete: false},
+		},
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-4"] = &state.Session{
+		IssueNumber: 205,
+		Status:      state.StatusPROpen,
+		Branch:      "feat/partial-rollup",
+		PRNumber:    122,
+		StartedAt:   time.Now().UTC().Add(-time.Minute),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionMonitorOpenPR {
+		t.Fatalf("action = %q, want monitor_open_pr when current-head check rollup is partial", decision.RecommendedAction)
 	}
 }
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2974,28 +2974,20 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 	// CI must be green. Production readers expose the current-head rollup so
 	// a real queued/in-progress check-run can never be confused with the
 	// legacy commit-status-only pending state handled by #425.
-	ciStatus := ""
-	pendingCheckRuns := false
-	rollupHeadSHA := ""
-	if rollupReader, ok := e.reader.(prCheckRollupReader); ok {
-		rollup, err := rollupReader.PRCheckRollup(pr.Number)
-		if err != nil || !rollup.Complete || strings.TrimSpace(rollup.HeadSHA) == "" {
-			return false, "", nil
-		}
-		rollupHeadSHA = strings.TrimSpace(rollup.HeadSHA)
-		ciStatus = rollup.Verdict
-		pendingCheckRuns = rollup.PendingCheckRuns
-	} else {
-		ciReader, ok := e.reader.(prCIStatusReader)
-		if !ok {
-			return false, "", nil
-		}
-		var err error
-		ciStatus, err = ciReader.PRCIStatus(pr.Number)
-		if err != nil {
-			return false, "", nil
-		}
+	rollupReader, ok := e.reader.(prCheckRollupReader)
+	if !ok {
+		// Aggregate CI alone cannot distinguish an active check-run from a
+		// stale legacy commit status. Without the current-head rollup, the
+		// merge-state override is unsafe, so fail closed.
+		return false, "", nil
 	}
+	rollup, err := rollupReader.PRCheckRollup(pr.Number)
+	if err != nil || !rollup.Complete || strings.TrimSpace(rollup.HeadSHA) == "" {
+		return false, "", nil
+	}
+	rollupHeadSHA := strings.TrimSpace(rollup.HeadSHA)
+	ciStatus := rollup.Verdict
+	pendingCheckRuns := rollup.PendingCheckRuns
 
 	// #543: GitHub LIST endpoint never populates `mergeable`; fetch via
 	// single-PR endpoint when reader supports it. Read it after the rollup so
@@ -3013,7 +3005,7 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 
 	ciLower := strings.ToLower(strings.TrimSpace(ciStatus))
 	if ciLower != "success" {
-		if pendingCheckRuns {
+		if pendingCheckRuns || !legacyStatusOnlyPending(rollup) {
 			return false, "", nil
 		}
 		// #425 (sup-98): the aggregate PRCIStatus can stick at "pending"
@@ -3077,6 +3069,46 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 		reasons = append(reasons, fmt.Sprintf("PR #%d Greptile review approved", pr.Number))
 	}
 	return true, rollupHeadSHA, reasons
+}
+
+// legacyStatusOnlyPending proves the narrow #425 exception: the aggregate
+// verdict is pending because at least one legacy commit status is pending,
+// while every observed check-run is complete and non-blocking. Any missing,
+// unfamiliar, or failed signal keeps the deterministic merge path closed.
+func legacyStatusOnlyPending(rollup github.PRCheckRollup) bool {
+	if !strings.EqualFold(strings.TrimSpace(rollup.Verdict), "pending") {
+		return false
+	}
+
+	pendingLegacyStatus := false
+	for _, signal := range rollup.Signals {
+		source := strings.ToLower(strings.TrimSpace(signal.Source))
+		status := strings.ToLower(strings.TrimSpace(signal.Status))
+		conclusion := strings.ToLower(strings.TrimSpace(signal.Conclusion))
+
+		switch source {
+		case "check_run":
+			if status != "completed" {
+				return false
+			}
+			switch conclusion {
+			case "success", "neutral", "skipped":
+			default:
+				return false
+			}
+		case "commit_status":
+			switch status {
+			case "pending":
+				pendingLegacyStatus = true
+			case "success":
+			default:
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return pendingLegacyStatus
 }
 
 // monitorOpenPRReasons returns a short list of human-readable reasons


### PR DESCRIPTION
Refs #1009

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents pending check-runs from being bypassed by a clean merge state. The main changes are:

- Requires a complete current-head check rollup before deterministic merging.
- Limits the legacy pending-status exception to completed, non-blocking check-runs.
- Adds tests for pending, failed, partial, and unavailable check rollups.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused contract-validation pass for OpenPR decision logic, executing TestDecide\_OpenPR420\_RealPendingCheckRunBlocksCleanMergeState and TestDecide\_OpenPR\_CIAggregateStaleButMergeStateClean\_Merges.
- Showed that queued/in-progress current-head check-runs can influence monitor\_open\_pr behavior during a clean merge state, as exercised by the first test.
- Confirmed that a pending legacy commit status and a checked head SHA drive the merge\_pr decision in the CIAggregate scenario.
- The focused run exited with code 0 and the package run exited with code 0 after 3.714 seconds.
- Artifacts capturing the test outputs were produced and are available for review.

<a href="https://app.greptile.com/trex/runs/15303906/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Requires complete rollup data and narrows the legacy pending-status merge exception. |
| internal/supervisor/policy_blocks_merge_test.go | Adds merge-policy tests for active checks, failed checks, legacy statuses, and unavailable or partial rollups. |

<sub>Reviews (9): Last reviewed commit: ["fix: require current-head rollup for mer..."](https://github.com/befeast/maestro/commit/87bc99bac5e5c973bc19151ee612edd0487abdb8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46036715)</sub>

<!-- /greptile_comment -->