### PR TITLE
P0: closed-unmerged duplicate creates false done state and strands canonical PR repair

### DIFF
--- a/internal/orchestrator/closed_unmerged_reconcile_test.go
+++ b/internal/orchestrator/closed_unmerged_reconcile_test.go
@@ -50,6 +50,140 @@ func TestReconcileFalseDoneSessionAdoptsSoleOpenCanonicalPR(t *testing.T) {
 	}
 }
 
+func TestReconcileClosedUnmergedPRGateRoutesAwaitingRepairToCanonicalPR(t *testing.T) {
+	cfg := cfgWithBackends("codex", "codex")
+	issues := []github.Issue{makeIssue(345, "repair canonical PR", "maestro-ready")}
+	o, freshStarts, _ := newStartWorkersOrchestrator(cfg, issues)
+	o.isPRMergedFn = func(pr int) (bool, error) {
+		if pr != 389 {
+			t.Fatalf("merge check PR = %d, want closed duplicate #389", pr)
+		}
+		return false, nil
+	}
+	o.isIssueClosedFn = func(issue int) (bool, error) {
+		if issue != 345 {
+			t.Fatalf("issue close check = %d, want 345", issue)
+		}
+		return false, nil
+	}
+	o.hasOpenPRForIssueFn = func(issue int) (bool, error) { return issue == 345, nil }
+	authorizeCurrentFailedRepairGate(o, 388)
+
+	respawns := 0
+	o.respawnInPlaceFn = func(_ *config.Config, slot string, sess *state.Session, _ string, issue github.Issue, _, _ string) error {
+		respawns++
+		if slot != "ok-player-273" || issue.Number != 345 {
+			t.Fatalf("repair target = slot %q issue #%d, want ok-player-273 / #345", slot, issue.Number)
+		}
+		if sess.PRNumber != 388 || sess.Branch != "feat/ok-player-345-flatpak-beta-retry" {
+			t.Fatalf("repair resumed stale identity: %+v", sess)
+		}
+		sess.Status = state.StatusRunning
+		return nil
+	}
+
+	now := time.Date(2026, 7, 17, 19, 21, 0, 0, time.UTC)
+	s := state.NewState()
+	s.Sessions["ok-player-273"] = &state.Session{
+		IssueNumber: 345,
+		IssueTitle:  "repair canonical PR",
+		Status:      state.StatusPROpen,
+		PRNumber:    389,
+		Branch:      "feat/duplicate-389",
+		Worktree:    "/work/ok-player-273",
+		Backend:     "codex",
+	}
+	repair := repairApproval("repair-345", 345, 388, state.ApprovalStatusAwaitingDispatch, now)
+	repair.Target.Session = "ok-player-273"
+	s.Approvals = []state.Approval{repair}
+	canonical := github.PR{
+		Number:      388,
+		HeadRefName: "feat/ok-player-345-flatpak-beta-retry",
+		Title:       "Linux packaging for #345",
+	}
+
+	o.reconcileTerminalSessionsWithOpenPRs(s, []github.PR{canonical})
+
+	sess := s.Sessions["ok-player-273"]
+	if sess.Status != state.StatusPROpen || sess.PRNumber != 388 || sess.Branch != canonical.HeadRefName {
+		t.Fatalf("canonical PR was not adopted atomically: %+v", sess)
+	}
+	if sess.LastClosedPRNumber != 389 || sess.ReleasedForRedispatch {
+		t.Fatalf("closed duplicate settlement = %+v, want retained audit and active canonical lease", sess)
+	}
+	if got := approvalStatus(t, s, "repair-345"); got != state.ApprovalStatusAwaitingDispatch {
+		t.Fatalf("repair approval = %q, want awaiting_dispatch before canonical repair", got)
+	}
+
+	o.startNewWorkers(s, 1)
+
+	if respawns != 1 || len(*freshStarts) != 0 || len(s.Sessions) != 1 {
+		t.Fatalf("canonical repair did not stay in place: respawns=%d fresh=%v sessions=%v", respawns, *freshStarts, s.Sessions)
+	}
+	if got := approvalStatus(t, s, "repair-345"); got != state.ApprovalStatusSuperseded {
+		t.Fatalf("repair approval = %q, want consumed/superseded", got)
+	}
+}
+
+func TestReconcileFalseDoneCanonicalRecoverySurvivesRestart(t *testing.T) {
+	stateDir := t.TempDir()
+	finished := time.Date(2026, 7, 17, 17, 13, 56, 0, time.UTC)
+	now := time.Date(2026, 7, 17, 19, 22, 0, 0, time.UTC)
+	s := state.NewState()
+	s.Sessions["ok-player-273"] = &state.Session{
+		IssueNumber: 345,
+		Status:      state.StatusDone,
+		PRNumber:    389,
+		Branch:      "feat/duplicate-389",
+		FinishedAt:  &finished,
+	}
+	repair := repairApproval("repair-345", 345, 388, state.ApprovalStatusAwaitingDispatch, now)
+	repair.Target.Session = "ok-player-273"
+	s.Approvals = []state.Approval{repair}
+	if err := state.Save(stateDir, s); err != nil {
+		t.Fatalf("save false-done state: %v", err)
+	}
+
+	restarted, err := state.Load(stateDir)
+	if err != nil {
+		t.Fatalf("load false-done state after restart: %v", err)
+	}
+	o := &Orchestrator{
+		isPRMergedFn:          func(int) (bool, error) { return false, nil },
+		isIssueClosedFn:       func(int) (bool, error) { return false, nil },
+		hasMergedPRForIssueFn: func(int) (bool, error) { return false, nil },
+	}
+	canonical := []github.PR{{
+		Number:      388,
+		HeadRefName: "feat/ok-player-345-flatpak-beta-retry",
+		Title:       "Linux packaging for #345",
+	}}
+	o.reconcileTerminalSessionsWithOpenPRs(restarted, canonical)
+	o.reconcileResolvedRepairApprovals(restarted)
+	if err := state.Save(stateDir, restarted); err != nil {
+		t.Fatalf("save reconciled state: %v", err)
+	}
+
+	reloaded, err := state.Load(stateDir)
+	if err != nil {
+		t.Fatalf("reload reconciled state: %v", err)
+	}
+	o.reconcileTerminalSessionsWithOpenPRs(reloaded, canonical)
+	o.reconcileResolvedRepairApprovals(reloaded)
+
+	sess := reloaded.Sessions["ok-player-273"]
+	if sess.Status != state.StatusPROpen || sess.PRNumber != 388 || sess.Branch != canonical[0].HeadRefName || sess.FinishedAt != nil {
+		t.Fatalf("restart-safe canonical recovery = %+v, want active PR #388", sess)
+	}
+	if got := approvalStatus(t, reloaded, "repair-345"); got != state.ApprovalStatusAwaitingDispatch {
+		t.Fatalf("restart-safe approval = %q, want awaiting_dispatch", got)
+	}
+	approval, _ := reloaded.FindApproval("repair-345")
+	if len(approval.Audit) != 1 {
+		t.Fatalf("idempotent restart reconciliation appended audit entries: %+v", approval.Audit)
+	}
+}
+
 func TestReconcileFalseDoneSessionRefusesAmbiguousOpenPRs(t *testing.T) {
 	s := state.NewState()
 	s.Sessions["slot"] = &state.Session{IssueNumber: 345, Status: state.StatusDone, PRNumber: 389}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -5280,8 +5280,7 @@ func (o *Orchestrator) reconcileTerminalSessionsWithOpenPRs(s *state.State, prs 
 			continue
 		}
 		canonical := matches[0]
-		var allSlots, exactSlots []string
-		activeOther := ""
+		var allSlots, exactSlots, activeSlots []string
 		for _, slotName := range sortedStateSessionNames(s) {
 			sess := s.Sessions[slotName]
 			if sess == nil || sess.IssueNumber != issue {
@@ -5289,24 +5288,57 @@ func (o *Orchestrator) reconcileTerminalSessionsWithOpenPRs(s *state.State, prs 
 			}
 			allSlots = append(allSlots, slotName)
 			if repairIssueSessionActive(sess.Status) || (sess.PRNumber == canonical.Number && sess.Status == state.StatusRetryExhausted) {
-				activeOther = slotName
+				activeSlots = append(activeSlots, slotName)
 			}
 			if terminalOpenPRAdoptionCandidate(sess) &&
 				(sess.PRNumber == canonical.Number || sess.LastClosedPRNumber == canonical.Number || sess.Branch == canonical.HeadRefName) {
 				exactSlots = append(exactSlots, slotName)
 			}
 		}
-		if activeOther != "" {
+		if len(activeSlots) > 1 {
+			log.Printf("[orch] terminal/open-PR reconcile held for issue #%d / PR #%d: %d active sessions claim the issue", issue, canonical.Number, len(activeSlots))
+			continue
+		}
+		if len(activeSlots) == 1 {
 			// Never activate a second session while another issue-level lease is
 			// live, even if the open PR points at an older canonical branch. The
 			// active canonical session still needs a durable handoff from terminal
 			// sibling branches, however: otherwise work preserved by a duplicate
 			// worker remains invisible once the canonical PR is reattached.
-			active := s.Sessions[activeOther]
+			activeSlot := activeSlots[0]
+			active := s.Sessions[activeSlot]
 			if active != nil && (active.PRNumber == canonical.Number || active.Branch == canonical.HeadRefName) {
-				o.attachPreservedSiblingHandoffs(s, issue, activeOther, active, canonical, allSlots)
+				o.attachPreservedSiblingHandoffs(s, issue, activeSlot, active, canonical, allSlots)
+				continue
 			}
-			continue
+			// A disappearing duplicate can still be recorded as pr_open/queued
+			// during this first reconciliation pass. Do not defer canonical
+			// adoption to the next cycle: an awaiting repair approval for the sole
+			// open canonical PR runs later in this same cycle and would otherwise
+			// see the stale duplicate PR identity and be rejected. Verify the exact
+			// recorded PR did not merge and the issue remains open, release that
+			// stale gate truthfully, then fall through to the normal deterministic
+			// canonical-session selection below.
+			if !staleOpenPRGateAdoptionCandidate(active, canonical) {
+				continue
+			}
+			merged, err := o.isPRMerged(active.PRNumber)
+			if err != nil {
+				log.Printf("[orch] terminal/open-PR reconcile held for issue #%d / session %s: stale PR #%d merge state unavailable: %v", issue, activeSlot, active.PRNumber, err)
+				continue
+			}
+			if merged {
+				continue
+			}
+			closed, err := o.isIssueClosed(issue)
+			if err != nil {
+				log.Printf("[orch] terminal/open-PR reconcile held for issue #%d / session %s: authoritative issue state unavailable: %v", issue, activeSlot, err)
+				continue
+			}
+			if closed {
+				continue
+			}
+			o.releaseClosedUnmergedSession(active, activeSlot)
 		}
 
 		candidateSlot := ""
@@ -5392,13 +5424,27 @@ func terminalOpenPRAdoptionCandidate(sess *state.Session) bool {
 		return false
 	}
 	switch sess.Status {
-	case state.StatusDone, state.StatusFailed:
+	case state.StatusDone, state.StatusFailed, state.StatusRetryExhausted:
 		return true
 	case state.StatusDead:
 		return sess.NextRetryAt == nil
 	default:
 		return false
 	}
+}
+
+// staleOpenPRGateAdoptionCandidate reports whether a non-running PR gate may be
+// settled and rebound to the sole open canonical PR in the same reconciliation
+// pass. Running/code_landed sessions are deliberately excluded: only GitHub's
+// authoritative terminal reconciliation may move those active lifecycles.
+func staleOpenPRGateAdoptionCandidate(sess *state.Session, canonical github.PR) bool {
+	if sess == nil || sess.PRNumber <= 0 {
+		return false
+	}
+	if sess.Status != state.StatusPROpen && sess.Status != state.StatusQueued {
+		return false
+	}
+	return sess.PRNumber != canonical.Number && sess.Branch != canonical.HeadRefName
 }
 
 func (o *Orchestrator) attachPreservedSiblingHandoffs(s *state.State, issue int, canonicalSlot string, canonicalSession *state.Session, canonical github.PR, allSlots []string) {


### PR DESCRIPTION
Refs #949

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR repairs sessions stranded by a closed, unmerged duplicate PR. The main changes are:

- Tracks all active sessions for each issue during reconciliation.
- Releases stale PR gates and adopts the sole open canonical PR in the same cycle.
- Allows retry-exhausted sessions to adopt a canonical PR.
- Adds same-cycle repair and restart-persistence tests.

<h3>Confidence Score: 4/5</h3>

The stale-gate release path needs to distinguish a closed PR from a live unmerged PR before merging.

A still-open PR can satisfy the new `merged == false` gate. The resulting release clears a live session's PR identity and rebinds its slot.

internal/orchestrator/orchestrator.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the regression by running a focused Go regression test for reconcileTerminalSessionsWithOpenPRs with an explicit OPEN duplicate fixture (PR #389) and the open canonical PR #388.
- Inspected the test call trace and confirmed two merge checks and two issue-closed checks, with no validation for closing the duplicate PR #389.
- Observed that the reconciliation changed the live session identity from PR #389 to PR #388 and recorded the still-open PR #389 as LastClosedPRNumber, causing the regression assertion to fail.
- Collected artifacts documenting the reproduction and its failure mode for reviewer inspection.
- The verbose Go test output shows three passing tests, package PASS, and test exit code 0.

<a href="https://app.greptile.com/trex/runs/15403229/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds stale-gate release and canonical PR adoption, but does not confirm that the stale PR is closed before releasing its session. |
| internal/orchestrator/closed_unmerged_reconcile_test.go | Adds tests for same-cycle canonical repair and restart-safe reconciliation. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:5326-5341
**Unmerged PR Treated As Closed**

When the recorded duplicate PR is still open but unmerged, `isPRMerged` returns false and the open issue passes the next check. This path then marks the live session failed, clears its PR identity, and rebinds the slot to another PR without first confirming that the recorded PR is closed.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["orchestrator: adopt canonical PR before ..."](https://github.com/befeast/maestro/commit/18bdaf1d69a8194e58b05f849bced49b27fa8507) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46290407)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->