### PR TITLE
orchestrator: no-PR retry_exhausted labels 'blocked' per-slot, ignoring live/merged PR from another slot

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4923,22 +4923,6 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		if !found {
 			if sess.Status == state.StatusRetryExhausted {
 				if sess.PRNumber == 0 {
-					// A no-PR terminal sibling is not an issue-level blocker when
-					// another open PR already owns the issue. In particular, it must
-					// not apply the blocked label behind the canonical PR's back.
-					// Preserve the sibling for commit handoff and let the canonical
-					// PR maintenance path converge in place.
-					canonicalOpen := false
-					for _, openPR := range prs {
-						if github.PRReferencesIssue(openPR, sess.IssueNumber) {
-							canonicalOpen = true
-							break
-						}
-					}
-					if canonicalOpen {
-						log.Printf("[orch] no-PR retry_exhausted session %s for issue #%d is superseded by an open canonical PR — preserving sibling work without blocking the issue", slotName, sess.IssueNumber)
-						continue
-					}
 					// #577: worker exhausted retries without ever producing a PR
 					// (e.g. the issue was already implemented by a prior merge via
 					// `Refs #N`, so the worker found zero diff). Without action the
@@ -4948,7 +4932,7 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 					// already closes it and auto-close is allowed) or label it
 					// blocked so the supervisor's dynamic-wave drops it and picks
 					// the next eligible candidate.
-					o.reconcileNoPRRetryExhausted(s, slotName, sess)
+					o.reconcileNoPRRetryExhausted(s, slotName, sess, prs)
 					continue
 				}
 				// #818: retry_exhausted session records a PR, but no open PR
@@ -5726,10 +5710,195 @@ func mergeFlowPRForSession(sess *state.Session, byBranch map[string]github.PR, b
 	return github.PR{}, false
 }
 
-// noPRReconciledStatus marks a retry_exhausted session whose worker never
-// produced a PR as having been reconciled by autoMergePRs. The marker keeps
-// the reconciliation idempotent so subsequent cycles do not re-label, re-close,
-// or re-notify, and so the "waiting for reconciliation" log stops firing.
+// prBelongsToIssue reports whether an already-fetched PR is part of the
+// issue's aggregate session state. The durable session identity is important:
+// worker PR bodies use non-closing references, and historical/manual PRs may
+// omit an issue reference entirely even though their owning session records the
+// exact issue, PR number, and branch.
+func prBelongsToIssue(s *state.State, issueNumber int, pr github.PR) bool {
+	if issueNumber <= 0 {
+		return false
+	}
+	if github.PRReferencesIssue(pr, issueNumber) {
+		return true
+	}
+	if s == nil {
+		return false
+	}
+	for _, sess := range s.Sessions {
+		if sess == nil || sess.IssueNumber != issueNumber {
+			continue
+		}
+		if pr.Number > 0 && (sess.PRNumber == pr.Number || sess.LastClosedPRNumber == pr.Number) {
+			return true
+		}
+		if branch := strings.TrimSpace(sess.Branch); branch != "" && branch == pr.HeadRefName {
+			return true
+		}
+	}
+	return false
+}
+
+func openPRForIssueState(s *state.State, issueNumber int, prs []github.PR) (github.PR, bool) {
+	for _, pr := range prs {
+		if prBelongsToIssue(s, issueNumber, pr) {
+			return pr, true
+		}
+	}
+	return github.PR{}, false
+}
+
+// mergedPRForIssueState checks the issue's aggregate durable identity before a
+// no-PR retry_exhausted slot is allowed to block it. It recognizes a merged PR
+// owned by any sibling session even when the PR used only `Refs #N` (or no
+// textual reference), then falls back to the legacy closing-keyword lookup for
+// historical work without a retained session.
+func (o *Orchestrator) mergedPRForIssueState(s *state.State, issueNumber int) (int, bool, error) {
+	if issueNumber <= 0 {
+		return 0, false, nil
+	}
+
+	seen := make(map[int]struct{})
+	var firstErr error
+	checkPR := func(prNumber int) (int, bool) {
+		if prNumber <= 0 {
+			return 0, false
+		}
+		if _, ok := seen[prNumber]; ok {
+			return 0, false
+		}
+		seen[prNumber] = struct{}{}
+		merged, err := o.isPRMerged(prNumber)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("check PR #%d: %w", prNumber, err)
+			}
+			return 0, false
+		}
+		if merged {
+			return prNumber, true
+		}
+		return 0, false
+	}
+
+	if s != nil {
+		for _, slotName := range sortedStateSessionNames(s) {
+			sess := s.Sessions[slotName]
+			if sess == nil || sess.IssueNumber != issueNumber {
+				continue
+			}
+			if prNumber, merged := checkPR(sess.PRNumber); merged {
+				return prNumber, true, nil
+			}
+			if prNumber, merged := checkPR(sess.LastClosedPRNumber); merged {
+				return prNumber, true, nil
+			}
+		}
+	}
+
+	// During a real cycle the shared closed-PR snapshot lets this path detect
+	// bare non-closing references without one subprocess per stale slot. Direct
+	// unit callers opt in by injecting listClosedPRsFn; otherwise preserve the
+	// legacy hasMergedPRForIssue test surface below.
+	if o.cycleActive || o.listClosedPRsFn != nil {
+		prs, err := o.listClosedPRsForCycle()
+		if err != nil {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("list closed PRs: %w", err)
+			}
+		} else {
+			for _, pr := range prs {
+				if pr.MergedAt != "" && prBelongsToIssue(s, issueNumber, pr) {
+					return pr.Number, true, nil
+				}
+			}
+		}
+	}
+
+	merged, err := o.hasMergedPRForIssue(issueNumber)
+	if err != nil {
+		if firstErr != nil {
+			return 0, false, fmt.Errorf("aggregate merged-PR state unavailable (%v; legacy lookup: %w)", firstErr, err)
+		}
+		return 0, false, err
+	}
+	if merged {
+		prNumber := 0
+		if o.mergedPRForIssueFn != nil || o.gh != nil {
+			if resolved, resolveErr := o.mergedPRForIssue(issueNumber); resolveErr == nil {
+				prNumber = resolved
+			}
+		}
+		return prNumber, true, nil
+	}
+	if firstErr != nil {
+		return 0, false, firstErr
+	}
+	return 0, false, nil
+}
+
+// settleNoPRRetryExhaustedSiblings retires every stale no-PR terminal slot for
+// an issue after authoritative issue-level state proves that blocking is moot.
+// It intentionally does not sync the project board: a stale slot must never
+// overwrite the live/closed issue's aggregate status. skipSlot remains the
+// canonical code_landed owner when delivery approval is required.
+func settleNoPRRetryExhaustedSiblings(s *state.State, issueNumber int, skipSlot string, issueClosed bool, now time.Time) int {
+	if s == nil || issueNumber <= 0 {
+		return 0
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	settled := 0
+	for _, slotName := range sortedStateSessionNames(s) {
+		if slotName == skipSlot {
+			continue
+		}
+		sess := s.Sessions[slotName]
+		if sess == nil || sess.IssueNumber != issueNumber || sess.Status != state.StatusRetryExhausted || sess.PRNumber != 0 {
+			continue
+		}
+		sess.Status = state.StatusDone
+		sess.LastNotifiedStatus = noPRReconciledStatus
+		sess.NextRetryAt = nil
+		sess.RetryHoldReason = ""
+		sess.RestartCheckpointAt = nil
+		sess.ReleasedForRedispatch = true
+		if sess.FinishedAt == nil {
+			sess.FinishedAt = &now
+		}
+		state.MarkWorkerEnded(sess, now)
+		if issueClosed {
+			sess.IssueClosedAt = &now
+			sess.LastTerminalReconcileAt = &now
+		}
+		settled++
+	}
+	return settled
+}
+
+func markNoPRRetryExhaustedReconciled(s *state.State, issueNumber int) int {
+	if s == nil || issueNumber <= 0 {
+		return 0
+	}
+	marked := 0
+	for _, sess := range s.Sessions {
+		if sess == nil || sess.IssueNumber != issueNumber || sess.Status != state.StatusRetryExhausted || sess.PRNumber != 0 {
+			continue
+		}
+		if sess.LastNotifiedStatus != noPRReconciledStatus {
+			sess.LastNotifiedStatus = noPRReconciledStatus
+			marked++
+		}
+	}
+	return marked
+}
+
+// noPRReconciledStatus marks no-PR retry_exhausted sessions for one issue after
+// their aggregate issue outcome has been reconciled by autoMergePRs. Marking
+// every stale sibling keeps later map iterations and subsequent cycles from
+// re-labelling, re-closing, re-syncing, or re-notifying per slot.
 const noPRReconciledStatus = "no_pr_reconciled"
 
 // closedPRCloseRetryStatus marks a merged-PR retry_exhausted session whose
@@ -5743,11 +5912,11 @@ const closedPRCloseRetryStatus = "closed_pr_close_retry"
 // retries without opening a PR (often because the issue was already
 // implemented by a prior merge via `Refs #N`), so the merge flow has nothing
 // to advance, the session is terminal, and at max_parallel=1 the dynamic-wave
-// queue halts. This helper runs once per session: it auto-closes the issue
-// when a merged PR already closes it (and close_issue is a configured safe
-// action), otherwise it adds the configured blocked label so the supervisor
-// drops the issue from the wave and selects the next eligible candidate.
-func (o *Orchestrator) reconcileNoPRRetryExhausted(s *state.State, slotName string, sess *state.Session) {
+// queue halts. This helper first evaluates the current issue-level state. An
+// open sibling PR preserves the stale slots, while a closed issue or merged
+// sibling PR retires them. Only a genuinely stuck issue receives the configured
+// blocked label, once for the aggregate issue rather than once per slot.
+func (o *Orchestrator) reconcileNoPRRetryExhausted(s *state.State, slotName string, sess *state.Session, openPRs []github.PR) {
 	if sess == nil || sess.IssueNumber <= 0 {
 		return
 	}
@@ -5757,11 +5926,27 @@ func (o *Orchestrator) reconcileNoPRRetryExhausted(s *state.State, slotName stri
 		return
 	}
 
-	merged, err := o.hasMergedPRForIssue(sess.IssueNumber)
+	closed, err := o.isIssueClosed(sess.IssueNumber)
+	if err != nil {
+		log.Printf("[orch] no-PR retry_exhausted: could not check issue #%d state (slot %s): %v", sess.IssueNumber, slotName, err)
+		return
+	}
+	if closed {
+		settled := settleNoPRRetryExhaustedSiblings(s, sess.IssueNumber, "", true, time.Now().UTC())
+		log.Printf("[orch] no-PR retry_exhausted: issue #%d is already closed; reconciled %d stale no-PR slot(s) to done without applying blocked or syncing stale slot status", sess.IssueNumber, settled)
+		return
+	}
+
+	if openPR, ok := openPRForIssueState(s, sess.IssueNumber, openPRs); ok {
+		log.Printf("[orch] no-PR retry_exhausted: issue #%d has open PR #%d in aggregate session state; slot %s is superseded in flight, preserving it without applying blocked", sess.IssueNumber, openPR.Number, slotName)
+		return
+	}
+
+	mergedPR, merged, err := o.mergedPRForIssueState(s, sess.IssueNumber)
 	if err != nil {
 		// Don't mark reconciled on transient GitHub failure; try again next
 		// cycle. Log so operators can correlate with API errors.
-		log.Printf("[orch] no-PR retry_exhausted: could not check merged PR for issue #%d (slot %s): %v", sess.IssueNumber, slotName, err)
+		log.Printf("[orch] no-PR retry_exhausted: could not check aggregate merged PR state for issue #%d (slot %s): %v", sess.IssueNumber, slotName, err)
 		return
 	}
 
@@ -5770,12 +5955,20 @@ func (o *Orchestrator) reconcileNoPRRetryExhausted(s *state.State, slotName stri
 		// approval_required mode it must enter the standing delivery gate before
 		// this retry-reconciliation path may close the issue or report Done.
 		if o.approvalRequiredDeliveryEnabled() {
-			prNumber, prErr := o.mergedPRForIssue(sess.IssueNumber)
+			prNumber := mergedPR
+			var prErr error
+			if prNumber <= 0 {
+				prNumber, prErr = o.mergedPRForIssue(sess.IssueNumber)
+			}
 			if prErr != nil || prNumber <= 0 {
 				log.Printf("[orch] no-PR retry_exhausted: merged work for issue #%d could not be pinned to a PR for delivery: %v — holding", sess.IssueNumber, prErr)
 				return
 			}
 			o.markCodeLanded(sess, prNumber)
+			settled := settleNoPRRetryExhaustedSiblings(s, sess.IssueNumber, slotName, false, time.Now().UTC())
+			if settled > 0 {
+				log.Printf("[orch] no-PR retry_exhausted: merged PR #%d owns issue #%d; reconciled %d stale sibling slot(s) to done while slot %s holds delivery", prNumber, sess.IssueNumber, settled, slotName)
+			}
 			if !o.reconcileCodeLandedDelivery(s, sess) {
 				log.Printf("[orch] no-PR retry_exhausted: issue #%d is held in code_landed for delivery approval", sess.IssueNumber)
 			}
@@ -5786,6 +5979,7 @@ func (o *Orchestrator) reconcileNoPRRetryExhausted(s *state.State, slotName stri
 		// action without an approval gate; otherwise surface it as a
 		// close-candidate via notification.
 		comment := fmt.Sprintf("Maestro: closing this issue because worker session %s exhausted retries without producing a PR (the work appears to be implemented by an already-merged PR).", slotName)
+		issueNowClosed := false
 		if o.supervisorActionAllowed(config.SupervisorActionCloseIssue) && !o.supervisorActionRequiresApproval(config.SupervisorActionCloseIssue) {
 			if cerr := o.closeIssue(sess.IssueNumber, comment); cerr != nil {
 				log.Printf("[orch] no-PR retry_exhausted: auto-close failed for issue #%d (slot %s): %v", sess.IssueNumber, slotName, cerr)
@@ -5799,12 +5993,20 @@ func (o *Orchestrator) reconcileNoPRRetryExhausted(s *state.State, slotName stri
 				o.notifier.Sendf("✅ maestro: closed issue #%d after retry_exhausted with no PR (already implemented by a merged PR)", sess.IssueNumber)
 			}
 			o.syncProject(sess.IssueNumber, github.ProjectStatusDone)
+			issueNowClosed = true
 		} else {
 			log.Printf("[orch] no-PR retry_exhausted: issue #%d (slot %s) has a merged PR — surfaced as operator close-candidate", sess.IssueNumber, slotName)
 			if o.notifier != nil {
 				o.notifier.Sendf("⚠️ maestro: issue #%d retry_exhausted with no PR; a merged PR already implements it — operator close-candidate", sess.IssueNumber)
 			}
 		}
+		settled := settleNoPRRetryExhaustedSiblings(s, sess.IssueNumber, "", issueNowClosed, time.Now().UTC())
+		if mergedPR > 0 {
+			log.Printf("[orch] no-PR retry_exhausted: merged PR #%d owns issue #%d; reconciled %d stale no-PR slot(s) to done without applying blocked", mergedPR, sess.IssueNumber, settled)
+		} else {
+			log.Printf("[orch] no-PR retry_exhausted: merged work owns issue #%d; reconciled %d stale no-PR slot(s) to done without applying blocked", sess.IssueNumber, settled)
+		}
+		return
 	} else {
 		// No merged PR detected — apply the configured blocked label so the
 		// supervisor's dynamic-wave skips this issue on the next cycle and
@@ -5827,10 +6029,10 @@ func (o *Orchestrator) reconcileNoPRRetryExhausted(s *state.State, slotName stri
 		o.syncProject(sess.IssueNumber, github.ProjectStatusBlocked)
 	}
 
-	// Mark the session reconciled so future cycles short-circuit. The status
-	// stays retry_exhausted (terminal) but the marker prevents repeated
-	// labels, close attempts, or notifications.
-	sess.LastNotifiedStatus = noPRReconciledStatus
+	// A genuinely stuck issue keeps every historical retry_exhausted status,
+	// but the issue-level marker prevents sibling slots from repeating the same
+	// label, status sync, and notification later in this or a future cycle.
+	markNoPRRetryExhaustedReconciled(s, sess.IssueNumber)
 }
 
 // reconcileClosedPRRetryExhausted handles retry_exhausted sessions whose PR

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -10435,6 +10435,9 @@ func TestAutoMergePRs_NoPRRetryExhaustedAppliesBlockedLabel(t *testing.T) {
 		cfg:           cfg,
 		notifier:      &notify.Notifier{},
 		listOpenPRsFn: func() ([]github.PR, error) { return nil, nil },
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
 		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
 			return false, nil
 		},
@@ -10470,7 +10473,47 @@ func TestAutoMergePRs_NoPRRetryExhaustedAppliesBlockedLabel(t *testing.T) {
 	}
 }
 
-func TestAutoMergePRs_NoPRRetryExhaustedSiblingDoesNotBlockCanonicalOpenPR(t *testing.T) {
+func TestAutoMergePRs_NoPRRetryExhaustedGenuinelyStuckIssueBlocksOnceAcrossSlots(t *testing.T) {
+	cfg := &config.Config{
+		Repo:       "owner/repo",
+		Supervisor: config.SupervisorConfig{BlockedLabel: "blocked"},
+	}
+	labelCalls := 0
+	o := &Orchestrator{
+		cfg:             cfg,
+		notifier:        &notify.Notifier{},
+		listOpenPRsFn:   func() ([]github.PR, error) { return nil, nil },
+		isIssueClosedFn: func(issueNumber int) (bool, error) { return false, nil },
+		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
+		addIssueLabelFn: func(number int, label string) error {
+			labelCalls++
+			return nil
+		},
+	}
+	s := state.NewState()
+	for _, slot := range []string{"slot-a", "slot-b", "slot-c"} {
+		s.Sessions[slot] = &state.Session{
+			IssueNumber: 836,
+			Status:      state.StatusRetryExhausted,
+			Branch:      slot,
+		}
+	}
+
+	o.autoMergePRs(s)
+
+	if labelCalls != 1 {
+		t.Fatalf("blocked label calls = %d, want one aggregate issue action", labelCalls)
+	}
+	for _, slot := range []string{"slot-a", "slot-b", "slot-c"} {
+		if got := s.Sessions[slot].LastNotifiedStatus; got != noPRReconciledStatus {
+			t.Fatalf("%s LastNotifiedStatus = %q, want %q", slot, got, noPRReconciledStatus)
+		}
+	}
+}
+
+func TestAutoMergePRs_NoPRRetryExhaustedSlotsDoNotBlockSiblingOpenPR(t *testing.T) {
 	cfg := &config.Config{
 		Repo:       "owner/repo",
 		ReviewGate: "none",
@@ -10481,9 +10524,12 @@ func TestAutoMergePRs_NoPRRetryExhaustedSiblingDoesNotBlockCanonicalOpenPR(t *te
 		cfg:      cfg,
 		notifier: &notify.Notifier{},
 		listOpenPRsFn: func() ([]github.PR, error) {
-			return []github.PR{{Number: 397, HeadRefName: "canonical", Title: "Fedora fix for #346"}}, nil
+			// Deliberately omit an issue reference: aggregate ownership must come
+			// from the sibling session's issue/PR/branch identity, not PR text.
+			return []github.PR{{Number: 850, HeadRefName: "slot-d"}}, nil
 		},
-		ghPRCIStatusFn: func(int) (string, error) { return "pending", nil },
+		isIssueClosedFn: func(issueNumber int) (bool, error) { return false, nil },
+		ghPRCIStatusFn:  func(int) (string, error) { return "pending", nil },
 		ghPRMergeStatusFn: func(int) (string, string, error) {
 			return "MERGEABLE", "blocked", nil
 		},
@@ -10493,25 +10539,171 @@ func TestAutoMergePRs_NoPRRetryExhaustedSiblingDoesNotBlockCanonicalOpenPR(t *te
 		},
 	}
 	s := state.NewState()
-	s.Sessions["canonical-slot"] = &state.Session{
-		IssueNumber: 346,
-		Status:      state.StatusRetryExhausted,
-		PRNumber:    397,
-		Branch:      "canonical",
+	for _, slot := range []string{"slot-a", "slot-b", "slot-c"} {
+		s.Sessions[slot] = &state.Session{
+			IssueNumber: 835,
+			Status:      state.StatusRetryExhausted,
+			Branch:      slot,
+		}
 	}
-	s.Sessions["preserved-sibling"] = &state.Session{
-		IssueNumber: 346,
-		Status:      state.StatusRetryExhausted,
-		Branch:      "preserved-sibling",
+	s.Sessions["slot-d"] = &state.Session{
+		IssueNumber: 835,
+		Status:      state.StatusPROpen,
+		PRNumber:    850,
+		Branch:      "slot-d",
 	}
+
+	var logs strings.Builder
+	previousLogOutput := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(previousLogOutput)
 
 	o.autoMergePRs(s)
 
 	if len(addedLabels) != 0 {
-		t.Fatalf("terminal sibling applied labels behind canonical PR: %v", addedLabels)
+		t.Fatalf("dead sibling slots applied labels behind open PR: %v", addedLabels)
 	}
-	if got := s.Sessions["preserved-sibling"].LastNotifiedStatus; got == noPRReconciledStatus {
-		t.Fatalf("terminal sibling was falsely reconciled as a blocking no-PR outcome")
+	for _, slot := range []string{"slot-a", "slot-b", "slot-c"} {
+		sess := s.Sessions[slot]
+		if sess.Status != state.StatusRetryExhausted {
+			t.Fatalf("%s status = %q, want retry_exhausted while sibling PR is in flight", slot, sess.Status)
+		}
+		if sess.LastNotifiedStatus == noPRReconciledStatus {
+			t.Fatalf("%s was falsely reconciled as a blocking no-PR outcome", slot)
+		}
+	}
+	if !strings.Contains(logs.String(), "issue #835 has open PR #850 in aggregate session state") ||
+		!strings.Contains(logs.String(), "without applying blocked") {
+		t.Fatalf("journal does not explain aggregate open-PR suppression:\n%s", logs.String())
+	}
+}
+
+func TestAutoMergePRs_NoPRRetryExhaustedClosedIssueSettlesAllStaleSlots(t *testing.T) {
+	now := time.Now().UTC()
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		GitHubProjects: config.GitHubProjectsConfig{
+			Enabled:       true,
+			ProjectNumber: 1,
+		},
+		Supervisor: config.SupervisorConfig{BlockedLabel: "blocked"},
+	}
+	labelCalls := 0
+	var projectStatuses []github.ProjectStatus
+	o := &Orchestrator{
+		cfg:                  cfg,
+		notifier:             &notify.Notifier{},
+		projectRateAllowed:   true,
+		projectRateCheckedAt: now,
+		listOpenPRsFn:        func() ([]github.PR, error) { return nil, nil },
+		isIssueClosedFn:      func(issueNumber int) (bool, error) { return true, nil },
+		addIssueLabelFn: func(number int, label string) error {
+			labelCalls++
+			return nil
+		},
+		syncProjectFn: func(issueNumber int, status github.ProjectStatus) bool {
+			projectStatuses = append(projectStatuses, status)
+			return true
+		},
+		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
+			t.Fatalf("merged-PR lookup must not run after authoritative issue closure")
+			return false, nil
+		},
+	}
+	s := state.NewState()
+	for _, slot := range []string{"slot-a", "slot-b", "slot-c"} {
+		s.Sessions[slot] = &state.Session{
+			IssueNumber: 835,
+			Status:      state.StatusRetryExhausted,
+			Branch:      slot,
+		}
+	}
+
+	var logs strings.Builder
+	previousLogOutput := log.Writer()
+	log.SetOutput(&logs)
+	defer log.SetOutput(previousLogOutput)
+
+	o.autoMergePRs(s)
+
+	if labelCalls != 0 {
+		t.Fatalf("closed issue received %d blocked-label call(s), want 0", labelCalls)
+	}
+	if len(projectStatuses) != 0 {
+		t.Fatalf("closed issue received stale-slot project syncs %v, want none", projectStatuses)
+	}
+	for _, slot := range []string{"slot-a", "slot-b", "slot-c"} {
+		sess := s.Sessions[slot]
+		if sess.Status != state.StatusDone || sess.IssueClosedAt == nil || sess.LastNotifiedStatus != noPRReconciledStatus {
+			t.Fatalf("%s = status %q closed_at=%v notified=%q, want reconciled done", slot, sess.Status, sess.IssueClosedAt, sess.LastNotifiedStatus)
+		}
+	}
+	if !strings.Contains(logs.String(), "already closed; reconciled 3 stale no-PR slot(s) to done") {
+		t.Fatalf("journal missing closed-issue reconciliation reason:\n%s", logs.String())
+	}
+
+	logBefore := logs.Len()
+	o.autoMergePRs(s)
+	if labelCalls != 0 || len(projectStatuses) != 0 || logs.Len() != logBefore {
+		t.Fatalf("second cycle was not quiet: labels=%d statuses=%v logs=%q", labelCalls, projectStatuses, logs.String()[logBefore:])
+	}
+}
+
+func TestAutoMergePRs_NoPRRetryExhaustedMergedSiblingSettlesAllStaleSlots(t *testing.T) {
+	cfg := &config.Config{
+		Repo:       "owner/repo",
+		Supervisor: config.SupervisorConfig{BlockedLabel: "blocked"},
+	}
+	labelCalls := 0
+	o := &Orchestrator{
+		cfg:             cfg,
+		notifier:        &notify.Notifier{},
+		listOpenPRsFn:   func() ([]github.PR, error) { return nil, nil },
+		isIssueClosedFn: func(issueNumber int) (bool, error) { return false, nil },
+		isPRMergedFn:    func(prNumber int) (bool, error) { return prNumber == 850, nil },
+		addIssueLabelFn: func(number int, label string) error {
+			labelCalls++
+			return nil
+		},
+		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
+			t.Fatalf("same-issue session PR identity should establish aggregate merge state")
+			return false, nil
+		},
+	}
+	s := state.NewState()
+	for _, slot := range []string{"slot-a", "slot-b", "slot-c"} {
+		s.Sessions[slot] = &state.Session{
+			IssueNumber: 835,
+			Status:      state.StatusRetryExhausted,
+			Branch:      slot,
+		}
+	}
+	// The canonical slot already settled after its non-closing `Refs #835` PR
+	// merged. The stale no-PR slots must use that durable PR identity rather
+	// than the legacy closing-keyword lookup.
+	s.Sessions["slot-d"] = &state.Session{
+		IssueNumber: 835,
+		Status:      state.StatusDone,
+		PRNumber:    850,
+		PRMerged:    true,
+		Branch:      "slot-d",
+	}
+
+	o.autoMergePRs(s)
+
+	if labelCalls != 0 {
+		t.Fatalf("merged sibling PR still allowed %d blocked-label call(s)", labelCalls)
+	}
+	for _, slot := range []string{"slot-a", "slot-b", "slot-c"} {
+		sess := s.Sessions[slot]
+		if sess.Status != state.StatusDone || sess.LastNotifiedStatus != noPRReconciledStatus {
+			t.Fatalf("%s = status %q notified=%q, want reconciled done", slot, sess.Status, sess.LastNotifiedStatus)
+		}
+	}
+
+	o.autoMergePRs(s)
+	if labelCalls != 0 {
+		t.Fatalf("second cycle re-applied blocked label after merged sibling reconciliation")
 	}
 }
 
@@ -10533,6 +10725,9 @@ func TestAutoMergePRs_NoPRRetryExhaustedAutoClosesWhenMergedPRDetected(t *testin
 		cfg:           cfg,
 		notifier:      &notify.Notifier{},
 		listOpenPRsFn: func() ([]github.PR, error) { return nil, nil },
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
 		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
 			return issueNumber == 490, nil
 		},
@@ -10587,6 +10782,9 @@ func TestAutoMergePRs_NoPRRetryExhaustedMergedPRSurfacesCloseCandidate(t *testin
 		cfg:           cfg,
 		notifier:      &notify.Notifier{},
 		listOpenPRsFn: func() ([]github.PR, error) { return nil, nil },
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
 		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
 			return true, nil
 		},
@@ -10635,6 +10833,9 @@ func TestAutoMergePRs_NoPRRetryExhaustedHasMergedPRErrorDefersReconcile(t *testi
 		cfg:           cfg,
 		notifier:      &notify.Notifier{},
 		listOpenPRsFn: func() ([]github.PR, error) { return nil, nil },
+		isIssueClosedFn: func(issueNumber int) (bool, error) {
+			return false, nil
+		},
 		hasMergedPRForIssueFn: func(issueNumber int) (bool, error) {
 			return false, fmt.Errorf("gh: transient API failure")
 		},


### PR DESCRIPTION
Refs #860

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes no-PR retry exhaustion reconcile at the issue level. The main changes are:

- Detect open and merged PRs through sibling session identity.
- Settle stale no-PR slots when work is merged or the issue is closed.
- Apply the blocked label once across duplicate slots.
- Add tests for open, merged, closed, and blocked outcomes.

<h3>Confidence Score: 4/5</h3>

The merged-PR ownership check needs a fix before merging.

A merged PR that only mentions an issue can be treated as implementing it. That false match can close the issue or mark all stale slots done.

internal/orchestrator/orchestrator.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the focused Go regression test that exercises a merged textual mention with nonmatching durable session identities, in a run with two retry-exhausted no-PR sessions, which merged PR #990 and attempted to close issue #777; the run showed zero blocked-label calls and both retry-exhausted slots changed to done, but the test failed with exit code 1 because the blocked-label outcome did not occur and the mention was treated as ownership.
- Compared to the baseline commit 31151a4, the post-HEAD run exited with code 0, produced one blocked action across three slots, and allowed the sibling-open-PR path to pass while preserving stale retry-exhausted slots without new blocking.
- Collected artifacts documenting the reproduction and baseline comparison for reviewer inspection, including the focused Go repro test and its verbose failure output, plus baseline comparison logs.

<a href="https://app.greptile.com/trex/runs/15406105/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds aggregate PR ownership checks and issue-wide settlement, with an overly broad textual fallback for merged PR ownership. |
| internal/orchestrator/orchestrator_test.go | Adds coverage for deduplicated blocking and sibling open, merged, and closed issue outcomes. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:5722-5724
**Merged Mention Becomes Ownership**

When a merged PR merely references this issue without implementing it, `PRReferencesIssue` makes the closed-PR snapshot treat that PR as the issue's completed work. The reconciliation path can then auto-close the issue or retire every no-PR slot as done, instead of applying the blocked label.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-1104-8..."](https://github.com/befeast/maestro/commit/3cfce95f9df3528e8505aa3aeee056cab37cbc80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46294517)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->