### PR TITLE
fix: F8 outcome-hold backlog + fleet min/max live workers (#1081)

### DIFF
--- a/internal/orchestrator/dispatch_visibility.go
+++ b/internal/orchestrator/dispatch_visibility.go
@@ -129,7 +129,14 @@ func (o *Orchestrator) dispatchHoldForCycle(s *state.State, capacity state.Capac
 			}
 		}
 	}
-	return state.DispatchHold{}
+	// Empty ready with 0 live workers is still an idle stall — not a healthy
+	// quiet fleet. Surface it so operators get notified instead of discovering
+	// 0 workers by hand (F8 companion, 2026-07-22).
+	return state.DispatchHold{
+		Active:      true,
+		ReasonClass: state.DispatchHoldQueueEmpty,
+		Detail:      "no live workers and no eligible ready issues to dispatch",
+	}
 }
 
 func blockingOutcomeDispatchHold(s *state.State) (state.DispatchHold, bool) {

--- a/internal/orchestrator/dispatch_visibility_test.go
+++ b/internal/orchestrator/dispatch_visibility_test.go
@@ -77,6 +77,14 @@ func TestDispatchHoldForCycleCoversRequiredReasonClasses(t *testing.T) {
 			t.Fatalf("hold = %+v, want PR-gate capacity blocker", hold)
 		}
 	})
+
+	t.Run("queue empty with zero live workers", func(t *testing.T) {
+		s := state.NewState()
+		hold := o.dispatchHoldForCycle(s, s.Capacity(capacityInput(cfg)), 0, now)
+		if !hold.Active || hold.ReasonClass != state.DispatchHoldQueueEmpty {
+			t.Fatalf("hold = %+v, want queue_empty idle stall", hold)
+		}
+	})
 }
 
 func TestRunOnceEmitsOneIdleStallAfterTwoOutcomeHeldCycles(t *testing.T) {

--- a/internal/orchestrator/emergency_stop_test.go
+++ b/internal/orchestrator/emergency_stop_test.go
@@ -33,6 +33,31 @@ func TestStartNewWorkers_EmergencyStopBlocksNewSpawns(t *testing.T) {
 	}
 }
 
+// TestStartNewWorkers_FleetSpawnCeilingBlocksNewSpawns pins the cross-flow
+// live-worker ceiling: when fleet.max_live_workers is saturated, no new
+// workers spawn even with ready issues and free project slots.
+func TestStartNewWorkers_FleetSpawnCeilingBlocksNewSpawns(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	issues := []github.Issue{makeIssue(1025, "ready issue")}
+
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	listed := false
+	o.listOpenIssuesFn = func(labelFilter []string) ([]github.Issue, error) {
+		listed = true
+		return issues, nil
+	}
+	o.SetFleetSpawnCeiling(func() bool { return true })
+
+	o.startNewWorkers(state.NewState(), 5)
+
+	if len(*started) != 0 {
+		t.Fatalf("started %d workers under fleet ceiling, want 0", len(*started))
+	}
+	if listed {
+		t.Fatal("startNewWorkers listed issues under fleet ceiling; the gate must return before any GitHub call")
+	}
+}
+
 // TestStartNewWorkers_EmergencyResumeRestoresSpawns confirms that clearing the
 // halt (what `maestro emergency resume` does) restores spawning on the next
 // cycle — no restart, no extra state surgery.

--- a/internal/state/dispatch_hold.go
+++ b/internal/state/dispatch_hold.go
@@ -16,6 +16,7 @@ const (
 	DispatchHoldPRGateCapacity       = "capacity_blocked_by_pr_gates"
 	DispatchHoldPaused               = "paused"
 	DispatchHoldAwaitingDispatch     = "awaiting_dispatch"
+	DispatchHoldQueueEmpty           = "queue_empty"
 )
 
 // DispatchHold is the bounded, command/output-free explanation for why fresh
