### PR TITLE
feat: first-class Kimi Code CLI backend (print mode, stream-json)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Replaces the previous `ao` (agent-orchestrator npm package) + shell scripts setu
 
 ## What it does
 
-maestro orchestrates multiple parallel AI coding agents (Claude, Codex, Gemini, Cline), each working on a separate GitHub issue in its own git worktree. It:
+maestro orchestrates multiple parallel AI coding agents (Claude, Codex, Gemini, Cline, Kimi), each working on a separate GitHub issue in its own git worktree. It:
 
 - Picks open GitHub issues matching a label (e.g. `enhancement`)
 - Creates git worktrees for each agent
-- Spawns the configured backend CLI (e.g. `claude`, `codex`, `gemini`, or `cline`) in each worktree with a task prompt
+- Spawns the configured backend CLI (e.g. `claude`, `codex`, `gemini`, `cline`, or `kimi`) in each worktree with a task prompt
 - Monitors agent progress (process alive? PR created? CI green?)
 - Auto-merges PRs when CI passes
 - Rebases PRs that have merge conflicts
@@ -74,7 +74,7 @@ Maestro integration.
 git --version        # any recent version
 gh --version         # 2.x+
 tmux -V              # any recent version
-claude --version     # or: codex --version / gemini --version / cline --version
+claude --version     # or: codex --version / gemini --version / cline --version / kimi --version
 gopls version        # optional; used for Go symbol context when available
 ```
 
@@ -314,6 +314,9 @@ model:
       cmd: gemini        # Google Gemini CLI
     cline:
       cmd: cline         # Cline CLI (e.g. SAP AI Core / any OpenAI-compatible provider)
+    kimi:
+      cmd: kimi          # Kimi Code CLI (print mode, stream-json)
+      provider: moonshot
 ```
 
 ### Supported backends
@@ -339,13 +342,18 @@ model:
 > Headless mode: `cline -y "task"` — auto-approves all actions and exits when done.
 > SAP AI Core example: set provider to `sapaicore`, model to `anthropic--claude-4.5-opus`.
 
+> [!NOTE]
+> **Kimi Code** — Moonshot AI Kimi Code CLI
+> Install/configure with the upstream Kimi Code instructions, then verify `kimi --version`.
+> Maestro runs `kimi --print --output-format=stream-json` with the worker prompt on stdin; print mode auto-approves tool calls.
+
 ### Custom-named backends
 
 Backends do not have to be named after the CLI they run. A custom key (e.g. a model nickname) keeps full CLI-specific behaviour — permission-bypass flags and stdin prompt delivery — as long as Maestro can tell which CLI it wraps. Resolution order:
 
-1. the backend name itself (`claude`, `codex`, `gemini`, `cline`),
-2. the `provider` field (`anthropic`/`claude` → Claude, `openai`/`codex` → Codex, `google`/`gemini` → Gemini, `cline` → Cline),
-3. the binary basename of `cmd` (`claude`, `codex`, `gemini`, `cline`).
+1. the backend name itself (`claude`, `codex`, `gemini`, `cline`, `kimi`),
+2. the `provider` field (`anthropic`/`claude` → Claude, `openai`/`codex` → Codex, `google`/`gemini` → Gemini, `cline` → Cline, `moonshot`/`kimi` → Kimi),
+3. the binary basename of `cmd` (`claude`, `codex`, `gemini`, `cline`, `kimi`).
 
 ```yaml
 model:
@@ -357,11 +365,14 @@ model:
     fast:
       provider: openai       # → codex exec path (exec, bypass flag, prompt via stdin)
       cmd: codex --profile fast
+    kimi-k2:
+      provider: moonshot     # → kimi print path (stream-json, prompt via stdin)
+      cmd: kimi
 ```
 
 A backend that matches none of the above falls back to the generic exec path: `prompt_mode` applies, no permission-bypass flag is added, and Maestro logs a startup warning naming the backend. Use the generic path only for genuinely custom CLIs.
 
-### Claude / Codex usage capture (tokens + cost)
+### Claude / Codex / Kimi usage capture (tokens + cost)
 
 Plain `claude -p` text mode prints no parseable token total, and `codex exec` text mode only prints a fuzzy single total — so a worker's `tokens_used_total` and USD cost are unreliable or `0`. Opt a `claude` or `codex` backend into structured usage capture with `usage_stream: true`:
 
@@ -380,7 +391,10 @@ model:
         output_usd_per_mtok: 10
 ```
 
-When enabled, the worker runs the backend in structured-stream mode (`claude --output-format stream-json --verbose`, or `codex exec --json`) and its NDJSON is piped through `maestro stream-split`, which writes the raw frames to a side-channel `<slot>.jsonl` (parsed for `input`/`output`/cache tokens) while keeping `<slot>.log` human-readable. The session then reports non-zero split tokens in `maestro history --json` and the `/api/v1/fleet` cost panel. Off by default; an operator-pinned `--output-format` (claude) or `--json` (codex) in `extra_args` overrides it. Claude reports its own `total_cost_usd`; codex does not, so its cost is **virtual** — computed from the configured `pricing` block (tokens-only `$0` when no rates are set). (The `pi` backend captures usage natively and needs no opt-in.)
+When enabled, the worker runs the backend in structured-stream mode (`claude --output-format stream-json --verbose`, or `codex exec --json`) and its NDJSON is piped through `maestro stream-split`, which writes the raw frames to a side-channel `<slot>.jsonl` (parsed for `input`/`output`/cache tokens) while keeping `<slot>.log` human-readable. Claude and Codex are off by default, and an operator-pinned `--output-format` or `--json` overrides their managed format. Kimi always uses the same splitter in `--print --output-format=stream-json` mode and needs no `usage_stream` opt-in. The session then reports non-zero split tokens in `maestro history --json` and the `/api/v1/fleet` cost panel. Claude reports its own `total_cost_usd`; codex and Kimi do not, so their cost is **virtual** — computed from the configured `pricing` block (tokens-only `$0` when no rates are set). (The `pi` backend captures usage natively and needs no opt-in.)
+
+For Kimi native authentication versus CLIProxyAPI custom-provider routing, see
+the [project setup runbook](docs/project-setup-runbook.md#kimi-code-worker-authentication-and-proxy-routing).
 
 #### Claude harness through CLIProxyAPI: non-Anthropic telemetry smoke (2026-07-21)
 
@@ -451,8 +465,10 @@ Maestro fails the worker start closed if the selected backend/output mode cannot
 enforce a live ceiling. Claude, Pi, and OpenCode stop from their usage event
 stream; Codex combines cumulative rollout `token_count` telemetry with its
 native rollout budget inside the agent loop (`--ephemeral` is rejected).
-Enforcement lags by at most one provider response, not by the orchestration poll
-interval.
+Kimi's stream currently supports accounting but is not accepted as a reliable
+live ceiling, so a positive `worker_max_tokens` rejects Kimi at worker start.
+Enforcement for supported backends lags by at most one provider response, not by
+the orchestration poll interval.
 
 ### Optional worker MCP tools
 
@@ -823,8 +839,8 @@ maestro logs <slot>    # e.g. maestro logs pan-1
 ```
 
 Common causes:
-- AI CLI not authenticated/configured — run `claude auth` (or `codex auth` / `gemini auth`); for Cline, configure provider credentials in `~/.cline/data/globalState.json` + `secrets.json`
-- AI CLI not found in PATH — verify with `which claude` / `which codex` / `which gemini` / `which cline`, or use an absolute path in config: `cmd: /usr/local/bin/claude`
+- AI CLI not authenticated/configured — run `claude auth` (or `codex auth` / `gemini auth`); for Cline or Kimi, complete the CLI's provider setup in its user configuration
+- AI CLI not found in PATH — verify with `which claude` / `which codex` / `which gemini` / `which cline` / `which kimi`, or use an absolute path in config: `cmd: /usr/local/bin/claude`
 - Git worktree creation failed (ensure the local repo clone is clean)
 
 ### `maestro run` exits with "load config" error
