### PR TITLE
P0: worker spawn broken after process-lease pane — empty pane_current_path fails identity check

### DIFF
--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -28,23 +28,31 @@ var (
 		return tmuxsession.StartDetached(tmuxName, worktree, runnerPath, lease)
 	}
 	readTmuxPaneIdentity = func(tmuxName string) (int, string, error) {
-		out, err := tmuxsession.CommandForSession(tmuxName, "list-panes", "-t", "="+strings.TrimSpace(tmuxName)+":", "-F", "#{pane_pid}\t#{pane_current_path}").Output()
+		out, err := tmuxsession.CommandForSession(tmuxName, "list-panes", "-t", "="+strings.TrimSpace(tmuxName)+":", "-F", "#{pane_pid}\t#{pane_current_path}\t#{pane_start_path}").Output()
 		if err != nil {
 			return 0, "", err
 		}
-		parts := strings.SplitN(strings.TrimSpace(string(out)), "\t", 2)
-		if len(parts) != 2 {
-			return 0, "", fmt.Errorf("unexpected tmux pane identity")
-		}
-		pid, err := strconv.Atoi(strings.TrimSpace(parts[0]))
-		if err != nil || pid <= 0 {
-			return 0, "", fmt.Errorf("invalid tmux pane pid")
-		}
-		return pid, filepath.Clean(strings.TrimSpace(parts[1])), nil
+		return parseTmuxPaneIdentity(out)
 	}
 )
 
-// TmuxPaneIdentity returns the live pane PID and its current worktree for an
+func parseTmuxPaneIdentity(out []byte) (int, string, error) {
+	parts := strings.SplitN(strings.TrimRight(string(out), "\r\n"), "\t", 3)
+	if len(parts) != 3 {
+		return 0, "", fmt.Errorf("unexpected tmux pane identity")
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil || pid <= 0 {
+		return 0, "", fmt.Errorf("invalid tmux pane pid")
+	}
+	panePath := strings.TrimSpace(parts[2])
+	if panePath == "" {
+		panePath = strings.TrimSpace(parts[1])
+	}
+	return pid, filepath.Clean(panePath), nil
+}
+
+// TmuxPaneIdentity returns the live pane PID and its originating worktree for an
 // exact tmux session. Recovery callers must validate both values before
 // adopting a pane: a deterministic session name alone is not sufficient proof
 // that the pane belongs to the retained worker after a failed respawn.

--- a/internal/worker/checkpoint_test.go
+++ b/internal/worker/checkpoint_test.go
@@ -99,6 +99,48 @@ func TestStartOrReconcileTmuxSession_ObservesAfterConfirmedSpawnWithoutReplay(t 
 	}
 }
 
+func TestStartOrReconcileTmuxSession_ProcessLeasePaneUsesStartPath(t *testing.T) {
+	originalSpawn := runTmuxNewSession
+	originalRead := readTmuxPaneIdentity
+	t.Cleanup(func() {
+		runTmuxNewSession = originalSpawn
+		readTmuxPaneIdentity = originalRead
+	})
+	runTmuxNewSession = func(tmuxName, worktree, runnerPath string, lease tmuxsession.ProcessLease) ([]byte, error) {
+		return nil, nil
+	}
+	readTmuxPaneIdentity = func(tmuxName string) (int, string, error) {
+		return parseTmuxPaneIdentity([]byte("505\t\t/worktrees/slot-1\n"))
+	}
+
+	pid, err := startOrReconcileTmuxSession("maestro-slot-1", "/worktrees/slot-1", "/state/slot-1-run.sh", checkpointTestLease, 0)
+	if err != nil || pid != 505 {
+		t.Fatalf("observed process-lease pane: pid=%d err=%v", pid, err)
+	}
+}
+
+func TestParseTmuxPaneIdentity_PrefersStartPathAndFallsBackToCurrentPath(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want string
+	}{
+		{name: "start path", out: "606\t/worktrees/current\t/worktrees/start\n", want: "/worktrees/start"},
+		{name: "current path fallback", out: "707\t/worktrees/current\t\n", want: "/worktrees/current"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, got, err := parseTmuxPaneIdentity([]byte(tt.out))
+			if err != nil {
+				t.Fatalf("parse pane identity: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("pane path = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRestoreMissingWorktreePreservesExistingBranchHead(t *testing.T) {
 	root := t.TempDir()
 	repo := filepath.Join(root, "repo")


### PR DESCRIPTION
Refs #1079

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates worker recovery to identify tmux panes by their originating worktree. The main changes are:

- Requests `pane_start_path` alongside the PID and current path.
- Prefers the start path with a current-path fallback.
- Adds tests for process-lease panes and path selection.

<h3>Confidence Score: 5/5</h3>

The main recovery fix is sound, with a non-blocking multi-pane parsing edge case.

Single-pane process-lease recovery now uses the originating worktree.

Sessions with multiple panes produce output that the new parser combines into one invalid path.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The pre-validation result showed that the parent two-field parser rejected an empty pane\_current\_path record with an unexpected tmux pane identity.
- After validation, the focused tests and both parser subtests passed with exit code 0, confirming the contract behaves as intended.
- Validation used the existing stubbed integration seam and did not perform real tmux execution.

<a href="https://app.greptile.com/trex/runs/15385396/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/checkpoint.go | Adds start-path parsing for tmux pane identity, but the parser does not handle multi-pane output. |
| internal/worker/checkpoint_test.go | Adds tests for empty current paths, start-path preference, and current-path fallback. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/worker/checkpoint.go:40
**Multi-Pane Output Corrupts Path**

When a retained session has more than one pane, `list-panes` returns multiple lines. Splitting the entire output on only two tabs puts the remaining pane records into `parts[2]`, so reconciliation compares a newline-containing path with the worktree and rejects the session instead of parsing or explicitly handling each pane.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["worker: use tmux pane start path for ide..."](https://github.com/befeast/maestro/commit/434e7f2b188f88a1c092cf6e62f2757793036d16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46241246)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->