### PR TITLE
P0: delayed restart approval deletes canonical retained worktree after in-place recovery

### DIFF
--- a/internal/approver/executor_test.go
+++ b/internal/approver/executor_test.go
@@ -851,6 +851,66 @@ func TestExecute_RestartWorker_StaleTargetStateSkipped(t *testing.T) {
 	}
 }
 
+// #964: a replacement worker can return the session projection to the same
+// running status, branch, retry count, and next-retry state that existed when
+// restart_worker was approved. The durable attempt generation and start time
+// distinguish that replacement even if the OS reuses the same PID. A delayed
+// approval for the earlier attempt must be skipped before the retained-worktree
+// refusal or worker controller can run.
+func TestExecute_RestartWorker_StaleAfterRespawnDeathCycleSkipped(t *testing.T) {
+	wc := &fakeWorkers{}
+	target := &state.SupervisorTarget{Session: "slot-1", Issue: 42}
+	firstStarted := time.Date(2026, 7, 17, 23, 30, 0, 0, time.UTC)
+	sess := &state.Session{
+		IssueNumber:      42,
+		Status:           state.StatusRunning,
+		Worktree:         "/srv/wt/slot-1",
+		Branch:           "issue-42",
+		PID:              4242,
+		StartedAt:        firstStarted,
+		WorkerGeneration: 7,
+		RetryCount:       1,
+	}
+	st := state.NewState()
+	st.Sessions["slot-1"] = sess
+	a := mkApproval(config.SupervisorActionRestartWorker, target, "restart me", "")
+	a.TargetStateHash = st.ApprovalTargetStateHash(target)
+
+	// The approved attempt dies and is repaired in place. The replacement is
+	// running in the same slot/worktree/branch with the same retry projection;
+	// retain the PID too to prove process-ID reuse cannot defeat the fence.
+	finished := firstStarted.Add(10 * time.Minute)
+	sess.Status = state.StatusDead
+	sess.FinishedAt = &finished
+	sess.PID = 0
+	sess.Status = state.StatusRunning
+	sess.StartedAt = finished.Add(time.Minute)
+	sess.WorkerGeneration++
+	sess.FinishedAt = nil
+	sess.PID = 4242
+
+	if current := st.ApprovalTargetStateHash(target); current == a.TargetStateHash {
+		t.Fatal("target-state hash did not change across an intervening death and in-place respawn")
+	}
+	ex := &Executor{
+		Cfg:      newCfg(),
+		Workers:  wc,
+		Sessions: fakeSessions{"slot-1": sess},
+		State:    st,
+	}
+
+	res := ex.Execute(a)
+	if res.Status != state.ApprovalStatusExecutionSkipped {
+		t.Fatalf("status = %q, want execution_skipped; res=%+v", res.Status, res)
+	}
+	if len(wc.restartCalls) != 0 || len(wc.stopCalls) != 0 {
+		t.Fatalf("stale approval must not touch the replacement worker; restart=%+v stop=%+v", wc.restartCalls, wc.stopCalls)
+	}
+	if !strings.Contains(res.Summary, "changed after approval") || !strings.Contains(res.Summary, "no worker or worktree was touched") {
+		t.Fatalf("summary = %q, want stale-state and no-side-effect explanation", res.Summary)
+	}
+}
+
 // #964: a PR-less retained worktree is still canonical durable work. The
 // destructive restart controller must not run; repair resumes it in place.
 func TestExecute_RestartWorker_RefusedForRetainedWorktree(t *testing.T) {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -4145,14 +4145,16 @@ func (s *State) ApprovalTargetStateHash(target *SupervisorTarget) string {
 			continue
 		}
 		snapshot.Sessions = append(snapshot.Sessions, approvalSessionSnapshot{
-			Slot:        name,
-			IssueNumber: sess.IssueNumber,
-			Status:      sess.Status,
-			Branch:      sess.Branch,
-			PRNumber:    sess.PRNumber,
-			FinishedAt:  sess.FinishedAt,
-			RetryCount:  sess.RetryCount,
-			NextRetryAt: sess.NextRetryAt,
+			Slot:             name,
+			IssueNumber:      sess.IssueNumber,
+			Status:           sess.Status,
+			Branch:           sess.Branch,
+			PRNumber:         sess.PRNumber,
+			StartedAt:        sess.StartedAt,
+			WorkerGeneration: sess.WorkerGeneration,
+			FinishedAt:       sess.FinishedAt,
+			RetryCount:       sess.RetryCount,
+			NextRetryAt:      sess.NextRetryAt,
 		})
 	}
 	return stableHash(snapshot)
