### PR TITLE
P0: Fleet operator state falsely reports failing retry-exhausted PR as green/auto-merging

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -162,6 +162,11 @@ type Options struct {
 	// RunInterval is the orchestrator poll interval; a project's
 	// poll_interval_seconds in config overrides it per flow.
 	RunInterval time.Duration
+	// refreshCh is the daemon-internal edge trigger for an immediate project
+	// reconciliation. It is populated per flow and intentionally unexported:
+	// callers configure cadence, while accepted GitHub gate webhooks wake the
+	// matching flow without waiting for that cadence.
+	refreshCh <-chan struct{}
 	// SuperviseInterval is the supervisor decision-loop interval per flow.
 	SuperviseInterval time.Duration
 
@@ -872,6 +877,7 @@ func (d *Daemon) configureWebhookIngestion(fleet *server.FleetServer) {
 	}
 
 	ingestor := webhook.NewIngestor(store, secret)
+	ingestor.SetAfterAccepted(d.refreshPRGateFromWebhook)
 
 	// Wire the GitHub mirror read model (#825, phase C). It lives in the same
 	// maestro.db as the raw deliveries; the ingestor projects each accepted
@@ -900,6 +906,39 @@ func (d *Daemon) configureWebhookIngestion(fleet *server.FleetServer) {
 	}
 	fleet.SetWebhookIngestor(ingestor, path)
 	log.Printf("[daemon] webhook ingestion active — POST %s validates X-Hub-Signature-256 and lands deliveries in %s", path, dbPath)
+}
+
+// refreshPRGateFromWebhook coalesces accepted GitHub gate updates into one
+// immediate orchestrator cycle for every flow serving that repository. The
+// channel is buffered and the send is non-blocking, so a burst of check-run
+// updates cannot queue concurrent RunOnce calls or delay the webhook response.
+func (d *Daemon) refreshPRGateFromWebhook(eventType, repo string) {
+	switch strings.TrimSpace(eventType) {
+	case "check_run", "check_suite", "status":
+	default:
+		return
+	}
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		return
+	}
+
+	d.mu.Lock()
+	channels := make([]chan struct{}, 0, 1)
+	for _, flow := range d.flows {
+		if flow == nil || flow.cfg == nil || flow.refreshCh == nil || !strings.EqualFold(strings.TrimSpace(flow.cfg.Repo), repo) {
+			continue
+		}
+		channels = append(channels, flow.refreshCh)
+	}
+	d.mu.Unlock()
+
+	for _, refreshCh := range channels {
+		select {
+		case refreshCh <- struct{}{}:
+		default:
+		}
+	}
 }
 
 // readWebhookSecret reads and trims the webhook secret from disk. The secret's

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -139,6 +139,39 @@ func TestRunStartsFlowPerProjectAndAggregatesFleet(t *testing.T) {
 	}
 }
 
+func TestCheckWebhookRefreshesOnlyMatchingProjectFlow(t *testing.T) {
+	d := New(fakeLoader{}, Options{Port: 0})
+	alpha := &projectFlow{
+		cfg:       &config.Config{Repo: "BeFeast/ok-player"},
+		refreshCh: make(chan struct{}, 1),
+	}
+	beta := &projectFlow{
+		cfg:       &config.Config{Repo: "BeFeast/maestro"},
+		refreshCh: make(chan struct{}, 1),
+	}
+	d.flows = map[string]*projectFlow{"alpha": alpha, "beta": beta}
+
+	// A burst coalesces to one pending reconciliation for the matching repo.
+	d.refreshPRGateFromWebhook("check_run", "befeast/OK-PLAYER")
+	d.refreshPRGateFromWebhook("check_suite", "BeFeast/ok-player")
+	if got := len(alpha.refreshCh); got != 1 {
+		t.Fatalf("alpha refreshes = %d, want one coalesced wake-up", got)
+	}
+	if got := len(beta.refreshCh); got != 0 {
+		t.Fatalf("beta refreshes = %d, want 0 for an unrelated repo", got)
+	}
+
+	<-alpha.refreshCh
+	d.refreshPRGateFromWebhook("issues", "BeFeast/ok-player")
+	if got := len(alpha.refreshCh); got != 0 {
+		t.Fatalf("non-gate event refreshes = %d, want 0", got)
+	}
+	d.refreshPRGateFromWebhook("status", "BeFeast/ok-player")
+	if got := len(alpha.refreshCh); got != 1 {
+		t.Fatalf("commit-status refreshes = %d, want 1", got)
+	}
+}
+
 func TestRunSkipsDuplicateFlowIdentity(t *testing.T) {
 	// Two configs that resolve to the same flow identity (same StateDir) are a
 	// true duplicate — the second must be skipped, not silently overwrite the

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -28,6 +28,10 @@ type projectFlow struct {
 	holder *configHolder
 	cancel context.CancelFunc
 	done   chan struct{} // closed once every flow goroutine has exited
+	// refreshCh coalesces webhook gate updates into immediate orchestrator
+	// reconciliations for this repository. One buffered wake-up is sufficient:
+	// a RunOnce reads the complete current PR head/check rollup.
+	refreshCh chan struct{}
 }
 
 // startFlow launches the orchestrator + supervisor loops (and the liveness
@@ -54,6 +58,7 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 		holder:    newConfigHolder(cfg),
 		cancel:    cancel,
 		done:      make(chan struct{}),
+		refreshCh: make(chan struct{}, 1),
 	}
 
 	// Per-flow hot-reload (#757, #768): when store-watch is enabled and this
