### PR TITLE
feat: first-class Kimi Code CLI backend (print mode, stream-json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,9 @@ model:
       cmd: codex         # OpenAI Codex CLI
     gemini:
       cmd: gemini        # Google Gemini CLI
+    kimi:
+      cmd: kimi          # MoonshotAI Kimi Code CLI
+      provider: moonshot
     cline:
       cmd: cline         # Cline CLI (e.g. SAP AI Core / any OpenAI-compatible provider)
 ```
@@ -333,6 +336,12 @@ model:
 > Auth: `gemini auth` or set `GEMINI_API_KEY`
 
 > [!NOTE]
+> **Kimi** — MoonshotAI Kimi Code CLI
+> Install: `uv tool install --python 3.13 kimi-cli` | `kimi --version`
+> Worker mode: prompt via stdin, `--print --output-format=stream-json`.
+> Auth and proxy routing: see [`docs/kimi-backend.md`](docs/kimi-backend.md).
+
+> [!NOTE]
 > **Cline** — Cline CLI, supports any OpenAI-compatible provider (including SAP AI Core, Azure OpenAI, etc.)
 > Install: `bun add -g cline` | `cline --version`
 > Config: `~/.cline/data/globalState.json` + `secrets.json` — configure provider and model before use.
@@ -343,9 +352,9 @@ model:
 
 Backends do not have to be named after the CLI they run. A custom key (e.g. a model nickname) keeps full CLI-specific behaviour — permission-bypass flags and stdin prompt delivery — as long as Maestro can tell which CLI it wraps. Resolution order:
 
-1. the backend name itself (`claude`, `codex`, `gemini`, `cline`),
-2. the `provider` field (`anthropic`/`claude` → Claude, `openai`/`codex` → Codex, `google`/`gemini` → Gemini, `cline` → Cline),
-3. the binary basename of `cmd` (`claude`, `codex`, `gemini`, `cline`).
+1. the backend name itself (`claude`, `codex`, `gemini`, `kimi`, `cline`),
+2. the `provider` field (`anthropic`/`claude` → Claude, `openai`/`codex` → Codex, `google`/`gemini` → Gemini, `moonshot`/`kimi` → Kimi, `cline` → Cline),
+3. the binary basename of `cmd` (`claude`, `codex`, `gemini`, `kimi`, `cline`).
 
 ```yaml
 model:
@@ -361,7 +370,7 @@ model:
 
 A backend that matches none of the above falls back to the generic exec path: `prompt_mode` applies, no permission-bypass flag is added, and Maestro logs a startup warning naming the backend. Use the generic path only for genuinely custom CLIs.
 
-### Claude / Codex usage capture (tokens + cost)
+### Structured usage capture (tokens + cost)
 
 Plain `claude -p` text mode prints no parseable token total, and `codex exec` text mode only prints a fuzzy single total — so a worker's `tokens_used_total` and USD cost are unreliable or `0`. Opt a `claude` or `codex` backend into structured usage capture with `usage_stream: true`:
 
@@ -381,6 +390,12 @@ model:
 ```
 
 When enabled, the worker runs the backend in structured-stream mode (`claude --output-format stream-json --verbose`, or `codex exec --json`) and its NDJSON is piped through `maestro stream-split`, which writes the raw frames to a side-channel `<slot>.jsonl` (parsed for `input`/`output`/cache tokens) while keeping `<slot>.log` human-readable. The session then reports non-zero split tokens in `maestro history --json` and the `/api/v1/fleet` cost panel. Off by default; an operator-pinned `--output-format` (claude) or `--json` (codex) in `extra_args` overrides it. Claude reports its own `total_cost_usd`; codex does not, so its cost is **virtual** — computed from the configured `pricing` block (tokens-only `$0` when no rates are set). (The `pi` backend captures usage natively and needs no opt-in.)
+
+Kimi uses stream-json by default and needs no `usage_stream` opt-in. When its
+stream carries native `input_other`, `output`, `input_cache_read`, and
+`input_cache_creation` usage, Maestro feeds those fields into the same
+watermark and split-cost path. See the Kimi runbook for the upstream telemetry
+and live-budget limitations.
 
 #### Claude harness through CLIProxyAPI: non-Anthropic telemetry smoke (2026-07-21)
 

--- a/docs/kimi-backend.md
+++ b/docs/kimi-backend.md
@@ -1,0 +1,62 @@
+# Kimi Code CLI backend
+
+Maestro treats `kimi` as a first-class worker backend. A backend named `kimi`,
+one declared with `provider: moonshot` (or `provider: kimi`), or one whose
+command basename is `kimi` resolves to the Kimi command builder.
+
+```yaml
+model:
+  default: moonshot-primary
+  backends:
+    moonshot-primary:
+      provider: moonshot
+      cmd: kimi
+```
+
+Add the normal backend `pricing` block when USD estimates are required; without
+rates, Fleet reports tokens only.
+
+## Worker contract
+
+The worker runs Kimi in non-interactive print mode with JSONL output:
+
+```text
+kimi --print --output-format=stream-json
+```
+
+Maestro supplies the prompt on stdin. Kimi print mode enables its unattended
+approval behavior, so no separate approval flag is required. An explicit
+operator `--output-format` in `cmd` or `extra_args` wins; choosing text output
+disables the JSONL side channel and structured usage accounting.
+
+When Kimi emits its native usage object, Maestro records uncached input,
+output, cache-read, and cache-creation tokens, advances the respawn-safe usage
+watermark, and applies configured split pricing in history and Fleet cost
+observability. Current Kimi releases do not guarantee a usage object on every
+print-mode response. Missing usage therefore remains unavailable rather than
+being treated as zero-token progress.
+
+`worker_max_tokens` is not supported for the Kimi kind. Maestro rejects a
+positive live budget at worker startup because Kimi stream-json does not
+guarantee response-by-response usage, so it cannot safely stop the process at
+the configured ceiling.
+
+## Authentication and pooled proxy routing
+
+Two authentication arrangements are supported:
+
+- Native Moonshot/Kimi: run `kimi login` once as the same operating-system user
+  that launches Maestro workers. Kimi keeps its authentication in its own
+  user-level configuration; do not copy that material into project YAML.
+- CLIProxyAPI: configure a custom Kimi provider/model in Kimi's user-level
+  config, using its `openai_legacy` provider type and the proxy
+  endpoint. Keep the provider credential in Kimi's user config or Maestro's
+  private worker credential boundary, never in the repository. Routing Kimi
+  through the shared proxy keeps requests on the pooled credential/quota path.
+
+Verify the selected setup without dumping configuration or environment values:
+
+```sh
+kimi --version
+printf 'Reply with OK.\n' | kimi --print --output-format=stream-json
+```

--- a/internal/config/backend_kind.go
+++ b/internal/config/backend_kind.go
@@ -17,6 +17,7 @@ const (
 	BackendKindCodex    = "codex"
 	BackendKindGemini   = "gemini"
 	BackendKindCline    = "cline"
+	BackendKindKimi     = "kimi"
 	BackendKindPi       = "pi"
 	BackendKindOpencode = "opencode"
 	BackendKindGeneric  = "generic"
@@ -34,6 +35,8 @@ var providerBackendKinds = map[string]string{
 	"google":    BackendKindGemini,
 	"gemini":    BackendKindGemini,
 	"cline":     BackendKindCline,
+	"moonshot":  BackendKindKimi,
+	"kimi":      BackendKindKimi,
 	"pi":        BackendKindPi,
 	"ollama":    BackendKindPi,
 	"opencode":  BackendKindOpencode,
@@ -41,10 +44,10 @@ var providerBackendKinds = map[string]string{
 
 // ResolveBackendKind decides which CLI-specific exec path a backend uses.
 // Resolution order (#684):
-//  1. the backend name itself — claude/codex/gemini/cline keys keep their
+//  1. the backend name itself — claude/codex/gemini/kimi/cline keys keep their
 //     existing behaviour,
 //  2. the per-backend provider field (anthropic → claude, openai → codex, …),
-//  3. the binary basename of cmd's first token (claude/codex/gemini/cline),
+//  3. the binary basename of cmd's first token (claude/codex/gemini/kimi/cline),
 //  4. the generic fallback (prompt_mode applies, no permission-bypass flag).
 //
 // Before #684, dispatch was keyed on the name alone: the Anthropic CLI
@@ -53,7 +56,7 @@ var providerBackendKinds = map[string]string{
 // mutating tool call was denied by the CLI's permission layer (sup-175).
 func ResolveBackendKind(name, provider, cmd string) string {
 	switch name {
-	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindPi, BackendKindOpencode:
+	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindKimi, BackendKindPi, BackendKindOpencode:
 		return name
 	}
 	if kind, ok := providerBackendKinds[strings.ToLower(strings.TrimSpace(provider))]; ok {
@@ -73,7 +76,7 @@ func backendKindFromCmd(cmd string) string {
 		return ""
 	}
 	switch base := filepath.Base(fields[0]); base {
-	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindPi, BackendKindOpencode:
+	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindKimi, BackendKindPi, BackendKindOpencode:
 		return base
 	}
 	return ""
@@ -105,7 +108,7 @@ func (c *Config) backendResolutionWarnings() []string {
 		kind := ResolveBackendKind(name, def.Provider, def.Cmd)
 		if kind == BackendKindGeneric {
 			warnings = append(warnings, fmt.Sprintf(
-				"config: backend %q resolves to the generic exec path (provider %q and cmd %q match no known CLI) — workers run without a permission-bypass flag (mutating tool calls may be denied) and the prompt is delivered per prompt_mode=%q (argv delivery risks E2BIG on large prompts). If this wraps a known CLI, set provider: anthropic|openai|google|cline|pi|ollama or use a claude/codex/gemini/cline/pi binary in cmd.",
+				"config: backend %q resolves to the generic exec path (provider %q and cmd %q match no known CLI) — workers run without a permission-bypass flag (mutating tool calls may be denied) and the prompt is delivered per prompt_mode=%q (argv delivery risks E2BIG on large prompts). If this wraps a known CLI, set provider: anthropic|openai|google|moonshot|kimi|cline|pi|ollama or use a claude/codex/gemini/kimi/cline/pi binary in cmd.",
 				name, def.Provider, def.Cmd, coalescePromptMode(def.PromptMode)))
 			continue
 		}

--- a/internal/config/backend_kind_test.go
+++ b/internal/config/backend_kind_test.go
@@ -19,11 +19,14 @@ func TestResolveBackendKind(t *testing.T) {
 		{"codex", "", "", BackendKindCodex},
 		{"gemini", "", "gemini-cli", BackendKindGemini},
 		{"cline", "", "", BackendKindCline},
+		{"kimi", "", "", BackendKindKimi},
 		// 2. Provider field resolves custom names (sup-175 `fable:` shape).
 		{"fable", "anthropic", "claude --model claude-fable-5 --effort xhigh", BackendKindClaude},
 		{"fast", "openai", "codex --profile fast", BackendKindCodex},
 		{"flash", "google", "gemini", BackendKindGemini},
 		{"wrapped", "cline", "cline", BackendKindCline},
+		{"moonshot", "moonshot", "kimi", BackendKindKimi},
+		{"kimi-custom", "kimi", "my-kimi-shim", BackendKindKimi},
 		// #730: provider pi / ollama resolves to the first-class pi backend.
 		{"pi-ollama", "ollama", "pi", BackendKindPi},
 		{"picustom", "pi", "my-pi-shim", BackendKindPi},
@@ -36,6 +39,7 @@ func TestResolveBackendKind(t *testing.T) {
 		{"mymodel", "", "codex --flag", BackendKindCodex},
 		{"mymodel", "groq", "gemini", BackendKindGemini},
 		{"picli", "", "/usr/local/bin/pi", BackendKindPi},
+		{"kimicli", "", "/usr/local/bin/kimi", BackendKindKimi},
 		// 4. Everything else is generic.
 		{"helper", "groq", "groq-cli", BackendKindGeneric},
 		{"custom", "", "my-cli --verbose", BackendKindGeneric},
@@ -81,8 +85,9 @@ func TestConfig_Warnings_CustomBackendProviderResolvedNoWarning(t *testing.T) {
 		Model: ModelConfig{
 			Default: "fable",
 			Backends: map[string]BackendDef{
-				"fable":   {Provider: "anthropic", Cmd: "claude --model claude-fable-5 --effort xhigh"},
-				"mymodel": {Cmd: "/usr/local/bin/codex --profile fast"},
+				"fable":            {Provider: "anthropic", Cmd: "claude --model claude-fable-5 --effort xhigh"},
+				"moonshot-primary": {Provider: "moonshot", Cmd: "kimi"},
+				"mymodel":          {Cmd: "/usr/local/bin/codex --profile fast"},
 			},
 		},
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -94,14 +94,11 @@ type BackendDef struct {
 	TierModel  string `yaml:"-" json:"-"`
 	TierEffort string `yaml:"-" json:"-"`
 
-	// #737: opt-in structured usage capture. When true, a claude-kind backend
-	// runs in `--output-format stream-json --verbose` mode and the worker
-	// runner pipes its NDJSON through `maestro stream-split`, which writes the
-	// raw frames to a side-channel slot.jsonl (parsed for tokens/cost) while
-	// keeping slot.log human-readable. Off by default: plain `claude -p` text
-	// mode prints no parseable token total, so usage/cost stay 0 (the #737
-	// symptom) until an operator opts in. Overridable via extra_args (a
-	// trailing --output-format wins). Only the claude kind consumes this today.
+	// #737/#947: opt-in structured usage capture for backends whose JSON mode
+	// is optional (claude/codex/opencode). The worker runner pipes NDJSON through
+	// `maestro stream-split`, which writes raw frames to slot.jsonl for usage
+	// accounting while keeping slot.log human-readable. Kimi is structured by
+	// default and does not require this flag.
 	UsageStream bool `yaml:"usage_stream,omitempty"`
 
 	// #507: NonAgentic marks a backend that is a TEXT-COMPLETION helper,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1347,6 +1347,13 @@ func (o *Orchestrator) updateTokensUsedFromOutput(slotName string, sess *state.S
 	if kind == config.BackendKindCodex && o.sessionUsageStream(sess) {
 		return o.updateCodexUsageFromJSONL(slotName, sess)
 	}
+	// Kimi's first-class worker command always defaults to stream-json, so it
+	// uses the side channel without requiring the claude/codex usage_stream
+	// opt-in. An operator-pinned text output produces no side channel and this
+	// path simply leaves usage unchanged.
+	if kind == config.BackendKindKimi {
+		return o.updateKimiUsageFromJSONL(slotName, sess)
+	}
 	if kind == config.BackendKindOpencode && o.sessionUsageStream(sess) {
 		return o.updateOpenCodeUsageFromJSONL(slotName, sess)
 	}
@@ -1553,6 +1560,53 @@ func (o *Orchestrator) updateCodexUsageFromJSONL(slotName string, sess *state.Se
 	log.Printf("[orch] %s codex usage: input=%d output=%d cache_read=%d tokens=%d (total=%d)",
 		slotName, usage.Input, usage.Output, usage.CacheRead, usage.TotalTokens, sess.TokensUsedTotal)
 	return true
+}
+
+// updateKimiUsageFromJSONL parses Kimi's first-class stream-json side channel
+// and stamps split tokens onto the session. ParseKimiUsage returns cumulative
+// usage across the append-only file, so UsageTokensWatermark keeps retries and
+// respawns from double-counting. Native Kimi usage normally has no USD field;
+// when absent, Fleet cost observability applies the backend's configured split
+// pricing to these counters.
+func (o *Orchestrator) updateKimiUsageFromJSONL(slotName string, sess *state.Session) bool {
+	jsonlPath := o.workerJSONLFile(slotName, sess)
+	if jsonlPath == "" {
+		return false
+	}
+	data, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		return false
+	}
+	usage, ok := worker.ParseKimiUsage(string(data))
+	if !ok {
+		return false
+	}
+	changed := false
+	if usage.TotalTokens > sess.UsageTokensWatermark {
+		delta := usage.TotalTokens - sess.UsageTokensWatermark
+		sess.UsageTokensWatermark = usage.TotalTokens
+		sess.TokensUsedAttempt += delta
+		sess.TokensUsedTotal += delta
+		sess.TokensInput = usage.Input
+		sess.TokensOutput = usage.Output
+		sess.TokensCacheRead = usage.CacheRead
+		sess.TokensCacheWrite = usage.CacheWrite
+		changed = true
+	}
+	if strings.TrimSpace(usage.Model) != "" && strings.TrimSpace(sess.Model) == "" {
+		sess.Model = usage.Model
+		changed = true
+	}
+	if usage.CostUSD > sess.CostUSDBackend {
+		sess.CostUSDBackend = usage.CostUSD
+		changed = true
+	}
+	if changed {
+		log.Printf("[orch] %s kimi usage: input=%d output=%d cache_read=%d cache_write=%d tokens=%d cost=$%.4f (total=%d)",
+			slotName, usage.Input, usage.Output, usage.CacheRead, usage.CacheWrite,
+			usage.TotalTokens, usage.CostUSD, sess.TokensUsedTotal)
+	}
+	return changed
 }
 
 // updateOpenCodeUsageFromJSONL parses the opencode --format json side-channel

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -11542,6 +11542,48 @@ func TestUpdateTokensUsedFromOutput_ClaudeBackendRetryNoDoubleCount(t *testing.T
 	}
 }
 
+func TestUpdateTokensUsedFromOutput_KimiFixtureStampsWatermarkAndSplitTokens(t *testing.T) {
+	dir := t.TempDir()
+	o := &Orchestrator{
+		cfg: &config.Config{
+			StateDir: dir,
+			Model: config.ModelConfig{
+				Default: "moonshot-primary",
+				Backends: map[string]config.BackendDef{
+					"moonshot-primary": {Cmd: "kimi", Provider: "moonshot"},
+				},
+			},
+		},
+	}
+	logFile := filepath.Join(dir, "sup-kimi.log")
+	sess := &state.Session{Backend: "moonshot-primary", LogFile: logFile}
+	fixture, err := os.ReadFile(filepath.Join("..", "worker", "testdata", "kimi_stream.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(worker.JSONLPathForLog(logFile), fixture, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !o.updateTokensUsedFromOutput("sup-kimi", sess, "rendered Kimi output") {
+		t.Fatal("expected Kimi JSONL usage to update the session")
+	}
+	if sess.TokensUsedAttempt != 2650 || sess.TokensUsedTotal != 2650 || sess.UsageTokensWatermark != 2650 {
+		t.Fatalf("tokens attempt/total/watermark = %d/%d/%d, want 2650/2650/2650",
+			sess.TokensUsedAttempt, sess.TokensUsedTotal, sess.UsageTokensWatermark)
+	}
+	if sess.TokensInput != 2100 || sess.TokensOutput != 180 || sess.TokensCacheRead != 350 || sess.TokensCacheWrite != 20 {
+		t.Fatalf("split tokens = %d/%d/%d/%d, want 2100/180/350/20",
+			sess.TokensInput, sess.TokensOutput, sess.TokensCacheRead, sess.TokensCacheWrite)
+	}
+	if sess.Model != "kimi-k2.5" {
+		t.Fatalf("Model = %q, want kimi-k2.5", sess.Model)
+	}
+	if o.updateTokensUsedFromOutput("sup-kimi", sess, "same rendered output") {
+		t.Fatal("unchanged cumulative Kimi usage must not advance the watermark")
+	}
+}
+
 // codexTurnFrame builds one terminal codex `exec --json` turn.completed event
 // with the given token totals, as the stream-splitter would append it.
 // cached_input_tokens is a subset of input_tokens (OpenAI semantics).

--- a/internal/router/resolve_test.go
+++ b/internal/router/resolve_test.go
@@ -62,7 +62,7 @@ func TestBackendFromLabels_EmptyModelValue(t *testing.T) {
 }
 
 func TestBackendFromLabels_AllKnownBackends(t *testing.T) {
-	backends := []string{"claude", "codex", "gemini", "cline"}
+	backends := []string{"claude", "codex", "gemini", "kimi", "cline"}
 	for _, b := range backends {
 		issue := makeIssue(10, "Test", "model:"+b)
 		got := BackendFromLabels(issue)

--- a/internal/server/cost_observability_test.go
+++ b/internal/server/cost_observability_test.go
@@ -595,4 +595,20 @@ func TestSessionCostEstimate_Precedence(t *testing.T) {
 	}
 }
 
+func TestSessionCostEstimate_KimiSplitUsage(t *testing.T) {
+	pricing := map[string]config.BackendPricing{
+		"moonshot-primary": {
+			InputUSDPerMtok:      2,
+			OutputUSDPerMtok:     8,
+			CacheReadUSDPerMtok:  0.5,
+			CacheWriteUSDPerMtok: 2,
+		},
+	}
+	got := sessionCostEstimate("moonshot-primary", 2650, 2100, 180, 350, 20, pricing, 0)
+	want := (2100*2 + 180*8 + 350*0.5 + 20*2) / 1_000_000.0
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("Kimi split estimate = %f, want %f", got, want)
+	}
+}
+
 func timePtr(t time.Time) *time.Time { return &t }

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -83,6 +83,7 @@ var knownBackends = map[string]Backend{
 	"cline":    clineBackend{},
 	"codex":    codexBackend{},
 	"gemini":   geminiBackend{},
+	"kimi":     kimiBackend{},
 	"opencode": opencodeBackend{},
 	"pi":       piBackend{},
 }
@@ -184,6 +185,39 @@ func (codexBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*e
 	cmd := exec.Command(binary, args...)
 	cmd.Dir = worktree
 	// Stdin redirection is handled by the runner script — no file opened here
+	return cmd, promptFile, nil
+}
+
+// --- Kimi Backend ---
+
+// kimiBackend runs Kimi Code CLI in non-interactive print mode. Print mode
+// implicitly enables Kimi's AFK/auto-approval behavior; with no -p/--prompt
+// value, a non-TTY stdin is read as the prompt. Keeping the prompt out of argv
+// avoids the Linux MAX_ARG_STRLEN ceiling for retry-expanded worker prompts.
+//
+// Kimi's stream-json contract is the first-class output mode here rather than
+// an opt-in. The stream splitter preserves the raw JSONL for usage accounting
+// and renders assistant/tool messages into the human-readable worker log.
+type kimiBackend struct{}
+
+func (kimiBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, string, error) {
+	kimiCmd := cfg.Cmd
+	if kimiCmd == "" {
+		kimiCmd = "kimi"
+	}
+	binary, cmdArgs := splitCmd(kimiCmd)
+	pinned := pinnedArgs(cmdArgs, cfg)
+	args := append([]string(nil), cmdArgs...)
+	if !argsHaveFlag(pinned, "--print") {
+		args = append(args, "--print")
+	}
+	if !argsHaveOutputFormat(pinned) {
+		args = append(args, "--output-format=stream-json")
+	}
+	args = appendTierModelEffort(args, pinned, config.BackendKindKimi, cfg)
+	args = append(args, cfg.ExtraArgs...)
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = worktree
 	return cmd, promptFile, nil
 }
 
@@ -685,17 +719,21 @@ func maestroExecutablePath() (string, bool) {
 }
 
 // streamSplitForBackend returns the worker runner's stream-split configuration,
-// or nil when the plain `tee` pipeline should be used. Only a structured-stream
-// backend (claude #737, codex #738) with usage_stream opted in streams NDJSON;
-// when the maestro binary cannot be resolved it degrades to nil (plain tee).
-// The resolved backend kind is passed to the splitter so it renders the right
-// human-readable form into slot.log.
+// or nil when the plain `tee` pipeline should be used. Claude/codex/opencode
+// require usage_stream; Kimi is structured by default, while Pi is structured
+// when its live budget needs the side channel. When the maestro binary cannot
+// be resolved this degrades to nil (plain tee). The resolved kind is passed to
+// the splitter so it renders the right human-readable form into slot.log.
 func streamSplitForBackend(backendName string, cfg BackendConfig, logFile string) *streamSplit {
 	kind := resolveBackendKind(backendName, cfg)
-	if !cfg.UsageStream && !(cfg.TokenBudget > 0 && kind == config.BackendKindPi) {
+	if kind == config.BackendKindKimi {
+		if !kimiUsesStreamJSON(cfg) {
+			return nil
+		}
+	} else if !cfg.UsageStream && !(cfg.TokenBudget > 0 && kind == config.BackendKindPi) {
 		return nil
 	}
-	if kind != config.BackendKindClaude && kind != config.BackendKindCodex && kind != config.BackendKindOpencode && kind != config.BackendKindPi {
+	if kind != config.BackendKindClaude && kind != config.BackendKindCodex && kind != config.BackendKindKimi && kind != config.BackendKindOpencode && kind != config.BackendKindPi {
 		return nil
 	}
 	bin, ok := maestroExecutablePath()
@@ -711,9 +749,40 @@ func streamSplitForBackend(backendName string, cfg BackendConfig, logFile string
 	}
 }
 
+// kimiUsesStreamJSON reports whether the effective Kimi output format is the
+// structured default. An operator can explicitly pin a different format in cmd
+// or extra_args; in that case the command still runs, but no JSON side channel
+// is installed and usage remains unavailable.
+func kimiUsesStreamJSON(cfg BackendConfig) bool {
+	_, cmdArgs := splitCmd(cfg.Cmd)
+	format, pinned := argsFlagValue(pinnedArgs(cmdArgs, cfg), "--output-format")
+	return !pinned || strings.EqualFold(strings.TrimSpace(format), "stream-json")
+}
+
+func argsFlagValue(args []string, flag string) (string, bool) {
+	var value string
+	found := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == flag {
+			found = true
+			if i+1 < len(args) {
+				value = args[i+1]
+				i++
+			}
+			continue
+		}
+		if strings.HasPrefix(arg, flag+"=") {
+			found = true
+			value = strings.TrimPrefix(arg, flag+"=")
+		}
+	}
+	return value, found
+}
+
 // BuildWorkerCmd creates the right exec.Cmd for a backend. The backend name,
 // provider field, and cmd binary resolve to a CLI-specific builder (claude,
-// codex, gemini, cline — see resolveBackendKind); anything else uses the
+// codex, gemini, kimi, cline — see resolveBackendKind); anything else uses the
 // generic builder with prompt_mode from config.
 // Returns the command, an optional stdinFile path (for backends that read
 // the prompt via stdin, e.g. claude/codex), and any error.
@@ -755,6 +824,8 @@ func validateLiveTokenBudget(backendName string, cfg BackendConfig) error {
 		if !cfg.UsageStream || argsHaveFlag(cfg.ExtraArgs, "--format") {
 			return fmt.Errorf("worker_max_tokens=%d requires OpenCode usage_stream with Maestro-managed JSON output", cfg.TokenBudget)
 		}
+	case config.BackendKindKimi:
+		return fmt.Errorf("worker_max_tokens=%d cannot be enforced live for Kimi: stream-json does not guarantee response-by-response usage; disable the budget or select a backend with live token telemetry", cfg.TokenBudget)
 	default:
 		return fmt.Errorf("worker_max_tokens=%d cannot be enforced live for backend %q; disable the budget or use claude, codex, pi, or opencode structured usage", cfg.TokenBudget, backendName)
 	}
@@ -816,6 +887,30 @@ func BuildSupervisorCmd(backendName string, cfg BackendConfig, promptFile, workt
 		cmd := exec.Command(binary, args...)
 		cmd.Dir = worktree
 		return cmd, "", nil
+	case "kimi":
+		kimiCmd := cfg.Cmd
+		if kimiCmd == "" {
+			kimiCmd = "kimi"
+		}
+		binary, cmdArgs := splitCmd(kimiCmd)
+		pinned := pinnedArgs(cmdArgs, cfg)
+		args := append([]string(nil), cmdArgs...)
+		if !argsHaveFlag(pinned, "--print") {
+			args = append(args, "--print")
+		}
+		if !argsHaveFlag(pinned, "--plan") {
+			args = append(args, "--plan")
+		}
+		if !argsHaveFlag(pinned, "--final-message-only") {
+			args = append(args, "--final-message-only")
+		}
+		if model := strings.TrimSpace(cfg.Model); model != "" && !argsHaveFlag(pinned, "--model") {
+			args = append(args, "--model", model)
+		}
+		args = append(args, cfg.ExtraArgs...)
+		cmd := exec.Command(binary, args...)
+		cmd.Dir = worktree
+		return cmd, promptFile, nil
 	case "cline":
 		promptData, err := os.ReadFile(promptFile)
 		if err != nil {

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -49,6 +49,73 @@ func TestBuildWorkerCmd_Claude(t *testing.T) {
 	}
 }
 
+func TestBuildWorkerCmd_Kimi(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("implement the issue"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	worktree := "/tmp/kimi-worktree"
+
+	cfg := BackendConfig{Cmd: "kimi", Provider: "moonshot"}
+	cmd, stdinFile, err := BuildWorkerCmd("moonshot-primary", cfg, promptFile, worktree)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stdinFile != promptFile {
+		t.Fatalf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+	wantArgs := []string{"kimi", "--print", "--output-format=stream-json"}
+	if !reflect.DeepEqual(cmd.Args, wantArgs) {
+		t.Fatalf("args = %v, want %v", cmd.Args, wantArgs)
+	}
+	if strings.Contains(strings.Join(cmd.Args, " "), "implement the issue") {
+		t.Fatalf("prompt content leaked into argv: %v", cmd.Args)
+	}
+	if cmd.Dir != worktree {
+		t.Fatalf("Dir = %q, want %q", cmd.Dir, worktree)
+	}
+}
+
+func TestBuildWorkerCmd_KimiCmdBasenameAndPinnedOutput(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("do the thing"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := BackendConfig{
+		Cmd:       "/opt/kimi/bin/kimi --thinking",
+		ExtraArgs: []string{"--output-format", "text"},
+	}
+	cmd, stdinFile, err := BuildWorkerCmd("custom", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdinFile != promptFile {
+		t.Fatalf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+	joined := strings.Join(cmd.Args, " ")
+	if !strings.Contains(joined, "--print") || !strings.Contains(joined, "--thinking") {
+		t.Fatalf("Kimi flags missing from %v", cmd.Args)
+	}
+	if strings.Contains(joined, "stream-json") {
+		t.Fatalf("operator-pinned output format must win: %v", cmd.Args)
+	}
+	if split := streamSplitForBackend("custom", cfg, "/tmp/slot.log"); split != nil {
+		t.Fatalf("text-mode Kimi must not install stream-split: %+v", split)
+	}
+}
+
+func TestStreamSplitForBackend_KimiDefaultsStructured(t *testing.T) {
+	split := streamSplitForBackend("kimi", BackendConfig{Cmd: "kimi"}, "/tmp/slot.log")
+	if split == nil {
+		t.Fatal("first-class Kimi backend should install stream-split by default")
+	}
+	if split.Backend != "kimi" || split.JSONLPath != "/tmp/slot.jsonl" {
+		t.Fatalf("split = %+v, want kimi /tmp/slot.jsonl", split)
+	}
+}
+
 // TestBuildWorkerCmd_ClaudeUsageStream verifies the #737 opt-in: when
 // UsageStream is set the claude worker runs in stream-json mode, and an
 // operator-pinned --output-format in extra_args overrides it (no duplicate).
@@ -996,9 +1063,34 @@ func TestBuildSupervisorCmd_CustomNameProviderAnthropic(t *testing.T) {
 	}
 }
 
+func TestBuildSupervisorCmd_KimiIsReadOnlyAndUsesStdin(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("make a decision"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := BackendConfig{Cmd: "kimi", Provider: "moonshot", Model: "kimi-for-coding"}
+	cmd, stdinFile, err := BuildSupervisorCmd("moonshot-primary", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdinFile != promptFile {
+		t.Fatalf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+	joined := strings.Join(cmd.Args, " ")
+	for _, want := range []string{"--print", "--plan", "--final-message-only", "--model kimi-for-coding"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("args missing %q: %v", want, cmd.Args)
+		}
+	}
+	if strings.Contains(joined, "make a decision") {
+		t.Fatalf("prompt content leaked into argv: %v", cmd.Args)
+	}
+}
+
 func TestKnownBackends(t *testing.T) {
 	backends := KnownBackends()
-	expected := map[string]bool{"claude": false, "codex": false, "gemini": false, "cline": false, "pi": false}
+	expected := map[string]bool{"claude": false, "codex": false, "gemini": false, "cline": false, "kimi": false, "pi": false}
 	for _, name := range backends {
 		if _, ok := expected[name]; ok {
 			expected[name] = true

--- a/internal/worker/kimi_usage.go
+++ b/internal/worker/kimi_usage.go
@@ -1,0 +1,206 @@
+package worker
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// KimiUsage is the cumulative usage parsed from Kimi Code CLI stream-json.
+// Kimi's native token names distinguish uncached input from cache reads and
+// cache creation, matching Maestro's split-cost accounting dimensions.
+type KimiUsage struct {
+	Model       string
+	Input       int
+	Output      int
+	CacheRead   int
+	CacheWrite  int
+	TotalTokens int
+	CostUSD     float64
+}
+
+type kimiUsageBlock struct {
+	Input      int
+	Output     int
+	CacheRead  int
+	CacheWrite int
+	CostUSD    float64
+}
+
+// ParseKimiUsage scans an appended Kimi JSONL side channel and sums usage
+// across steps and attempts. It accepts the native TokenUsage field names
+// (input_other/output/input_cache_read/input_cache_creation) in either a
+// top-level stream message or Kimi's StatusUpdate envelope. Camel-case aliases
+// are accepted for the newer TypeScript event contract.
+func ParseKimiUsage(text string) (KimiUsage, bool) {
+	var out KimiUsage
+	seen := false
+	byMessage := make(map[string]kimiUsageBlock)
+
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || line[0] != '{' {
+			continue
+		}
+		root, ok := decodeJSONObject([]byte(line))
+		if !ok {
+			continue
+		}
+		usageMap, container, ok := findKimiUsageMap(root)
+		if !ok {
+			continue
+		}
+		usage := decodeKimiUsageBlock(usageMap)
+		if usage.CostUSD == 0 {
+			usage.CostUSD = firstJSONNumber(container, "cost_usd", "total_cost_usd")
+		}
+		if usage.CostUSD == 0 {
+			usage.CostUSD = firstJSONNumber(root, "cost_usd", "total_cost_usd")
+		}
+		if model := firstJSONString(container, "model", "model_name"); model != "" {
+			out.Model = model
+		} else if model := firstJSONString(root, "model", "model_name"); model != "" {
+			out.Model = model
+		}
+
+		messageID := firstJSONString(container, "message_id", "messageId", "id")
+		if messageID == "" {
+			messageID = firstJSONString(root, "message_id", "messageId")
+		}
+		if messageID == "" {
+			addKimiUsage(&out, usage)
+		} else {
+			previous := byMessage[messageID]
+			addKimiUsage(&out, kimiUsageBlock{
+				Input:      positiveDelta(usage.Input, previous.Input),
+				Output:     positiveDelta(usage.Output, previous.Output),
+				CacheRead:  positiveDelta(usage.CacheRead, previous.CacheRead),
+				CacheWrite: positiveDelta(usage.CacheWrite, previous.CacheWrite),
+				CostUSD:    positiveFloatDelta(usage.CostUSD, previous.CostUSD),
+			})
+			byMessage[messageID] = usage
+		}
+		if kimiUsageTotal(usage) > 0 || usage.CostUSD > 0 {
+			seen = true
+		}
+	}
+
+	out.TotalTokens = out.Input + out.Output + out.CacheRead + out.CacheWrite
+	return out, seen
+}
+
+func addKimiUsage(out *KimiUsage, usage kimiUsageBlock) {
+	if out == nil {
+		return
+	}
+	out.Input += usage.Input
+	out.Output += usage.Output
+	out.CacheRead += usage.CacheRead
+	out.CacheWrite += usage.CacheWrite
+	out.CostUSD += usage.CostUSD
+}
+
+func positiveFloatDelta(current, previous float64) float64 {
+	if current > previous {
+		return current - previous
+	}
+	return 0
+}
+
+func kimiUsageTotal(usage kimiUsageBlock) int {
+	return usage.Input + usage.Output + usage.CacheRead + usage.CacheWrite
+}
+
+func decodeKimiUsageBlock(m map[string]json.RawMessage) kimiUsageBlock {
+	return kimiUsageBlock{
+		Input:      firstKimiJSONInt(m, "input_other", "inputOther"),
+		Output:     firstKimiJSONInt(m, "output", "output_tokens", "outputTokens"),
+		CacheRead:  firstKimiJSONInt(m, "input_cache_read", "inputCacheRead", "cache_read_input_tokens"),
+		CacheWrite: firstKimiJSONInt(m, "input_cache_creation", "inputCacheCreation", "cache_creation_input_tokens"),
+		CostUSD:    firstJSONNumber(m, "cost_usd", "total_cost_usd"),
+	}
+}
+
+// findKimiUsageMap finds one usage block and returns the closest containing
+// object as well, so callers can read sibling message_id/model/cost fields.
+func findKimiUsageMap(root map[string]json.RawMessage) (map[string]json.RawMessage, map[string]json.RawMessage, bool) {
+	if usage, ok := nestedJSONObject(root, "usage", "token_usage", "tokenUsage"); ok {
+		return usage, root, true
+	}
+	for _, key := range []string{"payload", "message", "data"} {
+		child, ok := objectField(root, key)
+		if !ok {
+			continue
+		}
+		if usage, container, ok := findKimiUsageMap(child); ok {
+			return usage, container, true
+		}
+	}
+	return nil, nil, false
+}
+
+func decodeJSONObject(data []byte) (map[string]json.RawMessage, bool) {
+	var out map[string]json.RawMessage
+	if json.Unmarshal(data, &out) != nil || out == nil {
+		return nil, false
+	}
+	return out, true
+}
+
+func objectField(m map[string]json.RawMessage, key string) (map[string]json.RawMessage, bool) {
+	raw, ok := m[key]
+	if !ok {
+		return nil, false
+	}
+	return decodeJSONObject(raw)
+}
+
+func nestedJSONObject(m map[string]json.RawMessage, keys ...string) (map[string]json.RawMessage, bool) {
+	for _, key := range keys {
+		if child, ok := objectField(m, key); ok {
+			return child, true
+		}
+	}
+	return nil, false
+}
+
+func firstKimiJSONInt(m map[string]json.RawMessage, keys ...string) int {
+	for _, key := range keys {
+		raw, ok := m[key]
+		if !ok {
+			continue
+		}
+		var value int
+		if json.Unmarshal(raw, &value) == nil {
+			return value
+		}
+	}
+	return 0
+}
+
+func firstJSONNumber(m map[string]json.RawMessage, keys ...string) float64 {
+	for _, key := range keys {
+		raw, ok := m[key]
+		if !ok {
+			continue
+		}
+		var value float64
+		if json.Unmarshal(raw, &value) == nil {
+			return value
+		}
+	}
+	return 0
+}
+
+func firstJSONString(m map[string]json.RawMessage, keys ...string) string {
+	for _, key := range keys {
+		raw, ok := m[key]
+		if !ok {
+			continue
+		}
+		var value string
+		if json.Unmarshal(raw, &value) == nil && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/worker/kimi_usage_test.go
+++ b/internal/worker/kimi_usage_test.go
@@ -1,0 +1,37 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseKimiUsage_Fixture(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("testdata", "kimi_stream.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage, ok := ParseKimiUsage(string(fixture))
+	if !ok {
+		t.Fatal("ParseKimiUsage returned ok=false")
+	}
+	if usage.Model != "kimi-k2.5" {
+		t.Errorf("Model = %q, want kimi-k2.5", usage.Model)
+	}
+	if usage.Input != 2100 || usage.Output != 180 || usage.CacheRead != 350 || usage.CacheWrite != 20 {
+		t.Fatalf("split usage = %+v, want input=2100 output=180 cache_read=350 cache_write=20", usage)
+	}
+	if usage.TotalTokens != 2650 {
+		t.Fatalf("TotalTokens = %d, want 2650", usage.TotalTokens)
+	}
+	if usage.CostUSD != 0 {
+		t.Fatalf("CostUSD = %v, want 0 for virtual pricing", usage.CostUSD)
+	}
+}
+
+func TestParseKimiUsage_NoUsage(t *testing.T) {
+	usage, ok := ParseKimiUsage("{\"role\":\"assistant\",\"content\":\"done\"}\nnot json\n")
+	if ok || usage.TotalTokens != 0 {
+		t.Fatalf("usage = %+v ok=%t, want no usage", usage, ok)
+	}
+}

--- a/internal/worker/stream_split.go
+++ b/internal/worker/stream_split.go
@@ -112,6 +112,8 @@ func renderStreamLine(backend, line string) string {
 		return renderClaudeStreamLine(line)
 	case "codex":
 		return renderCodexStreamLine(line)
+	case "kimi":
+		return renderKimiStreamLine(line)
 	case "opencode":
 		return renderOpenCodeStreamLine(line)
 	default:
@@ -131,6 +133,76 @@ func RenderClaudeStreamLine(line string) string {
 // rate-limit / auth-failure text intact).
 func RenderCodexStreamLine(line string) string {
 	return renderCodexStreamLine(line)
+}
+
+// RenderKimiStreamLine is the exported entry point for rendering one Kimi
+// Code CLI stream-json line.
+func RenderKimiStreamLine(line string) string {
+	return renderKimiStreamLine(line)
+}
+
+type kimiRenderToolCall struct {
+	Function struct {
+		Name string `json:"name"`
+	} `json:"function"`
+}
+
+// renderKimiStreamLine renders Kimi's Message-shaped JSONL into readable log
+// text while preserving unknown/error frames verbatim. Usage-only frames get a
+// compact summary; raw usage JSON remains in the side channel.
+func renderKimiStreamLine(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || trimmed[0] != '{' {
+		return line
+	}
+	root, ok := decodeJSONObject([]byte(trimmed))
+	if !ok {
+		return line
+	}
+	role := firstJSONString(root, "role")
+	switch role {
+	case "assistant":
+		parts := make([]string, 0, 2)
+		if raw, ok := root["content"]; ok {
+			if content := renderClaudeContent(raw); strings.TrimSpace(content) != "" {
+				parts = append(parts, content)
+			}
+		}
+		var calls []kimiRenderToolCall
+		if raw, ok := root["tool_calls"]; ok && json.Unmarshal(raw, &calls) == nil {
+			for _, call := range calls {
+				name := strings.TrimSpace(call.Function.Name)
+				if name == "" {
+					name = "unknown"
+				}
+				parts = append(parts, "[tool_use: "+name+"]")
+			}
+		}
+		if len(parts) > 0 {
+			return strings.Join(parts, "\n")
+		}
+	case "tool":
+		content := ""
+		if raw, ok := root["content"]; ok {
+			content = renderClaudeContent(raw)
+		}
+		if strings.TrimSpace(content) == "" {
+			return "[tool_result]"
+		}
+		return "[tool_result] " + content
+	case "meta":
+		if content := firstJSONString(root, "content", "error_message"); content != "" {
+			return "[kimi] " + content
+		}
+	}
+	if usageMap, _, ok := findKimiUsageMap(root); ok {
+		usage := decodeKimiUsageBlock(usageMap)
+		if kimiUsageTotal(usage) > 0 {
+			return fmt.Sprintf("[kimi] usage: input=%d cached=%d cache_write=%d output=%d",
+				usage.Input, usage.CacheRead, usage.CacheWrite, usage.Output)
+		}
+	}
+	return line
 }
 
 type claudeRenderFrame struct {

--- a/internal/worker/stream_split_test.go
+++ b/internal/worker/stream_split_test.go
@@ -159,6 +159,39 @@ func TestRunStreamSplit_Codex(t *testing.T) {
 	}
 }
 
+func TestRunStreamSplit_KimiFixture(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("testdata", "kimi_stream.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	jsonlPath := filepath.Join(dir, "sup-kimi.jsonl")
+	var out strings.Builder
+	if err := RunStreamSplit("kimi", jsonlPath, strings.NewReader(string(fixture)), &out); err != nil {
+		t.Fatalf("RunStreamSplit: %v", err)
+	}
+	raw, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != string(fixture) {
+		t.Fatal("Kimi stream-split did not preserve raw JSONL")
+	}
+	usage, ok := ParseKimiUsage(string(raw))
+	if !ok || usage.TotalTokens != 2650 {
+		t.Fatalf("parsed usage = %+v ok=%t, want total=2650", usage, ok)
+	}
+	rendered := out.String()
+	for _, want := range []string{"Checking the worktree.", "[kimi] usage:", "[tool_result] tests passed", "Done."} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered output missing %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, `"input_other"`) {
+		t.Fatalf("human-readable log leaked raw usage JSON:\n%s", rendered)
+	}
+}
+
 // The codex renderer must turn item events into readable text: a command and
 // its output/exit, a file change, and an agent message — never raw item JSON.
 func TestRenderCodexStreamLine_ItemsAreReadable(t *testing.T) {

--- a/internal/worker/testdata/kimi_stream.jsonl
+++ b/internal/worker/testdata/kimi_stream.jsonl
@@ -1,0 +1,5 @@
+{"role":"assistant","content":"Checking the worktree."}
+{"timestamp":1,"message":{"type":"StatusUpdate","payload":{"token_usage":{"input_other":1200,"output":80,"input_cache_read":300,"input_cache_creation":20},"message_id":"msg_1","model":"kimi-k2.5"}}}
+{"timestamp":1.1,"message":{"type":"StatusUpdate","payload":{"token_usage":{"input_other":1200,"output":80,"input_cache_read":300,"input_cache_creation":20},"message_id":"msg_1","model":"kimi-k2.5"}}}
+{"role":"tool","tool_call_id":"tool_1","content":"tests passed"}
+{"role":"assistant","content":"Done.","message_id":"msg_2","model":"kimi-k2.5","usage":{"inputOther":900,"output":100,"inputCacheRead":50,"inputCacheCreation":0}}

--- a/internal/worker/tier_argv_test.go
+++ b/internal/worker/tier_argv_test.go
@@ -67,6 +67,16 @@ func TestTierArgv_GeminiModelEffort(t *testing.T) {
 	}
 }
 
+func TestTierArgv_KimiModelAndDropsEffort(t *testing.T) {
+	args := buildArgs(t, "kimi", BackendConfig{Cmd: "kimi", TierModel: "kimi-k2.5", TierEffort: "high"})
+	if !strings.Contains(args, "--model kimi-k2.5") {
+		t.Errorf("kimi args missing tier model: %s", args)
+	}
+	if strings.Contains(args, "--effort") || strings.Contains(args, "model_reasoning_effort") {
+		t.Errorf("kimi must not emit an unsupported effort flag: %s", args)
+	}
+}
+
 func TestTierArgv_NoOverrideWhenEmpty(t *testing.T) {
 	// Without a tier override the argv is unchanged — no spurious --model/--effort.
 	args := buildArgs(t, "claude", BackendConfig{Cmd: "claude"})
@@ -83,7 +93,7 @@ func TestTierArgv_NoOverrideWhenEmpty(t *testing.T) {
 // TierModel/TierEffort carriers (set solely by a real policy tier override) may
 // thread, so a non-policy #513-metadata config dispatches byte-for-byte as before.
 func TestTierArgv_AttributionMetadataDoesNotLeak(t *testing.T) {
-	for _, backend := range []string{"claude", "codex", "gemini"} {
+	for _, backend := range []string{"claude", "codex", "gemini", "kimi"} {
 		cfg := BackendConfig{Cmd: backend, Provider: "anthropic", Model: "opus-4.8", Effort: "xhigh"}
 		args := buildArgs(t, backend, cfg)
 		if strings.Contains(args, "--model") || strings.Contains(args, "opus-4.8") {

--- a/internal/worker/token_budget_test.go
+++ b/internal/worker/token_budget_test.go
@@ -140,6 +140,13 @@ func TestBuildWorkerCmd_TokenBudgetFailClosedAndCodexProxy(t *testing.T) {
 		}
 	})
 
+	t.Run("kimi explicitly rejects live budget", func(t *testing.T) {
+		_, _, err := BuildWorkerCmd("kimi", BackendConfig{Cmd: "kimi", TokenBudget: 80_000}, "/tmp/prompt", "/tmp")
+		if err == nil || !strings.Contains(err.Error(), "cannot be enforced live for Kimi") {
+			t.Fatalf("error = %v, want explicit Kimi live-budget limitation", err)
+		}
+	})
+
 	t.Run("codex receives native rollout budget", func(t *testing.T) {
 		cmd, _, err := BuildWorkerCmd("codex", BackendConfig{Cmd: "codex", UsageStream: true, TokenBudget: 80_000}, "/tmp/prompt", "/tmp")
 		if err != nil {


### PR DESCRIPTION
Refs #947

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Kimi Code CLI as a first-class backend. The main changes are:

- Backend resolution by name, provider, or command basename.
- Worker and read-only supervisor command construction.
- Default stream-JSON rendering and usage accounting.
- Kimi setup documentation and focused tests.

<h3>Confidence Score: 4/5</h3>

Kimi usage accounting across worker respawns needs a fix before merging.

The command and backend-resolution paths are consistently integrated. Message-ID deduplication spans an append-only sidecar shared by multiple attempts. Reused process-local IDs can silently under-report retry tokens and cost.

internal/worker/kimi_usage.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced the Respawn IDs issue and observed that the parser under-counted tokens and cost for the second Kimi attempt, while the focused Go test failed.
- I captured repro artifacts documenting the two-Kimi-respawn scenario and the verbose failing test output to support the observed under-accounting.
- I validated the harness changes that introduce the ParseKimiUsage contract; after the change, the harness compiled and ran, recording the exact argv, stdin path, JSONL summary, and expected usage values.
- I confirmed the evidence flow for the contract validation, including argv/stdin details and the sidecar checksum, supported by the Go test source and the harness invocation wrapper artifacts.

<a href="https://app.greptile.com/trex/runs/15416793/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/backend_kind.go | Adds Kimi resolution by backend name, provider, and command basename. |
| internal/worker/backend.go | Adds Kimi worker and supervisor commands, stream splitting, and live-budget validation. |
| internal/worker/kimi_usage.go | Adds Kimi usage parsing, with deduplication that can suppress usage after a respawn. |
| internal/orchestrator/orchestrator.go | Connects cumulative Kimi usage to session watermarks and split-token counters. |
| internal/worker/stream_split.go | Adds readable rendering for Kimi messages, tool results, metadata, and usage frames. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/worker/kimi_usage.go:78-86
**Respawn IDs Suppress Token Usage**

The JSONL sidecar is retained across respawns, but this map deduplicates `message_id` values across the whole file. If a new Kimi process reuses an ID from an earlier attempt, equal or lower counters add nothing and only growth beyond the old counters is recorded, so retry tokens and cost are under-reported.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add first-class Kimi CLI backend"](https://github.com/befeast/maestro/commit/d2913b6f1cc938d98c4d49c1340b5adbf5fb21af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46323231)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->