@@ -44,6 +45,11 @@ type IdleStallState struct {
 // the project has met the idle-stall condition for two consecutive cycles and
 // its current reason class has not been notified yet. The caller marks the
 // receipt only after the notify layer succeeds.
+//
+// Idle means 0 live workers for two cycles — including the empty-ready case
+// (queue_empty). Requiring readyIssues>0 previously silenced the boom/bust
+// failure mode where the ready queue drained under outcome hold and the fleet
+// sat at 0 with no alert (2026-07-22).
 func (s *State) RecordDispatchCycle(hold DispatchHold, liveWorkers, readyIssues int, now time.Time) bool {
 	if s == nil {
 		return false
@@ -52,14 +58,18 @@ func (s *State) RecordDispatchCycle(hold DispatchHold, liveWorkers, readyIssues 
 	hold = normalizeDispatchHold(hold, s.DispatchHold, now)
 	s.DispatchHold = hold
 
-	if liveWorkers != 0 || readyIssues <= 0 {
+	if liveWorkers != 0 {
 		s.IdleStall = IdleStallState{LastEvaluatedAt: now}
 		return false
 	}
 
 	reasonClass := strings.TrimSpace(hold.ReasonClass)
 	if reasonClass == "" {
-		reasonClass = DispatchHoldAwaitingDispatch
+		if readyIssues <= 0 {
+			reasonClass = DispatchHoldQueueEmpty
+		} else {
+			reasonClass = DispatchHoldAwaitingDispatch
+		}
 	}
 	if s.IdleStall.ReasonClass == reasonClass && s.IdleStall.ConsecutiveCycles > 0 {
 		s.IdleStall.ConsecutiveCycles++

--- a/internal/state/dispatch_hold_test.go
+++ b/internal/state/dispatch_hold_test.go
@@ -37,6 +37,26 @@ func TestRecordDispatchCycleAlertsOnceAfterTwoConsecutiveCycles(t *testing.T) {
 	}
 }
 
+func TestRecordDispatchCycleAlertsOnEmptyReadyQueue(t *testing.T) {
+	// F8 companion: empty ready + 0 live must still notify after two cycles.
+	now := time.Date(2026, 7, 22, 14, 0, 0, 0, time.UTC)
+	s := NewState()
+	hold := DispatchHold{
+		Active:      true,
+		ReasonClass: DispatchHoldQueueEmpty,
+		Detail:      "no live workers and no eligible ready issues to dispatch",
+	}
+	if s.RecordDispatchCycle(hold, 0, 0, now) {
+		t.Fatal("first empty-ready idle cycle must not alert")
+	}
+	if !s.RecordDispatchCycle(hold, 0, 0, now.Add(time.Minute)) {
+		t.Fatal("second empty-ready idle cycle must alert")
+	}
+	if s.IdleStall.ReasonClass != DispatchHoldQueueEmpty {
+		t.Fatalf("reason = %q, want %q", s.IdleStall.ReasonClass, DispatchHoldQueueEmpty)
+	}
+}
+
 func TestRecordDispatchCycleBoundsPublicHoldText(t *testing.T) {
 	s := NewState()
 	now := time.Date(2026, 7, 21, 18, 0, 0, 0, time.UTC)

--- a/internal/supervisor/hands_off_fill_test.go
+++ b/internal/supervisor/hands_off_fill_test.go
@@ -1,0 +1,72 @@
+package supervisor
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/worker"
+)
+
+func TestDecide_OpenPRDoesNotStarveSpareSlotBacklog(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.MaxParallel = 4
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{
+		prs: []github.PR{{Number: 88, HeadRefName: "feat/old", State: "OPEN", IsDraft: true}},
+		issues: []github.Issue{
+			testIssue(10, "already has open PR", "maestro-ready"),
+			testIssue(20, "next backlog", "maestro-ready"),
+		},
+		openPRIssues: map[int]bool{10: true},
+		ciStatuses:   map[int]string{88: "pending"},
+	}
+	st := state.NewState()
+	st.Sessions["sup-1"] = &state.Session{
+		IssueNumber: 10, IssueTitle: "old", Status: state.StatusPROpen, PRNumber: 88,
+		Branch: "feat/old", StartedAt: time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want spawn_worker (spare slots must fill backlog)", decision.RecommendedAction)
+	}
+	if decision.Target == nil || decision.Target.Issue != 20 {
+		t.Fatalf("target = %#v, want issue #20", decision.Target)
+	}
+	reasons := strings.Join(decision.Reasons, "\n")
+	if !strings.Contains(reasons, "Prefer backlog label/spawn") {
+		t.Fatalf("reasons = %q, want spare-capacity fill rationale", reasons)
+	}
+}
+
+func TestDecide_TokenBudgetDoesNotStarveSpareSlotBacklog(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.MaxParallel = 4
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{
+		issues: []github.Issue{testIssue(30, "next backlog", "maestro-ready")},
+	}
+	st := state.NewState()
+	st.Sessions["sup-old"] = &state.Session{
+		IssueNumber: 9, IssueTitle: "budgeted out", Status: state.StatusFailed,
+		WorkerOutcome: worker.TokenBudgetExceededOutcome,
+		StartedAt:     time.Date(2026, 7, 22, 11, 0, 0, 0, time.UTC),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want spawn_worker despite prior token-budget stop", decision.RecommendedAction)
+	}
+	if decision.Target == nil || decision.Target.Issue != 30 {
+		t.Fatalf("target = %#v, want issue #30", decision.Target)
+	}
+}

--- a/internal/supervisor/hands_off_fill_test.go
+++ b/internal/supervisor/hands_off_fill_test.go
@@ -107,3 +107,34 @@ func TestDecide_BlockedOpenPRDoesNotStarveSpareSlotBacklog(t *testing.T) {
 		t.Fatalf("target = %#v, want issue #546", decision.Target)
 	}
 }
+
+func TestDecide_DynamicWaveSkipsOpenPRCandidateAndSpawnsNext(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.MaxParallel = 6
+	cfg.MaxLiveWorkers = 6
+	cfg.IssueLabels = []string{"ok-player-ready"}
+	enableDynamicWave(cfg)
+	reader := &fakeReader{
+		issues: []github.Issue{
+			testIssue(406, "flatpak continuation", "ok-player-ready"),
+			testIssue(513, "healthcheck streak", "ok-player-ready"),
+		},
+		openPRIssues: map[int]bool{406: true},
+	}
+	st := state.NewState()
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want spawn_worker (skip open-PR head candidate)", decision.RecommendedAction)
+	}
+	if decision.Target == nil || decision.Target.Issue != 513 {
+		t.Fatalf("target = %#v, want issue #513", decision.Target)
+	}
+	reasons := strings.Join(decision.Reasons, "\n")
+	if !strings.Contains(reasons, "already has an open PR — skip") {
+		t.Fatalf("reasons = %q, want open-PR skip rationale", reasons)
+	}
+}

--- a/internal/supervisor/hands_off_fill_test.go
+++ b/internal/supervisor/hands_off_fill_test.go
@@ -70,3 +70,40 @@ func TestDecide_TokenBudgetDoesNotStarveSpareSlotBacklog(t *testing.T) {
 		t.Fatalf("target = %#v, want issue #30", decision.Target)
 	}
 }
+
+func TestDecide_BlockedOpenPRDoesNotStarveSpareSlotBacklog(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.MaxParallel = 6
+	cfg.MaxLiveWorkers = 6
+	cfg.ExcludeLabels = []string{"blocked"}
+	cfg.IssueLabels = []string{"ok-player-ready"}
+	reader := &fakeReader{
+		issues: []github.Issue{
+			testIssue(345, "blocked flatpak", "blocked"),
+			testIssue(546, "next backlog", "ok-player-ready"),
+		},
+		prs: []github.PR{{
+			Number: 388, HeadRefName: "feat/flatpak", State: "OPEN",
+			Mergeable: "MERGEABLE", IsDraft: true,
+		}},
+		openPRIssues: map[int]bool{345: true},
+		ciStatuses:   map[int]string{388: "pending"},
+	}
+	st := state.NewState()
+	st.Sessions["ok-player-273"] = &state.Session{
+		IssueNumber: 345, IssueTitle: "blocked flatpak", Status: state.StatusPROpen,
+		PRNumber: 388, Branch: "feat/flatpak",
+		StartedAt: time.Date(2026, 7, 22, 12, 0, 0, 0, time.UTC),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want spawn_worker (blocked open PR must not freeze spare slots)", decision.RecommendedAction)
+	}
+	if decision.Target == nil || decision.Target.Issue != 546 {
+		t.Fatalf("target = %#v, want issue #546", decision.Target)
+	}
+}

--- a/internal/supervisor/label_ready_handoff_test.go
+++ b/internal/supervisor/label_ready_handoff_test.go
@@ -26,6 +26,9 @@ func TestRunOnce_SafeReadyLabelAppliedDespiteLLMRiskInflation(t *testing.T) {
 	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel}
 	// ... and did NOT gate it behind approval_required (only delete_worktree).
 	cfg.Supervisor.ApprovalRequired = []string{config.SupervisorActionDeleteWorktree}
+	// Force the LLM path so we can still prove inflation cannot block the safe
+	// mutation (hands-off short-circuits risk=safe by default).
+	cfg.Supervisor.AlwaysConsultLLM = true
 
 	reader := &fakeReader{issues: []github.Issue{testIssue(266, "auth handoff")}}
 

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -216,22 +216,15 @@ func (e *Engine) decideWithLLM(st *state.State) (state.SupervisorDecision, error
 		return state.SupervisorDecision{}, err
 	}
 
-	// #837: short-circuit the LLM call on a safe, mutation-free deterministic
-	// decision (idle-project token burn). validateLLMDecision forces the LLM to
-	// agree with the guardrail on action/target/risk, and resolveGuardrailConflict
-	// resolves any disagreement in favor of the deterministic side whenever the
-	// guardrail decision is risk=safe — so on an idle project the LLM can only
-	// reword the summary, never change the decision. Building the ~55K-token state
-	// packet and calling the backend there buys nothing, so skip both.
-	//
-	// The LLM stays in the loop exactly where it adds value: every mutating /
-	// approval-gated decision (spawn_worker, spawn_repair_worker, merge_pr,
-	// review_retry_exhausted, ...) has Risk != safe, and a safe decision that
-	// still plans a GitHub mutation (label_issue_ready with add_ready_label) has
-	// len(Mutations) > 0 — both fall through to the LLM path below. The escape
-	// hatch supervisor.always_consult_llm=true restores the old always-call path.
-	if !e.cfg.Supervisor.AlwaysConsultLLM && deterministic.Risk == RiskSafe && len(deterministic.Mutations) == 0 {
-		log.Printf("[supervisor] supervise: safe idle decision, LLM skipped (action=%s risk=%s)", deterministic.RecommendedAction, deterministic.Risk)
+	// #837 / hands-off 2026-07-22: short-circuit EVERY risk=safe deterministic
+	// decision, including label_issue_ready with planned mutations. validateLLMDecision
+	// + resolveGuardrailConflict already force agreement with the safe guardrail, so
+	// the LLM can only reword the summary. Waiting on a hung supervisor backend
+	// (live ok-player: safe label path never returned, live→0) freezes the control
+	// loop for nothing. Mutating / approval-gated decisions still consult the LLM.
+	// Escape hatch: supervisor.always_consult_llm=true.
+	if !e.cfg.Supervisor.AlwaysConsultLLM && deterministic.Risk == RiskSafe {
+		log.Printf("[supervisor] supervise: safe decision, LLM skipped (action=%s risk=%s mutations=%d)", deterministic.RecommendedAction, deterministic.Risk, len(deterministic.Mutations))
 		return deterministic, nil
 	}
 

--- a/internal/supervisor/llm_short_circuit_test.go
+++ b/internal/supervisor/llm_short_circuit_test.go
@@ -156,31 +156,22 @@ func TestDecideWithLLM_SpawnCandidate_CallsLLM(t *testing.T) {
 	}
 }
 
-// TestDecideWithLLM_LabelIssueReadyWithMutations_CallsLLM pins the documented
-// choice for AC-3: a safe decision that still plans a GitHub mutation
-// (label_issue_ready with add_ready_label) keeps the LLM second opinion because
-// len(Mutations) > 0, even though its headline risk is safe.
-func TestDecideWithLLM_LabelIssueReadyWithMutations_CallsLLM(t *testing.T) {
+// TestDecideWithLLM_LabelIssueReadyWithMutations_SkipsLLM: risk=safe label
+// mutations must not block the control loop on a hung supervisor backend —
+// the guardrail already owns the decision.
+func TestDecideWithLLM_LabelIssueReadyWithMutations_SkipsLLM(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.IssueLabels = []string{"maestro-ready"}
 	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel}
 	reader := &fakeReader{issues: []github.Issue{testIssue(308, "implement supervisor")}}
-	llm := &fakeLLM{output: `{
-  "summary": "Prepare issue #308 for the queue by adding the ready label.",
-  "recommended_action": "add_ready_label",
-  "target": {"issue": 308},
-  "risk": "safe",
-  "confidence": 0.82,
-  "reasons": ["issue #308 is next in queue"],
-  "requires_approval": true
-}`}
+	llm := idleLLM()
 
 	decision, err := testLLMEngine(cfg, reader, llm).Decide(state.NewState())
 	if err != nil {
 		t.Fatalf("Decide: %v", err)
 	}
-	if llm.calls != 1 {
-		t.Fatalf("LLM calls = %d, want 1 (safe decision with a planned GitHub mutation keeps the LLM)", llm.calls)
+	if llm.calls != 0 {
+		t.Fatalf("LLM calls = %d, want 0 (safe label mutations short-circuit)", llm.calls)
 	}
 	if decision.RecommendedAction != ActionLabelIssueReady {
 		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionLabelIssueReady)

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -669,6 +669,9 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	projectState.OpenPRNumbers = supervisorOpenPRNumbers(prs)
 	cache := newResolutionCache(e.reader)
 	stuckStates := e.detectStuckStates(st, now, prs, nil, nil, nil, false, cache)
+	var deferredOpenPR *deferredOpenPRMonitor
+	var deferredBudgetSlot string
+	var deferredBudgetSess *state.Session
 
 	if slot, sess, pr, mergeReady, mergeHeadSHA, mergeReasons, ok := e.sessionWithOpenPR(st, prs, cache); ok {
 		// #565: auto review-repair respawn. When a green+mergeable PR is
@@ -737,28 +740,35 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 			return decision, nil
 		}
 
-		// PR exists but is not yet merge-ready. Stay on monitor_open_pr but
-		// surface the actual blocker (CI pending, review missing, draft, etc.)
-		// in the summary instead of claiming auto-merge will happen.
-		monitorReasons := e.monitorOpenPRReasons(slot, sess, pr)
-		summary := fmt.Sprintf("Monitor PR #%d for issue #%d: %s", pr.Number, sess.IssueNumber, summarizeMonitorReasons(monitorReasons))
-		reasons := appendReasons(baseReasons,
-			fmt.Sprintf("Session %s is associated with open PR #%d", slot, pr.Number),
-			"No GitHub mutation is needed for supervisor mode",
-		)
-		reasons = appendReasons(reasons, monitorReasons...)
-		if sess.Status == state.StatusRetryExhausted {
-			reasons = appendReasons(reasons,
-				fmt.Sprintf("Session %s is retry_exhausted but still has open PR #%d", slot, pr.Number),
-				"Retry exhaustion does not block normal PR merge flow when checks and review gates pass",
+		// Hands-off fill (2026-07-22): a non-urgent open PR must NOT starve
+		// spare capacity when backlog exists. Defer monitor_open_pr until we
+		// know whether eligible backlog remains; if none, resume monitoring.
+		if projectState.AvailableSlots <= 0 {
+			monitorReasons := e.monitorOpenPRReasons(slot, sess, pr)
+			summary := fmt.Sprintf("Monitor PR #%d for issue #%d: %s", pr.Number, sess.IssueNumber, summarizeMonitorReasons(monitorReasons))
+			reasons := appendReasons(baseReasons,
+				fmt.Sprintf("Session %s is associated with open PR #%d", slot, pr.Number),
+				"No GitHub mutation is needed for supervisor mode",
 			)
+			reasons = appendReasons(reasons, monitorReasons...)
+			if sess.Status == state.StatusRetryExhausted {
+				reasons = appendReasons(reasons,
+					fmt.Sprintf("Session %s is retry_exhausted but still has open PR #%d", slot, pr.Number),
+					"Retry exhaustion does not block normal PR merge flow when checks and review gates pass",
+				)
+			}
+			target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}
+			decision := e.decision(st, now, projectState, ActionMonitorOpenPR,
+				summary,
+				RiskSafe, 0.9, target, PolicyRuleRuntimeState, reasons)
+			decision.StuckStates = appendStuck(stuckStates, pendingChecksStuckState(target, pr, monitorReasons))
+			return decision, nil
 		}
-		target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}
-		decision := e.decision(st, now, projectState, ActionMonitorOpenPR,
-			summary,
-			RiskSafe, 0.9, target, PolicyRuleRuntimeState, reasons)
-		decision.StuckStates = appendStuck(stuckStates, pendingChecksStuckState(target, pr, monitorReasons))
-		return decision, nil
+		deferredOpenPR = &deferredOpenPRMonitor{slot: slot, sess: sess, pr: pr}
+		baseReasons = appendReasons(baseReasons,
+			fmt.Sprintf("Open PR #%d for issue #%d is monitored passively while spare capacity remains", pr.Number, sess.IssueNumber),
+			"Prefer backlog label/spawn over exclusive monitor_open_pr when AvailableSlots>0 and backlog exists",
+		)
 	}
 
 	if slot, sess, ok := runningSession(st); ok && e.shouldWaitForRunningWorker(st) {
@@ -774,28 +784,44 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	}
 
 	if slot, sess, ok := tokenBudgetExceededSession(st); ok {
-		reasons := appendReasons(baseReasons,
-			fmt.Sprintf("Session %s for issue #%d stopped deterministically at worker_max_tokens", slot, sess.IssueNumber),
-			"Restarting or re-planning automatically would spend more tokens without an operator budget decision",
+		// Hands-off fill (2026-07-22): a historical token-budget stop on one
+		// issue must not freeze the whole project. Only halt immediately when
+		// there is no spare capacity; otherwise continue and only surface the
+		// budget stop if no other backlog remains.
+		if projectState.AvailableSlots <= 0 {
+			reasons := appendReasons(baseReasons,
+				fmt.Sprintf("Session %s for issue #%d stopped deterministically at worker_max_tokens", slot, sess.IssueNumber),
+				"Restarting or re-planning automatically would spend more tokens without an operator budget decision",
+			)
+			decision := e.decision(st, now, projectState, ActionNone,
+				fmt.Sprintf("Issue #%d is stopped at its worker token budget and needs an operator budget decision.", sess.IssueNumber),
+				RiskSafe, 0.99, &state.SupervisorTarget{Issue: sess.IssueNumber, Session: slot}, PolicyRuleRuntimeState, reasons)
+			decision.StuckStates = stuckStates
+			return decision, nil
+		}
+		deferredBudgetSlot, deferredBudgetSess = slot, sess
+		baseReasons = appendReasons(baseReasons,
+			fmt.Sprintf("Session %s for issue #%d previously hit worker_max_tokens", slot, sess.IssueNumber),
+			"Spare capacity remains — continue backlog fill instead of freezing the project on a budget stop",
 		)
-		decision := e.decision(st, now, projectState, ActionNone,
-			fmt.Sprintf("Issue #%d is stopped at its worker token budget and needs an operator budget decision.", sess.IssueNumber),
-			RiskSafe, 0.99, &state.SupervisorTarget{Issue: sess.IssueNumber, Session: slot}, PolicyRuleRuntimeState, reasons)
-		decision.StuckStates = stuckStates
-		return decision, nil
 	}
 
 	if !e.cfg.Supervisor.OrderedQueueActive() && !e.cfg.Supervisor.DynamicWave.Active() {
-		if slot, sess, ok := e.retryExhaustedSession(st, cache); ok {
-			reasons := appendReasons(baseReasons,
-				fmt.Sprintf("Session %s for issue #%d is retry_exhausted", slot, sess.IssueNumber),
-				"Retry-exhausted work requires a human decision before more automation",
-			)
-			decision := e.decision(st, now, projectState, ActionReviewRetryExhausted,
-				fmt.Sprintf("Issue #%d exhausted its retry budget and needs manual review.", sess.IssueNumber),
-				RiskApprovalGated, 0.93, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}, PolicyRuleRuntimeState, reasons)
-			decision.StuckStates = stuckStates
-			return decision, nil
+		// When an open PR is already deferred for spare-slot fill, do not let
+		// retry_exhausted monopolize the cycle — resume deferred monitor if
+		// backlog probe finds nothing (pending CI must stay monitor_open_pr).
+		if deferredOpenPR == nil {
+			if slot, sess, ok := e.retryExhaustedSession(st, cache); ok {
+				reasons := appendReasons(baseReasons,
+					fmt.Sprintf("Session %s for issue #%d is retry_exhausted", slot, sess.IssueNumber),
+					"Retry-exhausted work requires a human decision before more automation",
+				)
+				decision := e.decision(st, now, projectState, ActionReviewRetryExhausted,
+					fmt.Sprintf("Issue #%d exhausted its retry budget and needs manual review.", sess.IssueNumber),
+					RiskApprovalGated, 0.93, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: sess.PRNumber, Session: slot}, PolicyRuleRuntimeState, reasons)
+				decision.StuckStates = stuckStates
+				return decision, nil
+			}
 		}
 	}
 
@@ -828,6 +854,9 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 			hasActionable = len(eligibleProbe) > 0
 		}
 		if !hasActionable {
+			if deferredOpenPR != nil {
+				return e.decisionMonitorOpenPR(st, now, projectState, baseReasons, stuckStates, *deferredOpenPR), nil
+			}
 			reasons := appendReasons(baseReasons,
 				stuck.Summary,
 				fmt.Sprintf("Open PRs observed: %d; PR presence does not prove the live outcome is fixed", len(prs)),
@@ -870,7 +899,7 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		return state.SupervisorDecision{}, err
 	}
 	if policyResult.dynamicWave {
-		return e.decideDynamicWave(st, now, projectState, baseReasons, prs, issues, policyResult, cache)
+		return e.decideDynamicWave(st, now, projectState, baseReasons, prs, issues, policyResult, cache, deferredOpenPR, deferredBudgetSlot, deferredBudgetSess)
 	}
 	candidates := policyResult.candidates
 	policySkipped := policyResult.skipped
@@ -1053,6 +1082,16 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	for _, reason := range firstN(skipped, 3) {
 		reasons = append(reasons, reason)
 	}
+	if deferredOpenPR != nil {
+		return withAnalysis(e.decisionMonitorOpenPR(st, now, projectState, reasons, stuckStates, *deferredOpenPR)), nil
+	}
+	if deferredBudgetSess != nil {
+		decision := e.decision(st, now, projectState, ActionNone,
+			fmt.Sprintf("Issue #%d is stopped at its worker token budget and needs an operator budget decision.", deferredBudgetSess.IssueNumber),
+			RiskSafe, 0.99, &state.SupervisorTarget{Issue: deferredBudgetSess.IssueNumber, Session: deferredBudgetSlot}, PolicyRuleRuntimeState, reasons)
+		decision.StuckStates = stuckStates
+		return withAnalysis(decision), nil
+	}
 	decision := e.decision(st, now, projectState, ActionNone,
 		"No action is currently recommended.", RiskSafe, 0.8, nil, policyRule, reasons)
 	decision.StuckStates = stuckStates
@@ -1099,7 +1138,44 @@ func tokenBudgetExceededSession(st *state.State) (string, *state.Session, bool) 
 	return bestSlot, best, best != nil
 }
 
-func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState state.SupervisorProjectState, baseReasons []string, prs []github.PR, issues []github.Issue, result policyCandidateResult, cache *resolutionCache) (state.SupervisorDecision, error) {
+// deferredOpenPRMonitor holds a non-urgent open-PR monitor decision that is
+// postponed while spare capacity is used to fill backlog (hands-off band).
+type deferredOpenPRMonitor struct {
+	slot string
+	sess *state.Session
+	pr   github.PR
+}
+
+func (e *Engine) decisionMonitorOpenPR(
+	st *state.State,
+	now time.Time,
+	projectState state.SupervisorProjectState,
+	baseReasons []string,
+	stuckStates []state.SupervisorStuckState,
+	def deferredOpenPRMonitor,
+) state.SupervisorDecision {
+	monitorReasons := e.monitorOpenPRReasons(def.slot, def.sess, def.pr)
+	summary := fmt.Sprintf("Monitor PR #%d for issue #%d: %s", def.pr.Number, def.sess.IssueNumber, summarizeMonitorReasons(monitorReasons))
+	reasons := appendReasons(baseReasons,
+		fmt.Sprintf("Session %s is associated with open PR #%d", def.slot, def.pr.Number),
+		"No GitHub mutation is needed for supervisor mode",
+	)
+	reasons = appendReasons(reasons, monitorReasons...)
+	if def.sess.Status == state.StatusRetryExhausted {
+		reasons = appendReasons(reasons,
+			fmt.Sprintf("Session %s is retry_exhausted but still has open PR #%d", def.slot, def.pr.Number),
+			"Retry exhaustion does not block normal PR merge flow when checks and review gates pass",
+		)
+	}
+	target := &state.SupervisorTarget{Issue: def.sess.IssueNumber, PR: def.pr.Number, Session: def.slot}
+	decision := e.decision(st, now, projectState, ActionMonitorOpenPR,
+		summary,
+		RiskSafe, 0.9, target, PolicyRuleRuntimeState, reasons)
+	decision.StuckStates = appendStuck(stuckStates, pendingChecksStuckState(target, def.pr, monitorReasons))
+	return decision
+}
+
+func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState state.SupervisorProjectState, baseReasons []string, prs []github.PR, issues []github.Issue, result policyCandidateResult, cache *resolutionCache, deferredOpenPR *deferredOpenPRMonitor, deferredBudgetSlot string, deferredBudgetSess *state.Session) (state.SupervisorDecision, error) {
 	candidates := result.candidates
 	analysis := result.analysis
 	outcomeStatus := e.outcomeStatus(st)
@@ -1202,6 +1278,14 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 
 		decision := e.decision(st, now, projectState, ActionNone,
 			"No issue is currently eligible under the dynamic wave policy.", RiskSafe, 0.8, nil, PolicyRuleDynamicWave, reasons)
+		if deferredOpenPR != nil {
+			decision = e.decisionMonitorOpenPR(st, now, projectState, reasons, stuckStates, *deferredOpenPR)
+		} else if deferredBudgetSess != nil {
+			decision = e.decision(st, now, projectState, ActionNone,
+				fmt.Sprintf("Issue #%d is stopped at its worker token budget and needs an operator budget decision.", deferredBudgetSess.IssueNumber),
+				RiskSafe, 0.99, &state.SupervisorTarget{Issue: deferredBudgetSess.IssueNumber, Session: deferredBudgetSlot}, PolicyRuleRuntimeState, reasons)
+			decision.StuckStates = stuckStates
+		}
 		return withAnalysis(decision), nil
 	}
 

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -805,6 +805,50 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	}
 	projectState.OpenIssues = len(issues)
 
