### PR TITLE
bug: config watcher ignores max_live_workers-only changes

### DIFF
--- a/internal/daemon/watch_test.go
+++ b/internal/daemon/watch_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
 )
 
 // fakeWatchStore is an in-memory store that satisfies both ConfigLoader (so it
@@ -222,6 +223,115 @@ func TestWatchStoreWiresReloadChannel(t *testing.T) {
 
 	cancel()
 	<-done
+}
+
+// #884: a config-store write that changes only max_live_workers must reach the
+// already-running orchestrator loop within one watch interval. The same flow
+// must survive both an effective no-op write and the capacity reconfiguration:
+// cancelling it would stop every in-flight worker owned by that flow.
+func TestWatchStoreMaxLiveWorkersOnlyReconfiguresRunningOrchestrator(t *testing.T) {
+	store := newFakeWatchStore()
+	cfg := testConfig(t, "owner/alpha")
+	cfg.MaxParallel = 1
+	store.Set("alpha", cfg)
+
+	capacityState := state.NewState()
+	capacityState.Sessions["gate"] = &state.Session{Status: state.StatusPROpen}
+
+	var started, stopped, reloads int64
+	var availableSlots, separated int64
+	publishCapacity := func(current *config.Config) {
+		cap := capacityState.Capacity(state.CapacityInput{
+			MaxParallel:          current.MaxParallel,
+			MaxLiveWorkers:       current.MaxLiveWorkers,
+			MaxConcurrentByState: current.MaxConcurrentByState,
+		})
+		atomic.StoreInt64(&availableSlots, int64(cap.AvailableSlots))
+		if cap.Separated {
+			atomic.StoreInt64(&separated, 1)
+		} else {
+			atomic.StoreInt64(&separated, 0)
+		}
+	}
+	run := func(ctx context.Context, current *config.Config, opts Options, reloadCh <-chan *config.Config) {
+		atomic.AddInt64(&started, 1)
+		defer atomic.AddInt64(&stopped, 1)
+		publishCapacity(current)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case next := <-reloadCh:
+				if next == nil {
+					continue
+				}
+				publishCapacity(next)
+				atomic.AddInt64(&reloads, 1)
+			}
+		}
+	}
+	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
+		<-ctx.Done()
+	}
+	d := newWatchDaemon(store, run, sup)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	waitForNames(t, d, "alpha")
+	waitFor(t, func() bool { return atomic.LoadInt64(&started) == 1 })
+	waitFor(t, func() bool { return atomic.LoadInt64(&availableSlots) == 0 })
+	if got := atomic.LoadInt64(&separated); got != 0 {
+		t.Fatalf("initial separated = %d, want 0", got)
+	}
+	// Let the per-project watcher seed its initial fingerprint before advancing
+	// updated_at; otherwise an unusually slow goroutine start could absorb the
+	// first write into its baseline instead of emitting it.
+	time.Sleep(2 * d.opts.WatchStoreInterval)
+
+	// A timestamp-only/no-op store write still produces a reload event, but it
+	// must not replace or cancel the running flow.
+	noOp := *cfg
+	store.Set("alpha", &noOp)
+	waitFor(t, func() bool { return atomic.LoadInt64(&reloads) >= 1 })
+	if got := atomic.LoadInt64(&started); got != 1 {
+		t.Fatalf("run loops started after no-op reload = %d, want 1", got)
+	}
+	if got := atomic.LoadInt64(&stopped); got != 0 {
+		t.Fatalf("run loops stopped after no-op reload = %d, want 0", got)
+	}
+
+	// Change only max_live_workers. With one PR gate and max_parallel=1, the
+	// legacy model has no slot; separated accounting must expose one immediately.
+	edited := noOp
+	edited.MaxLiveWorkers = 1
+	store.Set("alpha", &edited)
+	waitFor(t, func() bool {
+		return atomic.LoadInt64(&reloads) >= 2 &&
+			atomic.LoadInt64(&separated) == 1 &&
+			atomic.LoadInt64(&availableSlots) == 1
+	})
+	waitFor(t, func() bool { return fleetProjectLiveWorkerLimit(t, d, "alpha") == 1 })
+	if got := atomic.LoadInt64(&started); got != 1 {
+		t.Fatalf("run loops started after effective reload = %d, want 1", got)
+	}
+	if got := atomic.LoadInt64(&stopped); got != 0 {
+		t.Fatalf("run loops stopped after effective reload = %d, want 0", got)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Run returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after cancellation")
+	}
+	if got := atomic.LoadInt64(&stopped); got != 1 {
+		t.Fatalf("run loops stopped after daemon shutdown = %d, want 1", got)
+	}
 }
 
 func TestReloadPumpCoalescesToLatestConfigWhenOrchestratorChannelIsFull(t *testing.T) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -3320,15 +3321,25 @@ func (o *Orchestrator) reloadConfig(newCfg *config.Config, ticker **time.Ticker)
 			old.Routing.RouterModel, newCfg.Routing.RouterModel, old.Routing.Mode, newCfg.Routing.Mode)
 	}
 