@@ -4223,9 +4225,15 @@ type approvalSessionSnapshot struct {
 	Status      SessionStatus `json:"status"`
 	Branch      string        `json:"branch,omitempty"`
 	PRNumber    int           `json:"pr_number,omitempty"`
-	FinishedAt  *time.Time    `json:"finished_at,omitempty"`
-	RetryCount  int           `json:"retry_count,omitempty"`
-	NextRetryAt *time.Time    `json:"next_retry_at,omitempty"`
+	// StartedAt and WorkerGeneration identify the exact worker attempt. An
+	// in-place respawn can return every other projected field to its prior value
+	// while replacing the process an earlier worker-control approval addressed
+	// (#964). StartedAt also fences legacy sessions whose generation is zero.
+	StartedAt        time.Time  `json:"started_at"`
+	WorkerGeneration uint64     `json:"worker_generation,omitempty"`
+	FinishedAt       *time.Time `json:"finished_at,omitempty"`
+	RetryCount       int        `json:"retry_count,omitempty"`
+	NextRetryAt      *time.Time `json:"next_retry_at,omitempty"`
 }
 
 func approvalID(decision SupervisorDecision, createdAt time.Time) string {

--- a/internal/supervisor/restart_worker_test.go
+++ b/internal/supervisor/restart_worker_test.go
@@ -1,8 +1,13 @@
 package supervisor
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/state"
 )
 
@@ -25,4 +30,69 @@ func TestClearWorktreeAfterRestart(t *testing.T) {
 	}
 	// Nil-safe.
 	clearWorktreeAfterRestart(nil)
