### PR TITLE
Pilot: dogfood Entire local checkpoints + optional worker entire search

### DIFF
--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,7 @@
+{
+  "enabled": true,
+  "strategy_options": {
+    "push_sessions": false
+  },
+  "telemetry": false
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ internal/server/web/mc/node_modules/
 
 # Generated test/verify artifacts
 .maestro/
+
+# Entire local checkpoint state (only settings.json is committed)
+/.entire/metadata/
+/.entire/logs/
+/.entire/tmp/
+/.entire/settings.local.json
+/.entire/redactors/local/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,3 +35,14 @@ from the repo root) working in the maestro repository.
 - `gofmt` changed Go files.
 - `go test ./...`
 - `go build ./cmd/maestro/`
+
+## Entire Local History (Maestro dogfood only)
+
+Entire is optional and local-only for the public `BeFeast/maestro` dogfood
+repo. If `command -v entire` succeeds and `entire status` shows enabled, a
+worker may run the read-only `entire search` or `entire why` commands to recover
+prior intent.
+
+Do not run `entire login`, create an Entire mirror, push any `entire/*` branch,
+or set `strategy_options.push_sessions` to `true`. Entire rewind/resume is not
+Maestro recovery; use Maestro's `CHECKPOINT.md` and respawn flow instead.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ You only need one — whichever you have access to.
 ### Optional for Go repositories
 - **`gopls`** — enables symbol-aware pre-worker research context for Go modules (`go install golang.org/x/tools/gopls@latest`)
 
+### Entire checkpoints in the Maestro dogfood repo
+
+The public `BeFeast/maestro` repository may use Entire for optional local
+checkpoint history. Its committed `.entire/settings.json` keeps
+`strategy_options.push_sessions` set to `false` (and telemetry disabled)
+because session payloads can contain prompts, tool calls, and local paths;
+redaction is best-effort and does not make those payloads safe to publish. Do
+not push `entire/*` refs. This is a repo-local dogfood policy, not fleet-wide
+Maestro integration.
+
 ### Verify prerequisites
 ```bash
 git --version        # any recent version


### PR DESCRIPTION
Refs #1089

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds optional local Entire checkpoint history for the Maestro dogfood repository. The main changes are:

- Enables repository-local Entire checkpoints with session pushing and telemetry disabled.
- Ignores known local Entire state and configuration files.
- Documents read-only worker usage and prohibits publishing Entire session data or refs.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed configuration or documentation.

The settings and written policy consistently disable remote session publication and telemetry.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the contract-validation shell script to establish the initial state; it exited with 0 and showed that all five generated Entire paths lacked ignore coverage in the parent revision.
- Re-ran the validation after capture and confirmed that it exited with 0 again and that TOTAL\_FAILURES was 0 across JSON, ignore, tracking, and documentation assertions.
- Checked the CLI availability to verify sandbox behavior, recording that command -v entire exited with code 1 as expected.
- Collected artifacts to support review, including the validation script and three log captures.

<a href="https://app.greptile.com/trex/runs/15408600/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .entire/settings.json | Adds repository-local Entire settings with session pushing and telemetry disabled. |
| .gitignore | Excludes known Entire metadata, logs, temporary state, local settings, and local redactors. |
| CLAUDE.md | Allows optional read-only Entire history queries while prohibiting login, mirrors, session pushing, and ref publication. |
| README.md | Documents the local-only dogfood policy and the sensitivity of Entire checkpoint payloads. |

<sub>Reviews (1): Last reviewed commit: ["docs: keep Entire checkpoints local for ..."](https://github.com/befeast/maestro/commit/b31606c30fe6baab840d44dcf0386cc9322fa6e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46300624)</sub>

<!-- /greptile_comment -->