### PR TITLE
Operator attention must ignore failed sessions superseded by a later authoritative session

### DIFF
--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -4571,10 +4571,11 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 			}
 		}
 		if worker.NeedsAttention {
-			if canonical, ok := fleetSupersedingIssueSession(worker, projectState.All); ok {
+			if canonical, ok := fleetSupersedingAttentionSession(worker, projectState.All, st); ok {
 				worker.NeedsAttention = false
+				worker.Live = false
 				worker.StatusReason = fmt.Sprintf("superseded by canonical session %s (%s)", canonical.Slot, canonical.Status)
-				worker.NextAction = "No operator action required: follow the canonical session for this issue."
+				worker.NextAction = "No operator action required: follow the current session or declared continuation."
 			}
 		}
 		if audit, isStale := staleSlots[worker.Slot]; isStale {
@@ -5045,6 +5046,24 @@ func fleetPRGateHasFailingChecks(snapshot *state.PRGateSnapshot) bool {
 func fleetPRGateChecksSucceeded(snapshot *state.PRGateSnapshot) bool {
 	return snapshot != nil && snapshot.CIRollupVerdict != state.PRGateCIFailure &&
 		snapshot.CIEffectiveVerdict == state.PRGateCISuccess
+}
+
+// fleetSupersedingAttentionSession applies the durable lifecycle predicate
+// before the Fleet-only compatibility rules below. State owns same-issue and
+// shared-PR chronological truth with full time.Time precision; the legacy
+// projection rules retain explicit duplicate-dispatch handling for historical
+// snapshots that predate precise session ordering.
+func fleetSupersedingAttentionSession(candidate sessionInfo, all []sessionInfo, st *state.State) (sessionInfo, bool) {
+	if st != nil {
+		if slot, _, ok := st.SupersedingSession(st.Sessions[candidate.Slot]); ok {
+			for _, peer := range all {
+				if peer.Slot == slot {
+					return peer, true
+				}
+			}
+		}
+	}
+	return fleetSupersedingIssueSession(candidate, all)
 }
 
 // fleetSupersedingIssueSession identifies terminal duplicate attempts that

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -4283,7 +4283,7 @@ func TestFleetAPISuppressesPredecessorAttentionBehindCurrentLifecycle(t *testing
 		wantFailed       int
 	}{
 		{name: "later done clears predecessor attention", currentStatus: state.StatusDone, wantAttention: 0, wantFailed: 2},
-		{name: "code landed QA owns attention", currentStatus: state.StatusCodeLanded, wantAttention: 1, wantOperatorSlot: "current", wantFailed: 2},
+		{name: "code landed needs no operator action", currentStatus: state.StatusCodeLanded, wantAttention: 0, wantOperatorSlot: "current", wantFailed: 2},
 		{name: "current regression owns attention", currentStatus: state.StatusFailed, wantAttention: 1, wantOperatorSlot: "current", wantFailed: 3},
 	}
 

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -4274,6 +4274,134 @@ func TestFleetSupersedingIssueSessionSuppressesTerminalDuplicate(t *testing.T) {
 	}
 }
 
+func TestFleetAPISuppressesPredecessorAttentionBehindCurrentLifecycle(t *testing.T) {
+	tests := []struct {
+		name             string
+		currentStatus    state.SessionStatus
+		wantAttention    int
+		wantOperatorSlot string
+		wantFailed       int
+	}{
+		{name: "later done clears predecessor attention", currentStatus: state.StatusDone, wantAttention: 0, wantFailed: 2},
+		{name: "code landed QA owns attention", currentStatus: state.StatusCodeLanded, wantAttention: 1, wantOperatorSlot: "current", wantFailed: 2},
+		{name: "current regression owns attention", currentStatus: state.StatusFailed, wantAttention: 1, wantOperatorSlot: "current", wantFailed: 3},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			stateDir := filepath.Join(dir, "state")
+			base := time.Now().UTC().Add(-time.Hour).Truncate(time.Second)
+			finishedA := base.Add(150 * time.Millisecond)
+			finishedB := base.Add(250 * time.Millisecond)
+			finishedCurrent := base.Add(400 * time.Millisecond)
+			saveFleetTestState(t, stateDir, map[string]*state.Session{
+				"attempt-a": {
+					IssueNumber: 976, IssueTitle: "historical failed A", Status: state.StatusFailed,
+					StartedAt: base.Add(100 * time.Millisecond), FinishedAt: &finishedA, TokensUsedTotal: 11,
+				},
+				"attempt-b": {
+					IssueNumber: 976, IssueTitle: "historical dead B", Status: state.StatusDead,
+					StartedAt: base.Add(200 * time.Millisecond), FinishedAt: &finishedB, TokensUsedTotal: 22,
+				},
+				"current": {
+					IssueNumber: 976, IssueTitle: "current lifecycle C", Status: tc.currentStatus, PRNumber: 1033,
+					StartedAt: base.Add(300 * time.Millisecond), FinishedAt: &finishedCurrent, TokensUsedTotal: 33,
+				},
+			})
+
+			disabled := false
+			srv := NewFleet([]FleetProject{
+				NewFleetProject("maestro", "/tmp/maestro.yaml", "", &config.Config{
+					Repo:        "BeFeast/maestro",
+					StateDir:    stateDir,
+					MaxParallel: 4,
+					StaleSessionReconciler: config.StaleSessionReconcilerConfig{
+						Enabled: &disabled,
+					},
+				}),
+			}, "127.0.0.1", 8786, true)
+
+			resp := srv.snapshot()
+			project := findFleetProject(t, resp.Projects, "maestro")
+			if project.NeedsAttention != tc.wantAttention {
+				t.Fatalf("needs_attention = %d, want %d; operator=%+v attention=%+v", project.NeedsAttention, tc.wantAttention, project.OperatorState, project.Attention)
+			}
+			if project.OperatorState.Session != tc.wantOperatorSlot {
+				t.Fatalf("operator session = %q, want %q; state=%+v", project.OperatorState.Session, tc.wantOperatorSlot, project.OperatorState)
+			}
+			if project.Failed != tc.wantFailed || project.Sessions != 3 {
+				t.Fatalf("historical accounting = failed:%d sessions:%d, want failed:%d sessions:3", project.Failed, project.Sessions, tc.wantFailed)
+			}
+
+			for slot, wantTokens := range map[string]int{"attempt-a": 11, "attempt-b": 22, "current": 33} {
+				worker := findFleetWorker(t, resp.Workers, slot)
+				if worker.TokensUsedTotal != wantTokens {
+					t.Fatalf("%s tokens = %d, want %d", slot, worker.TokensUsedTotal, wantTokens)
+				}
+				if slot != "current" && worker.NeedsAttention {
+					t.Fatalf("historical predecessor %s remained actionable: %+v", slot, worker)
+				}
+			}
+		})
+	}
+}
+
+func TestMakeSessionInfoPreservesSubsecondLifecycleOrdering(t *testing.T) {
+	started := time.Date(2026, 7, 21, 18, 0, 0, 987654321, time.UTC)
+	finished := started.Add(123456789 * time.Nanosecond)
+	info := makeSessionInfo("BeFeast/maestro", "current", &state.Session{
+		IssueNumber: 976,
+		Status:      state.StatusDone,
+		StartedAt:   started,
+		FinishedAt:  &finished,
+	})
+
+	if info.StartedAt != started.Format(time.RFC3339Nano) || info.FinishedAt != finished.Format(time.RFC3339Nano) {
+		t.Fatalf("projected timestamps = %q / %q, want nanosecond precision", info.StartedAt, info.FinishedAt)
+	}
+}
+
+func TestFleetAPISharedPRContinuationMakesDeadSourceNonActionable(t *testing.T) {
+	dir := t.TempDir()
+	stateDir := filepath.Join(dir, "state")
+	base := time.Now().UTC().Add(-time.Hour)
+	finished := base.Add(10 * time.Minute)
+	saveFleetTestState(t, stateDir, map[string]*state.Session{
+		"source": {
+			IssueNumber: 900, IssueTitle: "superseded source", Status: state.StatusDead, PRNumber: 1033,
+			StartedAt: base, FinishedAt: &finished, TokensUsedTotal: 21,
+		},
+		"continuation": {
+			IssueNumber: 976, IssueTitle: "active continuation", Status: state.StatusPROpen, PRNumber: 1033,
+			StartedAt: base.Add(20 * time.Minute), TokensUsedTotal: 34,
+		},
+	})
+
+	disabled := false
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("maestro", "/tmp/maestro.yaml", "", &config.Config{
+			Repo:        "BeFeast/maestro",
+			StateDir:    stateDir,
+			MaxParallel: 4,
+			StaleSessionReconciler: config.StaleSessionReconcilerConfig{
+				Enabled: &disabled,
+			},
+		}),
+	}, "127.0.0.1", 8786, true)
+
+	resp := srv.snapshot()
+	project := findFleetProject(t, resp.Projects, "maestro")
+	if project.NeedsAttention != 0 || project.OperatorState.Session != "continuation" || project.OperatorState.PRNumber != 1033 {
+		t.Fatalf("continuation did not own operator state: project=%+v", project)
+	}
+	source := findFleetWorker(t, resp.Workers, "source")
+	continuation := findFleetWorker(t, resp.Workers, "continuation")
+	if source.NeedsAttention || source.TokensUsedTotal != 21 || continuation.TokensUsedTotal != 34 || project.Sessions != 2 {
+		t.Fatalf("shared-PR history/accounting changed: source=%+v continuation=%+v project=%+v", source, continuation, project)
+	}
+}
+
 func TestFleetSupersedingIssueSessionUsesCanonicalMergedPRForReconciledDuplicate(t *testing.T) {
 	duplicate := sessionInfo{
 		Slot:           "ok-player-271",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -538,7 +538,7 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 		TokensCacheRead:           sess.TokensCacheRead,
 		TokensCacheWrite:          sess.TokensCacheWrite,
 		CostUSDBackend:            sess.CostUSDBackend,
-		StartedAt:                 sess.StartedAt.Format(time.RFC3339),
+		StartedAt:                 sess.StartedAt.Format(time.RFC3339Nano),
 		WorkerGeneration:          sess.WorkerGeneration,
 		Worktree:                  sess.Worktree,
 		Branch:                    sess.Branch,
@@ -566,7 +566,7 @@ func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 	end := now
 	if sess.FinishedAt != nil {
 		end = *sess.FinishedAt
-		info.FinishedAt = sess.FinishedAt.Format(time.RFC3339)
+		info.FinishedAt = sess.FinishedAt.Format(time.RFC3339Nano)
 	}
 	if sess.IssueClosedAt != nil {
 		info.IssueClosedAt = sess.IssueClosedAt.Format(time.RFC3339)

--- a/internal/state/session_supersession.go
+++ b/internal/state/session_supersession.go
@@ -1,0 +1,90 @@
+package state
+
+// SupersedingSession returns the newest durable session that makes candidate a
+// historical predecessor for operator-attention purposes. It is deliberately
+// read-only: callers use the result to filter current attention and supervisor
+// findings while preserving every session row, worktree, usage counter, and
+// attribution record.
+//
+// A terminal failure can be superseded through either durable lifecycle link:
+//   - a later session for the same issue, when the candidate owns no PR of its
+//     own; or
+//   - a later session for the same PR, including a continuation issue.
+//
+// A terminal attempt that owns its own PR is never hidden behind a session for
+// a DIFFERENT PR: that PR is a separate artifact and may still need operator
+// action or reconciliation, so only the same PR's later owner may supersede it.
+// This mirrors the rule the Fleet projection already enforced before this
+// predicate was centralized.
+//
+// Ordering compares SessionChangedAt — the newest durable lifecycle timestamp
+// (started / finished / issue-closed / last output) — not StartedAt. Start
+// order alone is not lifecycle order: a peer can start after the candidate and
+// still finish before the candidate's own terminal transition, in which case
+// the candidate holds the newest durable outcome and must stay actionable.
+// An unknown or tied timestamp never proves that a peer is later. The newest
+// qualifying peer wins, with the slot name used only as a deterministic tie
+// breaker between peers that share the same timestamp.
+func (s *State) SupersedingSession(candidate *Session) (string, *Session, bool) {
+	if s == nil || candidate == nil || candidate.IssueNumber <= 0 || candidate.StartedAt.IsZero() || !sessionStatusCanBeSuperseded(candidate.Status) {
+		return "", nil, false
+	}
+	candidateAt := SessionChangedAt(candidate)
+	if candidateAt.IsZero() {
+		return "", nil, false
+	}
+
+	var selectedSlot string
+	var selected *Session
+	var selectedAt = candidateAt
+	for slot, peer := range s.Sessions {
+		if peer == nil || peer == candidate || peer.StartedAt.IsZero() || peer.ReleasedForRedispatch {
+			continue
+		}
+		// A candidate that owns a PR is only superseded through that same PR.
+		sameIssue := peer.IssueNumber == candidate.IssueNumber && candidate.PRNumber <= 0
+		sharedPR := candidate.PRNumber > 0 && peer.PRNumber == candidate.PRNumber
+		if !sameIssue && !sharedPR {
+			continue
+		}
+		if !sessionStatusCanSupersede(peer.Status) {
+			continue
+		}
+		peerAt := SessionChangedAt(peer)
+		if peerAt.IsZero() || !peerAt.After(candidateAt) {
+			continue
+		}
+		if selected == nil || peerAt.After(selectedAt) || (peerAt.Equal(selectedAt) && slot < selectedSlot) {
+			selectedSlot = slot
+			selected = peer
+			selectedAt = peerAt
+		}
+	}
+	if selected == nil {
+		return "", nil, false
+	}
+	return selectedSlot, selected, true
+}
+
+func sessionStatusCanBeSuperseded(status SessionStatus) bool {
+	switch status {
+	case StatusDead, StatusFailed, StatusConflictFailed, StatusRetryExhausted:
+		return true
+	default:
+		return false
+	}
+}
+
+// sessionStatusCanSupersede lists the statuses an authoritative later session
+// may hold. StatusQueued is included: a replacement already waiting to run is
+// the current lifecycle for that issue, and leaving it out kept an exhausted
+// predecessor actionable while its successor was queued.
+func sessionStatusCanSupersede(status SessionStatus) bool {
+	switch status {
+	case StatusRunning, StatusQueued, StatusPROpen, StatusCodeLanded, StatusDone,
+		StatusDead, StatusFailed, StatusConflictFailed, StatusRetryExhausted:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/state/session_supersession.go
+++ b/internal/state/session_supersession.go
@@ -7,15 +7,16 @@ package state
 // attribution record.
 //
 // A terminal failure can be superseded through either durable lifecycle link:
-//   - a later session for the same issue, when the candidate owns no PR of its
-//     own; or
+//   - a later session for the same issue; or
 //   - a later session for the same PR, including a continuation issue.
 //
-// A terminal attempt that owns its own PR is never hidden behind a session for
-// a DIFFERENT PR: that PR is a separate artifact and may still need operator
-// action or reconciliation, so only the same PR's later owner may supersede it.
-// This mirrors the rule the Fleet projection already enforced before this
-// predicate was centralized.
+// One issue has one current lifecycle: an earlier terminal attempt is history
+// even when it owns a PR of its own. Review asked for the opposite — that an
+// attempt with its own distinct PR always stay actionable — and that was
+// declined deliberately (operator decision 2026-07-25): with an issue that has
+// already shipped through a later PR, every abandoned attempt would keep
+// emitting "reconcile the closed PR" findings forever. Suppression here is
+// display truth only; the PR itself is untouched and every session row remains.
 //
 // Ordering compares SessionChangedAt — the newest durable lifecycle timestamp
 // (started / finished / issue-closed / last output) — not StartedAt. Start
@@ -41,8 +42,7 @@ func (s *State) SupersedingSession(candidate *Session) (string, *Session, bool) 
 		if peer == nil || peer == candidate || peer.StartedAt.IsZero() || peer.ReleasedForRedispatch {
 			continue
 		}
-		// A candidate that owns a PR is only superseded through that same PR.
-		sameIssue := peer.IssueNumber == candidate.IssueNumber && candidate.PRNumber <= 0
+		sameIssue := peer.IssueNumber == candidate.IssueNumber
 		sharedPR := candidate.PRNumber > 0 && peer.PRNumber == candidate.PRNumber
 		if !sameIssue && !sharedPR {
 			continue

--- a/internal/state/session_supersession_test.go
+++ b/internal/state/session_supersession_test.go
@@ -78,11 +78,27 @@ func TestSupersedingSessionRequiresProvenLaterDurableOwner(t *testing.T) {
 	candidate := &Session{IssueNumber: 976, Status: StatusFailed, StartedAt: started}
 	st.Sessions["candidate"] = candidate
 	st.Sessions["same-time"] = &Session{IssueNumber: 976, Status: StatusDone, PRNumber: 1033, StartedAt: started}
-	st.Sessions["queued"] = &Session{IssueNumber: 976, Status: StatusQueued, StartedAt: started.Add(time.Second)}
 	st.Sessions["released"] = &Session{IssueNumber: 976, Status: StatusDone, PRNumber: 1034, StartedAt: started.Add(2 * time.Second), ReleasedForRedispatch: true}
 
 	if _, _, ok := st.SupersedingSession(candidate); ok {
-		t.Fatal("same-time, queued, or released peers must not prove supersession")
+		t.Fatal("same-time or released peers must not prove supersession")
+	}
+}
+
+// A replacement that is already queued is the current lifecycle for the issue.
+// Leaving StatusQueued out of the authoritative set kept an exhausted attempt
+// actionable — recommending its repair — while its successor was waiting to run.
+func TestSupersedingSessionAcceptsQueuedReplacement(t *testing.T) {
+	started := time.Date(2026, 7, 21, 13, 30, 0, 0, time.UTC)
+	st := NewState()
+	candidate := &Session{IssueNumber: 976, Status: StatusRetryExhausted, StartedAt: started}
+	st.Sessions["candidate"] = candidate
+	queued := &Session{IssueNumber: 976, Status: StatusQueued, StartedAt: started.Add(time.Second)}
+	st.Sessions["queued"] = queued
+
+	slot, got, ok := st.SupersedingSession(candidate)
+	if !ok || slot != "queued" || got != queued {
+		t.Fatalf("queued replacement = %q, %p, %v; want queued %p", slot, got, ok, queued)
 	}
 }
 

--- a/internal/state/session_supersession_test.go
+++ b/internal/state/session_supersession_test.go
@@ -1,0 +1,103 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSupersedingSessionUsesLaterCurrentIssueLifecycle(t *testing.T) {
+	base := time.Date(2026, 7, 21, 10, 0, 0, 0, time.UTC)
+	st := NewState()
+	failedA := &Session{IssueNumber: 976, Status: StatusFailed, StartedAt: base.Add(100 * time.Millisecond), TokensUsedTotal: 11}
+	failedB := &Session{IssueNumber: 976, Status: StatusDead, StartedAt: base.Add(200 * time.Millisecond), TokensUsedTotal: 22}
+	current := &Session{IssueNumber: 976, Status: StatusDone, PRNumber: 1033, StartedAt: base.Add(300 * time.Millisecond), TokensUsedTotal: 33}
+	st.Sessions["attempt-a"] = failedA
+	st.Sessions["attempt-b"] = failedB
+	st.Sessions["current"] = current
+
+	for _, predecessor := range []*Session{failedA, failedB} {
+		slot, got, ok := st.SupersedingSession(predecessor)
+		if !ok || slot != "current" || got != current {
+			t.Fatalf("superseding session = %q, %p, %v; want current %p", slot, got, ok, current)
+		}
+	}
+	if _, _, ok := st.SupersedingSession(current); ok {
+		t.Fatal("authoritative current session must not be superseded")
+	}
+
+	if len(st.Sessions) != 3 || st.Sessions["attempt-a"].TokensUsedTotal != 11 || st.Sessions["attempt-b"].TokensUsedTotal != 22 {
+		t.Fatalf("supersession mutated historical sessions: %#v", st.Sessions)
+	}
+}
+
+func TestSupersedingSessionKeepsNewestRegressionCurrent(t *testing.T) {
+	base := time.Date(2026, 7, 21, 11, 0, 0, 0, time.UTC)
+	st := NewState()
+	failedA := &Session{IssueNumber: 976, Status: StatusFailed, StartedAt: base}
+	failedB := &Session{IssueNumber: 976, Status: StatusDead, StartedAt: base.Add(time.Second)}
+	current := &Session{IssueNumber: 976, Status: StatusFailed, PRNumber: 1033, StartedAt: base.Add(2 * time.Second)}
+	st.Sessions["attempt-a"] = failedA
+	st.Sessions["attempt-b"] = failedB
+	st.Sessions["current"] = current
+
+	for _, predecessor := range []*Session{failedA, failedB} {
+		slot, got, ok := st.SupersedingSession(predecessor)
+		if !ok || slot != "current" || got != current {
+			t.Fatalf("regressed current owner = %q, %p, %v; want current %p", slot, got, ok, current)
+		}
+	}
+	if _, _, ok := st.SupersedingSession(current); ok {
+		t.Fatal("current regressed session must remain actionable")
+	}
+}
+
+func TestSupersedingSessionUsesSharedPRContinuation(t *testing.T) {
+	base := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	st := NewState()
+	source := &Session{IssueNumber: 900, Status: StatusDead, PRNumber: 1033, StartedAt: base}
+	continuation := &Session{IssueNumber: 976, Status: StatusPROpen, PRNumber: 1033, StartedAt: base.Add(time.Second)}
+	st.Sessions["source"] = source
+	st.Sessions["continuation"] = continuation
+
+	slot, got, ok := st.SupersedingSession(source)
+	if !ok || slot != "continuation" || got != continuation {
+		t.Fatalf("shared-PR superseding session = %q, %p, %v; want continuation %p", slot, got, ok, continuation)
+	}
+
+	unrelated := *continuation
+	unrelated.PRNumber = 1034
+	st.Sessions["continuation"] = &unrelated
+	if _, _, ok := st.SupersedingSession(source); ok {
+		t.Fatal("different-PR continuation must not supersede source issue")
+	}
+}
+
+func TestSupersedingSessionRequiresProvenLaterDurableOwner(t *testing.T) {
+	started := time.Date(2026, 7, 21, 13, 0, 0, 0, time.UTC)
+	st := NewState()
+	candidate := &Session{IssueNumber: 976, Status: StatusFailed, StartedAt: started}
+	st.Sessions["candidate"] = candidate
+	st.Sessions["same-time"] = &Session{IssueNumber: 976, Status: StatusDone, PRNumber: 1033, StartedAt: started}
+	st.Sessions["queued"] = &Session{IssueNumber: 976, Status: StatusQueued, StartedAt: started.Add(time.Second)}
+	st.Sessions["released"] = &Session{IssueNumber: 976, Status: StatusDone, PRNumber: 1034, StartedAt: started.Add(2 * time.Second), ReleasedForRedispatch: true}
+
+	if _, _, ok := st.SupersedingSession(candidate); ok {
+		t.Fatal("same-time, queued, or released peers must not prove supersession")
+	}
+}
+
+func TestSupersedingSessionSelectionIsDeterministic(t *testing.T) {
+	base := time.Date(2026, 7, 21, 14, 0, 0, 0, time.UTC)
+	for i := 0; i < 100; i++ {
+		st := NewState()
+		candidate := &Session{IssueNumber: 976, Status: StatusFailed, StartedAt: base}
+		st.Sessions["candidate"] = candidate
+		st.Sessions["later-z"] = &Session{IssueNumber: 976, Status: StatusPROpen, StartedAt: base.Add(time.Second)}
+		st.Sessions["later-a"] = &Session{IssueNumber: 976, Status: StatusCodeLanded, StartedAt: base.Add(time.Second)}
+
+		slot, _, ok := st.SupersedingSession(candidate)
+		if !ok || slot != "later-a" {
+			t.Fatalf("iteration %d selected %q, %v; want deterministic later-a", i, slot, ok)
+		}
+	}
+}

--- a/internal/supervisor/session_supersession_test.go
+++ b/internal/supervisor/session_supersession_test.go
@@ -1,0 +1,124 @@
+package supervisor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestDetectWorkerStuckStatesSuppressesPredecessorsAndSurfacesCurrentRegression(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+	eng := testEngine(cfg, reader)
+	base := time.Date(2026, 7, 21, 15, 0, 0, 0, time.UTC)
+	st := state.NewState()
+	st.Sessions["attempt-a"] = &state.Session{
+		IssueNumber: 976, Status: state.StatusFailed, StartedAt: base.Add(100 * time.Millisecond),
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+	}
+	st.Sessions["attempt-b"] = &state.Session{
+		IssueNumber: 976, Status: state.StatusDead, StartedAt: base.Add(200 * time.Millisecond),
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+	}
+	current := &state.Session{
+		IssueNumber: 976, Status: state.StatusDone, PRNumber: 1033, StartedAt: base.Add(300 * time.Millisecond),
+	}
+	st.Sessions["current"] = current
+
+	findings := eng.detectWorkerStuckStates(st, base.Add(time.Hour), newResolutionCache(eng.reader))
+	for _, finding := range findings {
+		if finding.Code == "stale_review_feedback" {
+			t.Fatalf("predecessor review finding leaked after later done session: %#v", finding)
+		}
+	}
+
+	current.Status = state.StatusFailed
+	current.PreviousAttemptFeedbackKind = state.RetryReasonReviewFeedback
+	findings = eng.detectWorkerStuckStates(st, base.Add(time.Hour), newResolutionCache(eng.reader))
+	var reviewFindings []state.SupervisorStuckState
+	for _, finding := range findings {
+		if finding.Code == "stale_review_feedback" {
+			reviewFindings = append(reviewFindings, finding)
+		}
+	}
+	if len(reviewFindings) != 1 || reviewFindings[0].Target == nil || reviewFindings[0].Target.Session != "current" {
+		t.Fatalf("review findings = %#v, want only current regression", reviewFindings)
+	}
+}
+
+func TestDetectPRStuckStatesSuppressesPredecessorPRsAndSurfacesCurrentRegression(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{ciStatuses: map[int]string{1033: "failure"}}
+	eng := testEngine(cfg, reader)
+	base := time.Date(2026, 7, 21, 16, 0, 0, 0, time.UTC)
+	st := state.NewState()
+	st.Sessions["attempt-a"] = &state.Session{
+		IssueNumber: 976, Status: state.StatusFailed, PRNumber: 1031, Branch: "feat/attempt-a", StartedAt: base.Add(100 * time.Millisecond),
+	}
+	st.Sessions["attempt-b"] = &state.Session{
+		IssueNumber: 976, Status: state.StatusDead, PRNumber: 1032, Branch: "feat/attempt-b", StartedAt: base.Add(200 * time.Millisecond),
+	}
+	current := &state.Session{
+		IssueNumber: 976, Status: state.StatusDone, PRNumber: 1033, Branch: "feat/current", StartedAt: base.Add(300 * time.Millisecond),
+	}
+	st.Sessions["current"] = current
+
+	findings := eng.detectPRStuckStates(st, nil, newResolutionCache(eng.reader))
+	if len(findings) != 0 {
+		t.Fatalf("historical predecessor PRs produced stuck findings: %#v", findings)
+	}
+
+	current.Status = state.StatusFailed
+	reader.prs = []github.PR{{Number: 1033, HeadRefName: "feat/current", State: "OPEN", Mergeable: "MERGEABLE"}}
+	findings = eng.detectPRStuckStates(st, reader.prs, newResolutionCache(eng.reader))
+	foundCurrentFailure := false
+	for _, finding := range findings {
+		if finding.Target != nil && (finding.Target.Session == "attempt-a" || finding.Target.Session == "attempt-b") {
+			t.Fatalf("predecessor consumed PR stuck attention: %#v", finding)
+		}
+		if finding.Code == "failing_checks" && finding.Target != nil && finding.Target.Session == "current" {
+			foundCurrentFailure = true
+		}
+	}
+	if !foundCurrentFailure {
+		t.Fatalf("current regressed PR was not surfaced: %#v", findings)
+	}
+}
+
+func TestDetectWorkerStuckStatesUsesActiveSharedPRContinuation(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+	eng := testEngine(cfg, reader)
+	base := time.Date(2026, 7, 21, 17, 0, 0, 0, time.UTC)
+	st := state.NewState()
+	st.Sessions["source"] = &state.Session{
+		IssueNumber: 900, Status: state.StatusDead, PRNumber: 1033, StartedAt: base,
+		PreviousAttemptFeedbackKind: state.RetryReasonReviewFeedback,
+	}
+	continuation := &state.Session{
+		IssueNumber: 976, Status: state.StatusPROpen, PRNumber: 1033, StartedAt: base.Add(time.Second),
+	}
+	st.Sessions["continuation"] = continuation
+
+	findings := eng.detectWorkerStuckStates(st, base.Add(time.Hour), newResolutionCache(eng.reader))
+	for _, finding := range findings {
+		if finding.Target != nil && finding.Target.Session == "source" {
+			t.Fatalf("declared continuation left source actionable: %#v", finding)
+		}
+	}
+
+	continuation.Status = state.StatusFailed
+	continuation.PreviousAttemptFeedbackKind = state.RetryReasonReviewFeedback
+	findings = eng.detectWorkerStuckStates(st, base.Add(time.Hour), newResolutionCache(eng.reader))
+	var reviewTargets []string
+	for _, finding := range findings {
+		if finding.Code == "stale_review_feedback" && finding.Target != nil {
+			reviewTargets = append(reviewTargets, finding.Target.Session)
+		}
+	}
+	if len(reviewTargets) != 1 || reviewTargets[0] != "continuation" {
+		t.Fatalf("review targets = %v, want only continuation", reviewTargets)
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1548,6 +1548,9 @@ func detectVisualEvidenceStuckStates(st *state.State) []state.SupervisorStuckSta
 		if sess == nil || sess.VisualEvidence != state.VisualEvidenceMissing || sess.PRNumber <= 0 {
 			continue
 		}
+		if _, _, superseded := st.SupersedingSession(sess); superseded {
+			continue
+		}
 		switch sess.Status {
 		case state.StatusPROpen, state.StatusQueued, state.StatusRetryExhausted:
 		default:
@@ -1886,6 +1889,9 @@ func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time, cache *
 		if sess == nil {
 			continue
 		}
+		if _, _, superseded := st.SupersedingSession(sess); superseded {
+			continue
+		}
 		target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}
 
 		// #877: a session the daemon deliberately checkpointed on shutdown
@@ -2003,13 +2009,13 @@ func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR, cache *re
 		if sess == nil {
 			continue
 		}
+		if _, _, superseded := st.SupersedingSession(sess); superseded {
+			continue
+		}
 		if !sessionCanStillBlockProgress(sess.Status) {
 			continue
 		}
 		if e.sessionResolvedOnGitHub(sess, cache) {
-			continue
-		}
-		if sess.Status == state.StatusRetryExhausted && e.retryExhaustedSessionSupersededByIssueProgress(st, sess) {
 			continue
 		}
 		pr, found := openPRForSession(sess, byNumber, byBranch)
@@ -2247,6 +2253,9 @@ func (e *Engine) detectEnvironmentStuckStates(st *state.State, eligible []github
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
 		if sess == nil || strings.TrimSpace(sess.Worktree) == "" || strings.TrimSpace(e.cfg.WorktreeBase) == "" {
+			continue
+		}
+		if _, _, superseded := st.SupersedingSession(sess); superseded {
 			continue
 		}
 		if !pathWithinBase(sess.Worktree, e.cfg.WorktreeBase) {
@@ -3043,6 +3052,9 @@ func (e *Engine) sessionWithOpenPR(st *state.State, prs []github.PR, cache *reso
 		if sess == nil || !sessionCanStillBlockProgress(sess.Status) || e.sessionResolvedOnGitHub(sess, cache) {
 			continue
 		}
+		if _, _, superseded := st.SupersedingSession(sess); superseded {
+			continue
+		}
 		var pr github.PR
 		var found bool
 		if sess.Branch != "" {
@@ -3607,42 +3619,8 @@ func (e *Engine) retryExhaustedSessionResolvedOnGitHub(sess *state.Session, cach
 }
 
 func (e *Engine) retryExhaustedSessionResolved(st *state.State, sess *state.Session, cache *resolutionCache) bool {
-	return e.retryExhaustedSessionResolvedOnGitHub(sess, cache) || e.retryExhaustedSessionSupersededByIssueProgress(st, sess)
-}
-
-func (e *Engine) retryExhaustedSessionSupersededByIssueProgress(st *state.State, exhausted *state.Session) bool {
-	if st == nil || exhausted == nil || exhausted.IssueNumber <= 0 {
-		return false
-	}
-	exhaustedAt := state.SessionChangedAt(exhausted)
-	for _, sess := range st.Sessions {
-		if sess == nil || sess == exhausted || sess.IssueNumber != exhausted.IssueNumber {
-			continue
-		}
-		if !sessionCanSupersedeRetryExhausted(sess) {
-			continue
-		}
-		if !exhaustedAt.IsZero() && !state.SessionChangedAt(sess).After(exhaustedAt) {
-			continue
-		}
-		if sess.Status == state.StatusRunning && sess.PID > 0 && !e.pidAlive(sess.PID) {
-			continue
-		}
-		return true
-	}
-	return false
-}
-
-func sessionCanSupersedeRetryExhausted(sess *state.Session) bool {
-	if sess == nil {
-		return false
-	}
-	switch sess.Status {
-	case state.StatusRunning, state.StatusQueued, state.StatusPROpen, state.StatusCodeLanded, state.StatusDone:
-		return true
-	default:
-		return false
-	}
+	_, _, superseded := st.SupersedingSession(sess)
+	return e.retryExhaustedSessionResolvedOnGitHub(sess, cache) || superseded
 }
 
 func (e *Engine) sessionResolvedOnGitHub(sess *state.Session, cache *resolutionCache) bool {
@@ -4664,7 +4642,7 @@ func (e *Engine) canonicalOpenPROwners(st *state.State, byNumber map[int]github.
 		if sess == nil || !sessionCanStillBlockProgress(sess.Status) || e.sessionResolvedOnGitHub(sess, cache) {
 			continue
 		}
-		if sess.Status == state.StatusRetryExhausted && e.retryExhaustedSessionSupersededByIssueProgress(st, sess) {
+		if _, _, superseded := st.SupersedingSession(sess); superseded {
 			continue
 		}
 		pr, found := openPRForSession(sess, byNumber, byBranch)


### PR DESCRIPTION
Refs #976

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes session supersession for operator attention. The main changes are:

- Adds a shared state predicate for finding authoritative later sessions.
- Applies supersession filtering across Fleet and Supervisor views.
- Preserves subsecond lifecycle timestamps.
- Adds coverage for same-issue and shared-PR continuations.

<h3>Confidence Score: 4/5</h3>

The centralized supersession path still has unresolved operator-attention behavior.

Same-issue lifecycle matching can cross independent PRs. Queued replacements are not treated as superseding exhausted attempts.

internal/state/session_supersession.go, internal/server/fleet.go, and internal/supervisor/supervisor.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The contract validation compared pre- and post-completion states and found that before completion the same-issue predecessors remained actionable, while after completion predecessor attention was cleared and a later regression exposed only the current state, with shared-PR continuation suppressing only the source.
- The validation confirmed that every captured Fleet request returned a 200 OK status.
- The validation noted that response messages were captured as JSON body projections in paired logs to support verification.
- Artifacts were collected to support review, including five Fleet logs and a Go source file for the validation logic.

<a href="https://app.greptile.com/trex/runs/15296824/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/session_supersession.go | Adds the shared lifecycle predicate used to suppress attention for historical sessions. |
| internal/server/fleet.go | Uses durable supersession when projecting worker and project operator attention. |
| internal/server/server.go | Preserves nanosecond precision in projected session timestamps. |
| internal/supervisor/supervisor.go | Applies the shared supersession predicate across stuck-state and open-PR ownership checks. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-904-97..."](https://github.com/befeast/maestro/commit/5231c5c0d758856021ac031f96ddaa6a59607e6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46049270)</sub>

<!-- /greptile_comment -->