### PR TITLE
P1: verify stream-json usage telemetry for non-Anthropic models under the claude harness (kimi-k3, grok-4.5, gpt-5.6-sol via CLIProxyAPI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,70 @@ model:
 
 When enabled, the worker runs the backend in structured-stream mode (`claude --output-format stream-json --verbose`, or `codex exec --json`) and its NDJSON is piped through `maestro stream-split`, which writes the raw frames to a side-channel `<slot>.jsonl` (parsed for `input`/`output`/cache tokens) while keeping `<slot>.log` human-readable. The session then reports non-zero split tokens in `maestro history --json` and the `/api/v1/fleet` cost panel. Off by default; an operator-pinned `--output-format` (claude) or `--json` (codex) in `extra_args` overrides it. Claude reports its own `total_cost_usd`; codex does not, so its cost is **virtual** — computed from the configured `pricing` block (tokens-only `$0` when no rates are set). (The `pi` backend captures usage natively and needs no opt-in.)
 
+#### Claude harness through CLIProxyAPI: non-Anthropic telemetry smoke (2026-07-21)
+
+Claude Code 2.1.216 was exercised in the same structured worker shape used by
+Maestro, with the proxy URL/credential inherited from the environment (values
+were neither printed nor captured):
+
+```sh
+printf 'Reply with exactly the word PONG.\n' |
+  claude --model <model> --effort low -p \
+    --output-format stream-json --verbose \
+    --dangerously-skip-permissions
+```
+
+All three translated upstreams completed successfully and emitted plausible,
+non-zero usage on the terminal `result` frame:
+
+| Requested/init model | Assistant model | Input | Output | Cache read | Total | `total_cost_usd` | Frame note |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `kimi-k3` | `kimi-k3` | 17,535 | 20 | 6,144 | 23,699 | 0.091247 | assistant output was `0`; live cap under-counts output |
+| `grok-4.5` | `grok-4.5-build` | 24,762 | 22 | 1,280 | 26,064 | 0.125000 | assistant usage was all zero; live cap is terminal-only |
+| `gpt-5.6-sol` | `gpt-5.6-sol` | 21,581 | 6 | 0 | 21,587 | 0.111585 | assistant usage was all zero; live cap is terminal-only |
+
+This confirms that the terminal result is authoritative for history/cost
+accounting, but it also finds a live-enforcement degradation: none of the three
+routes supplied fully plausible input/output usage on assistant frames. Kimi
+under-counted generated output until the result; Grok and Sol supplied no live
+count at all. A sanitized Grok capture (identifiers/timing removed; frame shapes
+and usage retained) lives at
+`internal/worker/testdata/claude_proxy_grok_4_5_stream.jsonl` and is round-tripped
+through `stream-split` in the Go test suite.
+
+`--effort low` was harmless for every route: the deployed proxy accepted all
+three calls, and current CLIProxyAPI model metadata declares a `low` reasoning
+level for Kimi K3, Grok 4.5, and GPT-5.6 Sol. CLIProxyAPI's thinking translation
+maps supported levels to the upstream request and strips the setting for a route
+that declares no thinking support; Maestro therefore keeps emitting the normal
+Claude `--effort` flag rather than special-casing model names.
+
+Maestro now logs and persists both degradation scopes on the active backend
+attribution:
+
+- `usage_unreliable_scope: live_budget` when assistant usage has a zero
+  input/output field. A later complete result still makes history/cost exact,
+  but `worker_max_tokens` was not enforceable response-by-response for that
+  segment.
+- `usage_unreliable_scope: accounting` when a successful terminal result omits
+  `usage` or reports zero input/output. Token totals are then a lower bound, and
+  the cost-observability API includes the session in
+  `usage_unreliable_sessions` instead of dropping it as no activity.
+
+In either scope, `0` tokens means unavailable — never progress. The live token
+monitor does not synthesize a budget hit or kill from missing usage; the
+stalled-progress watchdog remains driven by terminal/checkpoint, worktree/Git,
+process/tmux, and PR-review signals rather than token counters. Operators using
+a positive hard cap should therefore treat these three proxy routes as
+degraded until CLIProxyAPI supplies non-zero assistant-frame input and output.
+
+**External dashboard comparison remains operator verification.** The worker
+environment has proxy request credentials but no access to the external usage
+sink/dashboard, and current CLIProxyAPI usage-queue reads are destructive. The
+numbers above are the captured translated stream values, not an independently
+claimed dashboard match; keep issue #946 open until an operator compares these
+three request rows in the deployed dashboard.
+
 When `worker_max_tokens` is positive, structured usage is no longer optional:
 Maestro fails the worker start closed if the selected backend/output mode cannot
 enforce a live ceiling. Claude, Pi, and OpenCode stop from their usage event

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1394,9 +1394,9 @@ func (o *Orchestrator) workerJSONLFile(slotName string, sess *state.Session) str
 // ParseClaudeUsage returns the cumulative run total across every attempt;
 // the monotonic UsageTokensWatermark persists across respawns so only the
 // new attempt's tokens are added (no double-count on retry/respawn). Cost
-// prefers the backend-reported total_cost_usd. Returns true when anything
-// changed; false (usage stays 0) when the jsonl is absent — the documented
-// degradation when the stream-splitter was unavailable.
+// prefers the backend-reported total_cost_usd. A successful terminal frame
+// with missing/zero usage marks the active attribution usage-unreliable and
+// logs once; zero never advances token counters or budget progress.
 func (o *Orchestrator) updateClaudeUsageFromJSONL(slotName string, sess *state.Session) bool {
 	jsonlPath := o.workerJSONLFile(slotName, sess)
 	if jsonlPath == "" {
@@ -1409,11 +1409,14 @@ func (o *Orchestrator) updateClaudeUsageFromJSONL(slotName string, sess *state.S
 		return false
 	}
 	usage, ok := worker.ParseClaudeUsage(string(data))
-	if !ok {
-		return false
-	}
 	changed := false
-	if usage.TotalTokens > sess.UsageTokensWatermark {
+	if usage.UsageUnreliable && state.MarkActiveAttributionUsageUnreliable(sess, usage.UsageUnreliableReason, usage.UsageUnreliableScope) {
+		log.Printf("[orch] %s claude usage-unreliable: scope=%s reason=%s; preserving observed counters and treating zero tokens as unavailable, not progress",
+			slotName, usage.UsageUnreliableScope, usage.UsageUnreliableReason)
+		changed = true
+	}
+	telemetryChanged := false
+	if ok && usage.TotalTokens > sess.UsageTokensWatermark {
 		delta := usage.TotalTokens - sess.UsageTokensWatermark
 		sess.UsageTokensWatermark = usage.TotalTokens
 		sess.TokensUsedAttempt += delta
@@ -1426,24 +1429,24 @@ func (o *Orchestrator) updateClaudeUsageFromJSONL(slotName string, sess *state.S
 		sess.TokensOutput = usage.Output
 		sess.TokensCacheRead = usage.CacheRead
 		sess.TokensCacheWrite = usage.CacheWrite
-		changed = true
+		telemetryChanged = true
 	}
 	if strings.TrimSpace(usage.Model) != "" && strings.TrimSpace(sess.Model) == "" {
 		sess.Model = usage.Model
-		changed = true
+		telemetryChanged = true
 	}
 	// total_cost_usd is the run-cumulative the full-jsonl parse sums across
 	// every result frame, so guard with `>` (mirrors the Pi cost fix in #732):
 	// a first-non-zero freeze would never update past the first attempt.
 	if usage.CostUSD > sess.CostUSDBackend {
 		sess.CostUSDBackend = usage.CostUSD
-		changed = true
+		telemetryChanged = true
 	}
-	if changed {
+	if telemetryChanged {
 		log.Printf("[orch] %s claude usage: model=%s tokens=%d cost=$%.4f (total=%d)",
 			slotName, usage.Model, usage.TotalTokens, usage.CostUSD, sess.TokensUsedTotal)
 	}
-	return changed
+	return changed || telemetryChanged
 }
 
 // updateCodexUsageFromJSONL parses the codex `exec --json` side-channel

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -11142,7 +11142,14 @@ func claudeTestOrchestrator(t *testing.T, slot string) (*Orchestrator, *state.Se
 		},
 	}
 	logFile := dir + "/" + slot + ".log"
-	sess := &state.Session{Backend: "claude", LogFile: logFile}
+	sess := &state.Session{
+		Backend: "claude",
+		LogFile: logFile,
+		Attribution: []state.BackendAttribution{{
+			Backend:   "claude",
+			StartedAt: time.Now().UTC(),
+		}},
+	}
 	return o, sess, dir + "/" + slot + ".jsonl"
 }
 
@@ -11184,6 +11191,34 @@ func TestUpdateTokensUsedFromOutput_ClaudeBackendStampsUsage(t *testing.T) {
 	}
 	if !sess.HasSplitTokens() {
 		t.Error("HasSplitTokens() = false, want true")
+	}
+}
+
+// A translated upstream that completes successfully but emits zero usage is
+// explicit degraded observability, never zero-token progress. The worker stays
+// alive/terminal according to its own lifecycle; token budget enforcement does
+// not synthesize a kill from missing data.
+func TestUpdateTokensUsedFromOutput_ClaudeZeroUsageMarksAttributionWithoutProgress(t *testing.T) {
+	o, sess, jsonlPath := claudeTestOrchestrator(t, "sup-946")
+	frames := `{"type":"system","subtype":"init","model":"proxy-model"}` + "\n" +
+		`{"type":"result","subtype":"success","result":"done","usage":{"input_tokens":0,"output_tokens":0}}` + "\n"
+	if err := os.WriteFile(jsonlPath, []byte(frames), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !o.updateTokensUsedFromOutput("sup-946", sess, "healthy rendered output") {
+		t.Fatal("expected the reliability marker to change durable state")
+	}
+	if sess.TokensUsedAttempt != 0 || sess.TokensUsedTotal != 0 || sess.UsageTokensWatermark != 0 {
+		t.Fatalf("zero usage advanced token progress: attempt=%d total=%d watermark=%d",
+			sess.TokensUsedAttempt, sess.TokensUsedTotal, sess.UsageTokensWatermark)
+	}
+	seg := sess.Attribution[len(sess.Attribution)-1]
+	if !seg.UsageUnreliable || seg.UsageUnreliableReason != "terminal_result_zero_input_or_output" || seg.UsageUnreliableScope != state.UsageUnreliableScopeAccounting {
+		t.Fatalf("attribution = %+v, want explicit usage-unreliable marker", seg)
+	}
+	if o.updateTokensUsedFromOutput("sup-946", sess, "healthy rendered output") {
+		t.Fatal("unchanged unreliable stream should not report another state change")
 	}
 }
 

--- a/internal/server/cost_observability.go
+++ b/internal/server/cost_observability.go
@@ -13,9 +13,10 @@ import (
 // answer "how much did each backend / each issue burn today, this week"
 // before turning up max_parallel or adding another project.
 //
-// The aggregation reads only the per-session counters already persisted
-// on state.Session (TokensUsedTotal, Backend, FinishedAt/StartedAt). No
-// new on-disk fields are required.
+// The aggregation reads the per-session counters and backend attribution
+// already persisted on state.Session. Usage-unreliable sessions remain in the
+// rollup even when their token lower bound is zero, so the API never describes
+// missing telemetry as "no activity".
 type fleetCostObservability struct {
 	// WindowToday is the local-day rollup (UTC midnight floor).
 	WindowToday fleetCostWindow `json:"window_today"`
@@ -35,17 +36,19 @@ type fleetCostObservability struct {
 }
 
 // fleetCostWindow carries token + USD totals for one time window. USD
-// is the estimate computed via BackendPricing.EstimateCostUSD; tokens
-// are exact. PricedTokens / UnpricedTokens split the same tokens by
+// is the estimate computed via BackendPricing.EstimateCostUSD; tokens are
+// exact unless UsageUnreliableSessions is non-zero, in which case they are a
+// lower bound. PricedTokens / UnpricedTokens split the same tokens by
 // whether the backend has pricing configured — this lets the SPA tell
 // the operator "today: 1.2M tokens, $14.30 priced + 200K from
 // backends without rates".
 type fleetCostWindow struct {
-	Tokens         int     `json:"tokens"`
-	PricedTokens   int     `json:"priced_tokens"`
-	UnpricedTokens int     `json:"unpriced_tokens"`
-	USD            float64 `json:"usd"`
-	Sessions       int     `json:"sessions"`
+	Tokens                  int     `json:"tokens"`
+	PricedTokens            int     `json:"priced_tokens"`
+	UnpricedTokens          int     `json:"unpriced_tokens"`
+	USD                     float64 `json:"usd"`
+	Sessions                int     `json:"sessions"`
+	UsageUnreliableSessions int     `json:"usage_unreliable_sessions,omitempty"`
 }
 
 // fleetCostBackend is one backend row in the per-backend rollup.
@@ -67,12 +70,13 @@ type fleetCostBackend struct {
 // retries are visible. The SPA renders this on the worker / issue
 // drawer next to the current attempt's counters.
 type fleetCostIssue struct {
-	IssueNumber int      `json:"issue_number"`
-	IssueTitle  string   `json:"issue_title,omitempty"`
-	Tokens      int      `json:"tokens"`
-	USD         float64  `json:"usd"`
-	Sessions    int      `json:"sessions"`
-	Backends    []string `json:"backends,omitempty"`
+	IssueNumber             int      `json:"issue_number"`
+	IssueTitle              string   `json:"issue_title,omitempty"`
+	Tokens                  int      `json:"tokens"`
+	USD                     float64  `json:"usd"`
+	Sessions                int      `json:"sessions"`
+	UsageUnreliableSessions int      `json:"usage_unreliable_sessions,omitempty"`
+	Backends                []string `json:"backends,omitempty"`
 }
 
 // maxFleetCostIssues bounds the per-issue table size. Picked to keep
@@ -103,12 +107,13 @@ func buildFleetCostObservability(cfg *config.Config, st *state.State, now time.T
 		lifetime fleetCostWindow
 	}
 	type issueRow struct {
-		issue    int
-		title    string
-		tokens   int
-		usd      float64
-		sessions int
-		backends map[string]struct{}
+		issue                   int
+		title                   string
+		tokens                  int
+		usd                     float64
+		sessions                int
+		usageUnreliableSessions int
+		backends                map[string]struct{}
 	}
 
 	backends := make(map[string]*backendRow)
@@ -120,12 +125,13 @@ func buildFleetCostObservability(cfg *config.Config, st *state.State, now time.T
 			continue
 		}
 		tokens := sess.TokensUsedTotal
-		if tokens <= 0 {
+		usd := sessionCostUSD(sess, pricing)
+		usageUnreliable := state.SessionUsageAccountingUnreliable(sess)
+		if tokens <= 0 && usd <= 0 && !usageUnreliable {
 			continue
 		}
 		stamp := sessionCostTimestamp(sess)
 		backend := sess.Backend
-		usd := sessionCostUSD(sess, pricing)
 		priced := priceConfigured(backend)
 
 		row, ok := backends[backend]
@@ -133,16 +139,16 @@ func buildFleetCostObservability(cfg *config.Config, st *state.State, now time.T
 			row = &backendRow{}
 			backends[backend] = row
 		}
-		applyCostWindow(&row.lifetime, tokens, usd, priced, 1)
-		applyCostWindow(&out.Lifetime, tokens, usd, priced, 1)
+		applyCostWindow(&row.lifetime, tokens, usd, priced, 1, usageUnreliable)
+		applyCostWindow(&out.Lifetime, tokens, usd, priced, 1, usageUnreliable)
 		if !stamp.IsZero() {
 			if !stamp.Before(dayStart) {
-				applyCostWindow(&row.today, tokens, usd, priced, 1)
-				applyCostWindow(&out.WindowToday, tokens, usd, priced, 1)
+				applyCostWindow(&row.today, tokens, usd, priced, 1, usageUnreliable)
+				applyCostWindow(&out.WindowToday, tokens, usd, priced, 1, usageUnreliable)
 			}
 			if !stamp.Before(weekStart) {
-				applyCostWindow(&row.week, tokens, usd, priced, 1)
-				applyCostWindow(&out.Window7D, tokens, usd, priced, 1)
+				applyCostWindow(&row.week, tokens, usd, priced, 1, usageUnreliable)
+				applyCostWindow(&out.Window7D, tokens, usd, priced, 1, usageUnreliable)
 			}
 		}
 
@@ -158,6 +164,9 @@ func buildFleetCostObservability(cfg *config.Config, st *state.State, now time.T
 			ir.tokens += tokens
 			ir.usd += usd
 			ir.sessions++
+			if usageUnreliable {
+				ir.usageUnreliableSessions++
+			}
 			if backend != "" {
 				ir.backends[backend] = struct{}{}
 			}
@@ -206,12 +215,13 @@ func buildFleetCostObservability(cfg *config.Config, st *state.State, now time.T
 		}
 		sort.Strings(backendList)
 		out.PerIssue = append(out.PerIssue, fleetCostIssue{
-			IssueNumber: ir.issue,
-			IssueTitle:  ir.title,
-			Tokens:      ir.tokens,
-			USD:         ir.usd,
-			Sessions:    ir.sessions,
-			Backends:    backendList,
+			IssueNumber:             ir.issue,
+			IssueTitle:              ir.title,
+			Tokens:                  ir.tokens,
+			USD:                     ir.usd,
+			Sessions:                ir.sessions,
+			UsageUnreliableSessions: ir.usageUnreliableSessions,
+			Backends:                backendList,
 		})
 	}
 	sort.Slice(out.PerIssue, func(i, j int) bool {
@@ -227,7 +237,7 @@ func buildFleetCostObservability(cfg *config.Config, st *state.State, now time.T
 }
 
 // applyCostWindow accumulates a session into a window bucket.
-func applyCostWindow(w *fleetCostWindow, tokens int, usd float64, priced bool, sessions int) {
+func applyCostWindow(w *fleetCostWindow, tokens int, usd float64, priced bool, sessions int, usageUnreliable bool) {
 	w.Tokens += tokens
 	if priced {
 		w.PricedTokens += tokens
@@ -236,6 +246,9 @@ func applyCostWindow(w *fleetCostWindow, tokens int, usd float64, priced bool, s
 	}
 	w.USD += usd
 	w.Sessions += sessions
+	if usageUnreliable {
+		w.UsageUnreliableSessions += sessions
+	}
 }
 
 // backendPricingMap returns the per-backend pricing table from a config
@@ -362,6 +375,7 @@ func mergeCostWindow(dst *fleetCostWindow, src fleetCostWindow) {
 	dst.UnpricedTokens += src.UnpricedTokens
 	dst.USD += src.USD
 	dst.Sessions += src.Sessions
+	dst.UsageUnreliableSessions += src.UsageUnreliableSessions
 }
 
 // applySessionCostEstimate returns the USD estimate for a single

--- a/internal/server/cost_observability_test.go
+++ b/internal/server/cost_observability_test.go
@@ -494,6 +494,70 @@ func TestBuildFleetCostObservability_SelfReportedCostWins(t *testing.T) {
 	}
 }
 
+func TestBuildFleetCostObservability_UsageUnreliableIsNotSilentZeroActivity(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	cfg := &config.Config{Model: config.ModelConfig{Backends: map[string]config.BackendDef{"grok": {}}}}
+	st := &state.State{Sessions: map[string]*state.Session{
+		"sup-946": {
+			IssueNumber:    946,
+			IssueTitle:     "proxy usage telemetry",
+			Backend:        "grok",
+			Status:         state.StatusDone,
+			StartedAt:      now.Add(-time.Minute),
+			FinishedAt:     timePtr(now),
+			CostUSDBackend: 0.125,
+			Attribution: []state.BackendAttribution{{
+				Backend:               "grok",
+				UsageUnreliable:       true,
+				UsageUnreliableReason: "terminal_result_missing_usage",
+				UsageUnreliableScope:  state.UsageUnreliableScopeAccounting,
+			}},
+		},
+	}}
+
+	got := buildFleetCostObservability(cfg, st, now)
+	if got.Lifetime.Sessions != 1 || got.Lifetime.UsageUnreliableSessions != 1 {
+		t.Fatalf("lifetime = %+v, want one explicitly unreliable session", got.Lifetime)
+	}
+	if got.Lifetime.Tokens != 0 {
+		t.Fatalf("lifetime tokens = %d, want unavailable 0 lower bound", got.Lifetime.Tokens)
+	}
+	if math.Abs(got.Lifetime.USD-0.125) > 1e-9 {
+		t.Fatalf("lifetime USD = %f, want backend-reported 0.125", got.Lifetime.USD)
+	}
+	if len(got.PerIssue) != 1 || got.PerIssue[0].UsageUnreliableSessions != 1 {
+		t.Fatalf("per_issue = %+v, want explicit usage-unreliable rollup", got.PerIssue)
+	}
+}
+
+func TestBuildFleetCostObservability_LiveBudgetDegradationKeepsTerminalAccountingReliable(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	cfg := &config.Config{Model: config.ModelConfig{Backends: map[string]config.BackendDef{"grok": {}}}}
+	st := &state.State{Sessions: map[string]*state.Session{
+		"sup-live": {
+			Backend:         "grok",
+			Status:          state.StatusDone,
+			StartedAt:       now.Add(-time.Minute),
+			FinishedAt:      timePtr(now),
+			TokensUsedTotal: 26_064,
+			Attribution: []state.BackendAttribution{{
+				Backend:               "grok",
+				UsageUnreliable:       true,
+				UsageUnreliableReason: "live_assistant_zero_input_or_output",
+				UsageUnreliableScope:  state.UsageUnreliableScopeLiveBudget,
+			}},
+		},
+	}}
+
+	got := buildFleetCostObservability(cfg, st, now)
+	if got.Lifetime.Tokens != 26_064 || got.Lifetime.Sessions != 1 {
+		t.Fatalf("lifetime = %+v, want exact terminal accounting", got.Lifetime)
+	}
+	if got.Lifetime.UsageUnreliableSessions != 0 {
+		t.Fatalf("live-budget-only degradation polluted accounting rollup: %+v", got.Lifetime)
+	}
+}
+
 // TestSessionCostEstimate_Precedence covers the per-session cost helper's
 // self-reported > split > blended precedence (#739).
 func TestSessionCostEstimate_Precedence(t *testing.T) {

--- a/internal/state/attribution.go
+++ b/internal/state/attribution.go
@@ -69,7 +69,89 @@ func attributionSegmentLabel(seg BackendAttribution) string {
 		seen[key] = struct{}{}
 		parts = append(parts, value)
 	}
+	if seg.UsageUnreliable {
+		parts = append(parts, "usage-unreliable")
+	}
 	return strings.Join(parts, " ")
+}
+
+// MarkActiveAttributionUsageUnreliable marks the currently-open backend
+// segment as unable to provide trustworthy token usage. The marker is
+// monotonic for the segment: a later good frame cannot reconstruct usage that
+// was absent from an earlier provider response, so it must not clear the flag.
+// It returns true only when durable attribution changed, which lets callers
+// log the degradation once instead of on every polling cycle.
+func MarkActiveAttributionUsageUnreliable(sess *Session, reason, scope string) bool {
+	if sess == nil {
+		return false
+	}
+	if len(sess.Attribution) == 0 {
+		// Imported/legacy sessions can predate the attribution timeline. Create a
+		// minimal segment from durable session identity rather than dropping the
+		// reliability warning; newer sessions already have a metadata-rich segment.
+		sess.Attribution = append(sess.Attribution, BackendAttribution{
+			Backend:   strings.TrimSpace(sess.Backend),
+			Model:     strings.TrimSpace(sess.Model),
+			StartedAt: sess.StartedAt,
+			Reason:    "usage_observation",
+		})
+	}
+	seg := &sess.Attribution[len(sess.Attribution)-1]
+	reason = strings.TrimSpace(reason)
+	scope = strings.TrimSpace(scope)
+	if scope == "" {
+		scope = UsageUnreliableScopeAccounting
+	}
+	changed := false
+	if !seg.UsageUnreliable {
+		seg.UsageUnreliable = true
+		changed = true
+	}
+	// Accounting loss is stronger than live-budget-only loss: once a terminal
+	// result itself is incomplete, the session totals become a lower bound and
+	// the active marker must upgrade accordingly.
+	upgradeScope := seg.UsageUnreliableScope == "" ||
+		(seg.UsageUnreliableScope == UsageUnreliableScopeLiveBudget && scope == UsageUnreliableScopeAccounting)
+	if upgradeScope {
+		seg.UsageUnreliableScope = scope
+		changed = true
+	}
+	if reason != "" && (seg.UsageUnreliableReason == "" || upgradeScope) {
+		seg.UsageUnreliableReason = reason
+		changed = true
+	}
+	return changed
+}
+
+// SessionUsageUnreliable reports whether any backend segment in the session
+// lost trustworthy usage telemetry. Session token/cost totals span all
+// segments, so one unreliable segment makes the aggregate a lower bound.
+func SessionUsageUnreliable(sess *Session) bool {
+	if sess == nil {
+		return false
+	}
+	for _, seg := range sess.Attribution {
+		if seg.UsageUnreliable {
+			return true
+		}
+	}
+	return false
+}
+
+// SessionUsageAccountingUnreliable reports whether session-level token/cost
+// totals are a lower bound. A live_budget-only marker does not qualify because
+// a later terminal result can still make accounting exact even though the live
+// worker ceiling could not be enforced response-by-response.
+func SessionUsageAccountingUnreliable(sess *Session) bool {
+	if sess == nil {
+		return false
+	}
+	for _, seg := range sess.Attribution {
+		if seg.UsageUnreliable && seg.UsageUnreliableScope != UsageUnreliableScopeLiveBudget {
+			return true
+		}
+	}
+	return false
 }
 
 func attributionSegmentRange(origin time.Time, seg BackendAttribution, now time.Time) string {

--- a/internal/state/attribution_test.go
+++ b/internal/state/attribution_test.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -18,6 +19,62 @@ func TestFormatAttributionTimelineSingleSegment(t *testing.T) {
 	want := "codex openai gpt-5.5 medium (0-end)"
 	if got != want {
 		t.Fatalf("FormatAttributionTimeline() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatAttributionTimelineMarksUsageUnreliable(t *testing.T) {
+	started := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	got := FormatAttributionTimeline([]BackendAttribution{{
+		Backend:         "grok",
+		Model:           "grok-4.5",
+		UsageUnreliable: true,
+		StartedAt:       started,
+	}}, started.Add(time.Minute))
+	if !strings.Contains(got, "usage-unreliable") {
+		t.Fatalf("FormatAttributionTimeline() = %q, want usage-unreliable marker", got)
+	}
+}
+
+func TestMarkActiveAttributionUsageUnreliableIsMonotonic(t *testing.T) {
+	sess := &Session{Attribution: []BackendAttribution{{Backend: "grok"}}}
+	if !MarkActiveAttributionUsageUnreliable(sess, "live_assistant_zero_input_or_output", UsageUnreliableScopeLiveBudget) {
+		t.Fatal("first mark did not report a durable change")
+	}
+	if !SessionUsageUnreliable(sess) {
+		t.Fatal("session did not report unreliable usage")
+	}
+	if got := sess.Attribution[0].UsageUnreliableReason; got != "live_assistant_zero_input_or_output" {
+		t.Fatalf("reason = %q, want live assistant degradation", got)
+	}
+	if SessionUsageAccountingUnreliable(sess) {
+		t.Fatal("live-budget-only degradation marked accounting totals unreliable")
+	}
+	if !MarkActiveAttributionUsageUnreliable(sess, "terminal_result_zero_input_or_output", UsageUnreliableScopeAccounting) {
+		t.Fatal("accounting degradation did not upgrade the live-budget marker")
+	}
+	if got := sess.Attribution[0].UsageUnreliableReason; got != "terminal_result_zero_input_or_output" {
+		t.Fatalf("reason = %q, want upgraded accounting reason", got)
+	}
+	if !SessionUsageAccountingUnreliable(sess) {
+		t.Fatal("accounting degradation was not reported")
+	}
+	if MarkActiveAttributionUsageUnreliable(sess, "later_reason", UsageUnreliableScopeLiveBudget) {
+		t.Fatal("weaker repeat mark replaced accounting degradation")
+	}
+}
+
+func TestMarkActiveAttributionUsageUnreliableCreatesLegacySegment(t *testing.T) {
+	started := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	sess := &Session{Backend: "claude", Model: "proxy-model", StartedAt: started}
+	if !MarkActiveAttributionUsageUnreliable(sess, "terminal_result_missing_usage", UsageUnreliableScopeAccounting) {
+		t.Fatal("legacy session was not marked")
+	}
+	if len(sess.Attribution) != 1 {
+		t.Fatalf("attribution len = %d, want 1", len(sess.Attribution))
+	}
+	seg := sess.Attribution[0]
+	if seg.Backend != "claude" || seg.Model != "proxy-model" || seg.Reason != "usage_observation" || !seg.UsageUnreliable || seg.UsageUnreliableScope != UsageUnreliableScopeAccounting {
+		t.Fatalf("legacy attribution = %+v", seg)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -326,17 +326,25 @@ const (
 // rate-limit fallover or pipeline-phase machinery respawns it on a
 // different backend.
 type BackendAttribution struct {
-	Backend   string     `json:"backend"`              // shim name (claude, codex, freellm, opencode, …)
-	Provider  string     `json:"provider,omitempty"`   // anthropic, openai, groq, …
-	Model     string     `json:"model,omitempty"`      // opus-4.8, gpt-5.5, llama-3.3-70b-versatile, …
-	Variant   string     `json:"variant,omitempty"`    // opus[1m], fast, sonnet, …
-	Effort    string     `json:"effort,omitempty"`     // xhigh, medium, low, …
-	TaskType  string     `json:"task_type,omitempty"`  // router classification: refactor, bugfix, test, vision, design, docs, infra
-	StartedAt time.Time  `json:"started_at"`           // when this segment became active
-	EndedAt   *time.Time `json:"ended_at,omitempty"`   // when the segment was closed; nil if still active
-	EndReason string     `json:"end_reason,omitempty"` // why the segment closed: "completed", "provider_limit", "fallover", "in_place_respawn", "killed"
-	Reason    string     `json:"reason,omitempty"`     // why this segment was started: "initial_spawn", "fallover", "in_place_respawn", "phase_transition"
+	Backend               string     `json:"backend"`                           // shim name (claude, codex, freellm, opencode, …)
+	Provider              string     `json:"provider,omitempty"`                // anthropic, openai, groq, …
+	Model                 string     `json:"model,omitempty"`                   // opus-4.8, gpt-5.5, llama-3.3-70b-versatile, …
+	Variant               string     `json:"variant,omitempty"`                 // opus[1m], fast, sonnet, …
+	Effort                string     `json:"effort,omitempty"`                  // xhigh, medium, low, …
+	TaskType              string     `json:"task_type,omitempty"`               // router classification: refactor, bugfix, test, vision, design, docs, infra
+	UsageUnreliable       bool       `json:"usage_unreliable,omitempty"`        // provider stream omitted plausible input/output usage for live budgets or terminal accounting
+	UsageUnreliableReason string     `json:"usage_unreliable_reason,omitempty"` // stable secret-free reason for the degradation
+	UsageUnreliableScope  string     `json:"usage_unreliable_scope,omitempty"`  // live_budget (terminal totals still usable) or accounting (session totals are a lower bound)
+	StartedAt             time.Time  `json:"started_at"`                        // when this segment became active
+	EndedAt               *time.Time `json:"ended_at,omitempty"`                // when the segment was closed; nil if still active
+	EndReason             string     `json:"end_reason,omitempty"`              // why the segment closed: "completed", "provider_limit", "fallover", "in_place_respawn", "killed"
+	Reason                string     `json:"reason,omitempty"`                  // why this segment was started: "initial_spawn", "fallover", "in_place_respawn", "phase_transition"
 }
+
+const (
+	UsageUnreliableScopeLiveBudget = "live_budget"
+	UsageUnreliableScopeAccounting = "accounting"
+)
 
 // SessionAttention explains why a session needs operator attention and the
 // safest next action Maestro can infer from persisted state.

--- a/internal/supervisor/material_progress_test.go
+++ b/internal/supervisor/material_progress_test.go
@@ -63,6 +63,44 @@ func TestCollectMaterialProgressObservations_ExactWorkersCannotMaskEachOther(t *
 	}
 }
 
+func TestMaterialProgressWatchdog_UsageUnreliableDoesNotKillHealthyWorker(t *testing.T) {
+	st := state.NewState()
+	t0 := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	st.Sessions["slot-946"] = &state.Session{
+		IssueNumber:    946,
+		Status:         state.StatusRunning,
+		PID:            946,
+		StartedAt:      t0.Add(-time.Hour),
+		LastOutputHash: "healthy-output-1",
+		Attribution: []state.BackendAttribution{{
+			Backend:               "grok",
+			UsageUnreliable:       true,
+			UsageUnreliableReason: "live_assistant_zero_input_or_output",
+			UsageUnreliableScope:  state.UsageUnreliableScopeLiveBudget,
+		}},
+	}
+
+	budget := 20 * time.Minute
+	if _, err := st.RecordMaterialProgress(collectMaterialProgressObservations(st, t0), budget, time.Minute, t0); err != nil {
+		t.Fatal(err)
+	}
+	// Token telemetry remains unavailable, but independently-observed terminal
+	// output advances. The watchdog must treat the worker as healthy.
+	st.Sessions["slot-946"].LastOutputHash = "healthy-output-2"
+	decisions, err := st.RecordMaterialProgress(
+		collectMaterialProgressObservations(st, t0.Add(budget+time.Minute)),
+		budget,
+		time.Minute,
+		t0.Add(budget+time.Minute),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decisions) != 1 || decisions[0].Action != progress.ActionNone || decisions[0].RecommendsRecovery() {
+		t.Fatalf("usage-unreliable healthy worker decision = %+v, want progress/no recovery", decisions)
+	}
+}
+
 func TestCollectMaterialProgressObservations_WorkerReplacementHasNewLease(t *testing.T) {
 	st := state.NewState()
 	t0 := time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)

--- a/internal/worker/claude_usage.go
+++ b/internal/worker/claude_usage.go
@@ -14,14 +14,25 @@ import (
 // total across attempts — monotonic as the log grows, which is what the
 // orchestrator's respawn-safe token watermark expects.
 type ClaudeUsage struct {
-	Model       string  // session model (system/init), falling back to the assistant message model
-	Input       int     // sum of input_tokens across result frames
-	Output      int     // sum of output_tokens across result frames
-	CacheRead   int     // sum of cache_read_input_tokens across result frames
-	CacheWrite  int     // sum of cache_creation_input_tokens across result frames
-	TotalTokens int     // Input + Output + CacheRead + CacheWrite
-	CostUSD     float64 // sum of total_cost_usd across result frames
+	Model                 string  // session model (system/init), falling back to the assistant message model
+	Input                 int     // sum of input_tokens across result frames
+	Output                int     // sum of output_tokens across result frames
+	CacheRead             int     // sum of cache_read_input_tokens across result frames
+	CacheWrite            int     // sum of cache_creation_input_tokens across result frames
+	TotalTokens           int     // Input + Output + CacheRead + CacheWrite
+	CostUSD               float64 // sum of total_cost_usd across result frames
+	UsageUnreliable       bool    // live assistant or successful terminal usage omitted plausible input/output
+	UsageUnreliableReason string  // stable secret-free degradation reason
+	UsageUnreliableScope  string  // live_budget or accounting
 }
+
+const (
+	claudeUsageMissingResult     = "terminal_result_missing_usage"
+	claudeUsageZeroResult        = "terminal_result_zero_input_or_output"
+	claudeUsageZeroLiveAssistant = "live_assistant_zero_input_or_output"
+	claudeUsageScopeLiveBudget   = "live_budget"
+	claudeUsageScopeAccounting   = "accounting"
+)
 
 // claudeStreamFrame is the subset of a claude stream-json line this package
 // decodes. `model` is present on the system/init frame; `message` on
@@ -29,6 +40,7 @@ type ClaudeUsage struct {
 type claudeStreamFrame struct {
 	Type         string               `json:"type"`
 	Subtype      string               `json:"subtype"`
+	IsError      bool                 `json:"is_error"`
 	Model        string               `json:"model"`
 	Message      *claudeStreamMessage `json:"message"`
 	Usage        *claudeUsageBlock    `json:"usage"`
@@ -57,8 +69,10 @@ type claudeUsageBlock struct {
 // ParseClaudeUsage scans a claude stream-json NDJSON stream (the appended
 // slot.jsonl) and aggregates usage across every terminal `result` frame.
 // It returns ok=false when no usage-bearing result frame is found, so callers
-// can leave tokens/cost at 0 (the documented degradation when the
-// stream-splitter was unavailable or no frame has landed yet).
+// do not treat zero as token progress. A successful terminal frame with a
+// missing usage object or zero input/output marks accounting unreliable. A
+// zero input/output field on an assistant frame marks live-budget telemetry
+// unreliable even when the later terminal result makes accounting exact.
 func ParseClaudeUsage(text string) (ClaudeUsage, bool) {
 	var out ClaudeUsage
 	seen := false
@@ -70,17 +84,31 @@ func ParseClaudeUsage(text string) (ClaudeUsage, bool) {
 		if usage == nil || claudeUsageTotal(&live) > claudeUsageTotal(usage) {
 			usage = &live
 		}
-		if claudeUsageTotal(usage) == 0 {
-			live = claudeUsageBlock{}
-			return
+		selected := claudeUsageBlock{}
+		if usage != nil {
+			selected = *usage
 		}
-		out.Input += usage.InputTokens
-		out.Output += usage.OutputTokens
-		out.CacheRead += usage.CacheReadInputTokens
-		out.CacheWrite += usage.CacheCreationInputTokens
-		seen = true
 		live = claudeUsageBlock{}
 		clear(liveMessages)
+		if claudeUsageTotal(&selected) == 0 {
+			return
+		}
+		out.Input += selected.InputTokens
+		out.Output += selected.OutputTokens
+		out.CacheRead += selected.CacheReadInputTokens
+		out.CacheWrite += selected.CacheCreationInputTokens
+		seen = true
+	}
+	markUnreliable := func(reason, scope string) {
+		out.UsageUnreliable = true
+		upgrade := out.UsageUnreliableScope == "" ||
+			(out.UsageUnreliableScope == claudeUsageScopeLiveBudget && scope == claudeUsageScopeAccounting)
+		if upgrade {
+			out.UsageUnreliableScope = scope
+		}
+		if out.UsageUnreliableReason == "" || upgrade {
+			out.UsageUnreliableReason = reason
+		}
 	}
 
 	for _, raw := range strings.Split(text, "\n") {
@@ -104,6 +132,9 @@ func ParseClaudeUsage(text string) (ClaudeUsage, bool) {
 					assistantModel = fr.Message.Model
 				}
 				if fr.Message.Usage != nil {
+					if fr.Message.Usage.InputTokens <= 0 || fr.Message.Usage.OutputTokens <= 0 {
+						markUnreliable(claudeUsageZeroLiveAssistant, claudeUsageScopeLiveBudget)
+					}
 					messageID := strings.TrimSpace(fr.Message.ID)
 					if messageID == "" {
 						live.InputTokens += fr.Message.Usage.InputTokens
@@ -121,8 +152,16 @@ func ParseClaudeUsage(text string) (ClaudeUsage, bool) {
 				}
 			}
 		case "result":
-			if fr.Usage == nil {
-				continue
+			// Explicit provider errors may legitimately omit usage. Successful
+			// completions may not: without plausible input/output counts the
+			// stream cannot safely drive budgets or cost attribution.
+			if !fr.IsError {
+				switch {
+				case fr.Usage == nil:
+					markUnreliable(claudeUsageMissingResult, claudeUsageScopeAccounting)
+				case fr.Usage.InputTokens <= 0 || fr.Usage.OutputTokens <= 0:
+					markUnreliable(claudeUsageZeroResult, claudeUsageScopeAccounting)
+				}
 			}
 			flushLive(fr.Usage)
 			out.CostUSD += fr.TotalCostUSD

--- a/internal/worker/claude_usage_test.go
+++ b/internal/worker/claude_usage_test.go
@@ -55,6 +55,41 @@ not json at all
 	}
 }
 
+func TestParseClaudeUsage_MissingTerminalUsageIsExplicitlyUnreliable(t *testing.T) {
+	const stream = `{"type":"system","subtype":"init","model":"proxy-model"}
+{"type":"assistant","message":{"id":"msg-1","model":"proxy-model","usage":{"input_tokens":100,"output_tokens":5}}}
+{"type":"result","subtype":"success","result":"done","total_cost_usd":0.12}
+`
+	usage, ok := ParseClaudeUsage(stream)
+	if !ok {
+		t.Fatal("assistant-frame lower bound should remain observable")
+	}
+	if usage.TotalTokens != 105 {
+		t.Fatalf("TotalTokens = %d, want lower-bound 105", usage.TotalTokens)
+	}
+	if !usage.UsageUnreliable || usage.UsageUnreliableReason != claudeUsageMissingResult || usage.UsageUnreliableScope != claudeUsageScopeAccounting {
+		t.Fatalf("usage reliability = %+v, want missing-result degradation", usage)
+	}
+	if usage.CostUSD != 0.12 {
+		t.Fatalf("CostUSD = %v, want trustworthy backend-reported 0.12", usage.CostUSD)
+	}
+}
+
+func TestParseClaudeUsage_ZeroTerminalUsageIsNotProgress(t *testing.T) {
+	const stream = `{"type":"result","subtype":"success","result":"done","usage":{"input_tokens":0,"output_tokens":0}}
+`
+	usage, ok := ParseClaudeUsage(stream)
+	if ok {
+		t.Fatalf("zero usage returned ok=true: %+v", usage)
+	}
+	if usage.TotalTokens != 0 {
+		t.Fatalf("TotalTokens = %d, want 0", usage.TotalTokens)
+	}
+	if !usage.UsageUnreliable || usage.UsageUnreliableReason != claudeUsageZeroResult || usage.UsageUnreliableScope != claudeUsageScopeAccounting {
+		t.Fatalf("usage reliability = %+v, want zero-result degradation", usage)
+	}
+}
+
 func TestParseClaudeUsage_LiveAssistantFramesBeforeResult(t *testing.T) {
 	const live = `{"type":"system","subtype":"init","model":"claude-opus"}
 {"type":"assistant","message":{"role":"assistant","model":"claude-opus","usage":{"input_tokens":30000,"output_tokens":1000,"cache_creation_input_tokens":2000,"cache_read_input_tokens":7000}}}

--- a/internal/worker/stream_split_test.go
+++ b/internal/worker/stream_split_test.go
@@ -56,6 +56,48 @@ func TestRunStreamSplit_SplitsRawAndRendered(t *testing.T) {
 	}
 }
 
+// This fixture is a sanitized 2026-07-21 live capture from Claude Code 2.1.216
+// running `--model grok-4.5` through CLIProxyAPI. Identifiers/timing were
+// removed, while the configured/init model, translated assistant model, frame
+// shapes, and usage/cost values are retained. The assistant frame reports
+// zeros; the terminal result carries the authoritative non-zero totals.
+func TestRunStreamSplit_ParsesCapturedNonAnthropicProxyStream(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("testdata", "claude_proxy_grok_4_5_stream.jsonl"))
+	if err != nil {
+		t.Fatalf("read proxy fixture: %v", err)
+	}
+	dir := t.TempDir()
+	jsonlPath := filepath.Join(dir, "sup-946.jsonl")
+	var rendered strings.Builder
+	if err := RunStreamSplit("claude", jsonlPath, strings.NewReader(string(fixture)), &rendered); err != nil {
+		t.Fatalf("RunStreamSplit: %v", err)
+	}
+
+	raw, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		t.Fatalf("read split side channel: %v", err)
+	}
+	if string(raw) != string(fixture) {
+		t.Fatal("stream-split did not preserve the captured proxy frames verbatim")
+	}
+	usage, ok := ParseClaudeUsage(string(raw))
+	if !ok {
+		t.Fatal("captured non-Anthropic result usage was not parsed")
+	}
+	if !usage.UsageUnreliable || usage.UsageUnreliableScope != claudeUsageScopeLiveBudget || usage.UsageUnreliableReason != claudeUsageZeroLiveAssistant {
+		t.Fatalf("captured zero assistant usage did not mark live-budget degradation: %+v", usage)
+	}
+	if usage.Model != "grok-4.5" || usage.Input != 24762 || usage.Output != 22 || usage.CacheRead != 1280 || usage.TotalTokens != 26064 {
+		t.Fatalf("parsed proxy usage = %+v, want grok-4.5 24762/22/1280 total=26064", usage)
+	}
+	if usage.CostUSD != 0.125 {
+		t.Fatalf("CostUSD = %v, want 0.125", usage.CostUSD)
+	}
+	if !strings.Contains(rendered.String(), "PONG") || !strings.Contains(rendered.String(), "[claude] result:") {
+		t.Fatalf("rendered proxy stream lost worker output:\n%s", rendered.String())
+	}
+}
+
 // If the jsonl path cannot be opened, RunStreamSplit must degrade to
 // pass-through so the worker log is never lost.
 func TestRunStreamSplit_DegradesWhenJSONLUnwritable(t *testing.T) {

--- a/internal/worker/testdata/claude_proxy_grok_4_5_stream.jsonl
+++ b/internal/worker/testdata/claude_proxy_grok_4_5_stream.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","model":"grok-4.5"}
+{"type":"assistant","message":{"id":"msg_REDACTED","type":"message","role":"assistant","model":"grok-4.5-build","content":[{"type":"text","text":"PONG"}],"stop_reason":"end_turn","usage":{"input_tokens":0,"output_tokens":0,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}
+{"type":"result","subtype":"success","num_turns":1,"result":"PONG","total_cost_usd":0.125,"usage":{"input_tokens":24762,"output_tokens":22,"cache_creation_input_tokens":0,"cache_read_input_tokens":1280}}

--- a/internal/worker/token_budget_test.go
+++ b/internal/worker/token_budget_test.go
@@ -61,6 +61,19 @@ func TestLiveTokenMonitor_ClaudeIgnoresCacheReadAndDeduplicatesMessageFrames(t *
 	}
 }
 
+func TestLiveTokenMonitor_ClaudeMissingUsageDoesNotKillHealthyWorker(t *testing.T) {
+	monitor := newLiveTokenMonitor("claude", 1)
+	for _, frame := range []string{
+		`{"type":"assistant","message":{"id":"msg-1","role":"assistant","usage":{"input_tokens":0,"output_tokens":0}}}`,
+		`{"type":"result","subtype":"success","result":"done"}`,
+	} {
+		observed, exceeded := monitor.observe(frame)
+		if observed != 0 || exceeded {
+			t.Fatalf("missing usage produced budget progress/kill: observed=%d exceeded=%t", observed, exceeded)
+		}
+	}
+}
+
 func TestLiveTokenMonitor_PiIgnoresCacheRead(t *testing.T) {
 	monitor := newLiveTokenMonitor("pi", 100_000)
 	line := `{"type":"turn_end","message":{"role":"assistant","usage":{"input":10,"output":20,"cacheRead":150000,"cacheWrite":30000}}}`


### PR DESCRIPTION
Refs #946

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR records degraded Claude stream telemetry and exposes it in cost reporting. The main changes are:

- Detect missing or zero usage in assistant and terminal frames.
- Persist reliability scope and reason on backend attribution segments.
- Include accounting-unreliable sessions in fleet cost rollups.
- Add proxy stream fixtures, tests, and operator documentation.

<h3>Confidence Score: 4/5</h3>

Attempt transitions can assign an old telemetry failure to the newly active backend segment.

The parser scans the full append-only stream across attempts. The new mutation always targets the last attribution segment.

Respawn, fallover, and phase-transition histories can therefore contain incorrect reliability metadata in internal/orchestrator/orchestrator.go and internal/worker/claude_usage.go.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- An initial focused Go reproduction was created and executed using the real Claude parser, orchestrator reconciliation path, runtime-attribution transition API, and a two-attempt JSONL stream, but the run reached the maximum steps and is blocked.
- The team identified remaining work to inspect the captured exit code and raw test output, add the required command header to the log artifact, and confirm whether the assertion reproduced the incorrect active-segment marker.
- Plans were set to validate and package the generated harness and the verbose log from trex-artifacts without rerunning broad tests.
- Before the changes, parsing, model identity, tokens, cost, and rendered output passed, but reliability metadata was unavailable.
- After enabling usage\_unreliable=true with scope live\_budget and reason live\_assistant\_zero\_input\_or\_output, the same fixture and path passed, and cost tests showed live-budget degradation does not mark terminal accounting unreliable; every captured command exited 0.

<a href="https://app.greptile.com/trex/runs/15314705/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/claude_usage.go | Classifies incomplete assistant and terminal usage while retaining observed token and cost totals. |
| internal/orchestrator/orchestrator.go | Persists cumulative parser reliability on the active attribution segment, which can misattribute an earlier attempt's degradation. |
| internal/state/attribution.go | Adds monotonic reliability markers and session-level accounting reliability queries. |
| internal/server/cost_observability.go | Adds unreliable-session counts to fleet windows and issue rollups. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:1412
**Old Attempt Marks Active Segment**

The JSONL contains frames from every attempt, so `usage.UsageUnreliable` can come from a closed attempt. After a respawn, fallover, or phase transition opens a new attribution segment, this call marks that new segment instead, causing history and accounting to report the wrong backend attempt as degraded.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-1009-9..."](https://github.com/befeast/maestro/commit/9156ba1c4c48eeb8697482e43c883b5101975ceb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46100003)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->