### PR TITLE
bug: awaiting repair dispatch races normal selection and spawns duplicate worker for one issue

### DIFF
--- a/internal/orchestrator/fresh_dispatch_claim_test.go
+++ b/internal/orchestrator/fresh_dispatch_claim_test.go
@@ -12,6 +12,143 @@ import (
 	"github.com/befeast/maestro/internal/worker"
 )
 
+func TestFreshDispatchClaim_RepairApprovalCannotRevokeInFlightStartup(t *testing.T) {
+	dir := t.TempDir()
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.StateDir = dir
+	cfg.WorktreeBase = filepath.Join(dir, "worktrees")
+	cfg.SessionPrefix = "txc"
+	issue := makeIssue(1, "single canonical worker", "maestro-ready")
+
+	seed := state.NewState()
+	seed.NextSlot = 2
+	seed.Sessions["txc-1"] = &state.Session{
+		IssueNumber: 1,
+		IssueTitle:  issue.Title,
+		Status:      state.StatusDead,
+		Backend:     "claude",
+	}
+	if err := state.Save(dir, seed); err != nil {
+		t.Fatal(err)
+	}
+
+	first, _, _ := newStartWorkersOrchestrator(cfg, []github.Issue{issue})
+	second, _, _ := newStartWorkersOrchestrator(cfg, []github.Issue{issue})
+	first.workerStartFn = nil
+	second.workerStartFn = nil
+
+	claimed := make(chan struct{})
+	release := make(chan struct{})
+	var starts atomic.Int32
+	first.workerStartClaimedFn = func(_ *config.Config, s *state.State, _ string, got github.Issue, _ string, backend, slot string) (string, error) {
+		starts.Add(1)
+		close(claimed)
+		<-release
+		startedAt := time.Now().UTC()
+		s.Sessions[slot] = &state.Session{
+			IssueNumber: got.Number,
+			IssueTitle:  got.Title,
+			Worktree:    filepath.Join(cfg.WorktreeBase, slot),
+			Branch:      worker.BranchName(slot, got),
+			PID:         4242,
+			TmuxSession: worker.TmuxSessionName(slot),
+			StartedAt:   startedAt,
+			Status:      state.StatusRunning,
+			Backend:     backend,
+		}
+		// Production StartReserved persists the launched session before it
+		// returns to the orchestrator's claim-completion step.
+		if err := state.Save(dir, s); err != nil {
+			return "", err
+		}
+		return slot, nil
+	}
+	second.workerStartClaimedFn = func(_ *config.Config, _ *state.State, _ string, _ github.Issue, _ string, _ string, _ string) (string, error) {
+		starts.Add(1)
+		return "", nil
+	}
+
+	firstState, err := state.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		first.startNewWorkers(firstState, 1)
+	}()
+	<-claimed
+
+	approvedAt := time.Now().UTC()
+	if err := state.Update(dir, func(latest *state.State) error {
+		approval := repairApproval("repair-1", 1, 0, state.ApprovalStatusAwaitingDispatch, approvedAt)
+		approval.Target.Session = "txc-1"
+		latest.Approvals = append(latest.Approvals, approval)
+		return nil
+	}); err != nil {
+		t.Fatalf("persist competing repair approval: %v", err)
+	}
+
+	secondState, err := state.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var repairs atomic.Int32
+	second.respawnWorkerFn = func(_ *config.Config, _ string, _ *state.Session, _ string, _ github.Issue, _ string, _ string) error {
+		repairs.Add(1)
+		return nil
+	}
+	second.startNewWorkers(secondState, 1)
+	if err := state.Save(dir, secondState); err != nil {
+		t.Fatalf("persist competing poll: %v", err)
+	}
+	if got := repairs.Load(); got != 0 {
+		t.Fatalf("repair started while fresh startup held the durable claim: got %d", got)
+	}
+	if got := approvalStatus(t, secondState, "repair-1"); got != state.ApprovalStatusStale {
+		t.Fatalf("competing repair approval = %q, want stale", got)
+	}
+	claim, active := secondState.FreshDispatchClaimFor(1)
+	if !active || claim.Slot != "txc-2" {
+		t.Fatalf("fresh claim after competing poll = %+v active=%t, want txc-2 retained", claim, active)
+	}
+
+	close(release)
+	<-firstDone
+
+	reloaded, err := state.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("fresh starts = %d, want one canonical startup", got)
+	}
+	if got := repairs.Load(); got != 0 {
+		t.Fatalf("repair starts = %d, want none after fresh reservation won", got)
+	}
+	if reloaded.Sessions["txc-2"] == nil || reloaded.Sessions["txc-2"].Status != state.StatusRunning {
+		t.Fatalf("canonical fresh session = %+v", reloaded.Sessions["txc-2"])
+	}
+	if reloaded.Sessions["txc-1"] == nil || reloaded.Sessions["txc-1"].Status != state.StatusDead {
+		t.Fatalf("original repair target changed = %+v", reloaded.Sessions["txc-1"])
+	}
+	if reloaded.NextSlot != 3 {
+		t.Fatalf("next_slot = %d, want 3 (no duplicate allocation)", reloaded.NextSlot)
+	}
+	evidence := reloaded.FreshDispatchClaims[1]
+	if evidence == nil || evidence.Status != state.FreshDispatchClaimStatusCompleted || evidence.Slot != "txc-2" {
+		t.Fatalf("completed fresh claim = %+v", evidence)
+	}
+
+	second.startNewWorkers(reloaded, 1)
+	if got := starts.Load(); got != 1 {
+		t.Fatalf("reload/retry started another worker: starts=%d", got)
+	}
+	if got := repairs.Load(); got != 0 {
+		t.Fatalf("reload/retry dispatched stale repair: repairs=%d", got)
+	}
+}
+
 func TestFreshDispatchClaim_PreventsConcurrentDuplicateBeforeSessionRegistration(t *testing.T) {
 	dir := t.TempDir()
 	cfg := cfgWithBackends("claude", "claude")

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -9188,7 +9188,12 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			if !repairSpawn {
 				continue
 			}
-		} else if freshDispatchPending && s.IssueHasNonFreshClaim(issue.Number) {
+		} else if freshDispatchPending && s.IssueHasNonFreshClaim(issue.Number) && !repairSpawn {
+			// A selected repair must reach dispatchSpawnRepairWorker so its
+			// exact-session revalidation can see the earlier fresh claim and
+			// terminalize the competing repair authority. Skipping here would
+			// leave both claims active, while revoking the startup lease would
+			// reopen the duplicate-worker race.
 			log.Printf("[orch] refusing fresh dispatch renewal for issue #%d: a canonical session/PR claim appeared", issue.Number)
 			continue
 		}

