### PR TITLE
fix: stage self-deploy.sh from origin/main before launch (#1077)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -502,7 +502,7 @@ func (c GitHubMirrorConfig) ReconcileInterval() time.Duration {
 // unit's ExecStop drain semantics intact.
 type SelfDeployConfig struct {
 	Enabled        bool     `yaml:"enabled"`          // default false (opt-in)
-	Script         string   `yaml:"script"`           // deploy script path (default: <local_path>/scripts/self-deploy.sh)
+	Script         string   `yaml:"script"`           // deploy script path override; empty = stage origin/main:scripts/self-deploy.sh into state_dir (#1077), with checkout fallback
 	BinPath        string   `yaml:"bin_path"`         // install target (default: path of the running binary)
 	InstallViaSudo bool     `yaml:"install_via_sudo"` // #711: stage/rename/rollback bin_path via `sudo -n` so a root-owned target (e.g. /usr/local/bin/maestro) can be updated by the unprivileged deploy user; requires passwordless sudo (default false)
 	Scope          string   `yaml:"scope"`            // #716: systemd unit scope — "user" (systemctl --user, default for back-compat) or "system" (sudo -n systemctl restart, for system units like the Loki fleet)

--- a/internal/selfdeploy/selfdeploy.go
+++ b/internal/selfdeploy/selfdeploy.go
@@ -307,6 +307,106 @@ func MainAdvanced(runningVersion, mainHeadSHA string) bool {
 	return !strings.HasPrefix(head, built)
 }
 
+// stagedDeployScriptName is the state-dir copy of scripts/self-deploy.sh taken
+// from origin/main before launch (#1077). The running binary may pass flags the
+// checkout's stale branch copy does not understand; staging from origin/main
+// breaks that chicken-and-egg.
+const stagedDeployScriptName = "self-deploy.sh"
+
+const originMainDeployScriptRef = "origin/main:scripts/self-deploy.sh"
+
+// ResolveDeployScript returns the script path Trigger should invoke.
+//
+// When self_deploy.script is unset (default), it stages origin/main's
+// scripts/self-deploy.sh into the state dir after a best-effort fetch so a
+// feature-branch checkout cannot brick deploys with "unknown argument".
+// An explicit Script override is used as-is. If staging fails, Resolve falls
+// back to the checkout copy (pre-#1077 behavior) so tests and air-gapped hosts
+// still work.
+func ResolveDeployScript(cfg *config.Config) (string, error) {
+	if cfg == nil {
+		return "", fmt.Errorf("self-deploy: nil config")
+	}
+	localPath := strings.TrimSpace(cfg.LocalPath)
+	fallback := cfg.SelfDeploy.EffectiveScript(localPath)
+	if fallback == "" {
+		return "", fmt.Errorf("self-deploy: no deploy script configured")
+	}
+	if strings.TrimSpace(cfg.SelfDeploy.Script) != "" {
+		if _, err := os.Stat(fallback); err != nil {
+			return "", fmt.Errorf("self-deploy: script %s: %w", fallback, err)
+		}
+		return fallback, nil
+	}
+	stateDir := strings.TrimSpace(cfg.StateDir)
+	if stateDir == "" {
+		if _, err := os.Stat(fallback); err != nil {
+			return "", fmt.Errorf("self-deploy: script %s: %w", fallback, err)
+		}
+		return fallback, nil
+	}
+	dest := filepath.Join(stateDir, stagedDeployScriptName)
+	if err := stageOriginMainDeployScript(localPath, dest); err != nil {
+		if _, statErr := os.Stat(fallback); statErr != nil {
+			return "", fmt.Errorf("self-deploy: stage origin/main script: %w (checkout fallback also missing: %v)", err, statErr)
+		}
+		return fallback, nil
+	}
+	return dest, nil
+}
+
+// stageOriginMainDeployScript fetches origin and writes origin/main's
+// self-deploy.sh to dest atomically.
+func stageOriginMainDeployScript(repoDir, dest string) error {
+	repoDir = strings.TrimSpace(repoDir)
+	if repoDir == "" {
+		return fmt.Errorf("empty repo dir")
+	}
+	if _, err := os.Stat(filepath.Join(repoDir, ".git")); err != nil {
+		return fmt.Errorf("not a git checkout: %w", err)
+	}
+	fetch := exec.Command("git", "-C", repoDir, "fetch", "--prune", "origin")
+	if out, err := fetch.CombinedOutput(); err != nil {
+		// Fetch can fail offline; still try show in case origin/main is current.
+		_ = out
+	}
+	show := exec.Command("git", "-C", repoDir, "show", originMainDeployScriptRef)
+	body, err := show.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("git show %s: %w\n%s", originMainDeployScriptRef, err, ee.Stderr)
+		}
+		return fmt.Errorf("git show %s: %w", originMainDeployScriptRef, err)
+	}
+	if len(body) == 0 {
+		return fmt.Errorf("git show %s: empty", originMainDeployScriptRef)
+	}
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dest), "self-deploy-*.sh")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(body); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0o755); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, dest); err != nil {
+		return err
+	}
+	return nil
+}
+
 // TriggerCommand builds the detached systemd-run invocation for a deploy
 // after the given merged PR. Split from Trigger so tests can assert the
 // argv without systemd.
