### PR TITLE
P1: make search-guardrail resolution non-recursive and wrapper installation atomic

### DIFF
--- a/internal/worker/search_guardrail.go
+++ b/internal/worker/search_guardrail.go
@@ -13,12 +13,22 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 
 	"golang.org/x/sys/unix"
 )
 
 var searchGuardedCommands = []string{"rg", "find", "grep"}
+
+var searchGuardrailInstallMu sync.Mutex
+
+const (
+	searchGuardrailDirName     = "search-guardrails"
+	searchGuardrailMarker      = "[maestro] search guardrail:"
+	searchGuardrailScriptMark  = "# maestro-search-guardrail-wrapper"
+	searchGuardrailWrapperMode = 0o755
+)
 
 // workerCredentialEnvKeys are the provider credential env vars the worker
 // harness needs to reach CLIProxyAPI / upstream APIs. The daemon inherits them
@@ -84,27 +94,148 @@ const (
 )
 
 func ensureSearchGuardrailWrappers(stateDir string) (string, error) {
+	searchGuardrailInstallMu.Lock()
+	defer searchGuardrailInstallMu.Unlock()
+
 	if strings.TrimSpace(stateDir) == "" {
 		return "", fmt.Errorf("empty state dir")
 	}
-	guardDir := filepath.Join(stateDir, "search-guardrails")
+	guardDir, err := filepath.Abs(filepath.Join(stateDir, searchGuardrailDirName))
+	if err != nil {
+		return "", fmt.Errorf("prepare search guardrails: resolve destination directory")
+	}
+
+	// Resolve every target from the daemon's PATH before creating or publishing
+	// wrappers. In particular, never let a nested Maestro worker pin an older
+	// wrapper inherited through PATH as the "real" command.
+	targets := make(map[string]string, len(searchGuardedCommands))
+	for _, name := range searchGuardedCommands {
+		target, err := resolveTrustedSearchCommand(name, guardDir)
+		if err != nil {
+			return "", fmt.Errorf("prepare search guardrail %s: resolve trusted executable", name)
+		}
+		targets[name] = target
+	}
+
 	if err := os.MkdirAll(guardDir, 0755); err != nil {
-		return "", fmt.Errorf("create search guardrail dir: %w", err)
+		return "", fmt.Errorf("prepare search guardrails: create destination directory")
 	}
 	for _, name := range searchGuardedCommands {
 		path := filepath.Join(guardDir, name)
-		if err := os.WriteFile(path, []byte(searchGuardrailWrapperScript), 0755); err != nil {
-			return "", fmt.Errorf("write search guardrail wrapper %s: %w", name, err)
+		content := buildSearchGuardrailWrapperScript(name, targets[name], guardDir)
+		if searchGuardrailWrapperCurrent(path, content) {
+			continue
+		}
+		if err := writeFileAtomicMode(guardDir, path, content, searchGuardrailWrapperMode); err != nil {
+			// These errors can be surfaced through worker failures and eventually
+			// copied to GitHub. Keep the command and failed stage, but not a private
+			// state-directory path from the underlying filesystem error.
+			return "", fmt.Errorf("prepare search guardrail %s: install wrapper atomically", name)
 		}
 	}
 	return guardDir, nil
 }
 
-const searchGuardrailWrapperScript = `#!/bin/sh
-cmd=${0##*/}
-real_path=$(PATH="${MAESTRO_ORIGINAL_PATH:-$PATH}" command -v "$cmd" 2>/dev/null)
-if [ -z "$real_path" ]; then
-  echo "[maestro] search guardrail: unable to locate real $cmd" >&2
+func searchGuardrailWrapperCurrent(path, content string) bool {
+	f, err := openFilePathNoFollow(path, unix.O_RDONLY)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != searchGuardrailWrapperMode {
+		return false
+	}
+	if err := checkOwnedByUs(path, info); err != nil {
+		return false
+	}
+	data, err := io.ReadAll(io.LimitReader(f, int64(len(content)+1)))
+	return err == nil && string(data) == content
+}
+
+func resolveTrustedSearchCommand(name, guardDir string) (string, error) {
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			dir = "."
+		}
+		candidate, err := filepath.Abs(filepath.Join(dir, name))
+		if err != nil || isSearchGuardrailPath(candidate, guardDir) {
+			continue
+		}
+		info, err := os.Stat(candidate)
+		if err != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
+			continue
+		}
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err != nil {
+			continue
+		}
+		resolved, err = filepath.Abs(resolved)
+		if err != nil || isSearchGuardrailPath(resolved, guardDir) {
+			continue
+		}
+		if isMaestroSearchGuardrailExecutable(resolved) {
+			continue
+		}
+		return resolved, nil
+	}
+	return "", fmt.Errorf("no executable outside a search guardrail directory")
+}
+
+func isMaestroSearchGuardrailExecutable(path string) bool {
+	f, err := openFilePathNoFollow(path, unix.O_RDONLY)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, 64<<10))
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(data, []byte(searchGuardrailScriptMark)) ||
+		bytes.Contains(data, []byte(searchGuardrailMarker))
+}
+
+func isSearchGuardrailPath(path, guardDir string) bool {
+	path = filepath.Clean(path)
+	guardDir = filepath.Clean(guardDir)
+	if rel, err := filepath.Rel(guardDir, path); err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return true
+	}
+	for dir := filepath.Dir(path); dir != filepath.Dir(dir); dir = filepath.Dir(dir) {
+		if filepath.Base(dir) == searchGuardrailDirName {
+			return true
+		}
+	}
+	return false
+}
+
+func buildSearchGuardrailWrapperScript(name, realPath, guardDir string) string {
+	return `#!/bin/sh
+` + searchGuardrailScriptMark + `
+cmd=` + shellQuote(name) + `
+real_path=` + shellQuote(realPath) + `
+guard_dir=` + shellQuote(guardDir) + `
+
+case "$real_path" in
+  "$guard_dir"|"$guard_dir"/*|*/search-guardrails/*)
+    echo "[maestro] search guardrail: refusing unsafe executable for $cmd" >&2
+    exit 126
+    ;;
+esac
+if [ "$real_path" = "$0" ] || [ "$real_path" -ef "$0" ] 2>/dev/null; then
+  echo "[maestro] search guardrail: refusing self-execution for $cmd" >&2
+  exit 126
+fi
+for guard_path in "$guard_dir"/*; do
+  [ -e "$guard_path" ] || continue
+  if [ "$real_path" -ef "$guard_path" ] 2>/dev/null; then
+    echo "[maestro] search guardrail: refusing unsafe executable for $cmd" >&2
+    exit 126
+  fi
+done
+if [ ! -f "$real_path" ] || [ ! -x "$real_path" ]; then
+  echo "[maestro] search guardrail: trusted executable unavailable for $cmd" >&2
   exit 127
 fi
 
@@ -324,6 +455,7 @@ fi
 
 exec "$real_path" "$@"
 `
+}
 
 // streamSplit configures the worker runner to route a backend's structured
 // NDJSON stream through `maestro stream-split` before tee: the raw frames are

--- a/internal/worker/search_guardrail_test.go
+++ b/internal/worker/search_guardrail_test.go
@@ -2,12 +2,16 @@ package worker
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/befeast/maestro/internal/state"
 )
@@ -31,11 +35,6 @@ func newSearchGuardrailHarness(t *testing.T) searchGuardrailHarness {
 		t.Fatalf("create fake bin: %v", err)
 	}
 
-	guardDir, err := ensureSearchGuardrailWrappers(filepath.Join(baseDir, "state"))
-	if err != nil {
-		t.Fatalf("ensureSearchGuardrailWrappers: %v", err)
-	}
-
 	fakeScript := `#!/bin/sh
 printf 'real:%s:%s\n' "$0" "$PWD"
 printf 'args:'
@@ -48,6 +47,12 @@ printf '\n'
 		if err := os.WriteFile(filepath.Join(fakeDir, name), []byte(fakeScript), 0755); err != nil {
 			t.Fatalf("write fake %s: %v", name, err)
 		}
+	}
+	t.Setenv("PATH", fakeDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	guardDir, err := ensureSearchGuardrailWrappers(filepath.Join(baseDir, "state"))
+	if err != nil {
+		t.Fatalf("ensureSearchGuardrailWrappers: %v", err)
 	}
 
 	return searchGuardrailHarness{
@@ -199,6 +204,509 @@ func TestSearchGuardrailWrapperAllowsExplicitBroadSearch(t *testing.T) {
 	if !strings.Contains(output, "real:") {
 		t.Fatalf("guarded rg did not run real command, output:\n%s", output)
 	}
+}
+
+func TestSearchGuardrailWrapperPinsTrustedExecutable(t *testing.T) {
+	baseDir := t.TempDir()
+	firstBin := filepath.Join(baseDir, "first-bin")
+	secondBin := filepath.Join(baseDir, "second-bin")
+	for _, dir := range []string{firstBin, secondBin} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create fake bin: %v", err)
+		}
+	}
+	for _, name := range searchGuardedCommands {
+		if err := os.WriteFile(filepath.Join(firstBin, name), []byte("#!/bin/sh\nprintf 'first:"+name+"\\n'\n"), 0o755); err != nil {
+			t.Fatalf("write first %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(secondBin, name), []byte("#!/bin/sh\nprintf 'second:"+name+"\\n'\n"), 0o755); err != nil {
+			t.Fatalf("write second %s: %v", name, err)
+		}
+	}
+	t.Setenv("PATH", firstBin+string(os.PathListSeparator)+secondBin)
+
+	guardDir, err := ensureSearchGuardrailWrappers(filepath.Join(baseDir, "state"))
+	if err != nil {
+		t.Fatalf("ensureSearchGuardrailWrappers: %v", err)
+	}
+
+	for _, name := range searchGuardedCommands {
+		cmd := exec.Command(filepath.Join(guardDir, name))
+		cmd.Dir = baseDir
+		cmd.Env = []string{
+			"MAESTRO_ALLOW_BROAD_SEARCH=1",
+			"MAESTRO_ORIGINAL_PATH=" + guardDir + ":::" + secondBin,
+			"PATH=" + guardDir + string(os.PathListSeparator) + secondBin,
+		}
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("run pinned %s: %v\n%s", name, err, output)
+		}
+		if got, want := string(output), "first:"+name+"\n"; got != want {
+			t.Fatalf("pinned %s output = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestEnsureSearchGuardrailWrappersSkipsInheritedGuardrail(t *testing.T) {
+	baseDir := t.TempDir()
+	inheritedGuardDir := filepath.Join(baseDir, "inherited", searchGuardrailDirName)
+	inheritedAlias := filepath.Join(baseDir, "inherited-alias")
+	trustedBin := filepath.Join(baseDir, "trusted-bin")
+	for _, dir := range []string{inheritedGuardDir, trustedBin} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create fake bin: %v", err)
+		}
+	}
+	if err := os.Symlink(inheritedGuardDir, inheritedAlias); err != nil {
+		t.Fatalf("create inherited guard alias: %v", err)
+	}
+	for _, name := range searchGuardedCommands {
+		if err := os.WriteFile(filepath.Join(inheritedGuardDir, name), []byte("#!/bin/sh\nprintf 'recursive:"+name+"\\n'\n"), 0o755); err != nil {
+			t.Fatalf("write inherited wrapper %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(trustedBin, name), []byte("#!/bin/sh\nprintf 'trusted:"+name+"\\n'\n"), 0o755); err != nil {
+			t.Fatalf("write trusted %s: %v", name, err)
+		}
+	}
+	t.Setenv("PATH", inheritedAlias+string(os.PathListSeparator)+trustedBin)
+
+	guardDir, err := ensureSearchGuardrailWrappers(filepath.Join(baseDir, "state"))
+	if err != nil {
+		t.Fatalf("ensure wrappers behind inherited guardrail: %v", err)
+	}
+	hardlinkBin := filepath.Join(baseDir, "hardlink-bin")
+	if err := os.MkdirAll(hardlinkBin, 0o755); err != nil {
+		t.Fatalf("create hardlink bin: %v", err)
+	}
+	for _, name := range searchGuardedCommands {
+		if err := os.Link(filepath.Join(guardDir, name), filepath.Join(hardlinkBin, name)); err != nil {
+			t.Fatalf("hardlink installed %s wrapper: %v", name, err)
+		}
+	}
+	t.Setenv("PATH", hardlinkBin+string(os.PathListSeparator)+trustedBin)
+	if _, err := ensureSearchGuardrailWrappers(filepath.Join(baseDir, "state")); err != nil {
+		t.Fatalf("refresh wrappers behind hardlinked wrappers: %v", err)
+	}
+	copiedBin := filepath.Join(baseDir, "copied-bin")
+	if err := os.MkdirAll(copiedBin, 0o755); err != nil {
+		t.Fatalf("create copied wrapper bin: %v", err)
+	}
+	for _, name := range searchGuardedCommands {
+		content, err := os.ReadFile(filepath.Join(hardlinkBin, name))
+		if err != nil {
+			t.Fatalf("read copied source %s: %v", name, err)
+		}
+		if err := os.WriteFile(filepath.Join(copiedBin, name), content, 0o755); err != nil {
+			t.Fatalf("copy installed %s wrapper: %v", name, err)
+		}
+	}
+	t.Setenv("PATH", copiedBin+string(os.PathListSeparator)+trustedBin)
+	if _, err := ensureSearchGuardrailWrappers(filepath.Join(baseDir, "state")); err != nil {
+		t.Fatalf("refresh wrappers behind copied wrappers: %v", err)
+	}
+	for _, name := range searchGuardedCommands {
+		cmd := exec.Command(filepath.Join(guardDir, name))
+		cmd.Dir = baseDir
+		cmd.Env = []string{"MAESTRO_ALLOW_BROAD_SEARCH=1", "PATH=" + guardDir}
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("run %s: %v\n%s", name, err, output)
+		}
+		if got, want := string(output), "trusted:"+name+"\n"; got != want {
+			t.Fatalf("guarded %s output = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestSearchGuardrailWrapperRefusesUnsafeTargetsWithoutOriginalPath(t *testing.T) {
+	guardDir := filepath.Join(t.TempDir(), searchGuardrailDirName)
+	if err := os.MkdirAll(guardDir, 0o755); err != nil {
+		t.Fatalf("create guard dir: %v", err)
+	}
+	insideTarget := filepath.Join(guardDir, "grep")
+	if err := os.WriteFile(insideTarget, []byte("#!/bin/sh\nexit 99\n"), 0o755); err != nil {
+		t.Fatalf("write inside target: %v", err)
+	}
+	insideAlias := filepath.Join(filepath.Dir(guardDir), "inside-alias")
+	if err := os.Symlink(insideTarget, insideAlias); err != nil {
+		t.Fatalf("create inside target alias: %v", err)
+	}
+	missingTarget := filepath.Join(filepath.Dir(guardDir), "private-bin", "grep")
+
+	tests := []struct {
+		name       string
+		wrapper    string
+		realTarget func(string) string
+		original   string
+		code       int
+		message    string
+	}{
+		{
+			name:       "inside guard directory with original path absent",
+			wrapper:    "inside-probe",
+			realTarget: func(string) string { return insideTarget },
+			code:       126,
+			message:    "refusing",
+		},
+		{
+			name:       "outside alias to guard directory target",
+			wrapper:    "alias-probe",
+			realTarget: func(string) string { return insideAlias },
+			code:       126,
+			message:    "refusing",
+		},
+		{
+			name:       "self with malformed original path",
+			wrapper:    "self-probe",
+			realTarget: func(wrapper string) string { return wrapper },
+			original:   guardDir + "::::",
+			code:       126,
+			message:    "refusing",
+		},
+		{
+			name:       "missing trusted target hides private path",
+			wrapper:    "missing-probe",
+			realTarget: func(string) string { return missingTarget },
+			code:       127,
+			message:    "unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapper := filepath.Join(guardDir, tt.wrapper)
+			content := buildSearchGuardrailWrapperScript("grep", tt.realTarget(wrapper), guardDir)
+			if err := os.WriteFile(wrapper, []byte(content), searchGuardrailWrapperMode); err != nil {
+				t.Fatalf("write wrapper: %v", err)
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, wrapper)
+			cmd.Dir = t.TempDir()
+			cmd.Env = []string{"PATH=" + guardDir, "MAESTRO_ALLOW_BROAD_SEARCH=1"}
+			if tt.original != "" {
+				cmd.Env = append(cmd.Env, "MAESTRO_ORIGINAL_PATH="+tt.original)
+			}
+			output, err := cmd.CombinedOutput()
+			if ctx.Err() != nil {
+				t.Fatalf("unsafe wrapper recursed until timeout: %v", ctx.Err())
+			}
+			exitErr, ok := err.(*exec.ExitError)
+			if !ok || exitErr.ExitCode() != tt.code {
+				t.Fatalf("unsafe wrapper error = %v, output:\n%s", err, output)
+			}
+			if !strings.Contains(string(output), tt.message) || !strings.Contains(string(output), "grep") {
+				t.Fatalf("unsafe wrapper error lacks command and refusal stage: %s", output)
+			}
+			if strings.Contains(string(output), missingTarget) {
+				t.Fatalf("unsafe wrapper error exposed private target path: %s", output)
+			}
+		})
+	}
+}
+
+func TestEnsureSearchGuardrailWrappersAtomicallyReplacesInode(t *testing.T) {
+	baseDir := t.TempDir()
+	firstBin := filepath.Join(baseDir, "first-bin")
+	secondBin := filepath.Join(baseDir, "second-bin")
+	for _, dir := range []string{firstBin, secondBin} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create fake bin: %v", err)
+		}
+		for _, name := range searchGuardedCommands {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+				t.Fatalf("write fake %s: %v", name, err)
+			}
+		}
+	}
+	t.Setenv("PATH", firstBin)
+	stateDir := filepath.Join(baseDir, "state")
+	guardDir, err := ensureSearchGuardrailWrappers(stateDir)
+	if err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	path := filepath.Join(guardDir, "grep")
+	oldInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat old wrapper: %v", err)
+	}
+	oldFile, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open old wrapper: %v", err)
+	}
+	defer oldFile.Close()
+
+	t.Setenv("PATH", secondBin)
+	if _, err := ensureSearchGuardrailWrappers(stateDir); err != nil {
+		t.Fatalf("refresh wrappers: %v", err)
+	}
+	newInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat new wrapper: %v", err)
+	}
+	if os.SameFile(oldInfo, newInfo) {
+		t.Fatal("wrapper refresh reused the executing inode instead of atomically replacing it")
+	}
+	if newInfo.Mode().Perm() != searchGuardrailWrapperMode {
+		t.Fatalf("new wrapper mode = %o, want %o", newInfo.Mode().Perm(), searchGuardrailWrapperMode)
+	}
+	oldContent, err := io.ReadAll(oldFile)
+	if err != nil {
+		t.Fatalf("read old inode: %v", err)
+	}
+	newContent, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read new inode: %v", err)
+	}
+	if !strings.Contains(string(oldContent), firstBin) || !strings.Contains(string(oldContent), "exec \"$real_path\"") {
+		t.Fatalf("old inode was truncated or changed:\n%s", oldContent)
+	}
+	if !strings.Contains(string(newContent), secondBin) {
+		t.Fatalf("new wrapper did not capture refreshed target:\n%s", newContent)
+	}
+}
+
+func TestEnsureSearchGuardrailWrappersConcurrentPreparation(t *testing.T) {
+	baseDir := t.TempDir()
+	fakeBin := filepath.Join(baseDir, "fake-bin")
+	worktree := filepath.Join(baseDir, "worktree")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatalf("create fake bin: %v", err)
+	}
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	for _, name := range searchGuardedCommands {
+		content := "#!/bin/sh\n/bin/sleep 0.005\nexit 0\n"
+		if err := os.WriteFile(filepath.Join(fakeBin, name), []byte(content), 0o755); err != nil {
+			t.Fatalf("write fake %s: %v", name, err)
+		}
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+"/usr/bin:/bin")
+	stateDir := filepath.Join(baseDir, "state")
+	guardDir, err := ensureSearchGuardrailWrappers(stateDir)
+	if err != nil {
+		t.Fatalf("initial ensure: %v", err)
+	}
+	initialWrappers := make(map[string]os.FileInfo, len(searchGuardedCommands))
+	for _, name := range searchGuardedCommands {
+		info, err := os.Stat(filepath.Join(guardDir, name))
+		if err != nil {
+			t.Fatalf("stat initial %s wrapper: %v", name, err)
+		}
+		initialWrappers[name] = info
+	}
+
+	start := make(chan struct{})
+	errs := make(chan error, 32)
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 12; j++ {
+				if _, err := ensureSearchGuardrailWrappers(stateDir); err != nil {
+					errs <- fmt.Errorf("concurrent prepare: %w", err)
+					return
+				}
+			}
+		}()
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 12; j++ {
+				name := searchGuardedCommands[(index+j)%len(searchGuardedCommands)]
+				cmd := exec.Command(filepath.Join(guardDir, name))
+				cmd.Dir = worktree
+				cmd.Env = []string{
+					"MAESTRO_ALLOW_BROAD_SEARCH=1",
+					"MAESTRO_ORIGINAL_PATH=" + guardDir,
+					"PATH=" + guardDir + string(os.PathListSeparator) + fakeBin + string(os.PathListSeparator) + "/usr/bin:/bin",
+				}
+				if output, err := cmd.CombinedOutput(); err != nil {
+					errs <- fmt.Errorf("guarded %s failed: %w (%s)", name, err, output)
+					return
+				}
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+	if t.Failed() {
+		return
+	}
+
+	entries, err := os.ReadDir(guardDir)
+	if err != nil {
+		t.Fatalf("read guard dir: %v", err)
+	}
+	if len(entries) != len(searchGuardedCommands) {
+		t.Fatalf("guard dir contains %d entries, want %d: %v", len(entries), len(searchGuardedCommands), entries)
+	}
+	for _, entry := range entries {
+		info, err := entry.Info()
+		if err != nil {
+			t.Fatalf("stat %s: %v", entry.Name(), err)
+		}
+		if !info.Mode().IsRegular() || info.Mode().Perm() != searchGuardrailWrapperMode {
+			t.Fatalf("wrapper %s mode = %v, want regular %o", entry.Name(), info.Mode(), searchGuardrailWrapperMode)
+		}
+		if initial := initialWrappers[entry.Name()]; initial == nil || !os.SameFile(initial, info) {
+			t.Fatalf("idempotent prepare replaced unchanged wrapper %s", entry.Name())
+		}
+	}
+}
+
+func TestSearchGuardrailXdgMimeRegressionDuringWrapperRefresh(t *testing.T) {
+	baseDir := t.TempDir()
+	fakeBin := filepath.Join(baseDir, "fake-bin")
+	worktree := filepath.Join(baseDir, "worktree")
+	for _, dir := range []string{fakeBin, worktree} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create test dir: %v", err)
+		}
+	}
+	for _, name := range []string{"rg", "find"} {
+		if err := os.WriteFile(filepath.Join(fakeBin, name), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatalf("write fake %s: %v", name, err)
+		}
+	}
+	grepScript := `#!/bin/sh
+if [ -n "${MAESTRO_TEST_GREP_MARKER:-}" ]; then
+  : > "$MAESTRO_TEST_GREP_MARKER"
+  while [ ! -e "$MAESTRO_TEST_GREP_RELEASE" ]; do
+    /bin/sleep 0.01
+  done
+fi
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(fakeBin, "grep"), []byte(grepScript), 0o755); err != nil {
+		t.Fatalf("write fake grep: %v", err)
+	}
+	xdgMimeScript := `#!/bin/sh
+if [ "$1" != "query" ] || [ "$2" != "default" ] || [ "$3" != "video/mp4" ]; then
+  exit 64
+fi
+printf 'video/mp4\n' | grep -q video
+printf 'maestro-test.desktop\n'
+`
+	if err := os.WriteFile(filepath.Join(fakeBin, "xdg-mime"), []byte(xdgMimeScript), 0o755); err != nil {
+		t.Fatalf("write fake xdg-mime: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+"/usr/bin:/bin")
+	stateDir := filepath.Join(baseDir, "state")
+	guardDir, err := ensureSearchGuardrailWrappers(stateDir)
+	if err != nil {
+		t.Fatalf("initial ensure: %v", err)
+	}
+
+	marker := filepath.Join(baseDir, "grep-active")
+	release := filepath.Join(baseDir, "release-grep")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "xdg-mime", "query", "default", "video/mp4")
+	cmd.Dir = worktree
+	cmd.Env = []string{
+		"MAESTRO_WORKTREE=" + worktree,
+		"MAESTRO_TEST_GREP_MARKER=" + marker,
+		"MAESTRO_TEST_GREP_RELEASE=" + release,
+		"MAESTRO_ORIGINAL_PATH=" + guardDir + "::::",
+		"PATH=" + guardDir + string(os.PathListSeparator) + fakeBin + string(os.PathListSeparator) + "/usr/bin:/bin",
+	}
+	var output bytes.Buffer
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start xdg-mime query default video/mp4: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.WriteFile(release, nil, 0o600)
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+		}
+	})
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := os.Stat(marker); err == nil {
+			break
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat active grep marker: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("xdg-mime never reached its guarded grep child; output:\n%s", output.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if secondGuardDir, err := ensureSearchGuardrailWrappers(stateDir); err != nil {
+		t.Fatalf("prepare second worker while guarded grep is active: %v", err)
+	} else if secondGuardDir != guardDir {
+		t.Fatalf("second guard dir = %q, want %q", secondGuardDir, guardDir)
+	}
+	if err := os.WriteFile(release, nil, 0o600); err != nil {
+		t.Fatalf("release guarded grep: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("xdg-mime query failed after wrapper refresh: %v\n%s", err, output.String())
+		}
+	case <-ctx.Done():
+		t.Fatalf("xdg-mime query did not terminate: %v\n%s", ctx.Err(), output.String())
+	}
+	if got, want := output.String(), "maestro-test.desktop\n"; got != want {
+		t.Fatalf("xdg-mime output = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureSearchGuardrailWrapperErrorsArePathSafe(t *testing.T) {
+	t.Run("resolution", func(t *testing.T) {
+		missingBin := t.TempDir()
+		stateDir := filepath.Join(t.TempDir(), "private-state")
+		t.Setenv("PATH", missingBin)
+		_, err := ensureSearchGuardrailWrappers(stateDir)
+		if err == nil {
+			t.Fatal("missing guarded commands unexpectedly succeeded")
+		}
+		message := err.Error()
+		if !strings.Contains(message, "rg") || !strings.Contains(message, "resolve trusted executable") {
+			t.Fatalf("resolution error lacks command/stage: %v", err)
+		}
+		if strings.Contains(message, missingBin) || strings.Contains(message, stateDir) {
+			t.Fatalf("resolution error exposed a private path: %v", err)
+		}
+	})
+
+	t.Run("installation", func(t *testing.T) {
+		stateDir := t.TempDir()
+		guardDir := filepath.Join(stateDir, searchGuardrailDirName)
+		redirect := t.TempDir()
+		if err := os.Symlink(redirect, guardDir); err != nil {
+			t.Fatalf("create guard-dir symlink: %v", err)
+		}
+		_, err := ensureSearchGuardrailWrappers(stateDir)
+		if err == nil {
+			t.Fatal("unsafe guard directory unexpectedly succeeded")
+		}
+		message := err.Error()
+		if !strings.Contains(message, "rg") || !strings.Contains(message, "install wrapper atomically") {
+			t.Fatalf("installation error lacks command/stage: %v", err)
+		}
+		if strings.Contains(message, stateDir) || strings.Contains(message, redirect) {
+			t.Fatalf("installation error exposed a private path: %v", err)
+		}
+	})
 }
 
 func TestBuildWorkerRunnerScriptIncludesSearchGuardrails(t *testing.T) {


### PR DESCRIPTION
Refs #919

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes search guardrail setup non-recursive and installs wrappers atomically. The main changes are:

- Resolves and pins search executables before wrapper creation.
- Rejects inherited or self-referential guardrail wrappers.
- Serializes setup and atomically replaces changed wrapper files.
- Adds tests for recursion, concurrent setup, replacement, and safe errors.

<h3>Confidence Score: 4/5</h3>

Executable resolution needs fixes before merging because wrappers can pin stale or unintended command paths.

Symlink-backed tools can stop working after routine upgrades. Empty `PATH` entries can select a command from the daemon's working directory. Atomic replacement and recursive-wrapper handling are otherwise covered well.

internal/worker/search_guardrail.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The focused Go test reproduced a stale pinned PATH wrapper by rotating the PATH symlink from grep-v1 to grep-v2, showing that direct execution through the stable PATH entry prints NEW-grep and that the previously installed wrapper exits with code 127.
- The empty PATH entry test reproduced that the wrapper pins to the working-directory binary, with the generated wrapper real\_path pointing to the daemon directory; executing it yields CWD\_FIXTURE instead of EXPECTED\_PATH\_FIXTURE, and the focused test fails as designed.
- The race-enabled wrapper refresh tests compared behavior across revisions and showed that the atomic replacement and concurrent preparation scenarios all passed with exit code 0.
- The isolated atomic-replacement regression work showed that, after changes, all three repository tests passed with exit code 0, including concurrent preparation and refresh during guarded grep activity.

<a href="https://app.greptile.com/trex/runs/15319229/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/search_guardrail.go | Adds serialized wrapper preparation, executable resolution, inherited-wrapper detection, and atomic installation; pinned executable paths can become stale or select a working-directory command. |
| internal/worker/search_guardrail_test.go | Adds broad tests for pinned targets, recursive wrapper avoidance, unsafe targets, atomic replacement, concurrent preparation, active children, and sanitized errors. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
internal/worker/search_guardrail.go:179
**Pinned Symlink Target Becomes Stale**

When a package or tool upgrade replaces a symlink-backed executable, this stores the resolved versioned target rather than the stable path found in `PATH`. A long-lived worker then exits 127 after the old target is removed, even though the original path points to a valid replacement.

### Issue 2 of 2
internal/worker/search_guardrail.go:158-160
**Empty PATH Entry Pins Working-Directory Binary**

When the daemon's `PATH` contains an empty entry such as `/usr/bin::/usr/local/bin`, POSIX lookup treats it as the current directory. If that directory contains `rg`, `find`, or `grep`, the new resolver permanently pins that executable into every worker wrapper instead of selecting the expected system command, so searches run an unintended binary.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-1015-9..."](https://github.com/befeast/maestro/commit/2dfbc936693f2ce603803a01a47ccc329bd4a031) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46108174)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->