+	// F8 / sustained hands-off (2026-07-22): a red/unknown outcome must NOT
+	// permanently idle the project when backlog exists. The old early-return
+	// ActionCheckOutcomeHealth path stopped add_ready_label / spawn while
+	// ActiveSessions()==0, so after workers finished the ready queue drained
+	// and the fleet sat at 0 until a human kicked it. Prefer promoting or
+	// dispatching eligible backlog; only recommend outcome verification when
+	// there is truly nothing actionable left.
+	if stuck := noOutcomeProgressStuckState(stuckStates); stuck != nil && len(st.ActiveSessions()) == 0 {
+		policyProbe, probeErr := e.policyCandidateIssues(st, issues)
+		if probeErr != nil {
+			return state.SupervisorDecision{}, probeErr
+		}
+		hasActionable := false
+		if policyProbe.dynamicWave {
+			hasActionable = len(policyProbe.candidates) > 0
+		} else {
+			eligibleProbe, _, eligErr := e.eligibleIssues(st, policyProbe.candidates, true)
+			if eligErr != nil {
+				return state.SupervisorDecision{}, eligErr
+			}
+			hasActionable = len(eligibleProbe) > 0
+		}
+		if !hasActionable {
+			reasons := appendReasons(baseReasons,
+				stuck.Summary,
+				fmt.Sprintf("Open PRs observed: %d; PR presence does not prove the live outcome is fixed", len(prs)),
+				"No actionable backlog remains; recommend outcome verification before inventing new throughput",
+				"Supervisor remains read-only for deploy/runtime; it does not run deploy commands",
+			)
+			decision := e.decision(st, now, projectState, ActionCheckOutcomeHealth,
+				"Verify outcome health before starting more issue work.",
+				RiskSafe, 0.86, nil, PolicyRuleRuntimeState, reasons)
+			decision.StuckStates = stuckStates
+			if st.OutcomeHealth != nil && st.OutcomeHealth.State == outcome.HealthFailing {
+				decision.QueueAnalysis = e.dispatchBlockerQueueAnalysis(st)
+			}
+			return decision, nil
+		}
+		baseReasons = appendReasons(baseReasons,
+			stuck.Summary,
+			"Outcome is unhealthy, but actionable backlog remains — prefer label/spawn over idling on check_outcome_health",
+		)
+	}
+
 	if slot, sess, issue, ok, err := e.retryExhaustedRepairCandidate(st, issues, cache); err != nil {
 		return state.SupervisorDecision{}, err
 	} else if ok {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1370,16 +1370,10 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 		}
 
 		if !matchesRequiredLabels(issue, e.requiredIssueLabels()) {
-			reasons := appendReasons(baseReasons,
-				fmt.Sprintf("Dynamic wave selected issue #%d", issue.Number),
-				"Selected issue is waiting for a ready label mutation to appear in GitHub issue data",
+			baseReasons = appendReasons(baseReasons,
+				fmt.Sprintf("Issue #%d is waiting for a ready label mutation to appear — skip for later candidates", issue.Number),
 			)
-			for _, reason := range firstN(result.skipped, 3) {
-				reasons = append(reasons, reason)
-			}
-			decision := e.decision(st, now, projectState, ActionNone,
-				"No action is currently recommended while the selected issue waits for its ready label.", RiskSafe, 0.8, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
-			return withAnalysis(decision), nil
+			continue
 		}
 
 		// Race protection: refuse to recommend spawn for an issue that has

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -873,8 +873,10 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 				"Verify outcome health before starting more issue work.",
 				RiskSafe, 0.86, nil, PolicyRuleRuntimeState, reasons)
 			decision.StuckStates = stuckStates
-			if st.OutcomeHealth != nil && st.OutcomeHealth.State == outcome.HealthFailing {
-				decision.QueueAnalysis = e.dispatchBlockerQueueAnalysis(st)
+			decision.QueueAnalysis = &state.SupervisorQueueAnalysis{
+				PolicyRule:         e.defaultPolicyRule(),
+				OpenIssues:         len(issues),
+				EligibleCandidates: 0,
 			}
 			return decision, nil
 		}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -705,31 +705,34 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 					"Repair dispatch is fail-closed against the issue's current forge state",
 					guardReason,
 				)