@@ -907,7 +923,7 @@ maestro spawn --issue <number>   # retry the issue
 - `gopkg.in/yaml.v3` (config parsing)
 - `gh` CLI (GitHub operations)
 - `git` (worktree management)
-- `claude` / `codex` / `gemini` / `cline` CLI (agent invocation — at least one required)
+- `claude` / `codex` / `gemini` / `cline` / `kimi` CLI (agent invocation — at least one required)
 
 ## Acknowledgments
 

--- a/docs/fleet-settings-runbook.md
+++ b/docs/fleet-settings-runbook.md
@@ -108,6 +108,9 @@ The ceiling fails closed when Maestro cannot enforce it live:
   rollout telemetry file.
 - Pi must retain Maestro-managed JSON mode.
 - OpenCode requires `usage_stream: true` with Maestro-managed JSON output.
+- Kimi's print-mode stream is captured for token/cost accounting but is not
+  currently accepted as a reliable live ceiling, so Kimi is rejected while a
+  positive `worker_max_tokens` is active.
 - Gemini, Cline, generic CLIs, and operator-overridden non-structured output
   cannot start while a positive `worker_max_tokens` is active.
 

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -330,6 +330,40 @@ model:
 
 `model.backends.<name>.effort` is the backend's default reasoning-effort policy for newly started workers. For Claude-compatible workers Maestro emits `--effort <value>`; for Codex-compatible workers it emits `-c model_reasoning_effort=<value>`; backends without a supported effort flag receive no effort flag. A configured backend effort replaces stale effort pins in Claude/Codex `cmd` or `extra_args`; routing-tier or pipeline phase effort overrides are narrower per-dispatch overrides and are shown in backend-selection/effective-config surfaces so an operator can tell whether the backend default or the dispatch override applied.
 
+### Kimi Code worker authentication and proxy routing
+
+Register Kimi Code as a Moonshot backend so Maestro selects its first-class
+print-mode path:
+
+```yaml
+model:
+  default: kimi
+  backends:
+    kimi:
+      cmd: kimi
+      provider: moonshot
+```
+
+Authenticate in one of two operator-owned ways:
+
+- Native Moonshot: complete Kimi Code's normal login/setup flow as the service
+  user. The resulting Kimi user configuration stays outside the repository and
+  outside Maestro project YAML.
+- CLIProxyAPI: define an OpenAI-compatible custom provider and model alias in
+  Kimi Code's user configuration, point it at the proxy endpoint, and select
+  that alias as Kimi's default model (or pin it in Kimi CLI arguments). Keep the
+  proxy credential in the existing private worker-credential boundary; never
+  copy it into a repository, issue, worker prompt, or Maestro config row.
+
+The Maestro `provider: moonshot` value selects the Kimi command builder; Kimi's
+own provider/model configuration decides whether requests go directly to
+Moonshot or through CLIProxyAPI. Maestro runs workers as
+`kimi --print --output-format=stream-json` with the prompt on stdin and records
+split usage for history and cost observability. Kimi does not currently expose
+a stream Maestro accepts as a reliable live hard ceiling, so projects using
+this backend must leave `worker_max_tokens: 0`; a positive value fails worker
+startup closed.
+
 ### Provider-local defaults and fallbacks
 
 Use provider lanes when the project should exhaust models within one provider