+}
+
+// #964: the restart controller is the destructive boundary — worker.Stop runs
+// `git worktree remove --force`. Enforce "restart_worker must never delete a
+// retained canonical worktree" here, independent of the approver executor gate:
+// a session that still retains a worktree (PR-less durable work included) is
+// refused before any process teardown or directory removal, and the worktree
+// on disk is left intact for spawn_repair_worker to recover in place.
+func TestNewWorkerController_RestartRefusesRetainedWorktree(t *testing.T) {
+	// Use a real registered git worktree with uncommitted content. Without the
+	// guard, worker.Stop's `git worktree remove --force` would delete it.
+	repo := t.TempDir()
+	runRestartWorkerGit(t, repo, "init", "-q")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("fixture\n"), 0o644); err != nil {
+		t.Fatalf("write repository fixture: %v", err)
+	}
+	runRestartWorkerGit(t, repo, "add", "README.md")
+	runRestartWorkerGit(t, repo, "-c", "user.name=Maestro Test", "-c", "user.email=maestro@example.invalid", "commit", "-qm", "fixture")
+	wt := filepath.Join(t.TempDir(), "slot-1")
+	runRestartWorkerGit(t, repo, "worktree", "add", "-q", "-b", "issue-42", wt)
+	dirtyPath := filepath.Join(wt, "uncommitted.txt")
+	wantDirty := "canonical retained work\n"
+	if err := os.WriteFile(dirtyPath, []byte(wantDirty), 0o644); err != nil {
+		t.Fatalf("write dirty worktree fixture: %v", err)
+	}
+	sess := &state.Session{
+		IssueNumber: 42,
+		Status:      state.StatusDead,
+		Worktree:    wt,
+		NextRetryAt: nil,
+	}
+	wc := NewWorkerController(&config.Config{LocalPath: repo})
+
+	err := wc.Restart("test-retained-restart", sess)
+	if err == nil {
+		t.Fatalf("Restart returned nil, want refusal for retained worktree %q", wt)
+	}
+	if !strings.Contains(err.Error(), wt) || !strings.Contains(err.Error(), "spawn_repair_worker") {
+		t.Fatalf("err = %v, want it to name the retained worktree and the in-place repair path", err)
+	}
+	// No destructive side effects: the directory survives and the session is
+	// left untouched so recovery can resume in place.
+	if _, statErr := os.Stat(wt); statErr != nil {
+		t.Fatalf("retained worktree %q was removed by a refused restart: %v", wt, statErr)
+	}
+	if got, readErr := os.ReadFile(dirtyPath); readErr != nil || string(got) != wantDirty {
+		t.Fatalf("dirty retained work changed: got %q, err=%v; want %q", got, readErr, wantDirty)
+	}
+	if sess.Worktree != wt {
+		t.Fatalf("sess.Worktree = %q, want it preserved as %q", sess.Worktree, wt)
+	}
+	if sess.Status != state.StatusDead {
+		t.Fatalf("sess.Status = %q, want unchanged StatusDead", sess.Status)
+	}
+	if sess.NextRetryAt != nil {
+		t.Fatalf("sess.NextRetryAt = %v, want unchanged (nil) — refused restart must not queue a respawn", sess.NextRetryAt)
+	}
+}
+
+func runRestartWorkerGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmdArgs := append([]string{"-C", dir}, args...)
+	if out, err := exec.Command("git", cmdArgs...).CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -4621,6 +4621,9 @@ func commandBinary(cmd, fallback string) string {
 //     dispatcher cycle. worker.Stop removed the worktree, so the stale
 //     worktree/PR pointers are cleared (#874) — otherwise respawnDueRetries
 //     would choose RespawnInPlace against a directory that no longer exists.
+//     A session that still retains a worktree is refused here at the
+//     destructive boundary (#964): restart never deletes retained canonical
+//     work, so recovery for such a slot must go through spawn_repair_worker.
 func NewWorkerController(cfg *config.Config) approver.WorkerControllerFuncs {
 	return approver.WorkerControllerFuncs{
 		Stop: func(slot string, sess *state.Session) error {
@@ -4640,6 +4643,23 @@ func NewWorkerController(cfg *config.Config) approver.WorkerControllerFuncs {
 			return nil
 		},
 		Restart: func(slot string, sess *state.Session) error {
+			// #964: restart is destructive — worker.Stop below runs
+			// `git worktree remove --force` on sess.Worktree before the
+			// orchestrator respawns the slot. The approver executor already
+			// fences restart_worker away from any session that retains a
+			// worktree (open PR or PR-less durable work) and routes recovery to
+			// spawn_repair_worker in place. Enforce the same invariant here at
+			// the destructive boundary itself so the guarantee does not depend
+			// on a single upstream gate: a future control path, a reconcile that
+			// reaches the controller directly, or a regression that drops the
+			// executor fence must not silently delete a retained canonical
+			// worktree. Fail closed instead of removing it.
+			if sess != nil && strings.TrimSpace(sess.Worktree) != "" {
+				return fmt.Errorf(
+					"restart_worker refused: slot %s retains worktree %s; destructive restart would discard it — use spawn_repair_worker to recover the same slot in place",
+					slot, sess.Worktree,
+				)
+			}
 			if err := worker.Stop(cfg, slot, sess); err != nil {
 				return err
 			}


### PR DESCRIPTION
Refs #964

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR protects retained worktrees during delayed restart approvals. The main changes are:

- Adds worker start time and generation to approval state hashes.
- Rejects destructive restarts for sessions with retained worktrees.
- Adds tests for stale approvals, respawn cycles, and retained worktree preservation.

<h3>Confidence Score: 4/5</h3>

Pending approvals created before an upgrade can still be skipped after the hash format changes.

Stored approval hashes are not recomputed when loaded, and the new snapshot fields produce a different digest for an otherwise unchanged session.

internal/state/state.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the general-contract-validation-proof by confirming that before the change, the respawn death-cycle hash remained unchanged and the real controller would accept a destructive restart for the retained worktree, and after the change, the exit code was 0 with the stale approval skipped and the retained-worktree checks passing.
- Verified that the stale approval was skipped without triggering any worker or worktree calls and that both retained-worktree executor checks passed.
- Confirmed that the real dirty registered worktree remained intact with unchanged session state after the change.
- Captured and documented the reproduction script that records exact commands, working directory, source revision, and command exit codes.

<a href="https://app.greptile.com/trex/runs/15404055/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/state/state.go | Adds worker-attempt fields to approval hashes, changing the persisted hash format without upgrade compatibility. |
| internal/supervisor/supervisor.go | Prevents restart from deleting a retained worktree before the destructive stop operation. |
| internal/approver/executor_test.go | Covers stale delayed approvals after an in-place worker respawn. |
| internal/supervisor/restart_worker_test.go | Verifies that refused restarts preserve retained worktrees and session state. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-1100-9..."](https://github.com/befeast/maestro/commit/23b1b51ae320de477a50986ea99f1fbffcaaa4f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46290243)</sub>

<!-- /greptile_comment -->