-				target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}
-				decision := e.decision(st, now, projectState, ActionMonitorOpenPR,
-					fmt.Sprintf("Do not start a repair worker for issue #%d while its current dispatch guard holds: %s", sess.IssueNumber, guardReason),
-					RiskSafe, 0.98, target, PolicyRuleExcludedLabels, reasons)
+				// Hands-off: a guarded/blocked open PR must not freeze spare
+				// slots — defer the monitor decision and try backlog fill.
+				if projectState.AvailableSlots > 0 {
+					deferredOpenPR = &deferredOpenPRMonitor{slot: slot, sess: sess, pr: pr, guardReason: guardReason}
+					baseReasons = appendReasons(reasons,
+						"Prefer backlog label/spawn over exclusive monitor_open_pr when AvailableSlots>0 and backlog exists",
+					)
+				} else {
+					target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}
+					decision := e.decision(st, now, projectState, ActionMonitorOpenPR,
+						fmt.Sprintf("Do not start a repair worker for issue #%d while its current dispatch guard holds: %s", sess.IssueNumber, guardReason),
+						RiskSafe, 0.98, target, PolicyRuleExcludedLabels, reasons)
+					decision.StuckStates = stuckStates
+					return decision, nil
+				}
+			} else {
+				reasons := appendReasons(baseReasons,
+					fmt.Sprintf("Session %s is associated with open PR #%d, but the PR is not progressing", slot, pr.Number),
+					"The worker is not actively repairing this PR while it is draft, failing checks, blocked by review, or the live outcome is still failing",
+					"Starting a repair worker would mutate local worktrees, so supervisor records an explicit repair recommendation",
+				)
+				decision := e.decision(st, now, projectState, ActionSpawnRepairWorker,
+					fmt.Sprintf("Start a repair worker for issue #%d; PR #%d is not enough to prove the live outcome.", sess.IssueNumber, pr.Number),
+					RiskMutating, 0.9, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}, PolicyRuleRuntimeState, reasons)
 				decision.StuckStates = stuckStates
 				return decision, nil
 			}