--- a/internal/config/backend_kind.go
+++ b/internal/config/backend_kind.go
@@ -17,6 +17,7 @@ const (
 	BackendKindCodex    = "codex"
 	BackendKindGemini   = "gemini"
 	BackendKindCline    = "cline"
+	BackendKindKimi     = "kimi"
 	BackendKindPi       = "pi"
 	BackendKindOpencode = "opencode"
 	BackendKindGeneric  = "generic"
@@ -34,6 +35,8 @@ var providerBackendKinds = map[string]string{
 	"google":    BackendKindGemini,
 	"gemini":    BackendKindGemini,
 	"cline":     BackendKindCline,
+	"kimi":      BackendKindKimi,
+	"moonshot":  BackendKindKimi,
 	"pi":        BackendKindPi,
 	"ollama":    BackendKindPi,
 	"opencode":  BackendKindOpencode,
@@ -41,10 +44,10 @@ var providerBackendKinds = map[string]string{
 
 // ResolveBackendKind decides which CLI-specific exec path a backend uses.
 // Resolution order (#684):
-//  1. the backend name itself — claude/codex/gemini/cline keys keep their
+//  1. the backend name itself — claude/codex/gemini/cline/kimi keys keep their
 //     existing behaviour,
 //  2. the per-backend provider field (anthropic → claude, openai → codex, …),
-//  3. the binary basename of cmd's first token (claude/codex/gemini/cline),
+//  3. the binary basename of cmd's first token (claude/codex/gemini/cline/kimi),
 //  4. the generic fallback (prompt_mode applies, no permission-bypass flag).
 //
 // Before #684, dispatch was keyed on the name alone: the Anthropic CLI
@@ -53,7 +56,7 @@ var providerBackendKinds = map[string]string{
 // mutating tool call was denied by the CLI's permission layer (sup-175).
 func ResolveBackendKind(name, provider, cmd string) string {
 	switch name {
-	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindPi, BackendKindOpencode:
+	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindKimi, BackendKindPi, BackendKindOpencode:
 		return name
 	}
 	if kind, ok := providerBackendKinds[strings.ToLower(strings.TrimSpace(provider))]; ok {
@@ -73,7 +76,7 @@ func backendKindFromCmd(cmd string) string {
 		return ""
 	}
 	switch base := filepath.Base(fields[0]); base {
-	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindPi, BackendKindOpencode:
+	case BackendKindClaude, BackendKindCodex, BackendKindGemini, BackendKindCline, BackendKindKimi, BackendKindPi, BackendKindOpencode:
 		return base
 	}
 	return ""
@@ -105,7 +108,7 @@ func (c *Config) backendResolutionWarnings() []string {
 		kind := ResolveBackendKind(name, def.Provider, def.Cmd)
 		if kind == BackendKindGeneric {
 			warnings = append(warnings, fmt.Sprintf(
-				"config: backend %q resolves to the generic exec path (provider %q and cmd %q match no known CLI) — workers run without a permission-bypass flag (mutating tool calls may be denied) and the prompt is delivered per prompt_mode=%q (argv delivery risks E2BIG on large prompts). If this wraps a known CLI, set provider: anthropic|openai|google|cline|pi|ollama or use a claude/codex/gemini/cline/pi binary in cmd.",
+				"config: backend %q resolves to the generic exec path (provider %q and cmd %q match no known CLI) — workers run without a permission-bypass flag (mutating tool calls may be denied) and the prompt is delivered per prompt_mode=%q (argv delivery risks E2BIG on large prompts). If this wraps a known CLI, set provider: anthropic|openai|google|cline|moonshot|kimi|pi|ollama or use a claude/codex/gemini/cline/kimi/pi binary in cmd.",
 				name, def.Provider, def.Cmd, coalescePromptMode(def.PromptMode)))
 			continue
 		}

--- a/internal/config/backend_kind_test.go
+++ b/internal/config/backend_kind_test.go
@@ -19,11 +19,14 @@ func TestResolveBackendKind(t *testing.T) {
 		{"codex", "", "", BackendKindCodex},
 		{"gemini", "", "gemini-cli", BackendKindGemini},
 		{"cline", "", "", BackendKindCline},
+		{"kimi", "", "", BackendKindKimi},
 		// 2. Provider field resolves custom names (sup-175 `fable:` shape).
 		{"fable", "anthropic", "claude --model claude-fable-5 --effort xhigh", BackendKindClaude},
 		{"fast", "openai", "codex --profile fast", BackendKindCodex},
 		{"flash", "google", "gemini", BackendKindGemini},
 		{"wrapped", "cline", "cline", BackendKindCline},
+		{"k2", "moonshot", "kimi", BackendKindKimi},
+		{"k3", "kimi", "my-kimi-wrapper", BackendKindKimi},
 		// #730: provider pi / ollama resolves to the first-class pi backend.
 		{"pi-ollama", "ollama", "pi", BackendKindPi},
 		{"picustom", "pi", "my-pi-shim", BackendKindPi},
@@ -35,6 +38,7 @@ func TestResolveBackendKind(t *testing.T) {
 		{"mymodel", "", "/usr/local/bin/claude --model opus", BackendKindClaude},
 		{"mymodel", "", "codex --flag", BackendKindCodex},
 		{"mymodel", "groq", "gemini", BackendKindGemini},
+		{"moonshot-model", "", "/usr/local/bin/kimi --verbose", BackendKindKimi},
 		{"picli", "", "/usr/local/bin/pi", BackendKindPi},
 		// 4. Everything else is generic.
 		{"helper", "groq", "groq-cli", BackendKindGeneric},
@@ -107,6 +111,22 @@ func TestConfig_Warnings_PiBackendNoGenericWarning(t *testing.T) {
 	for _, msg := range cfg.Warnings() {
 		if strings.Contains(msg, "generic exec path") {
 			t.Fatalf("Warnings() = %v, pi backend should not trigger the generic path warning", cfg.Warnings())
+		}
+	}
+}
+
+func TestConfig_Warnings_KimiBackendNoGenericWarning(t *testing.T) {
+	cfg := &Config{
+		Model: ModelConfig{
+			Default: "kimi-k2",
+			Backends: map[string]BackendDef{
+				"kimi-k2": {Provider: "moonshot", Cmd: "kimi"},
+			},
+		},
+	}
+	for _, msg := range cfg.Warnings() {
+		if strings.Contains(msg, "generic exec path") {
+			t.Fatalf("Warnings() = %v, Kimi backend should not trigger the generic path warning", cfg.Warnings())
 		}
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,7 +101,8 @@ type BackendDef struct {
 	// keeping slot.log human-readable. Off by default: plain `claude -p` text
 	// mode prints no parseable token total, so usage/cost stay 0 (the #737
 	// symptom) until an operator opts in. Overridable via extra_args (a
-	// trailing --output-format wins). Only the claude kind consumes this today.
+	// trailing --output-format wins). Claude, Codex, and OpenCode consume this
+	// opt-in; Kimi's first-class print path always emits structured output.
 	UsageStream bool `yaml:"usage_stream,omitempty"`
 
 	// #507: NonAgentic marks a backend that is a TEXT-COMPLETION helper,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1347,6 +1347,11 @@ func (o *Orchestrator) updateTokensUsedFromOutput(slotName string, sess *state.S
 	if kind == config.BackendKindCodex && o.sessionUsageStream(sess) {
 		return o.updateCodexUsageFromJSONL(slotName, sess)
 	}
+	// Kimi's first-class print mode always emits stream-json, so usage capture
+	// is not gated by the legacy usage_stream opt-in.
+	if kind == config.BackendKindKimi {
+		return o.updateKimiUsageFromJSONL(slotName, sess)
+	}
 	if kind == config.BackendKindOpencode && o.sessionUsageStream(sess) {
 		return o.updateOpenCodeUsageFromJSONL(slotName, sess)
 	}
@@ -1553,6 +1558,47 @@ func (o *Orchestrator) updateCodexUsageFromJSONL(slotName string, sess *state.Se
 	log.Printf("[orch] %s codex usage: input=%d output=%d cache_read=%d tokens=%d (total=%d)",
 		slotName, usage.Input, usage.Output, usage.CacheRead, usage.TotalTokens, sess.TokensUsedTotal)
 	return true
+}
+
+// updateKimiUsageFromJSONL parses Kimi Code CLI's stream-json side channel and
+// stamps cache-aware split tokens onto the session. Kimi reports no USD cost,
+// so CostUSDBackend remains zero and the configured pricing block supplies a
+// virtual estimate to history and Fleet cost observability. The full JSONL is
+// cumulative across attempts; UsageTokensWatermark makes retries delta-only.
+func (o *Orchestrator) updateKimiUsageFromJSONL(slotName string, sess *state.Session) bool {
+	jsonlPath := o.workerJSONLFile(slotName, sess)
+	if jsonlPath == "" {
+		return false
+	}
+	data, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		return false
+	}
+	usage, ok := worker.ParseKimiUsage(string(data))
+	if !ok {
+		return false
+	}
+	changed := false
+	if usage.TotalTokens > sess.UsageTokensWatermark {
+		delta := usage.TotalTokens - sess.UsageTokensWatermark
+		sess.UsageTokensWatermark = usage.TotalTokens
+		sess.TokensUsedAttempt += delta
+		sess.TokensUsedTotal += delta
+		sess.TokensInput = usage.Input
+		sess.TokensOutput = usage.Output
+		sess.TokensCacheRead = usage.CacheRead
+		sess.TokensCacheWrite = usage.CacheWrite
+		changed = true
+	}
+	if strings.TrimSpace(usage.Model) != "" && strings.TrimSpace(sess.Model) == "" {
+		sess.Model = usage.Model
+		changed = true
+	}
+	if changed {
+		log.Printf("[orch] %s kimi usage: input=%d output=%d cache_read=%d cache_write=%d tokens=%d (total=%d)",
+			slotName, usage.Input, usage.Output, usage.CacheRead, usage.CacheWrite, usage.TotalTokens, sess.TokensUsedTotal)
+	}
+	return changed
 }
 
 // updateOpenCodeUsageFromJSONL parses the opencode --format json side-channel

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -11655,3 +11655,51 @@ func TestUpdateTokensUsedFromOutput_CodexBackendRetryNoDoubleCount(t *testing.T)
 		t.Errorf("UsageTokensWatermark = %d, want 1773", sess.UsageTokensWatermark)
 	}
 }
+
+func TestUpdateTokensUsedFromOutput_KimiFixtureStampsWatermarkAndSplits(t *testing.T) {
+	dir := t.TempDir()
+	slot := "sup-kimi"
+	o := &Orchestrator{
+		cfg: &config.Config{
+			StateDir: dir,
+			Model: config.ModelConfig{
+				Default: "kimi-k2",
+				Backends: map[string]config.BackendDef{
+					"kimi-k2": {
+						Cmd:      "kimi",
+						Provider: "moonshot",
+						Pricing:  config.BackendPricing{InputUSDPerMtok: 1, OutputUSDPerMtok: 2},
+					},
+				},
+			},
+		},
+	}
+	logFile := filepath.Join(dir, slot+".log")
+	jsonlPath := filepath.Join(dir, slot+".jsonl")
+	sess := &state.Session{Backend: "kimi-k2", LogFile: logFile}
+	fixture, err := os.ReadFile(filepath.Join("..", "worker", "testdata", "kimi_stream_usage.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(jsonlPath, fixture, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !o.updateTokensUsedFromOutput(slot, sess, "human-readable Kimi output") {
+		t.Fatal("expected Kimi JSONL usage to update the session")
+	}
+	if sess.TokensUsedAttempt != 2600 || sess.TokensUsedTotal != 2600 || sess.UsageTokensWatermark != 2600 {
+		t.Fatalf("tokens attempt/total/watermark = %d/%d/%d, want 2600/2600/2600",
+			sess.TokensUsedAttempt, sess.TokensUsedTotal, sess.UsageTokensWatermark)
+	}
+	if sess.TokensInput != 1800 || sess.TokensOutput != 100 || sess.TokensCacheRead != 600 || sess.TokensCacheWrite != 100 {
+		t.Fatalf("split tokens = %d/%d/%d/%d, want 1800/100/600/100",
+			sess.TokensInput, sess.TokensOutput, sess.TokensCacheRead, sess.TokensCacheWrite)
+	}
+	if sess.CostUSDBackend != 0 {
+		t.Fatalf("CostUSDBackend = %v, want 0 (Kimi cost is virtual)", sess.CostUSDBackend)
+	}
+	if o.updateTokensUsedFromOutput(slot, sess, "same output") {
+		t.Fatal("unchanged Kimi JSONL must not double-count")
+	}
+}

--- a/internal/server/cost_observability_test.go
+++ b/internal/server/cost_observability_test.go
@@ -405,6 +405,22 @@ func TestSessionCostEstimate_CodexVirtual(t *testing.T) {
 	}
 }
 
+func TestSessionCostEstimate_KimiVirtualSplit(t *testing.T) {
+	pricing := map[string]config.BackendPricing{
+		"kimi-k2": {
+			InputUSDPerMtok:      2,
+			OutputUSDPerMtok:     8,
+			CacheReadUSDPerMtok:  0.2,
+			CacheWriteUSDPerMtok: 2.5,
+		},
+	}
+	got := sessionCostEstimate("kimi-k2", 2600, 1800, 100, 600, 100, pricing, 0)
+	want := (1800*2.0 + 100*8.0 + 600*0.2 + 100*2.5) / 1_000_000
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("Kimi virtual split cost = %f, want %f", got, want)
+	}
+}
+
 // TestBuildFleetCostObservability_SplitCosting proves the rollup prices a
 // session carrying cache-aware split tokens (#739) with EstimateCostSplit —
 // the cache-read discount makes the panel's USD a small fraction of the naive

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -59,8 +59,8 @@ type BackendConfig struct {
 	TierEffort    string
 	// UsageStream opts a structured-stream worker into emitting NDJSON usage
 	// frames on a side-channel slot.jsonl: claude `--output-format stream-json
-	// --verbose` (#737) and codex `exec --json` (#738). Off by default;
-	// ignored by backends without a structured-stream mode.
+	// --verbose` (#737), codex `exec --json` (#738), and OpenCode JSON output.
+	// Off by default; Kimi always uses its structured print path independently.
 	UsageStream bool
 	// TokenBudget is the active per-attempt hard ceiling. A positive value
 	// requires an enforceable live-usage mode; BuildWorkerCmd fails closed for
@@ -83,6 +83,7 @@ var knownBackends = map[string]Backend{
 	"cline":    clineBackend{},
 	"codex":    codexBackend{},
 	"gemini":   geminiBackend{},
+	"kimi":     kimiBackend{},
 	"opencode": opencodeBackend{},
 	"pi":       piBackend{},
 }
@@ -184,6 +185,35 @@ func (codexBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*e
 	cmd := exec.Command(binary, args...)
 	cmd.Dir = worktree
 	// Stdin redirection is handled by the runner script — no file opened here
+	return cmd, promptFile, nil
+}
+
+// --- Kimi Backend ---
+
+// kimiBackend runs Kimi Code CLI in non-interactive print mode. Print mode
+// auto-approves tool calls and reads a text prompt from stdin when no -p value
+// is supplied, so large Maestro prompts never enter argv. Kimi's stream-json
+// output is always enabled for workers: the runner splits its JSONL into the
+// raw usage side channel and a human-readable worker log.
+type kimiBackend struct{}
+
+func (kimiBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, string, error) {
+	kimiCmd := cfg.Cmd
+	if kimiCmd == "" {
+		kimiCmd = "kimi"
+	}
+	binary, cmdArgs := splitCmd(kimiCmd)
+	args := append([]string(nil), cmdArgs...)
+	if !argsHaveFlag(cmdArgs, "--print") && !argsHaveFlag(cfg.ExtraArgs, "--print") {
+		args = append(args, "--print")
+	}
+	if !argsHaveOutputFormat(cmdArgs) && !argsHaveOutputFormat(cfg.ExtraArgs) {
+		args = append(args, "--output-format=stream-json")
+	}
+	args = appendTierModelEffort(args, pinnedArgs(cmdArgs, cfg), config.BackendKindKimi, cfg)
+	args = append(args, cfg.ExtraArgs...)
+	cmd := exec.Command(binary, args...)
+	cmd.Dir = worktree
 	return cmd, promptFile, nil
 }
 
@@ -686,16 +716,18 @@ func maestroExecutablePath() (string, bool) {
 
 // streamSplitForBackend returns the worker runner's stream-split configuration,
 // or nil when the plain `tee` pipeline should be used. Only a structured-stream
-// backend (claude #737, codex #738) with usage_stream opted in streams NDJSON;
-// when the maestro binary cannot be resolved it degrades to nil (plain tee).
-// The resolved backend kind is passed to the splitter so it renders the right
+// backend with structured output streams NDJSON when enabled. Kimi always uses
+// stream-json in its first-class print mode; claude/codex/opencode retain their
+// usage_stream opt-in, while Pi enables splitting when a live budget needs it.
+// When the maestro binary cannot be resolved this degrades to nil (plain tee).
+// The resolved kind is passed to the splitter so it renders the right
 // human-readable form into slot.log.
 func streamSplitForBackend(backendName string, cfg BackendConfig, logFile string) *streamSplit {
 	kind := resolveBackendKind(backendName, cfg)
-	if !cfg.UsageStream && !(cfg.TokenBudget > 0 && kind == config.BackendKindPi) {
+	if kind != config.BackendKindKimi && !cfg.UsageStream && !(cfg.TokenBudget > 0 && kind == config.BackendKindPi) {
 		return nil
 	}
-	if kind != config.BackendKindClaude && kind != config.BackendKindCodex && kind != config.BackendKindOpencode && kind != config.BackendKindPi {
+	if kind != config.BackendKindClaude && kind != config.BackendKindCodex && kind != config.BackendKindKimi && kind != config.BackendKindOpencode && kind != config.BackendKindPi {
 		return nil
 	}
 	bin, ok := maestroExecutablePath()
@@ -713,7 +745,7 @@ func streamSplitForBackend(backendName string, cfg BackendConfig, logFile string
 
 // BuildWorkerCmd creates the right exec.Cmd for a backend. The backend name,
 // provider field, and cmd binary resolve to a CLI-specific builder (claude,
-// codex, gemini, cline — see resolveBackendKind); anything else uses the
+// codex, gemini, cline, kimi — see resolveBackendKind); anything else uses the
 // generic builder with prompt_mode from config.
 // Returns the command, an optional stdinFile path (for backends that read
 // the prompt via stdin, e.g. claude/codex), and any error.
@@ -755,6 +787,8 @@ func validateLiveTokenBudget(backendName string, cfg BackendConfig) error {
 		if !cfg.UsageStream || argsHaveFlag(cfg.ExtraArgs, "--format") {
 			return fmt.Errorf("worker_max_tokens=%d requires OpenCode usage_stream with Maestro-managed JSON output", cfg.TokenBudget)
 		}
+	case config.BackendKindKimi:
+		return fmt.Errorf("worker_max_tokens=%d cannot be enforced live for Kimi; its print-mode stream is supported for accounting but not as a reliable live ceiling", cfg.TokenBudget)
 	default:
 		return fmt.Errorf("worker_max_tokens=%d cannot be enforced live for backend %q; disable the budget or use claude, codex, pi, or opencode structured usage", cfg.TokenBudget, backendName)
 	}
@@ -835,6 +869,26 @@ func BuildSupervisorCmd(backendName string, cfg BackendConfig, promptFile, workt
 		cmd := exec.Command(binary, args...)
 		cmd.Dir = worktree
 		return cmd, "", nil
+	case "kimi":
+		kimiCmd := cfg.Cmd
+		if kimiCmd == "" {
+			kimiCmd = "kimi"
+		}
+		binary, cmdArgs := splitCmd(kimiCmd)
+		args := append([]string(nil), cmdArgs...)
+		if !argsHaveFlag(cmdArgs, "--print") && !argsHaveFlag(cfg.ExtraArgs, "--print") {
+			args = append(args, "--print")
+		}
+		if !argsHaveFlag(cmdArgs, "--final-message-only") && !argsHaveFlag(cfg.ExtraArgs, "--final-message-only") {
+			args = append(args, "--final-message-only")
+		}
+		args = append(args, cfg.ExtraArgs...)
+		if model := strings.TrimSpace(cfg.Model); model != "" && !argsHaveFlag(pinnedArgs(cmdArgs, cfg), "--model") {
+			args = append(args, "--model", model)
+		}
+		cmd := exec.Command(binary, args...)
+		cmd.Dir = worktree
+		return cmd, promptFile, nil
 	case "pi":
 		piCmd := cfg.Cmd
 		if piCmd == "" {

--- a/internal/worker/backend_test.go
+++ b/internal/worker/backend_test.go
@@ -155,6 +155,84 @@ func TestBuildWorkerCmd_CodexUsageStream(t *testing.T) {
 	})
 }
 
+func TestBuildWorkerCmd_Kimi(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("implement the issue"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name        string
+		backendName string
+		cfg         BackendConfig
+	}{
+		{
+			name:        "provider resolves custom backend",
+			backendName: "kimi-k2",
+			cfg:         BackendConfig{Cmd: "kimi", Provider: "moonshot"},
+		},
+		{
+			name:        "command basename resolves custom backend",
+			backendName: "fast",
+			cfg:         BackendConfig{Cmd: "/usr/local/bin/kimi --verbose"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, stdinFile, err := BuildWorkerCmd(tt.backendName, tt.cfg, promptFile, "/tmp/kimi-worktree")
+			if err != nil {
+				t.Fatalf("BuildWorkerCmd: %v", err)
+			}
+			if stdinFile != promptFile {
+				t.Fatalf("stdinFile = %q, want %q", stdinFile, promptFile)
+			}
+			if cmd.Dir != "/tmp/kimi-worktree" {
+				t.Fatalf("Dir = %q, want /tmp/kimi-worktree", cmd.Dir)
+			}
+			args := cmd.Args[1:]
+			if !containsArg(args, "--print") {
+				t.Errorf("args = %v, want --print", args)
+			}
+			if !containsArg(args, "--output-format=stream-json") {
+				t.Errorf("args = %v, want --output-format=stream-json", args)
+			}
+			if strings.Contains(strings.Join(args, " "), "implement the issue") {
+				t.Errorf("prompt content must not appear in argv: %v", args)
+			}
+		})
+	}
+
+	t.Run("operator output format is not duplicated", func(t *testing.T) {
+		cfg := BackendConfig{
+			Cmd:       "kimi --print",
+			Provider:  "moonshot",
+			ExtraArgs: []string{"--output-format", "stream-json"},
+		}
+		cmd, _, err := BuildWorkerCmd("kimi-k2", cfg, promptFile, "/tmp/kimi-worktree")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if countFlag(cmd.Args, "--print") != 1 {
+			t.Fatalf("--print duplicated in args: %v", cmd.Args)
+		}
+		if countFlag(cmd.Args, "--output-format") != 1 {
+			t.Fatalf("--output-format duplicated in args: %v", cmd.Args)
+		}
+	})
+}
+
+func TestStreamSplitForBackend_KimiAlwaysEnabled(t *testing.T) {
+	split := streamSplitForBackend("kimi-k2", BackendConfig{Cmd: "kimi", Provider: "moonshot"}, "/tmp/kimi.log")
+	if split == nil {
+		t.Fatal("Kimi must use stream-split without a usage_stream opt-in")
+	}
+	if split.Backend != config.BackendKindKimi || split.JSONLPath != "/tmp/kimi.jsonl" {
+		t.Fatalf("split = %+v, want kimi backend and sibling JSONL path", split)
+	}
+}
+
 func TestBuildWorkerCmd_ClaudeLargePromptViaStdin(t *testing.T) {
 	dir := t.TempDir()
 	promptFile := filepath.Join(dir, "prompt.md")
@@ -537,6 +615,31 @@ func TestBuildSupervisorCmd_CodexReadOnly(t *testing.T) {
 	}
 	if strings.Contains(args, "dangerously") || strings.Contains(args, "bypass") {
 		t.Errorf("supervisor command should not include worker permission bypass flags: %s", args)
+	}
+}
+
+func TestBuildSupervisorCmd_Kimi(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("decide safely"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := BackendConfig{Cmd: "kimi", Provider: "moonshot", Model: "kimi-k2"}
+	cmd, stdinFile, err := BuildSupervisorCmd("kimi", cfg, promptFile, "/tmp/wt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stdinFile != promptFile {
+		t.Fatalf("stdinFile = %q, want %q", stdinFile, promptFile)
+	}
+	args := strings.Join(cmd.Args, " ")
+	for _, want := range []string{"--print", "--final-message-only", "--model kimi-k2"} {
+		if !strings.Contains(args, want) {
+			t.Errorf("Kimi supervisor args missing %q: %s", want, args)
+		}
+	}
+	if strings.Contains(args, "decide safely") {
+		t.Errorf("supervisor prompt leaked into argv: %s", args)
 	}
 }
 
@@ -998,7 +1101,7 @@ func TestBuildSupervisorCmd_CustomNameProviderAnthropic(t *testing.T) {
 
 func TestKnownBackends(t *testing.T) {
 	backends := KnownBackends()
-	expected := map[string]bool{"claude": false, "codex": false, "gemini": false, "cline": false, "pi": false}
+	expected := map[string]bool{"claude": false, "codex": false, "gemini": false, "cline": false, "kimi": false, "pi": false}
 	for _, name := range backends {
 		if _, ok := expected[name]; ok {
 			expected[name] = true
@@ -1009,6 +1112,25 @@ func TestKnownBackends(t *testing.T) {
 			t.Errorf("expected %q in KnownBackends(), got: %v", name, backends)
 		}
 	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}
+
+func countFlag(args []string, flag string) int {
+	count := 0
+	for _, arg := range args {
+		if arg == flag || strings.HasPrefix(arg, flag+"=") {
+			count++
+		}
+	}
+	return count
 }
 
 // #730: the Pi backend runs headless in JSON event-stream mode with the

--- a/internal/worker/kimi_usage.go
+++ b/internal/worker/kimi_usage.go
@@ -1,0 +1,238 @@
+package worker
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// KimiUsage is the cumulative provider usage parsed from Kimi Code CLI's
+// stream-json output. Kimi reports one TokenUsage block per model step using
+// input_other/output/input_cache_read/input_cache_creation fields. The
+// stream-splitter appends every attempt to one slot.jsonl, so summing distinct
+// step usage produces the monotonic run total used by Maestro's watermark.
+// Kimi does not report USD cost; configured backend pricing supplies the
+// virtual cost from these split counters.
+type KimiUsage struct {
+	Model       string
+	Input       int
+	Output      int
+	CacheRead   int
+	CacheWrite  int
+	TotalTokens int
+}
+
+type kimiStreamFrame struct {
+	Type       string          `json:"type"`
+	Role       string          `json:"role"`
+	Model      string          `json:"model"`
+	MessageID  string          `json:"message_id"`
+	SessionID  string          `json:"session_id"`
+	Usage      *kimiUsageBlock `json:"usage"`
+	TokenUsage *kimiUsageBlock `json:"token_usage"`
+	Payload    *kimiPayload    `json:"payload"`
+	Message    json.RawMessage `json:"message"`
+}
+
+type kimiPayload struct {
+	Model      string          `json:"model"`
+	MessageID  string          `json:"message_id"`
+	SessionID  string          `json:"session_id"`
+	Usage      *kimiUsageBlock `json:"usage"`
+	TokenUsage *kimiUsageBlock `json:"token_usage"`
+}
+
+// kimiUsageBlock accepts the public Kimi TokenUsage names plus common
+// stream-provider aliases. The aliases keep the parser compatible with Kimi
+// custom providers that preserve upstream usage naming in stream-json.
+type kimiUsageBlock struct {
+	InputOther              int `json:"input_other"`
+	InputOtherCamel         int `json:"inputOther"`
+	Input                   int `json:"input"`
+	InputTokens             int `json:"input_tokens"`
+	Output                  int `json:"output"`
+	OutputTokens            int `json:"output_tokens"`
+	InputCacheRead          int `json:"input_cache_read"`
+	InputCacheReadCamel     int `json:"inputCacheRead"`
+	CacheRead               int `json:"cache_read"`
+	CacheReadCamel          int `json:"cacheRead"`
+	InputCacheCreation      int `json:"input_cache_creation"`
+	InputCacheCreationCamel int `json:"inputCacheCreation"`
+	CacheCreationInput      int `json:"cache_creation_input_tokens"`
+	CacheWrite              int `json:"cache_write"`
+	CacheWriteCamel         int `json:"cacheWrite"`
+	TotalTokens             int `json:"total_tokens"`
+}
+
+type kimiUsageCounts struct {
+	Input      int
+	Output     int
+	CacheRead  int
+	CacheWrite int
+}
+
+func (u *kimiUsageBlock) counts() kimiUsageCounts {
+	if u == nil {
+		return kimiUsageCounts{}
+	}
+	counts := kimiUsageCounts{
+		Input:  firstPositive(u.InputOther, u.InputOtherCamel, u.Input, u.InputTokens),
+		Output: firstPositive(u.Output, u.OutputTokens),
+		CacheRead: firstPositive(
+			u.InputCacheRead,
+			u.InputCacheReadCamel,
+			u.CacheRead,
+			u.CacheReadCamel,
+		),
+		CacheWrite: firstPositive(
+			u.InputCacheCreation,
+			u.InputCacheCreationCamel,
+			u.CacheCreationInput,
+			u.CacheWrite,
+			u.CacheWriteCamel,
+		),
+	}
+	if counts.total() == 0 && u.TotalTokens > 0 {
+		counts.Input = u.TotalTokens
+	}
+	return counts
+}
+
+func (u kimiUsageCounts) total() int {
+	return u.Input + u.Output + u.CacheRead + u.CacheWrite
+}
+
+func (u *kimiUsageCounts) add(delta kimiUsageCounts) {
+	u.Input += delta.Input
+	u.Output += delta.Output
+	u.CacheRead += delta.CacheRead
+	u.CacheWrite += delta.CacheWrite
+}
+
+func (u kimiUsageCounts) positiveDelta(previous kimiUsageCounts) kimiUsageCounts {
+	return kimiUsageCounts{
+		Input:      positiveDelta(u.Input, previous.Input),
+		Output:     positiveDelta(u.Output, previous.Output),
+		CacheRead:  positiveDelta(u.CacheRead, previous.CacheRead),
+		CacheWrite: positiveDelta(u.CacheWrite, previous.CacheWrite),
+	}
+}
+
+// ParseKimiUsage scans an appended Kimi JSONL side channel and sums distinct
+// per-step usage. StatusUpdate.token_usage is the primary public shape. Direct
+// assistant usage blocks are also accepted for print-stream variants, and a
+// terminal result/turn.completed usage block is used only as a fallback when
+// no per-step usage was observed. Repeated updates for one message_id are
+// deduplicated by positive deltas.
+func ParseKimiUsage(text string) (KimiUsage, bool) {
+	var out KimiUsage
+	var stepTotal, terminalTotal kimiUsageCounts
+	stepSeen := false
+	terminalSeen := false
+	stepMessages := make(map[string]kimiUsageCounts)
+
+	for _, raw := range strings.Split(text, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || line[0] != '{' {
+			continue
+		}
+		var frame kimiStreamFrame
+		if json.Unmarshal([]byte(line), &frame) != nil {
+			continue
+		}
+		frame = unwrapKimiFrame(frame)
+		usage, messageID, model := kimiFrameUsage(frame)
+		if strings.TrimSpace(model) != "" {
+			out.Model = model
+		}
+		counts := usage.counts()
+		if counts.total() == 0 {
+			continue
+		}
+
+		frameType := strings.ToLower(strings.TrimSpace(frame.Type))
+		switch frameType {
+		case "result", "turn.completed", "turn_completed":
+			terminalTotal.add(counts)
+			terminalSeen = true
+		default:
+			if frameType != "statusupdate" && frameType != "status_update" && frameType != "usage" && strings.ToLower(strings.TrimSpace(frame.Role)) != "assistant" {
+				continue
+			}
+			key := strings.TrimSpace(messageID)
+			if sessionID := strings.TrimSpace(kimiFrameSessionID(frame)); key != "" && sessionID != "" {
+				key = sessionID + ":" + key
+			}
+			if key == "" {
+				stepTotal.add(counts)
+			} else {
+				previous := stepMessages[key]
+				stepTotal.add(counts.positiveDelta(previous))
+				stepMessages[key] = counts
+			}
+			stepSeen = true
+		}
+	}
+
+	selected := stepTotal
+	seen := stepSeen
+	if !seen && terminalSeen {
+		selected = terminalTotal
+		seen = true
+	}
+	out.Input = selected.Input
+	out.Output = selected.Output
+	out.CacheRead = selected.CacheRead
+	out.CacheWrite = selected.CacheWrite
+	out.TotalTokens = selected.total()
+	return out, seen
+}
+
+func unwrapKimiFrame(frame kimiStreamFrame) kimiStreamFrame {
+	if strings.TrimSpace(frame.Type) != "" || strings.TrimSpace(frame.Role) != "" || len(frame.Message) == 0 {
+		return frame
+	}
+	var nested kimiStreamFrame
+	if json.Unmarshal(frame.Message, &nested) == nil {
+		return nested
+	}
+	return frame
+}
+
+func kimiFrameUsage(frame kimiStreamFrame) (*kimiUsageBlock, string, string) {
+	usage := frame.TokenUsage
+	if usage == nil {
+		usage = frame.Usage
+	}
+	messageID := frame.MessageID
+	model := frame.Model
+	if frame.Payload != nil {
+		if frame.Payload.TokenUsage != nil {
+			usage = frame.Payload.TokenUsage
+		} else if frame.Payload.Usage != nil {
+			usage = frame.Payload.Usage
+		}
+		if strings.TrimSpace(frame.Payload.MessageID) != "" {
+			messageID = frame.Payload.MessageID
+		}
+		if strings.TrimSpace(frame.Payload.Model) != "" {
+			model = frame.Payload.Model
+		}
+	}
+	return usage, messageID, model
+}
+
+func kimiFrameSessionID(frame kimiStreamFrame) string {
+	if frame.Payload != nil && strings.TrimSpace(frame.Payload.SessionID) != "" {
+		return frame.Payload.SessionID
+	}
+	return frame.SessionID
+}
+
+func firstPositive(values ...int) int {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}

--- a/internal/worker/kimi_usage_test.go
+++ b/internal/worker/kimi_usage_test.go
@@ -1,0 +1,56 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseKimiUsage_Fixture(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("testdata", "kimi_stream_usage.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage, ok := ParseKimiUsage(string(data))
+	if !ok {
+		t.Fatal("ParseKimiUsage returned ok=false")
+	}
+	if usage.Input != 1800 || usage.Output != 100 {
+		t.Fatalf("input/output = %d/%d, want 1800/100", usage.Input, usage.Output)
+	}
+	if usage.CacheRead != 600 || usage.CacheWrite != 100 {
+		t.Fatalf("cache read/write = %d/%d, want 600/100", usage.CacheRead, usage.CacheWrite)
+	}
+	if usage.TotalTokens != 2600 {
+		t.Fatalf("TotalTokens = %d, want 2600", usage.TotalTokens)
+	}
+}
+
+func TestParseKimiUsage_DeduplicatesMessageUpdates(t *testing.T) {
+	const stream = `{"type":"StatusUpdate","payload":{"token_usage":{"input_other":100,"output":10,"input_cache_read":20,"input_cache_creation":5},"message_id":"same"}}
+{"type":"StatusUpdate","payload":{"token_usage":{"input_other":125,"output":15,"input_cache_read":20,"input_cache_creation":5},"message_id":"same"}}
+`
+	usage, ok := ParseKimiUsage(stream)
+	if !ok {
+		t.Fatal("ParseKimiUsage returned ok=false")
+	}
+	if usage.Input != 125 || usage.Output != 15 || usage.CacheRead != 20 || usage.CacheWrite != 5 || usage.TotalTokens != 165 {
+		t.Fatalf("usage = %+v, want deduplicated total 165", usage)
+	}
+}
+
+func TestParseKimiUsage_TerminalFallbackAndRecordedEnvelope(t *testing.T) {
+	const terminal = `{"type":"result","model":"kimi-k2","usage":{"input_tokens":700,"output_tokens":30,"cache_read":50,"cache_write":20}}
+`
+	usage, ok := ParseKimiUsage(terminal)
+	if !ok || usage.TotalTokens != 800 || usage.Model != "kimi-k2" {
+		t.Fatalf("terminal usage = %+v, ok=%t, want model kimi-k2 total 800", usage, ok)
+	}
+
+	const recorded = `{"timestamp":1,"message":{"type":"StatusUpdate","payload":{"token_usage":{"input_other":40,"output":2,"input_cache_read":8,"input_cache_creation":0},"message_id":"recorded"}}}
+`
+	usage, ok = ParseKimiUsage(recorded)
+	if !ok || usage.TotalTokens != 50 {
+		t.Fatalf("recorded envelope usage = %+v, ok=%t, want total 50", usage, ok)
+	}
+}

--- a/internal/worker/stream_split.go
+++ b/internal/worker/stream_split.go
@@ -112,6 +112,8 @@ func renderStreamLine(backend, line string) string {
 		return renderClaudeStreamLine(line)
 	case "codex":
 		return renderCodexStreamLine(line)
+	case "kimi":
+		return renderKimiStreamLine(line)
 	case "opencode":
 		return renderOpenCodeStreamLine(line)
 	default:
@@ -131,6 +133,12 @@ func RenderClaudeStreamLine(line string) string {
 // rate-limit / auth-failure text intact).
 func RenderCodexStreamLine(line string) string {
 	return renderCodexStreamLine(line)
+}
+
+// RenderKimiStreamLine is the exported entry point for rendering one Kimi
+// Code CLI stream-json line.
+func RenderKimiStreamLine(line string) string {
+	return renderKimiStreamLine(line)
 }
 
 type claudeRenderFrame struct {
@@ -244,6 +252,63 @@ func renderClaudeContent(raw json.RawMessage) string {
 		}
 	}
 	return strings.Join(parts, "\n")
+}
+
+type kimiRenderFrame struct {
+	Role       string               `json:"role"`
+	Type       string               `json:"type"`
+	Content    json.RawMessage      `json:"content"`
+	ToolCallID string               `json:"tool_call_id"`
+	ToolCalls  []kimiRenderToolCall `json:"tool_calls"`
+	Payload    *kimiPayload         `json:"payload"`
+}
+
+type kimiRenderToolCall struct {
+	Function struct {
+		Name string `json:"name"`
+	} `json:"function"`
+}
+
+func renderKimiStreamLine(line string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || trimmed[0] != '{' {
+		return line
+	}
+	var frame kimiRenderFrame
+	if json.Unmarshal([]byte(trimmed), &frame) != nil {
+		return line
+	}
+	switch strings.ToLower(strings.TrimSpace(frame.Role)) {
+	case "assistant":
+		parts := make([]string, 0, 1+len(frame.ToolCalls))
+		if content := renderClaudeContent(frame.Content); strings.TrimSpace(content) != "" {
+			parts = append(parts, content)
+		}
+		for _, call := range frame.ToolCalls {
+			parts = append(parts, "[tool_use: "+strings.TrimSpace(call.Function.Name)+"]")
+		}
+		return strings.Join(parts, "\n")
+	case "tool":
+		content := renderClaudeContent(frame.Content)
+		if strings.TrimSpace(content) == "" {
+			return "[tool_result]"
+		}
+		return "[tool_result] " + content
+	case "meta":
+		if content := renderClaudeContent(frame.Content); strings.TrimSpace(content) != "" {
+			return "[kimi] " + content
+		}
+		return ""
+	}
+	if strings.EqualFold(strings.TrimSpace(frame.Type), "StatusUpdate") && frame.Payload != nil && frame.Payload.TokenUsage != nil {
+		usage := frame.Payload.TokenUsage.counts()
+		if usage.total() > 0 {
+			return fmt.Sprintf("[kimi] usage: input=%d output=%d cache_read=%d cache_write=%d total=%d",
+				usage.Input, usage.Output, usage.CacheRead, usage.CacheWrite, usage.total())
+		}
+		return ""
+	}
+	return line
 }
 
 // codexRenderFrame is the subset of a codex `exec --json` line the renderer

--- a/internal/worker/stream_split_test.go
+++ b/internal/worker/stream_split_test.go
@@ -159,6 +159,40 @@ func TestRunStreamSplit_Codex(t *testing.T) {
 	}
 }
 
+func TestRunStreamSplit_KimiFixture(t *testing.T) {
+	fixture, err := os.ReadFile(filepath.Join("testdata", "kimi_stream_usage.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	jsonlPath := filepath.Join(dir, "kimi.jsonl")
+	var out strings.Builder
+	if err := RunStreamSplit("kimi", jsonlPath, strings.NewReader(string(fixture)), &out); err != nil {
+		t.Fatalf("RunStreamSplit: %v", err)
+	}
+
+	raw, err := os.ReadFile(jsonlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(raw) != string(fixture) {
+		t.Fatal("stream-split did not preserve Kimi JSONL verbatim")
+	}
+	usage, ok := ParseKimiUsage(string(raw))
+	if !ok || usage.TotalTokens != 2600 {
+		t.Fatalf("Kimi split usage = %+v, ok=%t, want total 2600", usage, ok)
+	}
+	rendered := out.String()
+	for _, want := range []string{"Inspecting the repository.", "[tool_use: Shell]", "Implementation complete.", "[kimi] usage:"} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("rendered Kimi output missing %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, `"input_cache_read"`) {
+		t.Fatalf("rendered Kimi log leaked raw usage JSON:\n%s", rendered)
+	}
+}
+
 // The codex renderer must turn item events into readable text: a command and
 // its output/exit, a file change, and an agent message — never raw item JSON.
 func TestRenderCodexStreamLine_ItemsAreReadable(t *testing.T) {

--- a/internal/worker/testdata/kimi_stream_usage.jsonl
+++ b/internal/worker/testdata/kimi_stream_usage.jsonl
@@ -1,0 +1,5 @@
+{"role":"assistant","content":"Inspecting the repository.","tool_calls":[{"type":"function","id":"tool-1","function":{"name":"Shell","arguments":"{\"command\":\"git status --short\"}"}}]}
+{"role":"tool","tool_call_id":"tool-1","content":""}
+{"type":"StatusUpdate","payload":{"token_usage":{"input_other":1200,"output":80,"input_cache_read":400,"input_cache_creation":100},"message_id":"message-1"}}
+{"role":"assistant","content":"Implementation complete."}
+{"type":"StatusUpdate","payload":{"token_usage":{"input_other":600,"output":20,"input_cache_read":200,"input_cache_creation":0},"message_id":"message-2"}}

--- a/internal/worker/tier_argv_test.go
+++ b/internal/worker/tier_argv_test.go
@@ -67,6 +67,16 @@ func TestTierArgv_GeminiModelEffort(t *testing.T) {
 	}
 }
 
+func TestTierArgv_KimiModelDropsEffort(t *testing.T) {
+	args := buildArgs(t, "kimi", BackendConfig{Cmd: "kimi", TierModel: "kimi-k2", TierEffort: "medium"})
+	if !strings.Contains(args, "--model kimi-k2") {
+		t.Errorf("Kimi args missing tier model: %s", args)
+	}
+	if strings.Contains(args, "--effort") || strings.Contains(args, "model_reasoning_effort") {
+		t.Errorf("Kimi must not emit an unsupported effort flag: %s", args)
+	}
+}
+
 func TestTierArgv_NoOverrideWhenEmpty(t *testing.T) {
 	// Without a tier override the argv is unchanged — no spurious --model/--effort.
 	args := buildArgs(t, "claude", BackendConfig{Cmd: "claude"})

--- a/internal/worker/token_budget_test.go
+++ b/internal/worker/token_budget_test.go
@@ -140,6 +140,13 @@ func TestBuildWorkerCmd_TokenBudgetFailClosedAndCodexProxy(t *testing.T) {
 		}
 	})
 
+	t.Run("kimi explicitly fails closed", func(t *testing.T) {
+		_, _, err := BuildWorkerCmd("kimi", BackendConfig{Cmd: "kimi", Provider: "moonshot", TokenBudget: 80_000}, "/tmp/prompt", "/tmp")
+		if err == nil || !strings.Contains(err.Error(), "cannot be enforced live for Kimi") {
+			t.Fatalf("error = %v, want explicit Kimi live-budget limitation", err)
+		}
+	})
+
 	t.Run("codex receives native rollout budget", func(t *testing.T) {
 		cmd, _, err := BuildWorkerCmd("codex", BackendConfig{Cmd: "codex", UsageStream: true, TokenBudget: 80_000}, "/tmp/prompt", "/tmp")
 		if err != nil {


### PR DESCRIPTION
Refs #947

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Kimi Code CLI as a first-class backend. The main changes are:

- Kimi backend resolution and worker/supervisor command construction.
- Stream-JSON rendering and token usage parsing.
- Session usage and virtual cost attribution.
- Configuration docs, runbooks, fixtures, and tests.

<h3>Confidence Score: 4/5</h3>

Kimi accounting can be disabled by output overrides and can overcount usage on retries or identifier-free updates.

- Non-stream output remains accepted even though Kimi accounting requires stream JSON.
- Retry state resets conflict with cumulative parsing of an append-only JSONL file.
- Cumulative updates without message IDs are summed as separate usage.

internal/worker/backend.go, internal/worker/kimi_usage.go, internal/orchestrator/orchestrator.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the verification that output format with text mode disables accounting during Kimi command construction and parsing; exercised the Go test over the Kimi command builder with --output-format text in both cmd and extra\_args, then ran each generated command against a safe fake Kimi executable to confirm plain text output; routed the output through the real Kimi stream splitter and usage parser, where the splitter remained selected, parsing returned ok=false, and all accounting fields stayed at zero.
- Verified the retry recount behavior: running a production path test with an append-only JSONL fixture, the initial poll recorded 2,600 tokens with a 2,600-token watermark; the attempt initialization preserved the 2,600-token total while resetting the counters to zero; re-polling the same JSONL raised the total to 5,200 tokens, duplicating the prior tokens.
- Verified the missing IDs double-count snapshots: parsed two ID-less cumulative usage frames (100 and 125 tokens); the parser returned ok=true with input=225 and total=225 instead of 125; the harness exited with status 1 after failing the cumulative-total assertion.
- Validated the end-to-end argv/stdin flow change: before, Kimi was invoked with the prompt in argv with no stdin; after, argv is --print --output-format=stream-json and the prompt is delivered through stdin; the rendered output is readable and matches the committed fixture, and usage parsing succeeds with targeted tests and probes exiting 0.

<a href="https://app.greptile.com/trex/runs/15416937/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/backend_kind.go | Adds Kimi resolution by backend name, provider, and command basename. |
| internal/worker/backend.go | Adds Kimi worker and supervisor commands, splitter selection, and token-limit rejection. |
| internal/worker/kimi_usage.go | Adds cumulative Kimi token parsing with per-message update deduplication. |
| internal/worker/stream_split.go | Adds readable Kimi stream rendering while retaining raw JSONL frames. |
| internal/orchestrator/orchestrator.go | Routes Kimi sessions through JSONL usage capture and stamps split token counters. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/worker/backend.go:209-212
**Output Override Disables Accounting**

When a Kimi backend sets `--output-format text` in `cmd` or `extra_args`, this branch suppresses the managed stream-JSON flag, but the runner still enables the Kimi JSON splitter and parser. The worker can finish normally while token and cost accounting remain zero, contrary to Kimi's always-on accounting contract.

### Issue 2 of 3
internal/orchestrator/orchestrator.go:1582-1586
**Retry Recounts Previous Usage**

The JSONL file is append-only across attempts, while attempt initialization resets `UsageTokensWatermark`. On the next retry poll, `ParseKimiUsage` returns the total from all attempts and this block adds the previous attempt again, inflating session tokens and virtual cost before the retry emits new usage.

### Issue 3 of 3
internal/worker/kimi_usage.go:165-170
**Missing IDs Double-Count Snapshots**

When Kimi or a custom provider emits cumulative `StatusUpdate` frames without `message_id`, every snapshot is added in full. Updates reporting 100 and then 125 input tokens are recorded as 225, so token totals and virtual costs are overstated.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: describe Kimi routing and limits"](https://github.com/befeast/maestro/commit/c448355858b70e213a8a8e25a1486a9d5dfa4a4e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46323465)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->