@@ -318,12 +418,9 @@ func TriggerCommand(cfg *config.Config, prNumber int, now time.Time) (string, []
 	if localPath == "" {
 		return "", nil, fmt.Errorf("self-deploy: local_path is required")
 	}
-	script := cfg.SelfDeploy.EffectiveScript(localPath)
-	if script == "" {
-		return "", nil, fmt.Errorf("self-deploy: no deploy script configured")
-	}
-	if _, err := os.Stat(script); err != nil {
-		return "", nil, fmt.Errorf("self-deploy: script %s: %w", script, err)
+	script, err := ResolveDeployScript(cfg)
+	if err != nil {
+		return "", nil, err
 	}
 	bin := strings.TrimSpace(cfg.SelfDeploy.BinPath)
 	if bin == "" {

--- a/internal/selfdeploy/selfdeploy_test.go
+++ b/internal/selfdeploy/selfdeploy_test.go
@@ -2,6 +2,7 @@ package selfdeploy
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -313,6 +314,114 @@ func TestTriggerCommandMissingScript(t *testing.T) {
 	if _, _, err := TriggerCommand(cfg, 1, time.Now().UTC()); err == nil {
 		t.Fatal("want error for missing script")
 	}
+}
+
+// #1077: without a git remote tip, Resolve falls back to the checkout script so
+// unit tests and air-gapped hosts still launch.
+func TestResolveDeployScriptFallsBackToCheckout(t *testing.T) {
+	cfg := triggerTestConfig(t)
+	got, err := ResolveDeployScript(cfg)
+	if err != nil {
+		t.Fatalf("ResolveDeployScript: %v", err)
+	}
+	want := filepath.Join(cfg.LocalPath, "scripts", "self-deploy.sh")
+	if got != want {
+		t.Fatalf("got %q, want checkout fallback %q", got, want)
+	}
+}
+
+// #1077: default path stages origin/main's script into the state dir so a
+// stale feature-branch checkout cannot brick deploys.
+func TestResolveDeployScriptStagesOriginMain(t *testing.T) {
+	cfg := triggerTestConfig(t)
+	seedGitCheckoutWithOriginMain(t, cfg.LocalPath, "#!/bin/bash\n# from-origin-main\n")
+
+	got, err := ResolveDeployScript(cfg)
+	if err != nil {
+		t.Fatalf("ResolveDeployScript: %v", err)
+	}
+	want := filepath.Join(cfg.StateDir, stagedDeployScriptName)
+	if got != want {
+		t.Fatalf("got %q, want staged %q", got, want)
+	}
+	body, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "from-origin-main") {
+		t.Fatalf("staged script body missing marker:\n%s", body)
+	}
+
+	// Stale checkout content must not be what Trigger invokes.
+	if err := os.WriteFile(filepath.Join(cfg.LocalPath, "scripts", "self-deploy.sh"), []byte("#!/bin/bash\n# stale-checkout\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	name, args, err := TriggerCommand(cfg, 1077, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("TriggerCommand: %v", err)
+	}
+	if name == "" {
+		t.Fatal("empty launcher name")
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, want) {
+		t.Fatalf("TriggerCommand must invoke staged script %q; got:\n%s", want, joined)
+	}
+	if strings.Contains(joined, filepath.Join(cfg.LocalPath, "scripts", "self-deploy.sh")) {
+		t.Fatalf("TriggerCommand must not invoke stale checkout script; got:\n%s", joined)
+	}
+}
+
+// #1077: explicit self_deploy.script override is used as-is (no staging).
+func TestResolveDeployScriptHonorsExplicitOverride(t *testing.T) {
+	cfg := triggerTestConfig(t)
+	seedGitCheckoutWithOriginMain(t, cfg.LocalPath, "#!/bin/bash\n# from-origin-main\n")
+	override := filepath.Join(cfg.LocalPath, "custom-deploy.sh")
+	if err := os.WriteFile(override, []byte("#!/bin/bash\n# override\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg.SelfDeploy.Script = override
+
+	got, err := ResolveDeployScript(cfg)
+	if err != nil {
+		t.Fatalf("ResolveDeployScript: %v", err)
+	}
+	if got != override {
+		t.Fatalf("got %q, want override %q", got, override)
+	}
+}
+
+// seedGitCheckoutWithOriginMain turns dir into a tiny git repo whose
+// refs/remotes/origin/main tip contains scripts/self-deploy.sh with body.
+func seedGitCheckoutWithOriginMain(t *testing.T, dir, scriptBody string) {
+	t.Helper()
+	script := filepath.Join(dir, "scripts", "self-deploy.sh")
+	if err := os.MkdirAll(filepath.Dir(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(script, []byte(scriptBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test",
+			"GIT_AUTHOR_EMAIL=test@example.com",
+			"GIT_COMMITTER_NAME=test",
+			"GIT_COMMITTER_EMAIL=test@example.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "test")
+	run("add", "scripts/self-deploy.sh")
+	run("commit", "-m", "seed")
+	run("branch", "-M", "main")
+	run("update-ref", "refs/remotes/origin/main", "HEAD")
 }
 
 func TestFindingDeployed(t *testing.T) {


### PR DESCRIPTION
## Summary
- Default self-deploy trigger now stages `origin/main:scripts/self-deploy.sh` into the state dir before `systemd-run`, so a dirty/stale feature-branch checkout cannot brick deploys with `unknown argument: --restart-timeout-seconds`.
- Explicit `self_deploy.script` overrides still run as-is; if staging fails, fall back to the checkout copy (tests / offline).
- Refs #1077 (incident 2026-07-22: fleet stuck on `g6c272bb` while merged #1073/#1076 waited).

## Test plan
- [x] `go test ./internal/selfdeploy/`
- [ ] After merge + self-deploy: with `local_path` on a branch whose tree lacks `--restart-timeout-seconds`, deploy still succeeds
- [ ] Confirm `/usr/local/bin/maestro version` advances and `maestro tmpfs-hygiene --dry-run` stays available

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stages the current deployment script from `origin/main` before starting self-deploy. The main changes are:

- Stage `scripts/self-deploy.sh` atomically in the state directory.
- Preserve explicit script overrides and checkout fallback behavior.
- Route deployment command construction through the new resolver.
- Add tests for staging, fallback, and explicit overrides.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after the existing review comments are resolved.

No additional blocking issues were found in the changed code.

The remaining fetch and test-environment concerns are already covered by existing comments.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex examined the HEAD^ checkout path and confirmed the old checkout script reported an unknown argument: --restart-timeout-seconds.
- T-Rex switched to the stateDir/self-deploy.sh path, verified it matches origin/main SHA-256, preserved the actual launch argv, and parsed the restart timeout successfully.
- T-Rex ran the selfdeploy unit tests as requested, and they completed with exit code 0.
- T-Rex noted the inclusion of the reusable integration harness in the repository as stale-script-integration\_test.go.

<a href="https://app.greptile.com/trex/runs/15393859/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/config.go | Clarifies the default script staging and fallback behavior. |
| internal/selfdeploy/selfdeploy.go | Adds origin/main script staging, atomic replacement, checkout fallback, and resolver integration. |
| internal/selfdeploy/selfdeploy_test.go | Adds tests for origin/main staging, checkout fallback, and explicit script overrides. |

<sub>Reviews (2): Last reviewed commit: ["fix: stage self-deploy.sh from origin/ma..."](https://github.com/befeast/maestro/commit/de2c3e4222cb1d63c264700c6879bba0cc0b10b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46231449)</sub>

<!-- /greptile_comment -->