### PR TITLE
P1: Terminalize over-budget / zombie sessions (no respawn thrash)

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -1452,6 +1452,7 @@ func newWorkerController(cfg *config.Config) approver.WorkerControllerFuncs {
 			sess.Status = state.StatusDead
 			sess.FinishedAt = &now
 			sess.NextRetryAt = &now
+			state.PrepareWorkerForOperatorRestart(sess)
 			// worker.Stop deleted the worktree; drop the stale pointers so
 			// respawnDueRetries fresh-respawns instead of RespawnInPlace
 			// against a directory that no longer exists (#874).

--- a/cmd/maestro/stream_split.go
+++ b/cmd/maestro/stream_split.go
@@ -20,10 +20,11 @@ func streamSplitCmd(args []string) {
 	jsonl := fs.String("jsonl", "", "path to append raw NDJSON frames to (side channel)")
 	maxTokens := fs.Int("max-tokens", 0, "hard token ceiling for this worker attempt")
 	budgetMarker := fs.String("budget-marker", "", "path for the deterministic token-budget stop marker")
+	workerGeneration := fs.Uint64("worker-generation", 0, "durable worker generation owning the budget marker")
 	if err := fs.Parse(args); err != nil {
 		os.Exit(2)
 	}
-	if err := worker.RunStreamSplitWithBudget(*backend, *jsonl, *maxTokens, *budgetMarker, os.Stdin, os.Stdout, worker.StopCurrentProcessGroup); err != nil {
+	if err := worker.RunStreamSplitWithBudget(*backend, *jsonl, *maxTokens, *budgetMarker, *workerGeneration, os.Stdin, os.Stdout, worker.StopCurrentProcessGroup); err != nil {
 		fmt.Fprintf(os.Stderr, "[maestro] stream-split: %v\n", err)
 		os.Exit(1)
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -50,8 +50,12 @@ const (
 	// owner dies, the next cycle renews the same exact slot/worktree/branch;
 	// it never allocates a duplicate identity merely to retry startup.
 	freshDispatchLeaseDuration = 10 * time.Minute
-	pipelineFullLabel          = "pipeline:full"
-	pipelineAdvisedLabel       = "pipeline:advised"
+	// A vanished worker gets one automatic recovery in its exact canonical
+	// session. If that replacement also vanishes, continuing to respawn is a
+	// zombie loop even when max_retries_per_issue is configured as unlimited.
+	maxAutomaticUnexpectedExitRetries = 1
+	pipelineFullLabel                 = "pipeline:full"
+	pipelineAdvisedLabel              = "pipeline:advised"
 )
 
 type cycleBoolResult struct {
@@ -1417,9 +1421,10 @@ func tokenBudgetObservation(sess *state.Session) (int, string) {
 }
 
 func (o *Orchestrator) markTokenBudgetExceeded(slotName string, sess *state.Session, marker worker.TokenBudgetMarker, now time.Time) {
-	if sess == nil || sess.WorkerOutcome == worker.TokenBudgetExceededOutcome {
+	if sess == nil {
 		return
 	}
+	firstTerminalization := sess.WorkerOutcome != worker.TokenBudgetExceededOutcome
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
@@ -1432,12 +1437,82 @@ func (o *Orchestrator) markTokenBudgetExceeded(slotName string, sess *state.Sess
 	sess.PID = 0
 	sess.TmuxSession = ""
 	sess.NextRetryAt = nil
-	sess.FinishedAt = &now
-	state.MarkWorkerEnded(sess, now)
+	sess.RetryHoldReason = ""
+	if sess.FinishedAt == nil {
+		sess.FinishedAt = &now
+	}
+	state.MarkWorkerEnded(sess, *sess.FinishedAt)
+	if !firstTerminalization {
+		return
+	}
 	log.Printf("[orch] worker %s stopped by token budget: observed=%d max=%d measure=%s", slotName, budgetObserved, marker.MaxTokens, budgetMeasure)
 	if o.notifier != nil {
 		o.notifier.Sendf("maestro: worker %s (issue #%d) stopped at its token budget: %s %s observed / %s configured",
 			slotName, sess.IssueNumber, worker.FormatTokens(budgetObserved), budgetMeasure, worker.FormatTokens(marker.MaxTokens))
+	}
+}
+
+// terminalizeTokenBudgetIfExceeded is the retry/reconcile backstop for a hard
+// budget stop. The live stream marker is authoritative when present; durable
+// per-attempt accounting covers the race where the process disappears before
+// the marker is consumed. An already-stamped outcome is normalized through the
+// same idempotent sink so stale Dead+NextRetryAt state cannot respawn.
+func (o *Orchestrator) terminalizeTokenBudgetIfExceeded(slotName string, sess *state.Session, now time.Time) bool {
+	if sess == nil {
+		return false
+	}
+	marker, markerOK := worker.ReadTokenBudgetMarker(sess.LogFile)
+	maxTokens := 0
+	if o != nil && o.cfg != nil {
+		maxTokens = o.cfg.WorkerMaxTokens
+	}
+	if !markerOK {
+		alreadyTerminal := sess.WorkerOutcome == worker.TokenBudgetExceededOutcome
+		if !alreadyTerminal && (maxTokens <= 0 || sess.TokensUsedAttempt < maxTokens) {
+			return false
+		}
+		marker = worker.TokenBudgetMarker{
+			Outcome:        worker.TokenBudgetExceededOutcome,
+			Backend:        sess.Backend,
+			TokensObserved: sess.TokensUsedAttempt,
+			MaxTokens:      maxTokens,
+			MeasuredAt:     now,
+		}
+	}
+	measuredAt := marker.MeasuredAt
+	if measuredAt.IsZero() {
+		measuredAt = now
+	}
+	o.markTokenBudgetExceeded(slotName, sess, marker, measuredAt)
+	return true
+}
+
+func (o *Orchestrator) markRepeatedUnexpectedExit(slotName string, sess *state.Session, now time.Time) {
+	if sess == nil {
+		return
+	}
+	firstTerminalization := sess.WorkerOutcome != state.WorkerOutcomeRepeatedUnexpectedExit
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	sess.WorkerOutcome = state.WorkerOutcomeRepeatedUnexpectedExit
+	sess.LastNotifiedStatus = state.WorkerOutcomeRepeatedUnexpectedExit
+	sess.Status = state.StatusFailed
+	sess.PID = 0
+	sess.TmuxSession = ""
+	sess.NextRetryAt = nil
+	sess.RetryHoldReason = ""
+	if sess.FinishedAt == nil {
+		sess.FinishedAt = &now
+	}
+	state.MarkWorkerEnded(sess, *sess.FinishedAt)
+	if !firstTerminalization {
+		return
+	}
+	log.Printf("[orch] worker %s terminalized after repeated unexpected exits; automatic respawn disabled", slotName)
+	if o.notifier != nil {
+		o.notifier.Sendf("maestro: worker %s (issue #%d: %s) disappeared again after automatic recovery — terminalized with no further auto-respawn",
+			slotName, sess.IssueNumber, sess.IssueTitle)
 	}
 }
 
@@ -2451,18 +2526,40 @@ func pendingRetryReservations(s *state.State) int {
 // respawnDueRetries checks dead sessions with a scheduled retry time and
 // respawns them when the backoff period has elapsed.
 func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
+	slotNames := make([]string, 0, len(s.Sessions))
+	for slotName := range s.Sessions {
+		slotNames = append(slotNames, slotName)
+	}
+	sort.Strings(slotNames)
+
+	// Terminal safety outcomes do not need a free worker slot to settle. Repair
+	// stale/racy Dead+NextRetryAt projections first so an over-budget worker can
+	// never remain queued merely because capacity is full, and a previously
+	// terminalized zombie cannot re-enter the spawn path after a state merge.
+	now := time.Now().UTC()
+	for _, slotName := range slotNames {
+		sess := s.Sessions[slotName]
+		if sess.Status != state.StatusDead || sess.NextRetryAt == nil {
+			continue
+		}
+		if sess.RetryReason == state.RetryReasonOperatorRestart {
+			continue
+		}
+		o.updateTokensUsedFromWorkerLog(slotName, sess)
+		if o.terminalizeTokenBudgetIfExceeded(slotName, sess, now) {
+			continue
+		}
+		if sess.WorkerOutcome == state.WorkerOutcomeRepeatedUnexpectedExit || sess.UnexpectedExitRetries > maxAutomaticUnexpectedExitRetries {
+			o.markRepeatedUnexpectedExit(slotName, sess, now)
+		}
+	}
+
 	if slots <= 0 {
 		if pending := pendingRetryReservations(s); pending > 0 {
 			log.Printf("[orch] retry queue has %d pending session(s), but no worker slots are available", pending)
 		}
 		return
 	}
-
-	slotNames := make([]string, 0, len(s.Sessions))
-	for slotName := range s.Sessions {
-		slotNames = append(slotNames, slotName)
-	}
-	sort.Strings(slotNames)
 
 	respawned := 0
 	for _, slotName := range slotNames {
@@ -3555,7 +3652,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		if isRestartCheckpointedDead && s.DrainActive() {
 			continue
 		}
-		if marker, ok := worker.ReadTokenBudgetMarker(sess.LogFile); ok {
+		if _, markerOK := worker.ReadTokenBudgetMarker(sess.LogFile); markerOK {
 			if strings.TrimSpace(sess.ProcessLeaseUnit) != "" {
 				if err := o.stopWorkerProcess(slotName, sess); err != nil {
 					log.Printf("[orch] reconcile: %s token-budget process lease cleanup deferred: %v", slotName, err)
@@ -3563,7 +3660,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 				}
 			}
 			o.runAfterRunHook(sess)
-			o.markTokenBudgetExceeded(slotName, sess, marker, marker.MeasuredAt)
+			o.terminalizeTokenBudgetIfExceeded(slotName, sess, time.Now().UTC())
 			reconciled = true
 			continue
 		}
@@ -3906,6 +4003,15 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		unexpectedRetryAllowed := strings.TrimSpace(sess.Worktree) != "" && o.canRetryIssue(s, sess)
 		o.updateTokensUsedFromWorkerLog(slotName, sess)
 		now := time.Now().UTC()
+		if o.terminalizeTokenBudgetIfExceeded(slotName, sess, now) {
+			reconciled = true
+			continue
+		}
+		if !s.DrainActive() && sess.UnexpectedExitRetries >= maxAutomaticUnexpectedExitRetries {
+			o.markRepeatedUnexpectedExit(slotName, sess, now)
+			reconciled = true
+			continue
+		}
 		// #967: preserve recovery intent while this is still known to be the
 		// explicit process/tmux-gone path. Inferring the cause later from a dead
 		// session's FinishedAt would also revive ordinary provider failures and
@@ -3928,6 +4034,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 				// the exact slot/branch/worktree after re-checking GitHub guards.
 				retryAt := now
 				sess.RetryCount++
+				sess.UnexpectedExitRetries++
 				sess.RetryReason = state.RetryReasonStalledProgress
 				sess.NextRetryAt = &retryAt
 				log.Printf("[orch] reconcile: %s scheduled immediate canonical in-place retry %d after unexpected worker exit", slotName, sess.RetryCount)
@@ -4532,7 +4639,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 		// Running-session lifecycle and process reconciliation. Closed issues
 		// were handled by the authoritative check at the top of this loop.
 		if sess.Status == state.StatusRunning {
-			if marker, ok := worker.ReadTokenBudgetMarker(sess.LogFile); ok {
+			if _, markerOK := worker.ReadTokenBudgetMarker(sess.LogFile); markerOK {
 				if strings.TrimSpace(sess.ProcessLeaseUnit) != "" {
 					if err := o.stopWorkerProcess(slotName, sess); err != nil {
 						log.Printf("[orch] token-budget process lease cleanup deferred for %s: %v", slotName, err)
@@ -4540,7 +4647,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 					}
 				}
 				o.runAfterRunHook(sess)
-				o.markTokenBudgetExceeded(slotName, sess, marker, marker.MeasuredAt)
+				o.terminalizeTokenBudgetIfExceeded(slotName, sess, time.Now().UTC())
 				if sess.Phase == state.PhaseAdvisor {
 					o.finishAdvisorGate(o.pipelineConfigForSession(sess), slotName, sess, pipeline.AdvisorVerdictInvalid, "token_budget_exceeded", fmt.Sprintf("Advisor reached its configured token budget before producing %s.", pipeline.AdvisorReviewFile))
 				}
@@ -4573,6 +4680,13 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 
 				// Worker process died — run after_run hook
 				o.runAfterRunHook(sess)
+				o.updateTokensUsedFromWorkerLog(slotName, sess)
+				if o.terminalizeTokenBudgetIfExceeded(slotName, sess, time.Now().UTC()) {
+					if sess.Phase == state.PhaseAdvisor {
+						o.finishAdvisorGate(o.pipelineConfigForSession(sess), slotName, sess, pipeline.AdvisorVerdictInvalid, "token_budget_exceeded", fmt.Sprintf("Advisor reached its configured token budget before producing %s.", pipeline.AdvisorReviewFile))
+					}
+					continue
+				}
 
 				// Check if there's an open PR for this branch BEFORE marking dead
 				if pr, found := branchToPR[sess.Branch]; found {
@@ -4701,10 +4815,14 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 
 					o.notifier.Sendf("🔄 maestro: worker %s (issue #%d) backend %s %s (%s), switched to %s — retry budget preserved",
 						slotName, sess.IssueNumber, previousBackend, cp.desc, failure.pattern, nextBackend)
+				} else if sess.UnexpectedExitRetries >= maxAutomaticUnexpectedExitRetries {
+					o.markRepeatedUnexpectedExit(slotName, sess, time.Now().UTC())
 				} else if o.canRetryIssue(s, sess) {
 					// Schedule retry with exponential backoff (respects max_retries_per_issue)
 					o.updateTokensUsedFromWorkerLog(slotName, sess)
 					sess.RetryCount++
+					sess.UnexpectedExitRetries++
+					sess.RetryReason = state.RetryReasonStalledProgress
 					backoffMs := retryBackoffMs(sess.RetryCount, o.cfg.MaxRetryBackoffMs)
 					retryAt := time.Now().UTC().Add(time.Duration(backoffMs) * time.Millisecond)
 					sess.NextRetryAt = &retryAt

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1461,22 +1461,25 @@ func (o *Orchestrator) terminalizeTokenBudgetIfExceeded(slotName string, sess *s
 	if sess == nil {
 		return false
 	}
-	marker, markerOK := worker.ReadTokenBudgetMarker(sess.LogFile)
+	marker, markerOK := worker.ReadTokenBudgetMarkerForAttempt(sess.LogFile, sess.WorkerGeneration, sess.StartedAt)
+	budgetObserved, budgetMeasure := tokenBudgetObservation(sess)
 	maxTokens := 0
 	if o != nil && o.cfg != nil {
 		maxTokens = o.cfg.WorkerMaxTokens
 	}
 	if !markerOK {
 		alreadyTerminal := sess.WorkerOutcome == worker.TokenBudgetExceededOutcome
-		if !alreadyTerminal && (maxTokens <= 0 || sess.TokensUsedAttempt < maxTokens) {
+		if !alreadyTerminal && (maxTokens <= 0 || budgetObserved < maxTokens) {
 			return false
 		}
 		marker = worker.TokenBudgetMarker{
-			Outcome:        worker.TokenBudgetExceededOutcome,
-			Backend:        sess.Backend,
-			TokensObserved: sess.TokensUsedAttempt,
-			MaxTokens:      maxTokens,
-			MeasuredAt:     now,
+			Outcome:          worker.TokenBudgetExceededOutcome,
+			Backend:          sess.Backend,
+			TokensObserved:   budgetObserved,
+			MaxTokens:        maxTokens,
+			Measure:          budgetMeasure,
+			WorkerGeneration: sess.WorkerGeneration,
+			MeasuredAt:       now,
 		}
 	}
 	measuredAt := marker.MeasuredAt
@@ -3652,7 +3655,7 @@ func (o *Orchestrator) reconcileRunningSessions(s *state.State) bool {
 		if isRestartCheckpointedDead && s.DrainActive() {
 			continue
 		}
-		if _, markerOK := worker.ReadTokenBudgetMarker(sess.LogFile); markerOK {
+		if _, markerOK := worker.ReadTokenBudgetMarkerForAttempt(sess.LogFile, sess.WorkerGeneration, sess.StartedAt); markerOK {
 			if strings.TrimSpace(sess.ProcessLeaseUnit) != "" {
 				if err := o.stopWorkerProcess(slotName, sess); err != nil {
 					log.Printf("[orch] reconcile: %s token-budget process lease cleanup deferred: %v", slotName, err)
@@ -4639,7 +4642,7 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 		// Running-session lifecycle and process reconciliation. Closed issues
 		// were handled by the authoritative check at the top of this loop.
 		if sess.Status == state.StatusRunning {
-			if _, markerOK := worker.ReadTokenBudgetMarker(sess.LogFile); markerOK {
+			if _, markerOK := worker.ReadTokenBudgetMarkerForAttempt(sess.LogFile, sess.WorkerGeneration, sess.StartedAt); markerOK {
 				if strings.TrimSpace(sess.ProcessLeaseUnit) != "" {
 					if err := o.stopWorkerProcess(slotName, sess); err != nil {
 						log.Printf("[orch] token-budget process lease cleanup deferred for %s: %v", slotName, err)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3651,6 +3651,56 @@ func TestReconcileRunningSessions_TokenBudgetMarkerPreemptsOpenPR(t *testing.T) 
 	}
 }
 
+func TestCheckSessions_StaleTokenBudgetMarkerDoesNotTerminateReplacement(t *testing.T) {
+	dir := t.TempDir()
+	logFile := filepath.Join(dir, "sup-906.log")
+	startedAt := time.Now().UTC()
+	marker := worker.TokenBudgetMarker{
+		Outcome:        worker.TokenBudgetExceededOutcome,
+		Backend:        "claude",
+		TokensObserved: 85_000,
+		MaxTokens:      80_000,
+		Measure:        worker.TokenBudgetMeasureUncached,
+		MeasuredAt:     startedAt.Add(-time.Minute),
+	}
+	data, err := json.Marshal(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(worker.TokenBudgetMarkerPathForLog(logFile), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	o, stopped := newCheckSessionsOrchestrator(&config.Config{
+		Repo:              "owner/repo",
+		StateDir:          dir,
+		WorkerMaxTokens:   80_000,
+		MaxRuntimeMinutes: 999,
+	}, "replacement still working")
+	s := state.NewState()
+	s.Sessions["sup-906"] = &state.Session{
+		IssueNumber:      906,
+		Status:           state.StatusRunning,
+		PID:              1234,
+		TmuxSession:      "maestro-sup-906",
+		Branch:           "feat/sup-906",
+		LogFile:          logFile,
+		Backend:          "claude",
+		WorkerGeneration: 2,
+		StartedAt:        startedAt,
+	}
+
+	o.checkSessions(s)
+
+	sess := s.Sessions["sup-906"]
+	if sess.Status != state.StatusRunning || sess.WorkerOutcome != "" {
+		t.Fatalf("replacement = status %q outcome %q, want running with no terminal outcome", sess.Status, sess.WorkerOutcome)
+	}
+	if sess.TokenBudgetTokensAttempt != 0 || len(*stopped) != 0 {
+		t.Fatalf("stale marker affected replacement: budget=%d stopped=%v", sess.TokenBudgetTokensAttempt, *stopped)
+	}
+}
+
 func TestAutoMergePRs_ParallelStatePersistence(t *testing.T) {
 	// Verify that state survives a save/load cycle after parallel merges.
 	// This addresses the "race conditions on the state file" concern from issue #159.

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -9596,6 +9596,9 @@ func TestCheckSessions_SoftThreshold_CheckpointAndRespawn(t *testing.T) {
 	if len(respawnedInPlace) != 1 || respawnedInPlace[0] != "mae-1" {
 		t.Fatalf("respawnedInPlace = %v, want [mae-1]", respawnedInPlace)
 	}
+	if sess.WorkerOutcome != "" || sess.UnexpectedExitRetries != 0 {
+		t.Fatalf("healthy checkpoint was terminalized: outcome=%q unexpected_retries=%d", sess.WorkerOutcome, sess.UnexpectedExitRetries)
+	}
 	// Worker should NOT be stopped (respawnInPlace handles the stop internally)
 	if len(stopped) != 0 {
 		t.Fatalf("stopped = %v, want empty (respawnInPlace handles stop)", stopped)

--- a/internal/orchestrator/unexpected_exit_retry_test.go
+++ b/internal/orchestrator/unexpected_exit_retry_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/notify"
 	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/worker"
 )
 
 // A process that disappears without a PR used to become Dead without a
@@ -78,6 +79,9 @@ func TestUnexpectedWorkerExitSchedulesImmediateCanonicalRetry(t *testing.T) {
 	if sess.RetryCount != 1 || sess.RetryReason != state.RetryReasonStalledProgress {
 		t.Fatalf("retry metadata = count %d reason %q", sess.RetryCount, sess.RetryReason)
 	}
+	if sess.UnexpectedExitRetries != 1 {
+		t.Fatalf("unexpected-exit retries = %d, want 1", sess.UnexpectedExitRetries)
+	}
 	if sess.NextRetryAt.After(time.Now().UTC()) {
 		t.Fatalf("retry scheduled in the future: %s", sess.NextRetryAt)
 	}
@@ -92,6 +96,190 @@ func TestUnexpectedWorkerExitSchedulesImmediateCanonicalRetry(t *testing.T) {
 	}
 	if sess.Status != state.StatusRunning || sess.PID != 5555 {
 		t.Fatalf("resumed state = status %q pid %d", sess.Status, sess.PID)
+	}
+}
+
+func TestUnexpectedWorkerExitAtTokenBudgetTerminalizesWithoutRetry(t *testing.T) {
+	worktree := t.TempDir()
+	if out, err := exec.Command("git", "init", "-b", "main", worktree).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:               "owner/repo",
+			WorkerMaxTokens:    100,
+			MaxRetriesPerIssue: 0, // unlimited must not override a deterministic budget stop
+		},
+		repo:                 "owner/repo",
+		notifier:             &notify.Notifier{},
+		pidAliveFn:           func(int) bool { return false },
+		tmuxSessionExistsFn:  func(string) bool { return false },
+		listOpenPRsFn:        func() ([]github.PR, error) { return nil, nil },
+		remoteBranchExistsFn: func(string) (bool, error) { return false, nil },
+		isIssueClosedFn:      func(int) (bool, error) { return false, nil },
+	}
+
+	s := state.NewState()
+	s.Sessions["ok-player-302"] = &state.Session{
+		IssueNumber:       406,
+		IssueTitle:        "over budget before marker reconciliation",
+		Status:            state.StatusRunning,
+		PID:               4242,
+		TmuxSession:       "maestro-ok-player-302",
+		Branch:            "feat/ok-player-302-406-over-budget",
+		Worktree:          worktree,
+		TokensUsedAttempt: 100,
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("dead over-budget process was not reconciled")
+	}
+	sess := s.Sessions["ok-player-302"]
+	if sess.Status != state.StatusFailed || sess.WorkerOutcome != worker.TokenBudgetExceededOutcome {
+		t.Fatalf("terminal state = %q/%q, want failed/%q", sess.Status, sess.WorkerOutcome, worker.TokenBudgetExceededOutcome)
+	}
+	if sess.NextRetryAt != nil || sess.UnexpectedExitRetries != 0 {
+		t.Fatalf("budget stop scheduled retry: next=%v unexpected=%d", sess.NextRetryAt, sess.UnexpectedExitRetries)
+	}
+}
+
+func TestRepeatedUnexpectedWorkerExitTerminalizesWithUnlimitedRetries(t *testing.T) {
+	worktree := t.TempDir()
+	if out, err := exec.Command("git", "init", "-b", "main", worktree).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+
+	respawned := 0
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:               "owner/repo",
+			MaxRetriesPerIssue: 0, // the zombie cap is independent of the general retry policy
+		},
+		repo:                 "owner/repo",
+		notifier:             &notify.Notifier{},
+		promptBase:           "test prompt",
+		pidAliveFn:           func(int) bool { return false },
+		tmuxSessionExistsFn:  func(string) bool { return false },
+		listOpenPRsFn:        func() ([]github.PR, error) { return nil, nil },
+		remoteBranchExistsFn: func(string) (bool, error) { return false, nil },
+		isIssueClosedFn:      func(int) (bool, error) { return false, nil },
+		getIssueFn:           func(number int) (github.Issue, error) { return makeIssue(number, "zombie loop"), nil },
+		respawnInPlaceFn: func(_ *config.Config, _ string, sess *state.Session, _ string, _ github.Issue, _, _ string) error {
+			respawned++
+			sess.Status = state.StatusRunning
+			sess.PID = 5555
+			sess.TmuxSession = "maestro-ok-player-302"
+			return nil
+		},
+	}
+
+	s := state.NewState()
+	sess := &state.Session{
+		IssueNumber: 406,
+		IssueTitle:  "zombie loop",
+		Status:      state.StatusRunning,
+		PID:         4242,
+		TmuxSession: "maestro-ok-player-302",
+		Branch:      "feat/ok-player-302-406-zombie",
+		Worktree:    worktree,
+		Backend:     "sol",
+	}
+	s.Sessions["ok-player-302"] = sess
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("first unexpected exit was not reconciled")
+	}
+	o.respawnDueRetries(s, 1)
+	if respawned != 1 || sess.Status != state.StatusRunning {
+		t.Fatalf("first recovery = respawned %d status %q, want one running replacement", respawned, sess.Status)
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("replacement exit was not reconciled")
+	}
+	if sess.Status != state.StatusFailed || sess.WorkerOutcome != state.WorkerOutcomeRepeatedUnexpectedExit {
+		t.Fatalf("replacement terminal state = %q/%q, want failed/%q", sess.Status, sess.WorkerOutcome, state.WorkerOutcomeRepeatedUnexpectedExit)
+	}
+	if sess.NextRetryAt != nil || sess.RetryCount != 1 || sess.UnexpectedExitRetries != 1 {
+		t.Fatalf("replacement retry metadata = next %v count %d unexpected %d", sess.NextRetryAt, sess.RetryCount, sess.UnexpectedExitRetries)
+	}
+
+	o.respawnDueRetries(s, 1)
+	if respawned != 1 {
+		t.Fatalf("terminal zombie respawned %d times, want exactly one recovery", respawned)
+	}
+	claim, ok := s.IssueClaimFor(406)
+	if !ok || claim.Kind != state.IssueClaimTerminalFailure {
+		t.Fatalf("terminal zombie claim = %+v, %v", claim, ok)
+	}
+}
+
+func TestRespawnDueRetries_OverBudgetTerminalizesWithoutAvailableSlot(t *testing.T) {
+	respawned := false
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", WorkerMaxTokens: 100, MaxRetriesPerIssue: 0},
+		notifier: &notify.Notifier{},
+		respawnWorkerFn: func(*config.Config, string, *state.Session, string, github.Issue, string, string) error {
+			respawned = true
+			return nil
+		},
+	}
+	past := time.Now().UTC().Add(-time.Second)
+	s := state.NewState()
+	sess := &state.Session{
+		IssueNumber:       407,
+		IssueTitle:        "queued over-budget retry",
+		Status:            state.StatusDead,
+		NextRetryAt:       &past,
+		TokensUsedAttempt: 125,
+	}
+	s.Sessions["ok-player-303"] = sess
+
+	o.respawnDueRetries(s, 0)
+	if respawned {
+		t.Fatal("over-budget retry must not respawn")
+	}
+	if sess.Status != state.StatusFailed || sess.WorkerOutcome != worker.TokenBudgetExceededOutcome || sess.NextRetryAt != nil {
+		t.Fatalf("terminal budget retry = status %q outcome %q next %v", sess.Status, sess.WorkerOutcome, sess.NextRetryAt)
+	}
+	if claim, ok := s.IssueClaimFor(407); !ok || claim.Kind != state.IssueClaimTerminalFailure {
+		t.Fatalf("terminal budget claim = %+v, %v", claim, ok)
+	}
+}
+
+func TestRespawnDueRetries_OperatorRestartBypassesOldAttemptBudgetLatch(t *testing.T) {
+	respawned := false
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", WorkerMaxTokens: 100, MaxRetriesPerIssue: 0},
+		notifier: &notify.Notifier{},
+		getIssueFn: func(number int) (github.Issue, error) {
+			return makeIssue(number, "intentional restart"), nil
+		},
+		isIssueClosedFn: func(int) (bool, error) { return false, nil },
+		respawnWorkerFn: func(*config.Config, string, *state.Session, string, github.Issue, string, string) error {
+			respawned = true
+			return nil
+		},
+	}
+	past := time.Now().UTC().Add(-time.Second)
+	s := state.NewState()
+	sess := &state.Session{
+		IssueNumber:       408,
+		IssueTitle:        "intentional restart",
+		Status:            state.StatusDead,
+		NextRetryAt:       &past,
+		RetryReason:       state.RetryReasonOperatorRestart,
+		TokensUsedAttempt: 125, // stale accounting from the terminal old attempt
+	}
+	s.Sessions["ok-player-304"] = sess
+
+	o.respawnDueRetries(s, 1)
+	if !respawned {
+		t.Fatal("approved operator restart was blocked by stale attempt accounting")
+	}
+	if sess.WorkerOutcome == worker.TokenBudgetExceededOutcome {
+		t.Fatal("old attempt budget latch was restored during intentional restart")
 	}
 }
 

--- a/internal/orchestrator/unexpected_exit_retry_test.go
+++ b/internal/orchestrator/unexpected_exit_retry_test.go
@@ -144,6 +144,55 @@ func TestUnexpectedWorkerExitAtTokenBudgetTerminalizesWithoutRetry(t *testing.T)
 	}
 }
 
+func TestUnexpectedWorkerExitBelowUncachedBudgetStillGetsOneRecovery(t *testing.T) {
+	worktree := t.TempDir()
+	if out, err := exec.Command("git", "init", "-b", "main", worktree).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+
+	o := &Orchestrator{
+		cfg: &config.Config{
+			Repo:               "owner/repo",
+			StateDir:           t.TempDir(),
+			WorkerMaxTokens:    160_000,
+			MaxRetriesPerIssue: 1,
+		},
+		repo:                 "owner/repo",
+		notifier:             &notify.Notifier{},
+		pidAliveFn:           func(int) bool { return false },
+		tmuxSessionExistsFn:  func(string) bool { return false },
+		listOpenPRsFn:        func() ([]github.PR, error) { return nil, nil },
+		remoteBranchExistsFn: func(string) (bool, error) { return false, nil },
+		isIssueClosedFn:      func(int) (bool, error) { return false, nil },
+	}
+
+	s := state.NewState()
+	s.Sessions["fin-26"] = &state.Session{
+		IssueNumber:              409,
+		IssueTitle:               "cache-heavy healthy attempt",
+		Status:                   state.StatusRunning,
+		PID:                      4242,
+		TmuxSession:              "maestro-fin-26",
+		Branch:                   "feat/fin-26-409-cache-heavy",
+		Worktree:                 worktree,
+		Backend:                  "claude",
+		TokensUsedAttempt:        200_506,
+		TokenBudgetTokensAttempt: 77_030,
+		TokenBudgetMeasure:       worker.TokenBudgetMeasureUncached,
+	}
+
+	if !o.reconcileRunningSessions(s) {
+		t.Fatal("cache-heavy dead process was not reconciled")
+	}
+	sess := s.Sessions["fin-26"]
+	if sess.Status != state.StatusDead || sess.NextRetryAt == nil {
+		t.Fatalf("reconciled state = %q retry=%v, want one canonical recovery", sess.Status, sess.NextRetryAt)
+	}
+	if sess.WorkerOutcome != "" || sess.UnexpectedExitRetries != 1 {
+		t.Fatalf("cache-heavy exit outcome=%q unexpected=%d, want non-terminal first recovery", sess.WorkerOutcome, sess.UnexpectedExitRetries)
+	}
+}
+
 func TestRepeatedUnexpectedWorkerExitTerminalizesWithUnlimitedRetries(t *testing.T) {
 	worktree := t.TempDir()
 	if out, err := exec.Command("git", "init", "-b", "main", worktree).CombinedOutput(); err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -468,7 +468,7 @@ type backendDriftInfo struct {
 
 func makeSessionInfo(repo, slot string, sess *state.Session) sessionInfo {
 	tokenBudgetMeasure := sess.TokenBudgetMeasure
-	marker, markerOK := worker.ReadTokenBudgetMarker(sess.LogFile)
+	marker, markerOK := worker.ReadTokenBudgetMarkerForAttempt(sess.LogFile, sess.WorkerGeneration, sess.StartedAt)
 	if markerOK {
 		tokenBudgetMeasure = marker.Measure
 	}

--- a/internal/state/issue_claim.go
+++ b/internal/state/issue_claim.go
@@ -58,6 +58,7 @@ const (
 	IssueClaimOpenPRMaintenance    = "open_pr_maintenance"
 	IssueClaimScheduledRetry       = "scheduled_retry"
 	IssueClaimRetainedWorktree     = "retained_worktree"
+	IssueClaimTerminalFailure      = "terminal_failure"
 	IssueClaimTerminalReconcile    = "terminal_reconciliation"
 	IssueClaimOperatorGate         = "operator_gate"
 	IssueClaimRepairDispatch       = "repair_dispatch"
@@ -588,6 +589,17 @@ func sessionIssueClaim(slot string, sess *Session) (IssueClaim, bool) {
 		}
 	}
 
+	// Deterministic safety outcomes are terminal until an operator explicitly
+	// releases or restarts them. Keep the issue claimed even after automatic
+	// worktree cleanup clears Worktree; otherwise an unlimited retry policy can
+	// fresh-dispatch the same over-budget/zombie issue again one cleanup cycle
+	// later and recreate the loop this terminal state was meant to stop.
+	if !sess.ReleasedForRedispatch && terminalWorkerOutcomeClaimsIssue(sess.WorkerOutcome) {
+		claim.Kind = IssueClaimTerminalFailure
+		claim.Reason = fmt.Sprintf("issue #%d is terminalized on session %s (%s)", sess.IssueNumber, slot, sess.WorkerOutcome)
+		return claim, true
+	}
+
 	// A dead/retry-exhausted/conflict session with a retained PR/worktree remains
 	// the maintenance owner until reconciliation proves the PR is closed or
 	// explicitly releases it for redispatch.
@@ -609,4 +621,13 @@ func sessionIssueClaim(slot string, sess *Session) (IssueClaim, bool) {
 		return claim, true
 	}
 	return IssueClaim{}, false
+}
+
+func terminalWorkerOutcomeClaimsIssue(outcome string) bool {
+	switch strings.TrimSpace(outcome) {
+	case string(DisplayTokenBudgetExceeded), WorkerOutcomeRepeatedUnexpectedExit:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/state/issue_claim_test.go
+++ b/internal/state/issue_claim_test.go
@@ -88,6 +88,33 @@ func TestIssueClaimFor_DeadScheduledRetryRemainsReserved(t *testing.T) {
 	}
 }
 
+func TestIssueClaimFor_TerminalSafetyOutcomeSurvivesWorktreeCleanup(t *testing.T) {
+	for _, outcome := range []string{string(DisplayTokenBudgetExceeded), WorkerOutcomeRepeatedUnexpectedExit} {
+		t.Run(outcome, func(t *testing.T) {
+			s := NewState()
+			s.Sessions["txc-1"] = &Session{
+				IssueNumber:   1,
+				Status:        StatusFailed,
+				WorkerOutcome: outcome,
+				// Worktree is intentionally empty: automatic cleanup already ran.
+			}
+
+			claim, ok := s.IssueClaimFor(1)
+			if !ok || claim.Kind != IssueClaimTerminalFailure || claim.Session != "txc-1" {
+				t.Fatalf("claim = %+v, %v, want durable terminal-failure claim", claim, ok)
+			}
+			if !strings.Contains(claim.Reason, outcome) {
+				t.Fatalf("reason = %q, want durable outcome %q", claim.Reason, outcome)
+			}
+
+			s.Sessions["txc-1"].ReleasedForRedispatch = true
+			if _, ok := s.IssueClaimFor(1); ok {
+				t.Fatal("explicit release must drop the terminal-failure claim")
+			}
+		})
+	}
+}
+
 func TestIssueClaimFor_DonePRRemainsReservedUntilExplicitRelease(t *testing.T) {
 	s := NewState()
 	finishedAt := time.Now().UTC()

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -80,12 +80,22 @@ const (
 	// DisplayTokenBudgetExceeded is a deterministic worker stop, not a retryable
 	// process death or provider outage.
 	DisplayTokenBudgetExceeded SessionDisplayStatus = "token_budget_exceeded"
-	LiveSessionRecentWindow                         = 24 * time.Hour
+	// DisplayRepeatedUnexpectedExit marks a worker whose one automatic
+	// unexpected-exit recovery also disappeared without producing a PR. This is
+	// terminal: another automatic spawn would be a zombie loop, not recovery.
+	DisplayRepeatedUnexpectedExit SessionDisplayStatus = WorkerOutcomeRepeatedUnexpectedExit
+	LiveSessionRecentWindow                            = 24 * time.Hour
 )
 
 const (
 	RetryReasonReviewFeedback  = "review_feedback"
 	RetryReasonStalledProgress = "stalled_progress"
+	RetryReasonOperatorRestart = "operator_restart"
+
+	// WorkerOutcomeRepeatedUnexpectedExit is the durable terminal reason for a
+	// worker that disappeared again after Maestro already gave the same
+	// canonical session one automatic unexpected-exit recovery.
+	WorkerOutcomeRepeatedUnexpectedExit = "repeated_unexpected_exit"
 )
 
 const (
@@ -268,6 +278,7 @@ type Session struct {
 	LastNotifiedStatus         string     `json:"last_notified_status,omitempty"`       // dedup: last notification type sent
 	LiveVerificationNotified   bool       `json:"live_verification_notified,omitempty"` // #570 one-shot: hold-for-live-verification board sync + operator notification already fired
 	RetryCount                 int        `json:"retry_count,omitempty"`                // per-session retry counter; the global per-issue limit (max_retries_per_issue) combines this with FailedAttemptsForIssue
+	UnexpectedExitRetries      int        `json:"unexpected_exit_retries,omitempty"`    // automatic recoveries consumed by process/tmux disappearance; independently capped to prevent zombie respawn loops
 	MaintenanceRetryCount      int        `json:"maintenance_retry_count,omitempty"`    // bounded post-PR maintenance attempts (review feedback / rebase conflict repair), separate from implementation retries
 	NextRetryAt                *time.Time `json:"next_retry_at,omitempty"`
 	RetryHoldReason            string     `json:"retry_hold_reason,omitempty"` // current dispatch guard holding a scheduled canonical retry; does not release its issue/worktree lease
@@ -483,6 +494,13 @@ func SessionAttentionForAt(sess *Session, alive *bool, now time.Time) SessionAtt
 			NeedsAttention: true,
 		}
 	}
+	if sess.WorkerOutcome == WorkerOutcomeRepeatedUnexpectedExit {
+		return SessionAttention{
+			Reason:         "Worker disappeared again after its automatic unexpected-exit recovery; Maestro terminalized the session to stop a zombie respawn loop.",
+			NextAction:     "Inspect the retained log/worktree and restart intentionally only after correcting the repeated exit cause.",
+			NeedsAttention: true,
+		}
+	}
 	if attention, ok := OperatorGateAttention(sess); ok {
 		return attention
 	}
@@ -684,6 +702,9 @@ func SessionDisplayStatusForAt(sess *Session, alive *bool, now time.Time) string
 	if sess.WorkerOutcome == string(DisplayTokenBudgetExceeded) {
 		return string(DisplayTokenBudgetExceeded)
 	}
+	if sess.WorkerOutcome == WorkerOutcomeRepeatedUnexpectedExit {
+		return string(DisplayRepeatedUnexpectedExit)
+	}
 	if sess.Status == StatusRunning && alive != nil && !*alive {
 		return string(sess.Status)
 	}
@@ -716,6 +737,21 @@ func formatSessionTokens(tokens int) string {
 		return "unknown"
 	}
 	return fmt.Sprintf("%d", tokens)
+}
+
+// PrepareWorkerForOperatorRestart clears automatic terminal latches from the
+// previous attempt and marks the queued retry as an explicit operator action.
+// The restart controller still owns Status/NextRetryAt/worktree mutation; this
+// helper only distinguishes intentional recovery from automatic respawn.
+func PrepareWorkerForOperatorRestart(sess *Session) {
+	if sess == nil {
+		return
+	}
+	sess.WorkerOutcome = ""
+	sess.LastNotifiedStatus = ""
+	sess.RetryHoldReason = ""
+	sess.UnexpectedExitRetries = 0
+	sess.RetryReason = RetryReasonOperatorRestart
 }
 
 // backendRateLimitedDisplayStatus reports whether a session represents a worker

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1354,6 +1354,48 @@ func TestSessionTokenBudgetExceededAttentionAndDisplay(t *testing.T) {
 	}
 }
 
+func TestSessionRepeatedUnexpectedExitAttentionAndDisplay(t *testing.T) {
+	sess := &Session{
+		Status:                StatusFailed,
+		WorkerOutcome:         WorkerOutcomeRepeatedUnexpectedExit,
+		RetryCount:            2,
+		UnexpectedExitRetries: 1,
+	}
+	if got := SessionDisplayStatusFor(sess, nil); got != string(DisplayRepeatedUnexpectedExit) {
+		t.Fatalf("display = %q, want %q", got, DisplayRepeatedUnexpectedExit)
+	}
+	attention := SessionAttentionFor(sess, nil)
+	if !attention.NeedsAttention || !containsString(attention.Reason, "zombie respawn loop") || !containsString(attention.NextAction, "restart intentionally") {
+		t.Fatalf("attention = %+v, want repeated-exit terminal guidance", attention)
+	}
+}
+
+func TestPrepareWorkerForOperatorRestartClearsTerminalLatch(t *testing.T) {
+	retryAt := time.Now().UTC()
+	sess := &Session{
+		Status:                StatusFailed,
+		WorkerOutcome:         WorkerOutcomeRepeatedUnexpectedExit,
+		LastNotifiedStatus:    WorkerOutcomeRepeatedUnexpectedExit,
+		RetryHoldReason:       "old hold",
+		RetryReason:           RetryReasonStalledProgress,
+		UnexpectedExitRetries: 1,
+		NextRetryAt:           &retryAt,
+	}
+
+	PrepareWorkerForOperatorRestart(sess)
+
+	if sess.WorkerOutcome != "" || sess.LastNotifiedStatus != "" || sess.RetryHoldReason != "" || sess.UnexpectedExitRetries != 0 {
+		t.Fatalf("terminal latch survived operator restart preparation: %+v", sess)
+	}
+	if sess.RetryReason != RetryReasonOperatorRestart {
+		t.Fatalf("retry reason = %q, want %q", sess.RetryReason, RetryReasonOperatorRestart)
+	}
+	if sess.Status != StatusFailed || sess.NextRetryAt != &retryAt {
+		t.Fatal("operator restart preparation must not own status or retry timing")
+	}
+	PrepareWorkerForOperatorRestart(nil)
+}
+
 func TestSessionDisplayStatusFor_BackendRateLimited(t *testing.T) {
 	now := time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC)
 	reset := time.Date(2026, 5, 30, 20, 13, 0, 0, time.UTC)

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -4667,6 +4667,7 @@ func NewWorkerController(cfg *config.Config) approver.WorkerControllerFuncs {
 			sess.Status = state.StatusDead
 			sess.FinishedAt = &now
 			sess.NextRetryAt = &now
+			state.PrepareWorkerForOperatorRestart(sess)
 			clearWorktreeAfterRestart(sess)
 			return nil
 		},

--- a/internal/worker/attribution.go
+++ b/internal/worker/attribution.go
@@ -38,6 +38,13 @@ func beginSessionAttempt(cfg *config.Config, sess *state.Session, backendName, r
 	sess.WorkerScratchDir = ""
 	sess.WorkerLeaseManifest = ""
 	sess.WorkerLeaseAttention = ""
+	// An approved operator restart is authority to bypass only the old
+	// attempt's terminal budget/zombie latch while it is queued. Once the new
+	// process exists, clear that handoff so ordinary live budget enforcement and
+	// unexpected-exit policy apply to this attempt normally.
+	if sess.RetryReason == state.RetryReasonOperatorRestart {
+		sess.RetryReason = ""
+	}
 	// A scheduled retry owns NextRetryAt only until a replacement process has
 	// actually started. Keeping the elapsed timestamp on a Running attempt makes
 	// Fleet report contradictory queued/running state and lets a later terminal

--- a/internal/worker/attribution_test.go
+++ b/internal/worker/attribution_test.go
@@ -83,6 +83,20 @@ func TestBeginSessionAttemptClearsScheduledRetryMarker(t *testing.T) {
 	}
 }
 
+func TestBeginSessionAttemptConsumesOperatorRestartHandoff(t *testing.T) {
+	cfg := attribCfgWithBackends()
+	sess := &state.Session{
+		Status:      state.StatusDead,
+		RetryReason: state.RetryReasonOperatorRestart,
+	}
+
+	beginSessionAttempt(cfg, sess, "claude", "in_place_respawn", "operator_restart", time.Now().UTC())
+
+	if sess.RetryReason != "" {
+		t.Fatalf("operator restart handoff = %q, want cleared on the live attempt", sess.RetryReason)
+	}
+}
+
 func TestRecordBackendAttribution_SecondCall_ClosesPreviousAndAppends(t *testing.T) {
 	cfg := attribCfgWithBackends()
 	sess := &state.Session{}

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -724,7 +724,7 @@ func maestroExecutablePath() (string, bool) {
 // when its live budget needs the side channel. When the maestro binary cannot
 // be resolved this degrades to nil (plain tee). The resolved kind is passed to
 // the splitter so it renders the right human-readable form into slot.log.
-func streamSplitForBackend(backendName string, cfg BackendConfig, logFile string) *streamSplit {
+func streamSplitForBackend(backendName string, cfg BackendConfig, logFile string, workerGeneration uint64) *streamSplit {
 	kind := resolveBackendKind(backendName, cfg)
 	if kind == config.BackendKindKimi {
 		if !kimiUsesStreamJSON(cfg) {
@@ -746,6 +746,7 @@ func streamSplitForBackend(backendName string, cfg BackendConfig, logFile string
 		JSONLPath:  JSONLPathForLog(logFile),
 		MaxTokens:  cfg.TokenBudget,
 		MarkerPath: TokenBudgetMarkerPathForLog(logFile),
+		Generation: workerGeneration,
 	}
 }
 

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -101,15 +101,18 @@ func TestBuildWorkerCmd_KimiCmdBasenameAndPinnedOutput(t *testing.T) {
 	if strings.Contains(joined, "stream-json") {
 		t.Fatalf("operator-pinned output format must win: %v", cmd.Args)
 	}
-	if split := streamSplitForBackend("custom", cfg, "/tmp/slot.log"); split != nil {
+	if split := streamSplitForBackend("custom", cfg, "/tmp/slot.log", 3); split != nil {
 		t.Fatalf("text-mode Kimi must not install stream-split: %+v", split)
 	}
 }
 
 func TestStreamSplitForBackend_KimiDefaultsStructured(t *testing.T) {
-	split := streamSplitForBackend("kimi", BackendConfig{Cmd: "kimi"}, "/tmp/slot.log")
+	split := streamSplitForBackend("kimi", BackendConfig{Cmd: "kimi"}, "/tmp/slot.log", 3)
 	if split == nil {
 		t.Fatal("first-class Kimi backend should install stream-split by default")
+	}
+	if split.Generation != 3 {
+		t.Fatalf("worker generation = %d, want 3", split.Generation)
 	}
 	if split.Backend != "kimi" || split.JSONLPath != "/tmp/slot.jsonl" {
 		t.Fatalf("split = %+v, want kimi /tmp/slot.jsonl", split)

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -441,7 +441,8 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 
 	// Write runner script
 	runnerPath := filepath.Join(cfg.StateDir, slotName+"-run.sh")
-	split := streamSplitForBackend(backendName, backendCfg, logFile)
+	nextGeneration := sess.WorkerGeneration + 1
+	split := streamSplitForBackend(backendName, backendCfg, logFile, nextGeneration)
 	if err := writeConfiguredWorkerRunnerScript(cfg, slotName, sess.Branch, promptFile, runnerPath, workerCmd.Args, stdinFile, logFile, sess.Worktree, split); err != nil {
 		return err
 	}
@@ -460,7 +461,6 @@ func RespawnInPlace(cfg *config.Config, slotName string, sess *state.Session, re
 	// pane PID, and worktree. A command transport error may arrive after tmux
 	// created the runner; observing that exact session adopts it instead of
 	// replaying the runner command and creating two live workers.
-	nextGeneration := sess.WorkerGeneration + 1
 	pid, lease, err := launchWorkerProcessLease(cfg, slotName, tmuxName, sess.Worktree, runnerPath, nextGeneration, sess.PID, "in_place_respawn")
 	if err != nil {
 		if lease.Unit != "" {

--- a/internal/worker/phase.go
+++ b/internal/worker/phase.go
@@ -82,7 +82,8 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 
 	// Write runner script
 	runnerPath := fmt.Sprintf("%s/%s-run.sh", cfg.StateDir, slotName)
-	split := streamSplitForBackend(backendName, backendCfg, logFile)
+	nextGeneration := sess.WorkerGeneration + 1
+	split := streamSplitForBackend(backendName, backendCfg, logFile, nextGeneration)
 	if err := writeConfiguredWorkerRunnerScript(cfg, slotName, sess.Branch, promptFile, runnerPath, workerCmd.Args, stdinFile, logFile, sess.Worktree, split); err != nil {
 		return err
 	}
@@ -97,7 +98,6 @@ func StartPhase(cfg *config.Config, sess *state.Session, slotName, prompt, backe
 		return fmt.Errorf("before_run hook: %w", err)
 	}
 
-	nextGeneration := sess.WorkerGeneration + 1
 	pid, processLease, err := launchWorkerProcessLease(cfg, slotName, tmuxName, sess.Worktree, runnerPath, nextGeneration, sess.PID, "phase_transition")
 	if err != nil {
 		if processLease.Unit != "" {

--- a/internal/worker/search_guardrail.go
+++ b/internal/worker/search_guardrail.go
@@ -472,6 +472,7 @@ type streamSplit struct {
 	JSONLPath  string // side-channel file for raw NDJSON frames (slot.jsonl)
 	MaxTokens  int    // active per-attempt hard ceiling (0 = accounting only)
 	MarkerPath string // deterministic budget-stop marker written before termination
+	Generation uint64 // durable worker generation stamped into the marker
 }
 
 // logPipeline builds the trailing `| ... | tee -a LOG` stage. When split is
@@ -490,6 +491,9 @@ func logPipeline(split *streamSplit, logFile string) string {
 	if split.MaxTokens > 0 {
 		splitter += " --max-tokens " + strconv.Itoa(split.MaxTokens)
 		splitter += " --budget-marker " + shellQuote(split.MarkerPath)
+		if split.Generation > 0 {
+			splitter += " --worker-generation " + strconv.FormatUint(split.Generation, 10)
+		}
 	}
 	return "2>&1 | " + splitter + " | " + tee
 }

--- a/internal/worker/search_guardrail_test.go
+++ b/internal/worker/search_guardrail_test.go
@@ -782,10 +782,17 @@ func TestBuildWorkerRunnerScriptStreamSplitPipeline(t *testing.T) {
 		"/tmp/state/search-guardrails",
 		"",
 		"/usr/local/bin/maestro",
-		&streamSplit{MaestroBin: "/usr/local/bin/maestro", Backend: "claude", JSONLPath: "/tmp/worker.jsonl"},
+		&streamSplit{
+			MaestroBin: "/usr/local/bin/maestro",
+			Backend:    "claude",
+			JSONLPath:  "/tmp/worker.jsonl",
+			MaxTokens:  80_000,
+			MarkerPath: "/tmp/worker.token-budget.json",
+			Generation: 7,
+		},
 	)
 
-	want := "2>&1 | /usr/local/bin/maestro stream-split --backend claude --jsonl /tmp/worker.jsonl | tee -a '/tmp/worker.log'"
+	want := "2>&1 | /usr/local/bin/maestro stream-split --backend claude --jsonl /tmp/worker.jsonl --max-tokens 80000 --budget-marker '/tmp/worker.token-budget.json' --worker-generation 7 | tee -a '/tmp/worker.log'"
 	if !strings.Contains(script, want) {
 		t.Fatalf("runner script missing stream-split pipeline %q\nscript:\n%s", want, script)
 	}

--- a/internal/worker/stream_split.go
+++ b/internal/worker/stream_split.go
@@ -32,13 +32,13 @@ func JSONLPathForLog(logFile string) string {
 // flushed per line so the orchestrator's live log polling (rate-limit /
 // silent-timeout detection) sees output in real time.
 func RunStreamSplit(backend, jsonlPath string, r io.Reader, w io.Writer) error {
-	return RunStreamSplitWithBudget(backend, jsonlPath, 0, "", r, w, nil)
+	return RunStreamSplitWithBudget(backend, jsonlPath, 0, "", 0, r, w, nil)
 }
 
 // RunStreamSplitWithBudget adds live token enforcement to the structured
 // stream. Usage is evaluated once per provider response/event, so measurement
 // lag is bounded to one backend response plus line-flush time.
-func RunStreamSplitWithBudget(backend, jsonlPath string, maxTokens int, markerPath string, r io.Reader, w io.Writer, stop func()) error {
+func RunStreamSplitWithBudget(backend, jsonlPath string, maxTokens int, markerPath string, workerGeneration uint64, r io.Reader, w io.Writer, stop func()) error {
 	var jf *os.File
 	if strings.TrimSpace(jsonlPath) != "" {
 		f, err := os.OpenFile(jsonlPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
@@ -69,7 +69,7 @@ func RunStreamSplitWithBudget(backend, jsonlPath string, maxTokens int, markerPa
 			}
 			line := strings.TrimRight(chunk, "\r\n")
 			if observed, exceeded := monitor.observe(line); exceeded {
-				if err := writeTokenBudgetMarker(markerPath, backend, monitor.measure, observed, maxTokens); err != nil {
+				if err := writeTokenBudgetMarker(markerPath, backend, monitor.measure, observed, maxTokens, workerGeneration); err != nil {
 					if stop != nil {
 						stop()
 					}

--- a/internal/worker/token_budget.go
+++ b/internal/worker/token_budget.go
@@ -23,12 +23,13 @@ var ErrTokenBudgetExceeded = errors.New(TokenBudgetExceededOutcome)
 // TokenBudgetMarker is the durable, non-sensitive handoff from the worker
 // stream process to orchestrator and Fleet reconciliation.
 type TokenBudgetMarker struct {
-	Outcome        string    `json:"outcome"`
-	Backend        string    `json:"backend"`
-	TokensObserved int       `json:"tokens_observed"`
-	MaxTokens      int       `json:"max_tokens"`
-	Measure        string    `json:"measure"`
-	MeasuredAt     time.Time `json:"measured_at"`
+	Outcome          string    `json:"outcome"`
+	Backend          string    `json:"backend"`
+	TokensObserved   int       `json:"tokens_observed"`
+	MaxTokens        int       `json:"max_tokens"`
+	Measure          string    `json:"measure"`
+	WorkerGeneration uint64    `json:"worker_generation,omitempty"`
+	MeasuredAt       time.Time `json:"measured_at"`
 }
 
 func TokenBudgetMarkerPathForLog(logFile string) string {
@@ -60,7 +61,28 @@ func ReadTokenBudgetMarker(logFile string) (TokenBudgetMarker, bool) {
 	return marker, true
 }
 
-func writeTokenBudgetMarker(path, backend, measure string, observed, maxTokens int) error {
+// ReadTokenBudgetMarkerForAttempt rejects a marker written by a predecessor
+// process that reused the same stable slot log path. New markers carry the
+// exact worker generation. Timestamp matching is retained only for markers
+// written by an older Maestro version during a rolling upgrade.
+func ReadTokenBudgetMarkerForAttempt(logFile string, workerGeneration uint64, startedAt time.Time) (TokenBudgetMarker, bool) {
+	marker, ok := ReadTokenBudgetMarker(logFile)
+	if !ok {
+		return TokenBudgetMarker{}, false
+	}
+	if marker.WorkerGeneration > 0 {
+		if workerGeneration == 0 || marker.WorkerGeneration != workerGeneration {
+			return TokenBudgetMarker{}, false
+		}
+		return marker, true
+	}
+	if !startedAt.IsZero() && (marker.MeasuredAt.IsZero() || marker.MeasuredAt.Before(startedAt)) {
+		return TokenBudgetMarker{}, false
+	}
+	return marker, true
+}
+
+func writeTokenBudgetMarker(path, backend, measure string, observed, maxTokens int, workerGeneration uint64) error {
 	if path == "" {
 		return fmt.Errorf("empty token-budget marker path")
 	}
@@ -68,12 +90,13 @@ func writeTokenBudgetMarker(path, backend, measure string, observed, maxTokens i
 		observed = maxTokens
 	}
 	marker := TokenBudgetMarker{
-		Outcome:        TokenBudgetExceededOutcome,
-		Backend:        backend,
-		TokensObserved: observed,
-		MaxTokens:      maxTokens,
-		Measure:        measure,
-		MeasuredAt:     time.Now().UTC(),
+		Outcome:          TokenBudgetExceededOutcome,
+		Backend:          backend,
+		TokensObserved:   observed,
+		MaxTokens:        maxTokens,
+		Measure:          measure,
+		WorkerGeneration: workerGeneration,
+		MeasuredAt:       time.Now().UTC(),
 	}
 	data, err := json.Marshal(marker)
 	if err != nil {

--- a/internal/worker/token_budget_test.go
+++ b/internal/worker/token_budget_test.go
@@ -1,11 +1,13 @@
 package worker
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestRunStreamSplitWithBudget_StopsBeforeRunawayCompletion(t *testing.T) {
@@ -16,7 +18,7 @@ func TestRunStreamSplitWithBudget_StopsBeforeRunawayCompletion(t *testing.T) {
 		claudeAssistantUsageFrame(45_000) + "\n" +
 		claudeAssistantUsageFrame(92_038) + "\n"
 	stopped := 0
-	err := RunStreamSplitWithBudget("claude", jsonl, 80_000, markerPath, strings.NewReader(stream), &strings.Builder{}, func() {
+	err := RunStreamSplitWithBudget("claude", jsonl, 80_000, markerPath, 7, strings.NewReader(stream), &strings.Builder{}, func() {
 		stopped++
 	})
 	if !errors.Is(err, ErrTokenBudgetExceeded) {
@@ -35,12 +37,63 @@ func TestRunStreamSplitWithBudget_StopsBeforeRunawayCompletion(t *testing.T) {
 	if marker.Measure != TokenBudgetMeasureUncached {
 		t.Fatalf("marker measure = %q, want %q", marker.Measure, TokenBudgetMeasureUncached)
 	}
+	if marker.WorkerGeneration != 7 {
+		t.Fatalf("marker generation = %d, want 7", marker.WorkerGeneration)
+	}
 	data, err := os.ReadFile(jsonl)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if strings.Contains(string(data), "92038") {
 		t.Fatal("177k runaway tail was consumed after the 80k budget stop")
+	}
+}
+
+func TestReadTokenBudgetMarkerForAttemptRejectsPredecessor(t *testing.T) {
+	dir := t.TempDir()
+	logFile := dir + "/slot.log"
+	markerPath := TokenBudgetMarkerPathForLog(logFile)
+
+	if err := writeTokenBudgetMarker(markerPath, "claude", TokenBudgetMeasureUncached, 85_000, 80_000, 4); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ReadTokenBudgetMarkerForAttempt(logFile, 5, time.Now().UTC()); ok {
+		t.Fatal("generation 4 marker matched generation 5 attempt")
+	}
+	if marker, ok := ReadTokenBudgetMarkerForAttempt(logFile, 4, time.Now().UTC()); !ok || marker.WorkerGeneration != 4 {
+		t.Fatalf("matching generation marker = %+v, %v", marker, ok)
+	}
+
+	startedAt := time.Now().UTC()
+	legacy := TokenBudgetMarker{
+		Outcome:        TokenBudgetExceededOutcome,
+		Backend:        "claude",
+		TokensObserved: 85_000,
+		MaxTokens:      80_000,
+		Measure:        TokenBudgetMeasureUncached,
+		MeasuredAt:     startedAt.Add(-time.Minute),
+	}
+	data, err := json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(markerPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ReadTokenBudgetMarkerForAttempt(logFile, 5, startedAt); ok {
+		t.Fatal("legacy marker from before the replacement start matched the new attempt")
+	}
+
+	legacy.MeasuredAt = time.Time{}
+	data, err = json.Marshal(legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(markerPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := ReadTokenBudgetMarkerForAttempt(logFile, 5, startedAt); ok {
+		t.Fatal("legacy marker without attempt time matched the replacement")
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -257,7 +257,7 @@ func StartReserved(cfg *config.Config, s *state.State, repo string, issue github
 
 	// Write runner script
 	runnerPath := filepath.Join(cfg.StateDir, slotName+"-run.sh")
-	split := streamSplitForBackend(backendName, backendCfg, logFile)
+	split := streamSplitForBackend(backendName, backendCfg, logFile, 1)
 	if err := writeConfiguredWorkerRunnerScript(cfg, slotName, branchName, promptFile, runnerPath, workerCmd.Args, stdinFile, logFile, worktreePath, split); err != nil {
 		return "", err
 	}
@@ -479,7 +479,8 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 
 	// Write runner script
 	runnerPath := filepath.Join(cfg.StateDir, slotName+"-run.sh")
-	split := streamSplitForBackend(backendName, backendCfg, logFile)
+	nextGeneration := sess.WorkerGeneration + 1
+	split := streamSplitForBackend(backendName, backendCfg, logFile, nextGeneration)
 	if err := writeConfiguredWorkerRunnerScript(cfg, slotName, branchName, promptFile, runnerPath, workerCmd.Args, stdinFile, logFile, worktreePath, split); err != nil {
 		return err
 	}
@@ -491,7 +492,6 @@ func Respawn(cfg *config.Config, slotName string, sess *state.Session, repo stri
 
 	// Start tmux session inside a new generation-specific process lease.
 	tmuxName := TmuxSessionName(slotName)
-	nextGeneration := sess.WorkerGeneration + 1
 	pid, processLease, err := launchWorkerProcessLease(cfg, slotName, tmuxName, worktreePath, runnerPath, nextGeneration, sess.PID, "fallover")
 	if err != nil {
 		if processLease.Unit != "" {


### PR DESCRIPTION
Refs #1082

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR terminalizes over-budget and repeatedly vanishing worker sessions. The main changes are:

- Binds token-budget markers to worker generations.
- Rejects stale markers from earlier attempts.
- Allows explicit operator restarts to clear terminal state.
- Stops automatic respawns after repeated unexpected exits.
- Keeps terminal failures claimed until explicit release.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

Stale markers are rejected when their worker generation does not match the active attempt. Replacement attempts reset attempt-scoped token accounting before normal enforcement resumes.

No blocking issue remains in the reviewed fix paths.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated the terminal-lifecycle-01-before.log from the general-contract-validation-proof, confirming exit 0 and that the first canonical retry is permitted with below-budget recovery.
- Validated the terminal-lifecycle-02-after.log from the general-contract-validation-proof, confirming exit 0 and the explicit runtime output indicating terminalized after repeated unexpected exits, automatic respawn disabled, token-budget stops, terminal claim tests for both outcomes, and operator restart latch-clearing tests.

<a href="https://app.greptile.com/trex/runs/15420943/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/worker/token_budget.go | Adds worker-generation identity to budget markers and rejects markers from earlier attempts. |
| internal/orchestrator/orchestrator.go | Terminalizes budget exhaustion and repeated unexpected exits before they can re-enter automatic retry paths. |
| internal/state/state.go | Adds durable repeated-exit state and explicit operator-restart preparation. |
| internal/state/issue_claim.go | Keeps terminal worker failures claimed until an operator releases them. |
| internal/worker/attribution.go | Consumes the operator-restart handoff when the replacement attempt starts. |
| internal/worker/worker.go | Passes the next worker generation to the token-budget marker writer. |
| internal/worker/checkpoint.go | Aligns in-place respawn markers with the replacement worker generation. |
| internal/worker/phase.go | Aligns phase-transition markers with the next worker generation. |

<sub>Reviews (2): Last reviewed commit: ["fix: bind terminal budget checks to work..."](https://github.com/befeast/maestro/commit/4e28cceb945305c8e37cb6421bf051a843c4651a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46322325)</sub>

<!-- /greptile_comment -->