@@ -93,7 +98,9 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 		defer recoverFlow(flow, "orchestrator")
 		// orchReloadCh (fed by the pump) is typed as <-chan; a nil channel
 		// leaves the orchestrator's reload arm inert (store-watch disabled).
-		d.runLoop(fctx, cfg, d.opts, orchReloadCh)
+		flowOpts := d.opts
+		flowOpts.refreshCh = flow.refreshCh
+		d.runLoop(fctx, cfg, flowOpts, orchReloadCh)
 	}()
 	go func() {
 		defer wg.Done()
@@ -451,14 +458,8 @@ func (d *Daemon) runOrchestrator(ctx context.Context, cfg *config.Config, opts O
 		runInterval = time.Duration(cfg.PollIntervalSeconds) * time.Second
 	}
 
-	// The daemon has no API-triggered refresh channel: the per-project HTTP
-	// server that drove one in `maestro run` is replaced by the shared
-	// FleetServer, which does not signal individual flows. Pass nil rather than
-	// a buffered channel nothing ever sends on, so orch.Run's `case <-refreshCh`
-	// arm is plainly inert instead of looking like a wired-but-dead feature
-	// (#764).
 	log.Printf("[%s] starting orchestrator — repo=%s interval=%s", cfg.SessionPrefix, cfg.Repo, runInterval)
-	if err := orch.Run(ctx, runInterval, false, nil); err != nil {
+	if err := orch.Run(ctx, runInterval, false, opts.refreshCh); err != nil {
 		log.Printf("[%s] orchestrator exited: %v", cfg.SessionPrefix, err)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2826,6 +2826,9 @@ func (o *Orchestrator) Run(ctx context.Context, interval time.Duration, once boo
 			case <-ctx.Done():
 				t.Stop()
 				return nil
+			case <-refreshCh:
+				t.Stop()
+				log.Printf("[orch] startup jitter interrupted by refresh (%s)", o.repo)
 			case <-t.C:
 			}
 		}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -4286,6 +4286,7 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 	var backendRestartTargets []controlActionWorkerTarget
 	var backendRestartSkipped []controlActionWorkerTarget
 	for _, worker := range projectState.All {
+		worker = reconcileFleetWorkerPRGate(worker, st, cfg.Repo)
 		worker.Actions = workerActionAffordances(item.ReadOnly, "/api/v1/fleet/actions", worker)
 		if worker.BackendDrift != nil && worker.BackendDrift.Stale {
 			target := controlActionWorkerTarget{
@@ -4365,6 +4366,37 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 	item.ActivityReason = activityReason
 	item.OperatorState = buildFleetProjectOperatorState(item)
 	return item, workers
+}
+
+// reconcileFleetWorkerPRGate attaches the latest durable gate observation to
+// the Fleet-only session projection. A current failed rollup also replaces any
+// stale retry/session wording so the attention row and project operator_state
+// tell one conservative story: repair the existing PR and do not merge it.
+func reconcileFleetWorkerPRGate(worker sessionInfo, st *state.State, project string) sessionInfo {
+	if st == nil || worker.IssueNumber <= 0 || worker.PRNumber <= 0 {
+		return worker
+	}
+	snapshot, ok := st.LatestPRGateSnapshot(project, worker.IssueNumber, worker.PRNumber)
+	if !ok {
+		return worker
+	}
+	worker.prGateSnapshot = &snapshot
+	if state.SessionStatus(worker.Status) == state.StatusRetryExhausted && fleetPRGateHasFailingChecks(&snapshot) {
+		worker.StatusReason = fmt.Sprintf("PR #%d has failing checks on the current reconciled head and is awaiting in-place repair after retry exhaustion.", worker.PRNumber)
+		worker.NextAction = "Repair the existing PR in place and wait for every required check to pass; do not merge while any check is failing."
+		worker.NeedsAttention = true
+	}
+	return worker
+}
+
+func fleetPRGateHasFailingChecks(snapshot *state.PRGateSnapshot) bool {
+	return snapshot != nil &&
+		(snapshot.CIRollupVerdict == state.PRGateCIFailure || snapshot.CIEffectiveVerdict == state.PRGateCIFailure)
+}
+
+func fleetPRGateChecksSucceeded(snapshot *state.PRGateSnapshot) bool {
+	return snapshot != nil && snapshot.CIRollupVerdict != state.PRGateCIFailure &&
+		snapshot.CIEffectiveVerdict == state.PRGateCISuccess
 }
 
 // fleetSupersedingIssueSession identifies terminal duplicate attempts that
@@ -4990,11 +5022,11 @@ func partitionFleetAttentionByResolvability(workers []sessionInfo, latest *super
 // attention list is "self-resolving" — convergence (the orchestrator's
 // auto-merge once gates clear) will resolve it without operator action.
 // Today this is the retry_exhausted-with-open-PR shape from issue #598, but
-// only when the latest supervisor reconciliation contains positive GitHub
-// evidence that the PR checks succeeded. Absence of failure evidence is not
-// proof of green: session notification fields can lag a freshly failed check
-// run, which previously produced the false "checks are green" state from
-// issue #955. Any current gate blocker for the same PR wins over success.
+// only when the durable PR-gate snapshot contains positive current-head
+// evidence that the effective CI gate succeeded. Absence of failure evidence
+// is not proof of green: session/retry and supervisor metadata can lag a freshly
+// failed check run, which previously produced the false "checks are green"
+// state from issue #955. Any contradictory failing attention state wins.
 func fleetSessionIsConvergenceBound(worker sessionInfo, latest *supervisorDecisionInfo) bool {
 	if state.SessionStatus(worker.Status) != state.StatusRetryExhausted {
 		return false
@@ -5002,13 +5034,12 @@ func fleetSessionIsConvergenceBound(worker sessionInfo, latest *supervisorDecisi
 	if worker.PRNumber <= 0 {
 		return false
 	}
-	if strings.EqualFold(strings.TrimSpace(worker.LastNotification), "ci_failure") {
+	if !fleetPRGateChecksSucceeded(worker.prGateSnapshot) {
 		return false
 	}
 	if latest == nil {
-		return false
+		return true
 	}
-	checksSucceeded := false
 	for _, stuck := range latest.StuckStates {
 		if stuck.Target == nil || stuck.Target.PR != worker.PRNumber {
 			continue
@@ -5020,13 +5051,13 @@ func fleetSessionIsConvergenceBound(worker sessionInfo, latest *supervisorDecisi
 			return false
 		case "retry_exhausted_open_pr":
 			for _, evidence := range stuck.Evidence {
-				if strings.Contains(strings.ToLower(evidence), "checks=success") {
-					checksSucceeded = true
+				if strings.Contains(strings.ToLower(evidence), "checks=failure") {
+					return false
 				}
 			}
 		}
 	}
-	return checksSucceeded
+	return true
 }
 
 // fleetAutoMergingOperatorState builds the calm operator state for a

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -4317,8 +4317,8 @@ func TestFleetSupersedingIssueSessionSuppressesDeadSourceBehindActiveContinuatio
 
 // TestFleetAPIRetryExhaustedWithOpenPRSelfResolvesCalmly pins the #598
 // regression. A retry_exhausted session whose linked PR is still open and
-// whose last notification is NOT a CI failure is convergence-bound: the
-// orchestrator will auto-merge it once the merge gate clears. The session
+// whose durable current-head gate snapshot is successful is convergence-bound:
+// the orchestrator will auto-merge it once the merge gate clears. The session
 // must stay surfaced (#564) AND counted in prs_open (#566), but the fleet
 // verdict tone must read calm — never the alarming "Action required — p1"
 // the legacy code path produced. The matching project card surfaces an
@@ -4356,6 +4356,10 @@ func TestFleetAPIRetryExhaustedWithOpenPRSelfResolvesCalmly(t *testing.T) {
 			},
 		},
 	})
+	recordFleetTestPRGate(t, stateDir, state.PRGateTransition{
+		Project: "befeast/maestro", IssueNumber: 442, PRNumber: 564, HeadSHA: strings.Repeat("a", 40),
+		CIObserved: true, CIRollupVerdict: state.PRGateCISuccess, CIEffectiveVerdict: state.PRGateCISuccess,
+	}, now.Add(-30*time.Second))
 
 	srv := NewFleet([]FleetProject{
 		NewFleetProject("maestro", "/tmp/maestro.yaml", "", &config.Config{
@@ -4489,6 +4493,90 @@ func TestFleetAPIRetryExhaustedWithFailedChecksRemainsActionable(t *testing.T) {
 	}
 	if cta := resp.NextAction.CTALabel; cta == "" || !contains(cta, "600") {
 		t.Fatalf("next_action.cta_label = %q, want a label naming PR #600", cta)
+	}
+}
+
+// TestFleetAPIRetryExhaustedStaleSuccessLosesToCurrentFailedGate pins #955.
+// Retry/session and supervisor metadata still say the PR is green, while the
+// durable current-head rollup says required checks failed. Fleet must project
+// one conservative repair state and must never suggest auto-merge.
+func TestFleetAPIRetryExhaustedStaleSuccessLosesToCurrentFailedGate(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	stateDir := filepath.Join(dir, "state")
+	finished := now.Add(-30 * time.Minute)
+	saveFleetTestSnapshot(t, stateDir, map[string]*state.Session{
+		"ok-player-277": {
+			IssueNumber:        346,
+			IssueTitle:         "Repair Fedora package checks",
+			Status:             state.StatusRetryExhausted,
+			PRNumber:           397,
+			StartedAt:          finished.Add(-time.Hour),
+			FinishedAt:         &finished,
+			LastNotifiedStatus: "review_retry_exhausted",
+		},
+	}, []state.SupervisorDecision{
+		{
+			ID:                "dec-stale-success",
+			CreatedAt:         now.Add(-time.Minute),
+			Project:           "ok-player",
+			RecommendedAction: "monitor_open_pr",
+			Risk:              "safe",
+			StuckStates: []state.SupervisorStuckState{
+				{
+					Code:     "retry_exhausted_open_pr",
+					Target:   &state.SupervisorTarget{Issue: 346, PR: 397},
+					Evidence: []string{"Session ok-player-277 status=retry_exhausted pr=397 checks=success"},
+				},
+			},
+		},
+	})
+	recordFleetTestPRGate(t, stateDir, state.PRGateTransition{
+		Project: "BeFeast/ok-player", IssueNumber: 346, PRNumber: 397,
+		HeadSHA:    "93f4f93d41350d2e4c14eb9455e4c1ee6321f412",
+		CIObserved: true, CIRollupVerdict: state.PRGateCIFailure, CIEffectiveVerdict: state.PRGateCIFailure,
+	}, now)
+
+	srv := NewFleet([]FleetProject{
+		NewFleetProject("ok-player", "/tmp/ok-player.yaml", "", &config.Config{
+			Repo:        "BeFeast/ok-player",
+			StateDir:    stateDir,
+			MaxParallel: 4,
+		}),
+	}, "127.0.0.1", 8786, true)
+	resp := srv.snapshot()
+
+	project := findFleetProject(t, resp.Projects, "ok-player")
+	if project.OperatorState.Kind != "attention" || project.OperatorState.Tone != "attention" {
+		t.Fatalf("operator_state = %+v, want one attention-tone repair state", project.OperatorState)
+	}
+	if project.OperatorState.PRNumber != 397 {
+		t.Fatalf("operator_state.pr_number = %d, want 397", project.OperatorState.PRNumber)
+	}
+	operatorText := strings.ToLower(project.OperatorState.Summary + " " + project.OperatorState.NextAction)
+	for _, forbidden := range []string{"checks are green", "auto-merg", "no action needed"} {
+		if strings.Contains(operatorText, forbidden) {
+			t.Fatalf("operator_state contains unsafe %q wording: %+v", forbidden, project.OperatorState)
+		}
+	}
+	for _, required := range []string{"failing checks", "in place", "do not merge"} {
+		if !strings.Contains(operatorText, required) {
+			t.Fatalf("operator_state text = %q, want %q", operatorText, required)
+		}
+	}
+	if project.SelfResolving != 0 || resp.Summary.SelfResolving != 0 {
+		t.Fatalf("self_resolving project=%d fleet=%d, want 0 for a failed current gate", project.SelfResolving, resp.Summary.SelfResolving)
+	}
+	if resp.Verdict.Tone != "attention" {
+		t.Fatalf("verdict tone = %q, want attention", resp.Verdict.Tone)
+	}
+
+	worker := findFleetWorker(t, resp.Workers, "ok-player-277")
+	workerText := strings.ToLower(worker.StatusReason + " " + worker.NextAction)
+	for _, required := range []string{"failing checks", "current reconciled head", "in place", "do not merge"} {
+		if !strings.Contains(workerText, required) {
+			t.Fatalf("worker repair projection = %q, want %q", workerText, required)
+		}
 	}
 }
 
@@ -5105,6 +5193,20 @@ func saveFleetTestSnapshot(t *testing.T, dir string, sessions map[string]*state.
 	}
 	if err := state.Save(dir, st); err != nil {
 		t.Fatalf("save state: %v", err)
+	}
+}
+
+func recordFleetTestPRGate(t *testing.T, dir string, transition state.PRGateTransition, at time.Time) {
+	t.Helper()
+	st, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state for PR gate: %v", err)
+	}
+	if _, _, err := st.RecordPRGateTransition(transition, at); err != nil {
+		t.Fatalf("record PR gate: %v", err)
+	}
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save PR gate: %v", err)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -345,9 +345,14 @@ type sessionInfo struct {
 	Backend        string `json:"backend,omitempty"`
 	// #730: model the backend self-reported for this run (Pi --mode json).
 	// Empty for backends that do not self-report a model.
-	Model              string `json:"model,omitempty"`
-	PRNumber           int    `json:"pr_number,omitempty"`
-	PRURL              string `json:"pr_url,omitempty"`
+	Model    string `json:"model,omitempty"`
+	PRNumber int    `json:"pr_number,omitempty"`
+	PRURL    string `json:"pr_url,omitempty"`
+	// prGateSnapshot is the latest durable, reconciled gate observation for
+	// this exact issue/PR. It is projection-only state: Fleet uses it to keep
+	// operator_state aligned with the current PR head/check rollup, but does not
+	// expose the internal snapshot on the session JSON shape.
+	prGateSnapshot     *state.PRGateSnapshot
 	TokensUsedAttempt  int    `json:"tokens_used_attempt"`
 	TokensUsedTotal    int    `json:"tokens_used_total"`
 	TokenBudgetMeasure string `json:"token_budget_measure,omitempty"`

--- a/internal/webhook/ingest.go
+++ b/internal/webhook/ingest.go
@@ -59,10 +59,11 @@ type Projector interface {
 // observability counters are guarded by a mutex, so the endpoint keeps working
 // while the daemon is under normal fleet load (#824 acceptance).
 type Ingestor struct {
-	store     Store
-	secret    string
-	now       func() time.Time
-	projector Projector
+	store         Store
+	secret        string
+	now           func() time.Time
+	projector     Projector
+	afterAccepted func(eventType, repo string)
 
 	mu sync.Mutex
 	// Session counters. accepted/duplicates/byEventType are seeded from the
@@ -108,6 +109,22 @@ func (in *Ingestor) liveProjector() Projector {
 	in.mu.Lock()
 	defer in.mu.Unlock()
 	return in.projector
+}
+
+// SetAfterAccepted wires a non-blocking runtime notification for newly stored
+// deliveries. The daemon uses it to wake the matching project flow after gate
+// events; duplicates do not call it because they carry no new GitHub state.
+// The callback must return quickly because it runs before the webhook response.
+func (in *Ingestor) SetAfterAccepted(fn func(eventType, repo string)) {
+	in.mu.Lock()
+	in.afterAccepted = fn
+	in.mu.Unlock()
+}
+
+func (in *Ingestor) liveAfterAccepted() func(eventType, repo string) {
+	in.mu.Lock()
+	defer in.mu.Unlock()
+	return in.afterAccepted
 }
 
 // seed loads durable totals from the store into the in-memory counters so a
@@ -243,6 +260,9 @@ func (in *Ingestor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			log.Printf("[webhook] mirror projection failed (delivery stored, mirror will lag) event=%q delivery=%s: %v",
 				eventType, deliveryID, err)
 		}
+	}
+	if afterAccepted := in.liveAfterAccepted(); afterAccepted != nil {
+		afterAccepted(eventType, env.Repo)
 	}
 	// One journal line per accepted delivery gives the "last webhook delivery
 	// time and counts" diagnostic straight from journalctl (#824 AC 10). The

--- a/internal/webhook/ingest_test.go
+++ b/internal/webhook/ingest_test.go
@@ -71,6 +71,29 @@ func TestIngestValidStoredOnce(t *testing.T) {
 	}
 }
 
+func TestIngestAfterAcceptedRunsForNewDeliveryOnly(t *testing.T) {
+	in, _ := newTestIngestor(t)
+	body := []byte(`{"action":"completed","repository":{"full_name":"BeFeast/ok-player"}}`)
+	var events []string
+	in.SetAfterAccepted(func(eventType, repo string) {
+		events = append(events, eventType+" "+repo)
+	})
+
+	first := httptest.NewRecorder()
+	in.ServeHTTP(first, signedRequest(t, DefaultPath, "check_run", "check-397", body, true))
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("first delivery: status=%d body=%s", first.Code, first.Body.String())
+	}
+	duplicate := httptest.NewRecorder()
+	in.ServeHTTP(duplicate, signedRequest(t, DefaultPath, "check_run", "check-397", body, true))
+	if duplicate.Code != http.StatusOK {
+		t.Fatalf("duplicate delivery: status=%d body=%s", duplicate.Code, duplicate.Body.String())
+	}
+	if len(events) != 1 || events[0] != "check_run BeFeast/ok-player" {
+		t.Fatalf("after-accepted events = %v, want one matching new delivery", events)
+	}
+}
+
 func TestIngestReplayIsNoOp(t *testing.T) {
 	in, store := newTestIngestor(t)
 	body := readFixture(t, "issues_opened.json")

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -3,11 +3,10 @@
 // validation, envelope parsing, and an idempotent HTTP handler that lands every
 // valid delivery in the shared maestro.db via internal/webhookstore.
 //
-// This is ingestion only. Nothing here mutates orchestration state or joins the
-// stored deliveries into the read path — that is phase C/D. The handler's job
-// is to authenticate a delivery by signature, key it by X-GitHub-Delivery for
-// idempotency, and persist it durably so a later phase can consume it and the
-// fleet stops polling GitHub for the same state.
+// This package does not interpret or mutate orchestration state. The handler
+// authenticates a delivery, keys it by X-GitHub-Delivery for idempotency, and
+// persists it durably; optional projector and after-accept hooks let the daemon
+// update its read model and wake the matching reconciliation loop.
 package webhook
 
 import (


### PR DESCRIPTION
Refs #955

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes Fleet use current durable PR-gate state and refresh it promptly after GitHub gate webhooks. The main changes are:

- Reconciles retry-exhausted workers with the latest gate snapshot.
- Requires explicit CI success before reporting a worker as self-resolving.
- Wakes the matching project flow after accepted check and status events.
- Adds tests for stale success, failed checks, webhook routing, and duplicate deliveries.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

No files require additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the general contract validation proof by running the Go test command for the fleet API retry tests, which reported 3/3 tests passed with exit code 0.
- Validated that the test run exercises the intended assertions on worker/project attention state, fleet verdict tone, self-resolving counts, operator-state wording, current-head gate precedence, and PR-specific next action as described by the proof.

<a href="https://app.greptile.com/trex/runs/15313121/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/server/fleet.go | Uses durable gate snapshots to prevent failed retry-exhausted PRs from appearing green or self-resolving. |
| internal/server/server.go | Adds an internal, non-serialized gate snapshot to each Fleet worker projection. |
| internal/daemon/daemon.go | Routes accepted gate webhook events to all active flows for the matching repository. |
| internal/daemon/flow.go | Adds a buffered per-flow refresh channel and passes it to the orchestrator. |
| internal/orchestrator/orchestrator.go | Allows a gate refresh to interrupt startup jitter and start reconciliation. |
| internal/webhook/ingest.go | Adds a synchronized callback for newly accepted, non-duplicate webhook deliveries. |
| internal/server/fleet_test.go | Covers current failures overriding stale successful session and supervisor metadata. |
| internal/webhook/ingest_test.go | Covers one callback for a new delivery and no callback for its duplicate. |

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-1008-9..."](https://github.com/befeast/maestro/commit/65f6f1c2d5a287d55263960ccd1c5ce7b7f98acb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46093310)</sub>

<!-- /greptile_comment -->