-	// Hot-reloadable fields
-	if newCfg.MaxParallel != old.MaxParallel {
-		changed = append(changed, fmt.Sprintf("max_parallel: %d→%d", old.MaxParallel, newCfg.MaxParallel))
-		o.cfg.MaxParallel = newCfg.MaxParallel
+	// Capacity is one dispatch decision, so compare and apply every input as one
+	// unit. Keeping max_parallel, max_live_workers, and max_concurrent_by_state
+	// behind one equality boundary prevents Fleet from publishing a freshly
+	// loaded capacity model while the running orchestrator retains one omitted
+	// field (#884).
+	if !dispatchCapacityConfigEqual(newCfg, old) {
+		if newCfg.MaxParallel != old.MaxParallel {
+			changed = append(changed, fmt.Sprintf("max_parallel: %d→%d", old.MaxParallel, newCfg.MaxParallel))
+		}
+		if newCfg.MaxLiveWorkers != old.MaxLiveWorkers {
+			changed = append(changed, fmt.Sprintf("max_live_workers: %d→%d", old.MaxLiveWorkers, newCfg.MaxLiveWorkers))
+		}
+		if !maps.Equal(newCfg.MaxConcurrentByState, old.MaxConcurrentByState) {
+			changed = append(changed, "max_concurrent_by_state")
+		}
+		applyDispatchCapacityConfig(o.cfg, newCfg)
 	}
-	if newCfg.MaxLiveWorkers != old.MaxLiveWorkers {
-		changed = append(changed, fmt.Sprintf("max_live_workers: %d→%d", old.MaxLiveWorkers, newCfg.MaxLiveWorkers))
-		o.cfg.MaxLiveWorkers = newCfg.MaxLiveWorkers
-	}
+
+	// Other hot-reloadable fields
 	if newCfg.MaxRuntimeMinutes != old.MaxRuntimeMinutes {
 		changed = append(changed, fmt.Sprintf("max_runtime_minutes: %d→%d", old.MaxRuntimeMinutes, newCfg.MaxRuntimeMinutes))
 		o.cfg.MaxRuntimeMinutes = newCfg.MaxRuntimeMinutes
@@ -3495,6 +3506,30 @@ func cloneStringMap(in map[string]string) map[string]string {
 		out[key] = value
 	}
 	return out
+}
+
+// dispatchCapacityConfigEqual compares every config field consumed by
+// capacityInput. Keep this as the single reload-detection boundary for dispatch
+// capacity so adding a capacity input cannot silently update only Fleet's view.
+func dispatchCapacityConfigEqual(a, b *config.Config) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.MaxParallel == b.MaxParallel &&
+		a.MaxLiveWorkers == b.MaxLiveWorkers &&
+		maps.Equal(a.MaxConcurrentByState, b.MaxConcurrentByState)
+}
+
+// applyDispatchCapacityConfig replaces the running orchestrator's complete
+// capacity model. Clone the map so the orchestrator keeps its private config
+// snapshot instead of aliasing the watcher/Fleet snapshot.
+func applyDispatchCapacityConfig(dst, src *config.Config) {
+	if dst == nil || src == nil {
+		return
+	}
+	dst.MaxParallel = src.MaxParallel
+	dst.MaxLiveWorkers = src.MaxLiveWorkers
+	dst.MaxConcurrentByState = maps.Clone(src.MaxConcurrentByState)
 }
 
 // markRestartRequired records a persistent restart-required signal both in memory

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -7784,6 +7784,47 @@ func TestReloadConfig_AppliesReloadableFields(t *testing.T) {
 	}
 }
 