--- a/internal/state/issue_claim.go
+++ b/internal/state/issue_claim.go
@@ -277,10 +277,16 @@ func (s *State) CompleteFreshDispatch(issueNumber int, leaseID string, sess *Ses
 }
 
 // ReconcileFreshDispatchClaims makes a pre-spawn lease terminal when its exact
-// Session was persisted by a later compatible save, or when a different
-// canonical session/PR claim appeared. This is the crash-after-launch repair:
-// it preserves the worker identity already present and prevents an old startup
-// lease from blocking the issue forever.
+// Session was persisted by a later compatible save. This is the
+// crash-after-launch repair: it preserves the worker identity already present
+// and prevents an old startup lease from blocking the issue forever.
+//
+// A different session or repair approval must not supersede an active startup
+// lease here. The fresh claim was committed atomically before worker setup; a
+// later claim can race in while setup is still outside state.json. Revoking the
+// lease would let repair dispatch start a second worker before the first one
+// registers. Keep both claims visible so the dispatcher can refuse/reconcile
+// the later authority without deleting either worktree.
 func (s *State) ReconcileFreshDispatchClaims(now time.Time) int {
 	if s == nil || len(s.FreshDispatchClaims) == 0 {
 		return 0
@@ -300,15 +306,6 @@ func (s *State) ReconcileFreshDispatchClaims(now time.Time) int {
 			claim.SessionStartedAt = sess.StartedAt.UTC()
 			claim.LeaseExpiresAt = time.Time{}
 			claim.TerminalReason = "session_persisted"
-			changed++
-			continue
-		}
-		if s.IssueHasNonFreshClaim(issue) {
-			claim.Status = FreshDispatchClaimStatusSuperseded
-			claim.CompletedAt = now
-			claim.UpdatedAt = now
-			claim.LeaseExpiresAt = time.Time{}
-			claim.TerminalReason = "canonical_claim_appeared"
 			changed++
 		}
 	}


### PR DESCRIPTION
Refs #892

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents repair dispatch from racing an in-flight worker startup. The main changes are:

- Preserve active fresh-dispatch leases when later claims appear.
- Route selected repairs through exact-session revalidation.
- Cover concurrent startup, persistence, and retry behavior.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the test command timeout 120s go test ./internal/orchestrator -run '^TestFreshDispatchClaim\_' -count=1 -v and observed the command exited with code 0, with both tests reported as passing.
- Reviewed runtime logs showing the repair dispatch refused as stale and the duplicate fresh dispatch skipped due to the canonical startup lease.

<a href="https://app.greptile.com/trex/runs/15407357/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Routes a selected repair past the early claim guard so exact-session revalidation can reject competing authority. |
| internal/state/issue_claim.go | Keeps an active startup lease until its matching session is persisted instead of superseding it when another claim appears. |
| internal/orchestrator/fresh_dispatch_claim_test.go | Adds coverage for concurrent repair approval, startup persistence, duplicate prevention, and reload behavior. |

<sub>Reviews (4): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-1103-8..."](https://github.com/befeast/maestro/commit/a2a0c3cf5078a270645800843720cdd3d50fabf1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46290825)</sub>

<!-- /greptile_comment -->