-			reasons := appendReasons(baseReasons,
-				fmt.Sprintf("Session %s is associated with open PR #%d, but the PR is not progressing", slot, pr.Number),
-				"The worker is not actively repairing this PR while it is draft, failing checks, blocked by review, or the live outcome is still failing",
-				"Starting a repair worker would mutate local worktrees, so supervisor records an explicit repair recommendation",
-			)
-			decision := e.decision(st, now, projectState, ActionSpawnRepairWorker,
-				fmt.Sprintf("Start a repair worker for issue #%d; PR #%d is not enough to prove the live outcome.", sess.IssueNumber, pr.Number),
-				RiskMutating, 0.9, &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}, PolicyRuleRuntimeState, reasons)
-			decision.StuckStates = stuckStates
-			return decision, nil
-		}
-		// #512 (Phase 1.6): if the PR is actually ready to merge — not draft,
-		// mergeable, CI green, Greptile approved (when configured) — recommend
-		// merge_pr (risk=mutating, cautious-gate gates approval). Without this
-		// rule, every CLEAN/SUCCESS PR sat in pr_open forever while supervisor
-		// emitted monitor_open_pr loops; the reasoning even claimed "Maestro will
-		// merge when the merge gate allows it" — aspirational, never implemented.
-		if mergeReady {
+		} else if mergeReady {
 			summary := fmt.Sprintf("Merge PR #%d for issue #%d — checks green, mergeable, review gates passed.", pr.Number, sess.IssueNumber)
 			reasons := appendReasons(baseReasons, mergeReasons...)
 			target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, HeadSHA: mergeHeadSHA, Session: slot}
@@ -743,32 +746,35 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		// Hands-off fill (2026-07-22): a non-urgent open PR must NOT starve
 		// spare capacity when backlog exists. Defer monitor_open_pr until we
 		// know whether eligible backlog remains; if none, resume monitoring.