+func TestDispatchCapacityConfigEqualIncludesEveryCapacityInput(t *testing.T) {
+	base := &config.Config{
+		MaxParallel:          4,
+		MaxLiveWorkers:       2,
+		MaxConcurrentByState: map[string]int{"running": 3},
+	}
+	tests := []struct {
+		name   string
+		mutate func(*config.Config)
+	}{
+		{name: "max_parallel", mutate: func(c *config.Config) { c.MaxParallel++ }},
+		{name: "max_live_workers", mutate: func(c *config.Config) { c.MaxLiveWorkers++ }},
+		{name: "max_concurrent_by_state", mutate: func(c *config.Config) {
+			c.MaxConcurrentByState = map[string]int{"running": 4}
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := *base
+			changed.MaxConcurrentByState = map[string]int{"running": 3}
+			tt.mutate(&changed)
+			if dispatchCapacityConfigEqual(base, &changed) {
+				t.Fatalf("dispatch capacity configs compare equal after %s changed", tt.name)
+			}
+		})
+	}
+
+	nonCapacity := *base
+	nonCapacity.MaxRuntimeMinutes = 90
+	if !dispatchCapacityConfigEqual(base, &nonCapacity) {
+		t.Fatal("non-capacity config change affected capacity equality")
+	}
+	emptyMap := *base
+	emptyMap.MaxConcurrentByState = map[string]int{}
+	nilMap := emptyMap
+	nilMap.MaxConcurrentByState = nil
+	if !dispatchCapacityConfigEqual(&emptyMap, &nilMap) {
+		t.Fatal("nil and empty per-state limits should be capacity-equivalent")
+	}
+}
+
 func TestReloadConfig_MaxLiveWorkersIncreaseExpandsCapacity(t *testing.T) {
 	cfg := cfgWithBackends("claude", "claude")
 	cfg.MaxParallel = 3
@@ -7851,6 +7892,48 @@ func TestReloadConfig_MaxLiveWorkersDecreaseStopsNewDispatch(t *testing.T) {
 	}
 	if got := s.Capacity(capacityInput(o.cfg)).LiveWorkers; got != 2 {
 		t.Fatalf("live workers after blocked dispatch = %d, want existing workers only", got)
+	}
+}
+
+func TestReloadConfig_AppliesEveryDispatchCapacityField(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.MaxParallel = 4
+	cfg.MaxLiveWorkers = 0
+	cfg.MaxConcurrentByState = map[string]int{"running": 1}
+	o := &Orchestrator{
+		cfg:      cfg,
+		repo:     cfg.Repo,
+		notifier: notify.NewWithToken("", "", "", ""),
+		router:   router.New(cfg),
+	}
+
+	s := state.NewState()
+	s.Sessions["existing"] = &state.Session{IssueNumber: 900, Status: state.StatusRunning}
+	if got := s.Capacity(capacityInput(o.cfg)).AvailableSlots; got != 0 {
+		t.Fatalf("initial available slots = %d, want 0 at running limit 1", got)
+	}
+
+	// max_concurrent_by_state is the third input to the shared dispatch-capacity
+	// calculation. A reload comparison that enumerates only the two scalar limits
+	// leaves the orchestrator stale even though Fleet reads the new store config.
+	newCfg := *cfg
+	newCfg.MaxConcurrentByState = map[string]int{"running": 3}
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	o.reloadConfig(&newCfg, &ticker)
+
+	if got := o.cfg.MaxConcurrentByState["running"]; got != 3 {
+		t.Fatalf("reloaded running limit = %d, want 3", got)
+	}
+	if got := s.Capacity(capacityInput(o.cfg)).AvailableSlots; got != 2 {
+		t.Fatalf("available slots after reload = %d, want 2", got)
+	}
+
+	// The orchestrator owns a private config snapshot. A caller mutating the
+	// reload object later must not silently change live dispatch capacity.
+	newCfg.MaxConcurrentByState["running"] = 9
+	if got := o.cfg.MaxConcurrentByState["running"]; got != 3 {
+		t.Fatalf("live running limit aliased reload input: got %d, want 3", got)
 	}
 }
 


### PR DESCRIPTION
Refs #884

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps the running orchestrator’s capacity settings synchronized with watched configuration. The main changes are:

- Compare all three dispatch-capacity inputs during reloads.
- Clone per-state limits into the orchestrator’s private snapshot.
- Test direct reloads and end-to-end watcher propagation.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The TestWatchStoreMaxLiveWorkersOnlyReconfiguresRunningOrchestrator test completed successfully in 0.10s while the daemon's store watcher and fleet were running.
- The orchestrator reconfiguration to max\_live\_workers 1→3 exited with code 0 and immediately started two new workers.
- The orchestrator reconfiguration to max\_live\_workers 3→1 exited with code 0, queued new issues, and retained the two existing live workers.
- Snapshot coverage passed for max\_parallel, max\_live\_workers, and max\_concurrent\_by\_state, and later mutation of the reload input did not alter the orchestrator's live snapshot.

<a href="https://app.greptile.com/trex/runs/15423009/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Reloads all dispatch-capacity fields together and clones the per-state limits map. |
| internal/orchestrator/orchestrator_test.go | Tests capacity-field comparison, live recalculation, and map ownership. |
| internal/daemon/watch_test.go | Tests no-op and max-live-workers-only updates through the running watcher flow. |

<sub>Reviews (1): Last reviewed commit: ["bug: reload all dispatch capacity fields"](https://github.com/befeast/maestro/commit/40f766fd65d5ce1e371b299c106afe581762609b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46335857)</sub>

<!-- /greptile_comment -->