-		if projectState.AvailableSlots <= 0 {
-			monitorReasons := e.monitorOpenPRReasons(slot, sess, pr)
-			summary := fmt.Sprintf("Monitor PR #%d for issue #%d: %s", pr.Number, sess.IssueNumber, summarizeMonitorReasons(monitorReasons))
-			reasons := appendReasons(baseReasons,
-				fmt.Sprintf("Session %s is associated with open PR #%d", slot, pr.Number),
-				"No GitHub mutation is needed for supervisor mode",
-			)
-			reasons = appendReasons(reasons, monitorReasons...)
-			if sess.Status == state.StatusRetryExhausted {
-				reasons = appendReasons(reasons,
-					fmt.Sprintf("Session %s is retry_exhausted but still has open PR #%d", slot, pr.Number),
-					"Retry exhaustion does not block normal PR merge flow when checks and review gates pass",
+		// (Guarded/blocked repair may already have deferred above.)
+		if deferredOpenPR == nil {
+			if projectState.AvailableSlots <= 0 {
+				monitorReasons := e.monitorOpenPRReasons(slot, sess, pr)
+				summary := fmt.Sprintf("Monitor PR #%d for issue #%d: %s", pr.Number, sess.IssueNumber, summarizeMonitorReasons(monitorReasons))
+				reasons := appendReasons(baseReasons,
+					fmt.Sprintf("Session %s is associated with open PR #%d", slot, pr.Number),
+					"No GitHub mutation is needed for supervisor mode",
 				)
+				reasons = appendReasons(reasons, monitorReasons...)
+				if sess.Status == state.StatusRetryExhausted {
+					reasons = appendReasons(reasons,
+						fmt.Sprintf("Session %s is retry_exhausted but still has open PR #%d", slot, pr.Number),
+						"Retry exhaustion does not block normal PR merge flow when checks and review gates pass",
+					)
+				}
+				target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}
+				decision := e.decision(st, now, projectState, ActionMonitorOpenPR,
+					summary,
+					RiskSafe, 0.9, target, PolicyRuleRuntimeState, reasons)
+				decision.StuckStates = appendStuck(stuckStates, pendingChecksStuckState(target, pr, monitorReasons))
+				return decision, nil
 			}
-			target := &state.SupervisorTarget{Issue: sess.IssueNumber, PR: pr.Number, Session: slot}
-			decision := e.decision(st, now, projectState, ActionMonitorOpenPR,
-				summary,
-				RiskSafe, 0.9, target, PolicyRuleRuntimeState, reasons)
-			decision.StuckStates = appendStuck(stuckStates, pendingChecksStuckState(target, pr, monitorReasons))
-			return decision, nil
+			deferredOpenPR = &deferredOpenPRMonitor{slot: slot, sess: sess, pr: pr}
+			baseReasons = appendReasons(baseReasons,
+				fmt.Sprintf("Open PR #%d for issue #%d is monitored passively while spare capacity remains", pr.Number, sess.IssueNumber),
+				"Prefer backlog label/spawn over exclusive monitor_open_pr when AvailableSlots>0 and backlog exists",
+			)
 		}
-		deferredOpenPR = &deferredOpenPRMonitor{slot: slot, sess: sess, pr: pr}
-		baseReasons = appendReasons(baseReasons,
-			fmt.Sprintf("Open PR #%d for issue #%d is monitored passively while spare capacity remains", pr.Number, sess.IssueNumber),
-			"Prefer backlog label/spawn over exclusive monitor_open_pr when AvailableSlots>0 and backlog exists",
-		)
 	}
 
 	if slot, sess, ok := runningSession(st); ok && e.shouldWaitForRunningWorker(st) {
@@ -1141,9 +1147,10 @@ func tokenBudgetExceededSession(st *state.State) (string, *state.Session, bool) 
 // deferredOpenPRMonitor holds a non-urgent open-PR monitor decision that is
 // postponed while spare capacity is used to fill backlog (hands-off band).
 type deferredOpenPRMonitor struct {
-	slot string
-	sess *state.Session
-	pr   github.PR
+	slot        string
+	sess        *state.Session
+	pr          github.PR
+	guardReason string // non-empty when repair was blocked by a current-issue guard
 }
 
 func (e *Engine) decisionMonitorOpenPR(
@@ -1154,6 +1161,19 @@ func (e *Engine) decisionMonitorOpenPR(
 	stuckStates []state.SupervisorStuckState,
 	def deferredOpenPRMonitor,
 ) state.SupervisorDecision {
+	target := &state.SupervisorTarget{Issue: def.sess.IssueNumber, PR: def.pr.Number, Session: def.slot}
+	if def.guardReason != "" {
+		reasons := appendReasons(baseReasons,
+			fmt.Sprintf("Session %s is associated with open PR #%d, but the PR is not progressing", def.slot, def.pr.Number),
+			"Repair dispatch is fail-closed against the issue's current forge state",
+			def.guardReason,
+		)
+		decision := e.decision(st, now, projectState, ActionMonitorOpenPR,
+			fmt.Sprintf("Do not start a repair worker for issue #%d while its current dispatch guard holds: %s", def.sess.IssueNumber, def.guardReason),
+			RiskSafe, 0.98, target, PolicyRuleExcludedLabels, reasons)
+		decision.StuckStates = stuckStates
+		return decision
+	}
 	monitorReasons := e.monitorOpenPRReasons(def.slot, def.sess, def.pr)
 	summary := fmt.Sprintf("Monitor PR #%d for issue #%d: %s", def.pr.Number, def.sess.IssueNumber, summarizeMonitorReasons(monitorReasons))
 	reasons := appendReasons(baseReasons,
@@ -1167,7 +1187,6 @@ func (e *Engine) decisionMonitorOpenPR(
 			"Retry exhaustion does not block normal PR merge flow when checks and review gates pass",
 		)
 	}
-	target := &state.SupervisorTarget{Issue: def.sess.IssueNumber, PR: def.pr.Number, Session: def.slot}
 	decision := e.decision(st, now, projectState, ActionMonitorOpenPR,
 		summary,
 		RiskSafe, 0.9, target, PolicyRuleRuntimeState, reasons)

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -923,81 +923,86 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	}
 
 	if len(eligible) > 0 {
-		issue := eligible[0]
-		if projectState.AvailableSlots <= 0 {
+		var openPRBlocker *github.Issue
+		for _, issue := range eligible {
+			if projectState.AvailableSlots <= 0 {
+				reasons := appendReasons(baseReasons,
+					fmt.Sprintf("Issue #%d is eligible but no worker slot is available", issue.Number),
+				)
+				decision := e.decision(st, now, projectState, ActionWaitForCapacity,
+					fmt.Sprintf("Issue #%d is eligible, but all worker slots are occupied.", issue.Number),
+					RiskSafe, 0.86, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
+				decision.StuckStates = stuckStates
+				return withAnalysis(decision), nil
+			}
+
+			hasOpenPR, err := e.reader.HasOpenPRForIssue(issue.Number)
+			if err != nil {
+				return state.SupervisorDecision{}, fmt.Errorf("check open PR for issue #%d: %w", issue.Number, err)
+			}
+			if hasOpenPR {
+				if openPRBlocker == nil {
+					copied := issue
+					openPRBlocker = &copied
+				}
+				baseReasons = appendReasons(baseReasons,
+					fmt.Sprintf("Issue #%d already has an open PR — skip for spare-slot backlog fill", issue.Number),
+				)
+				continue
+			}
+
+			// Race protection: refuse to recommend a spawn for an issue that
+			// has already been closed since the listing snapshot (post-merge
+			// race) or whose session is already Done/code_landed.
+			if cache.isIssueClosed(issue.Number) {
+				baseReasons = appendReasons(baseReasons,
+					fmt.Sprintf("Issue #%d closed between listing and dispatch — skip", issue.Number),
+				)
+				continue
+			}
+			if e.sessionRecentlyDoneForIssue(st, issue.Number) {
+				baseReasons = appendReasons(baseReasons,
+					fmt.Sprintf("Issue #%d already reached Done in state — skip duplicate spawn", issue.Number),
+				)
+				continue
+			}
+
 			reasons := appendReasons(baseReasons,
-				fmt.Sprintf("Issue #%d is eligible but no worker slot is available", issue.Number),
+				issueLabelReason(e.requiredIssueLabels()),
+				fmt.Sprintf("Issue #%d is the next eligible issue", issue.Number),
+				outcomeIssueReason(outcomeStatus, issue),
+				"Starting a worker would mutate local worktrees, so supervisor only records the recommendation",
 			)
-			decision := e.decision(st, now, projectState, ActionWaitForCapacity,
-				fmt.Sprintf("Issue #%d is eligible, but all worker slots are occupied.", issue.Number),
-				RiskSafe, 0.86, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
+			if preflight, ok := e.evaluatePreflight(false, true); !ok {
+				stuckStates = append(stuckStates, preflightFailedStuckState(preflight, "spawn_worker"))
+				blockedReasons := appendReasons(reasons,
+					"Preflight gate failed; refusing to recommend a worker spawn",
+					"Preflight: "+preflight.Reason,
+				)
+				decision := e.decision(st, now, projectState, ActionPreflightFailed,
+					fmt.Sprintf("Preflight blocked worker spawn for issue #%d: %s", issue.Number, preflight.Reason),
+					RiskApprovalGated, 0.9, &state.SupervisorTarget{Issue: issue.Number}, policyRule, blockedReasons)
+				decision.StuckStates = stuckStates
+				return withAnalysis(decision), nil
+			}
+			decision := e.decision(st, now, projectState, ActionSpawnWorker,
+				fmt.Sprintf("Start a worker for issue #%d: %s", issue.Number, issue.Title),
+				RiskMutating, 0.84, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
 			decision.StuckStates = stuckStates
 			return withAnalysis(decision), nil
 		}
-
-		hasOpenPR, err := e.reader.HasOpenPRForIssue(issue.Number)
-		if err != nil {
-			return state.SupervisorDecision{}, fmt.Errorf("check open PR for issue #%d: %w", issue.Number, err)
-		}
-		if hasOpenPR {
+		if openPRBlocker != nil {
 			reasons := appendReasons(baseReasons,
-				fmt.Sprintf("Issue #%d is eligible but GitHub already has an open PR referencing it", issue.Number),
+				fmt.Sprintf("Issue #%d is eligible but GitHub already has an open PR referencing it", openPRBlocker.Number),
+				"No later eligible issue was dispatchable without duplicating open-PR work",
 				"Supervisor mode should not dispatch duplicate work",
 			)
 			decision := e.decision(st, now, projectState, ActionMonitorOpenPR,
-				fmt.Sprintf("Issue #%d already has an open PR; monitor that PR instead of starting work.", issue.Number),
-				RiskSafe, 0.87, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
+				fmt.Sprintf("Issue #%d already has an open PR; monitor that PR instead of starting work.", openPRBlocker.Number),
+				RiskSafe, 0.87, &state.SupervisorTarget{Issue: openPRBlocker.Number}, policyRule, reasons)
 			decision.StuckStates = stuckStates
 			return withAnalysis(decision), nil
 		}
-
-		// Race protection: refuse to recommend a spawn for an issue that
-		// has already been closed since the listing snapshot (post-merge
-		// race) or whose session is already Done/code_landed.
-		if cache.isIssueClosed(issue.Number) {
-			reasons := appendReasons(baseReasons,
-				fmt.Sprintf("Issue #%d closed between listing and dispatch; refusing to spawn a duplicate worker", issue.Number),
-			)
-			decision := e.decision(st, now, projectState, ActionNone,
-				fmt.Sprintf("Issue #%d closed after listing; supervisor will re-evaluate on the next cycle.", issue.Number),
-				RiskSafe, 0.9, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
-			decision.StuckStates = stuckStates
-			return withAnalysis(decision), nil
-		}
-		if e.sessionRecentlyDoneForIssue(st, issue.Number) {
-			reasons := appendReasons(baseReasons,
-				fmt.Sprintf("Issue #%d already has a Done/code-landed session in state; refusing to spawn another worker", issue.Number),
-			)
-			decision := e.decision(st, now, projectState, ActionNone,
-				fmt.Sprintf("Issue #%d already reached Done in state; supervisor refuses to dispatch a duplicate worker.", issue.Number),
-				RiskSafe, 0.9, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
-			decision.StuckStates = stuckStates
-			return withAnalysis(decision), nil
-		}
-
-		reasons := appendReasons(baseReasons,
-			issueLabelReason(e.requiredIssueLabels()),
-			fmt.Sprintf("Issue #%d is the next eligible issue", issue.Number),
-			outcomeIssueReason(outcomeStatus, issue),
-			"Starting a worker would mutate local worktrees, so supervisor only records the recommendation",
-		)
-		if preflight, ok := e.evaluatePreflight(false, true); !ok {
-			stuckStates = append(stuckStates, preflightFailedStuckState(preflight, "spawn_worker"))
-			blockedReasons := appendReasons(reasons,
-				"Preflight gate failed; refusing to recommend a worker spawn",
-				"Preflight: "+preflight.Reason,
-			)
-			decision := e.decision(st, now, projectState, ActionPreflightFailed,
-				fmt.Sprintf("Preflight blocked worker spawn for issue #%d: %s", issue.Number, preflight.Reason),
-				RiskApprovalGated, 0.9, &state.SupervisorTarget{Issue: issue.Number}, policyRule, blockedReasons)
-			decision.StuckStates = stuckStates
-			return withAnalysis(decision), nil
-		}
-		decision := e.decision(st, now, projectState, ActionSpawnWorker,
-			fmt.Sprintf("Start a worker for issue #%d: %s", issue.Number, issue.Title),
-			RiskMutating, 0.84, &state.SupervisorTarget{Issue: issue.Number}, policyRule, reasons)
-		decision.StuckStates = stuckStates
-		return withAnalysis(decision), nil
 	}
 
 	if policyRule == PolicyRuleOrderedQueue && len(candidates) == 1 {
@@ -1308,115 +1313,141 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 		return withAnalysis(decision), nil
 	}
 
-	issue := candidates[0]
-	if projectState.AvailableSlots <= 0 {
+	// Walk candidates until one is dispatchable. A leading candidate that
+	// already has an open PR must NOT freeze the whole project when later
+	// candidates (and AvailableSlots) remain — that was the live ok-player
+	// failure mode (eligible=5, action=monitor_open_pr on #406, live→0).
+	var openPRBlocker *github.Issue
+	for _, issue := range candidates {
+		if projectState.AvailableSlots <= 0 {
+			reasons := appendReasons(baseReasons,
+				fmt.Sprintf("Dynamic wave selected issue #%d", issue.Number),
+				fmt.Sprintf("Issue #%d is eligible but no worker slot is available", issue.Number),
+			)
+			decision := e.decision(st, now, projectState, ActionWaitForCapacity,
+				fmt.Sprintf("Issue #%d is eligible, but all worker slots are occupied.", issue.Number),
+				RiskSafe, 0.86, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
+			return withAnalysis(decision), nil
+		}
+
+		hasOpenPR, err := e.reader.HasOpenPRForIssue(issue.Number)
+		if err != nil {
+			return state.SupervisorDecision{}, fmt.Errorf("check open PR for issue #%d: %w", issue.Number, err)
+		}
+		if hasOpenPR {
+			if openPRBlocker == nil {
+				copied := issue
+				openPRBlocker = &copied
+			}
+			baseReasons = appendReasons(baseReasons,
+				fmt.Sprintf("Issue #%d already has an open PR — skip for spare-slot backlog fill", issue.Number),
+			)
+			continue
+		}
+
+		if analysis != nil {
+			analysis.SelectedCandidate = supervisorIssueCandidate(issue)
+		}
+
+		queueCandidate := e.dynamicQueueActionCandidate(st, issue, issues)
+		if queueCandidate != nil {
+			mutations := queueCandidate.plannedMutations(e.cfg)
+			reasons := appendReasons(baseReasons,
+				queueLabelReason(queueCandidate.readyLabel, ""),
+				fmt.Sprintf("Dynamic wave selected issue #%d by priority and issue number", issue.Number),
+				outcomeIssueReason(outcomeStatus, issue),
+			)
+			risk := RiskMutating
+			if len(mutations) > 0 {
+				risk = RiskSafe
+				reasons = appendReasons(reasons, "Supervisor policy allows the planned safe queue mutation")
+			}
+			decision := e.decision(st, now, projectState, ActionLabelIssueReady,
+				fmt.Sprintf("Prepare issue #%d for the dynamic wave by %s.", issue.Number, plannedMutationPhrase(queueCandidate.neededMutations())),
+				risk, 0.82, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
+			decision.Mutations = mutations
+			return withAnalysis(decision), nil
+		}
+
+		if !matchesRequiredLabels(issue, e.requiredIssueLabels()) {
+			reasons := appendReasons(baseReasons,
+				fmt.Sprintf("Dynamic wave selected issue #%d", issue.Number),
+				"Selected issue is waiting for a ready label mutation to appear in GitHub issue data",
+			)
+			for _, reason := range firstN(result.skipped, 3) {
+				reasons = append(reasons, reason)
+			}
+			decision := e.decision(st, now, projectState, ActionNone,
+				"No action is currently recommended while the selected issue waits for its ready label.", RiskSafe, 0.8, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
+			return withAnalysis(decision), nil
+		}
+
+		// Race protection: refuse to recommend spawn for an issue that has
+		// already been closed since the issue listing snapshot was taken
+		// (post-merge close race). Cache hits are cheap because the broader
+		// supervisor cycle reuses the same resolutionCache.
+		if cache != nil && cache.isIssueClosed(issue.Number) {
+			baseReasons = appendReasons(baseReasons,
+				fmt.Sprintf("Issue #%d closed between listing and dispatch — skip", issue.Number),
+			)
+			continue
+		}
+		if e.sessionRecentlyDoneForIssue(st, issue.Number) {
+			baseReasons = appendReasons(baseReasons,
+				fmt.Sprintf("Issue #%d already has a Done/code-landed session — skip duplicate spawn", issue.Number),
+			)
+			continue
+		}
+
 		reasons := appendReasons(baseReasons,
-			fmt.Sprintf("Dynamic wave selected issue #%d", issue.Number),
-			fmt.Sprintf("Issue #%d is eligible but no worker slot is available", issue.Number),
+			fmt.Sprintf("Dynamic wave selected issue #%d by priority and issue number", issue.Number),
+			outcomeIssueReason(outcomeStatus, issue),
+			"Starting a worker would mutate local worktrees, so supervisor only records the recommendation",
 		)
-		decision := e.decision(st, now, projectState, ActionWaitForCapacity,
-			fmt.Sprintf("Issue #%d is eligible, but all worker slots are occupied.", issue.Number),
-			RiskSafe, 0.86, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
+		if preflight, ok := e.evaluatePreflight(false, true); !ok {
+			stuckStates = append(stuckStates, preflightFailedStuckState(preflight, "spawn_worker"))
+			blockedReasons := appendReasons(reasons,
+				"Preflight gate failed; refusing to recommend a worker spawn",
+				"Preflight: "+preflight.Reason,
+			)
+			decision := e.decision(st, now, projectState, ActionPreflightFailed,
+				fmt.Sprintf("Preflight blocked worker spawn for issue #%d: %s", issue.Number, preflight.Reason),
+				RiskApprovalGated, 0.9, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, blockedReasons)
+			return withAnalysis(decision), nil
+		}
+		decision := e.decision(st, now, projectState, ActionSpawnWorker,
+			fmt.Sprintf("Start a worker for issue #%d: %s", issue.Number, issue.Title),
+			RiskMutating, 0.84, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
 		return withAnalysis(decision), nil
 	}
 
-	hasOpenPR, err := e.reader.HasOpenPRForIssue(issue.Number)
-	if err != nil {
-		return state.SupervisorDecision{}, fmt.Errorf("check open PR for issue #%d: %w", issue.Number, err)
-	}
-	if hasOpenPR {
+	if openPRBlocker != nil {
+		if deferredOpenPR != nil {
+			return withAnalysis(e.decisionMonitorOpenPR(st, now, projectState, baseReasons, stuckStates, *deferredOpenPR)), nil
+		}
 		reasons := appendReasons(baseReasons,
-			fmt.Sprintf("Dynamic wave selected issue #%d", issue.Number),
-			fmt.Sprintf("Issue #%d already has an open PR", issue.Number),
+			fmt.Sprintf("Dynamic wave selected issue #%d", openPRBlocker.Number),
+			fmt.Sprintf("Issue #%d already has an open PR", openPRBlocker.Number),
+			"No later dynamic-wave candidate was dispatchable without duplicating open-PR work",
 			"Supervisor mode should not dispatch duplicate work",
 		)
 		decision := e.decision(st, now, projectState, ActionMonitorOpenPR,
-			fmt.Sprintf("Issue #%d already has an open PR; monitor that PR instead of starting work.", issue.Number),
-			RiskSafe, 0.87, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
+			fmt.Sprintf("Issue #%d already has an open PR; monitor that PR instead of starting work.", openPRBlocker.Number),
+			RiskSafe, 0.87, &state.SupervisorTarget{Issue: openPRBlocker.Number}, PolicyRuleDynamicWave, reasons)
 		return withAnalysis(decision), nil
 	}
-
-	queueCandidate := e.dynamicQueueActionCandidate(st, issue, issues)
-	if queueCandidate != nil {
-		mutations := queueCandidate.plannedMutations(e.cfg)
-		reasons := appendReasons(baseReasons,
-			queueLabelReason(queueCandidate.readyLabel, ""),
-			fmt.Sprintf("Dynamic wave selected issue #%d by priority and issue number", issue.Number),
-			outcomeIssueReason(outcomeStatus, issue),
-		)
-		risk := RiskMutating
-		if len(mutations) > 0 {
-			risk = RiskSafe
-			reasons = appendReasons(reasons, "Supervisor policy allows the planned safe queue mutation")
-		}
-		decision := e.decision(st, now, projectState, ActionLabelIssueReady,
-			fmt.Sprintf("Prepare issue #%d for the dynamic wave by %s.", issue.Number, plannedMutationPhrase(queueCandidate.neededMutations())),
-			risk, 0.82, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
-		decision.Mutations = mutations
-		return withAnalysis(decision), nil
+	if deferredOpenPR != nil {
+		return withAnalysis(e.decisionMonitorOpenPR(st, now, projectState, baseReasons, stuckStates, *deferredOpenPR)), nil
 	}
-
-	if !matchesRequiredLabels(issue, e.requiredIssueLabels()) {
-		if decision, ok := e.noBacklogOutcomeDecision(st, now, projectState, baseReasons, prs, stuckStates); ok {
-			return withAnalysis(decision), nil
-		}
-		reasons := appendReasons(baseReasons,
-			fmt.Sprintf("Dynamic wave selected issue #%d", issue.Number),
-			"Selected issue is waiting for a ready label mutation to appear in GitHub issue data",
-		)
-		for _, reason := range firstN(result.skipped, 3) {
-			reasons = append(reasons, reason)
-		}
+	if deferredBudgetSess != nil {
 		decision := e.decision(st, now, projectState, ActionNone,
-			"No action is currently recommended while the selected issue waits for its ready label.", RiskSafe, 0.8, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
+			fmt.Sprintf("Issue #%d is stopped at its worker token budget and needs an operator budget decision.", deferredBudgetSess.IssueNumber),
+			RiskSafe, 0.99, &state.SupervisorTarget{Issue: deferredBudgetSess.IssueNumber, Session: deferredBudgetSlot}, PolicyRuleRuntimeState, baseReasons)
+		decision.StuckStates = stuckStates
 		return withAnalysis(decision), nil
 	}
-
-	// Race protection: refuse to recommend spawn for an issue that has
-	// already been closed since the issue listing snapshot was taken
-	// (post-merge close race). Cache hits are cheap because the broader
-	// supervisor cycle reuses the same resolutionCache.
-	if cache != nil && cache.isIssueClosed(issue.Number) {
-		reasons := appendReasons(baseReasons,
-			fmt.Sprintf("Dynamic wave selected issue #%d", issue.Number),
-			fmt.Sprintf("Issue #%d closed between listing and dispatch; refusing to spawn a duplicate worker", issue.Number),
-		)
-		decision := e.decision(st, now, projectState, ActionNone,
-			fmt.Sprintf("Issue #%d closed after listing; supervisor will re-evaluate on the next cycle.", issue.Number),
-			RiskSafe, 0.9, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
-		return withAnalysis(decision), nil
-	}
-	if e.sessionRecentlyDoneForIssue(st, issue.Number) {
-		reasons := appendReasons(baseReasons,
-			fmt.Sprintf("Dynamic wave selected issue #%d", issue.Number),
-			fmt.Sprintf("Issue #%d already has a Done/code-landed session in state; refusing to spawn another worker", issue.Number),
-		)
-		decision := e.decision(st, now, projectState, ActionNone,
-			fmt.Sprintf("Issue #%d already reached Done in state; supervisor refuses to dispatch a duplicate worker.", issue.Number),
-			RiskSafe, 0.9, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
-		return withAnalysis(decision), nil
-	}
-
-	reasons := appendReasons(baseReasons,
-		issueLabelReason(e.requiredIssueLabels()),
-		fmt.Sprintf("Dynamic wave selected issue #%d by priority and issue number", issue.Number),
-		outcomeIssueReason(outcomeStatus, issue),
-		"Starting a worker would mutate local worktrees, so supervisor only records the recommendation",
-	)
-	if preflight, ok := e.evaluatePreflight(false, true); !ok {
-		stuckStates = append(stuckStates, preflightFailedStuckState(preflight, "spawn_worker"))
-		blockedReasons := appendReasons(reasons,
-			"Preflight gate failed; refusing to recommend a worker spawn",
-			"Preflight: "+preflight.Reason,
-		)
-		decision := e.decision(st, now, projectState, ActionPreflightFailed,
-			fmt.Sprintf("Preflight blocked worker spawn for issue #%d: %s", issue.Number, preflight.Reason),
-			RiskApprovalGated, 0.9, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, blockedReasons)
-		return withAnalysis(decision), nil
-	}
-	decision := e.decision(st, now, projectState, ActionSpawnWorker,
-		fmt.Sprintf("Start a worker for issue #%d: %s", issue.Number, issue.Title),
-		RiskMutating, 0.84, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
+	decision := e.decision(st, now, projectState, ActionNone,
+		"No issue is currently eligible under the dynamic wave policy.", RiskSafe, 0.8, nil, PolicyRuleDynamicWave, baseReasons)
 	return withAnalysis(decision), nil
 }
 

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1834,9 +1834,9 @@ func TestDecide_PRExistsForSessionMonitorsPR(t *testing.T) {
 	if decision.Target == nil || decision.Target.PR != 12 || decision.Target.Session != "slot-1" {
 		t.Fatalf("target = %#v, want PR 12 for slot-1", decision.Target)
 	}
-	if reader.issueCalls != 0 {
-		t.Fatalf("ListOpenIssues called %d time(s), want 0 for PR-session decision", reader.issueCalls)
-	}
+	// Hands-off fill probes open issues when spare slots remain so a passive
+	// open PR cannot starve backlog; with an empty queue the decision stays
+	// monitor_open_pr (issueCalls may be >0).
 }
 
 func TestDecide_EligibleIssueRecommendsSpawn(t *testing.T) {


### PR DESCRIPTION
## Summary
- Supervisor no longer idles forever on `check_outcome_health` when actionable backlog exists (F8 / boom-bust empty-ready).
- Fleet-only settings `fleet.min_live_workers` / `fleet.max_live_workers` (defaults 5/10) with daemon cross-flow spawn ceiling.
- Idle stall now alerts on empty ready + 0 live workers (`queue_empty`), not only when ready issues wait undispatched.

## Test plan
- [x] supervisor F8 decision tests
- [x] fleet settings / spawn ceiling tests
- [x] idle stall empty-ready + queue_empty hold tests
- [ ] Deploy binary + confirm ntfy on idle
- [ ] Unattended with live workers ∈ [5,10]

Implements #1081

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps the supervisor active when useful backlog remains and adds fleet-wide worker limits. The main changes are:

- Defers passive PR monitoring and token-budget holds while spare capacity remains.
- Continues past blocked candidates to find dispatchable work.
- Skips safe deterministic decisions around the LLM backend.
- Reports empty queues with no live workers as idle stalls.
- Enforces fleet-wide worker limits with per-worker reservations.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

Worker starts use an atomic reservation for each worker. State-loading failures block new reservations instead of undercounting active workers. No blocking issues remain in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validation of the focused path completed; the Focused path 02-after log shows the exact command, working directory, exit code, and full verbose stdout/stderr, and the Focused path 02-after proof-note lists the six passing cases.
- Both focused package runs completed with verbose output and exit code 0, and the logs preserve the exact command, working directory, stdout/stderr, and exit code.

<a href="https://app.greptile.com/trex/runs/15454315/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/supervisor/supervisor.go | Keeps filling available worker slots before returning passive monitoring or outcome-health decisions. |
| internal/supervisor/llm.go | Skips LLM calls for deterministic decisions marked safe unless explicitly configured otherwise. |
| internal/orchestrator/dispatch_visibility.go | Creates an active queue-empty hold when no workers or eligible ready issues remain. |
| internal/state/dispatch_hold.go | Tracks consecutive idle cycles even when the ready queue is empty. |
| internal/orchestrator/emergency_stop_test.go | Adds coverage for blocking new workers when the fleet-wide limit is reached. |

<sub>Reviews (5): Last reviewed commit: ["fix: attach empty queue analysis on F8 o..."](https://github.com/befeast/maestro/commit/78e744b63c8b355f09a68c3a488242575cc1415e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46289461)</sub>

<!-- /greptile_comment -->