### PR TITLE
bug: project plan cannot update rows that reference shared backends

### DIFF
--- a/cmd/maestro/project.go
+++ b/cmd/maestro/project.go
@@ -118,7 +118,7 @@ func projectPlanCmd(args []string) {
 		failGenesis("plan", *asJSON, "invalid_input", "project plan: --db must not be empty")
 	}
 
-	prepared := prepareGenesisFile(*file, "project plan", *asJSON)
+	prepared := prepareGenesisFile(*file, *dbPath, "project plan", *asJSON)
 	if err := validateGenesisRuntime(prepared); err != nil {
 		failGenesis("plan", *asJSON, "preflight_failed", fmt.Sprintf("project plan: preflight: %v", err))
 	}
@@ -159,7 +159,7 @@ func projectApplyCmd(args []string) {
 		failGenesis("apply", *asJSON, "invalid_input", "project apply: --db must not be empty")
 	}
 
-	prepared := prepareGenesisFile(*file, "project apply", *asJSON)
+	prepared := prepareGenesisFile(*file, *dbPath, "project apply", *asJSON)
 	if err := validateGenesisRuntime(prepared); err != nil {
 		failGenesis("apply", *asJSON, "preflight_failed", fmt.Sprintf("project apply: preflight: %v", err))
 	}
@@ -222,9 +222,10 @@ func validateApplyApproval(p *configstore.PreparedProject, confirm, fingerprint,
 
 // prepareGenesisFile reads and strict-validates the portable project file,
 // sharing the flag-plumbing between plan and apply. It fatals (with a clear
-// cmd-prefixed message) on any read/validation failure. Opening the store is the
-// caller's job so `plan` can avoid creating an absent store.
-func prepareGenesisFile(file, cmd string, asJSON bool) *configstore.PreparedProject {
+// cmd-prefixed message) on any read/validation failure. Existing stores are
+// opened through the zero-write snapshot reader so shared backend references can
+// be validated without changing DB/WAL/SHM; an absent store is never opened.
+func prepareGenesisFile(file, dbPath, cmd string, asJSON bool) *configstore.PreparedProject {
 	if strings.TrimSpace(file) == "" {
 		failGenesis(strings.TrimPrefix(cmd, "project "), asJSON, "invalid_input", fmt.Sprintf("%s: --file is required (a portable project YAML)", cmd))
 	}
@@ -232,7 +233,21 @@ func prepareGenesisFile(file, cmd string, asJSON bool) *configstore.PreparedProj
 	if err != nil {
 		failGenesis(strings.TrimPrefix(cmd, "project "), asJSON, "file_read_failed", fmt.Sprintf("%s: read %s: %v", cmd, file, err))
 	}
-	prepared, err := configstore.PrepareProject(file, data)
+	exists, err := inspectStoreFile(dbPath)
+	if err != nil {
+		failGenesis(strings.TrimPrefix(cmd, "project "), asJSON, "store_preflight_failed", fmt.Sprintf("%s: inspect config store %s: %v", cmd, dbPath, err))
+	}
+	var prepared *configstore.PreparedProject
+	if exists {
+		store, openErr := configstore.OpenReadOnly(dbPath)
+		if openErr != nil {
+			failGenesis(strings.TrimPrefix(cmd, "project "), asJSON, "store_open_failed", fmt.Sprintf("%s: open config store %s: %v", cmd, dbPath, openErr))
+		}
+		defer store.Close()
+		prepared, err = store.PrepareProject(context.Background(), file, data)
+	} else {
+		prepared, err = configstore.PrepareProject(file, data)
+	}
 	if err != nil {
 		failGenesis(strings.TrimPrefix(cmd, "project "), asJSON, "validation_failed", fmt.Sprintf("%s: %v", cmd, err))
 	}

--- a/cmd/maestro/project_test.go
+++ b/cmd/maestro/project_test.go
@@ -25,6 +25,22 @@ management_home:
   vault_path: Dev/Areas/demo
 `
 
+const projectTestSharedBackendYAML = projectTestYAML + `model:
+  default: claude
+  fallback_backends: [codex]
+  backends:
+    claude:
+      cmd: claude
+    codex:
+      cmd: codex
+      prompt_mode: stdin
+`
+
+const projectTestSharedBackendRawYAML = projectTestYAML + `model:
+  default: claude
+  fallback_backends: [codex]
+`
+
 func TestUnifiedDefaultStorePath(t *testing.T) {
 	t.Setenv("HOME", "/srv/example-home")
 	want := "/srv/example-home/.maestro/maestro.db"
@@ -415,6 +431,48 @@ func TestPlanReportActiveWALChangesNoDatabaseFiles(t *testing.T) {
 		}
 		if !bytes.Equal(before[path], after) {
 			t.Fatalf("project plan changed active SQLite file %s", path)
+		}
+	}
+}
+
+func TestPlanSharedBackendUpdateChangesNoDatabaseFiles(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "config.db")
+	store, err := configstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open writable fixture: %v", err)
+	}
+	defer store.Close()
+	if err := store.UpsertProject(context.Background(), "befeast-demo", projectTestSharedBackendYAML); err != nil {
+		t.Fatalf("seed shared-backend fixture: %v", err)
+	}
+	file := filepath.Join(dir, "project.yaml")
+	desired := strings.Replace(projectTestSharedBackendRawYAML, "/srv/example-src/demo", "/srv/updated-src/demo", 1)
+	if err := os.WriteFile(file, []byte(desired), 0o644); err != nil {
+		t.Fatalf("write desired project: %v", err)
+	}
+
+	paths := []string{dbPath, dbPath + "-wal", dbPath + "-shm"}
+	before := make(map[string][]byte, len(paths))
+	for _, path := range paths {
+		before[path], err = os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read active shared-backend fixture %s: %v", path, err)
+		}
+	}
+
+	prepared := prepareGenesisFile(file, dbPath, "project plan", false)
+	report := planReport(dbPath, prepared, false)
+	if report.Effect != configstore.EffectUpdate || report.Wrote {
+		t.Fatalf("shared-backend plan = %+v, want update+!wrote", report)
+	}
+	for _, path := range paths {
+		after, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read after shared-backend plan %s: %v", path, err)
+		}
+		if !bytes.Equal(before[path], after) {
+			t.Fatalf("shared-backend project plan changed active SQLite file %s", path)
 		}
 	}
 }

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -525,6 +525,12 @@ stop that never overwrites a row by name. Both emit a machine-readable receipt
 (store, project id, fingerprint, effect, daemon-reconciliation expectation, exact
 next commands) for scripted bootstrap adapters.
 
+For an existing row, the input may be either its backend-free stored project
+YAML or a `config-store export` that re-attaches fleet-shared `model.backends`.
+Plan resolves backend references from the target store without writing it. Any
+definition carried by an export must exactly match that store; missing or
+divergent definitions fail closed and must be changed at fleet scope instead.
+
 The running `maestro daemon --watch-store` observes the new row within one poll
 interval and starts exactly one flow — no restart, no `systemctl` step per project.
 Removal/rollback stays a separate explicit operator action:

--- a/internal/configstore/genesis.go
+++ b/internal/configstore/genesis.go
@@ -52,12 +52,18 @@ type PreparedProject struct {
 	ManagementHome config.ManagementHomeConfig
 	Fingerprint    string
 	// Canonical is the deterministic project document the fingerprint is taken
-	// over (backends normalized, re-marshaled). Raw is the original file bytes,
-	// stored verbatim on apply so comments/ordering survive the round-trip that
-	// UpsertProject itself performs.
+	// over (backends normalized, re-marshaled). Raw is the project-only document
+	// passed to apply; it preserves the original bytes unless preparation had to
+	// detach a matching model.backends block from a config-store export.
 	Canonical []byte
 	Raw       []byte
 	Warnings  []string
+
+	// portableBackends records definitions supplied by an exported portable
+	// document. They are never written by genesis: a target-store preparation
+	// accepts them only when they exactly match the fleet-shared definitions,
+	// then ApplyProject re-checks that equality in its write transaction.
+	portableBackends map[string]*yaml.Node
 }
 
 // ExistingRow is the identity summary of a config-store row that a plan/apply
@@ -97,8 +103,61 @@ type GenesisReport struct {
 //   - a valid, present project_id (the durable identity the flow is built around);
 //   - local_path and worktree_base required (a genesis row must be runnable).
 func PrepareProject(sourcePath string, data []byte) (*PreparedProject, error) {
-	cfg, err := config.ParseStrict(data)
+	return prepareProject(sourcePath, data, nil, false)
+}
+
+// PrepareProject validates a portable project document against the shared
+// backend definitions already present in this target store. This is the
+// store-aware entry point used by project plan/apply for existing stores:
+// project-only rows may reference shared backends without embedding them, while
+// config-store exports may carry definitions only as an exact, read-only proof
+// of what the target store already contains.
+func (s *Store) PrepareProject(ctx context.Context, sourcePath string, data []byte) (*PreparedProject, error) {
+	backends, err := s.loadBackends(ctx)
 	if err != nil {
+		return nil, fmt.Errorf("load target shared backends: %w", err)
+	}
+	return prepareProject(sourcePath, data, backends, true)
+}
+
+func prepareProject(sourcePath string, data []byte, sharedBackends map[string]*yaml.Node, storeAware bool) (*PreparedProject, error) {
+	var source yaml.Node
+	if err := yaml.Unmarshal(data, &source); err != nil {
+		return nil, err
+	}
+	portableBackends := detachBackends(&source)
+	if !storeAware && len(portableBackends) > 0 {
+		return nil, fmt.Errorf("portable project genesis must not define shared model.backends; configure fleet backends separately before plan/apply")
+	}
+	if storeAware {
+		if err := validatePortableBackends(portableBackends, sharedBackends); err != nil {
+			return nil, err
+		}
+	}
+
+	projectData := data
+	if len(portableBackends) > 0 {
+		removeEmptyTopLevelMapping(&source, "model")
+		var err error
+		projectData, err = marshalNode(&source)
+		if err != nil {
+			return nil, fmt.Errorf("detach portable model.backends: %w", err)
+		}
+	}
+
+	effective := cloneNode(&source)
+	if storeAware {
+		attachBackends(effective, sharedBackends)
+	}
+	effectiveData, err := marshalNode(effective)
+	if err != nil {
+		return nil, fmt.Errorf("attach target shared backends: %w", err)
+	}
+	cfg, err := config.ParseStrict(effectiveData)
+	if err != nil {
+		if storeAware && missingSharedBackendError(err) {
+			return nil, fmt.Errorf("target config store is missing a shared backend required by this project; configure it at fleet scope before plan/apply: %w", err)
+		}
 		return nil, err
 	}
 	id := strings.TrimSpace(cfg.ProjectID)
@@ -107,13 +166,6 @@ func PrepareProject(sourcePath string, data []byte) (*PreparedProject, error) {
 	}
 	if id != strings.ToLower(id) {
 		return nil, fmt.Errorf("project_id must use canonical lowercase UUID form; got %q", id)
-	}
-	var source yaml.Node
-	if err := yaml.Unmarshal(data, &source); err != nil {
-		return nil, err
-	}
-	if backends := detachBackends(&source); len(backends) > 0 {
-		return nil, fmt.Errorf("portable project genesis must not define shared model.backends; configure fleet backends separately before plan/apply")
 	}
 	repo := strings.TrimSpace(cfg.Repo)
 	parts := strings.Split(repo, "/")
@@ -152,15 +204,74 @@ func PrepareProject(sourcePath string, data []byte) (*PreparedProject, error) {
 		ManagementHome: cfg.ManagementHome,
 		Fingerprint:    fp,
 		Canonical:      canonical,
-		Raw:            data,
+		Raw:            projectData,
 		// Surface config load-time warnings on the genesis receipt so an
 		// operator sees them at plan/apply. This is where the #872 delivery
 		// deprecation nudges a legacy deploy_cmd (or an explicit
 		// delivery.mode: automatic) toward the safe approval_required default —
 		// new genesis output that names a delivery command defaults to
 		// approval_required, and an unattended automatic mode is called out.
-		Warnings: cfg.Warnings(),
+		Warnings:         cfg.Warnings(),
+		portableBackends: cloneBackendMap(portableBackends),
 	}, nil
+}
+
+func validatePortableBackends(portable, shared map[string]*yaml.Node) error {
+	names := make([]string, 0, len(portable))
+	for name := range portable {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		portableDef := portable[name]
+		sharedDef, ok := shared[name]
+		if !ok {
+			return fmt.Errorf("portable model.backends.%s is not defined in the target config store; configure that fleet backend before plan/apply", name)
+		}
+		equal, err := backendDefinitionsEqual(portableDef, sharedDef)
+		if err != nil {
+			return fmt.Errorf("compare portable model.backends.%s with target store: %w", name, err)
+		}
+		if !equal {
+			return fmt.Errorf("portable model.backends.%s diverges from the target config store; shared backend values cannot be redefined by project genesis (update the fleet backend separately or export the project again)", name)
+		}
+	}
+	return nil
+}
+
+func backendDefinitionsEqual(a, b *yaml.Node) (bool, error) {
+	left := cloneNode(a)
+	right := cloneNode(b)
+	normalizeYAMLPresentation(left)
+	normalizeYAMLPresentation(right)
+	sortMappingKeys(left)
+	sortMappingKeys(right)
+	leftYAML, err := marshalNode(left)
+	if err != nil {
+		return false, err
+	}
+	rightYAML, err := marshalNode(right)
+	if err != nil {
+		return false, err
+	}
+	return string(leftYAML) == string(rightYAML), nil
+}
+
+func cloneBackendMap(in map[string]*yaml.Node) map[string]*yaml.Node {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]*yaml.Node, len(in))
+	for name, def := range in {
+		out[name] = cloneNode(def)
+	}
+	return out
+}
+
+func missingSharedBackendError(err error) bool {
+	message := err.Error()
+	return strings.Contains(message, "model.backends") &&
+		(strings.Contains(message, "not defined") || strings.Contains(message, "not declared"))
 }
 
 // canonicalProjectDoc returns the deterministic project document and its
@@ -365,7 +476,7 @@ func (s *Store) ApplyProject(ctx context.Context, p *PreparedProject, confirm, w
 		if wb != report.BaselineFingerprint {
 			return report, fmt.Errorf("config store changed since plan (approved baseline %s, current %s); re-run `maestro project plan` and review before applying", wb, report.BaselineFingerprint)
 		}
-		if err := upsertProjectTx(ctx, tx, p.Name, string(p.Raw)); err != nil {
+		if err := upsertPreparedProjectTx(ctx, tx, p.Name, string(p.Raw)); err != nil {
 			return nil, err
 		}
 		if err := tx.Commit(); err != nil {
@@ -379,6 +490,9 @@ func (s *Store) ApplyProject(ctx context.Context, p *PreparedProject, confirm, w
 }
 
 func evaluateProjectTx(ctx context.Context, tx *sql.Tx, p *PreparedProject) (effect, conflict string, existing *ExistingRow, err error) {
+	if err := validatePreparedProjectTx(ctx, tx, p); err != nil {
+		return "", "", nil, err
+	}
 	row, err := existingRowTx(ctx, tx, p.Name)
 	if err != nil {
 		return "", "", nil, err
@@ -409,6 +523,53 @@ func evaluateProjectTx(ctx context.Context, tx *sql.Tx, p *PreparedProject) (eff
 		return EffectNoOp, "", row, nil
 	}
 	return EffectUpdate, "", row, nil
+}
+
+func validatePreparedProjectTx(ctx context.Context, tx *sql.Tx, p *PreparedProject) error {
+	backends, err := loadBackendsTx(ctx, tx)
+	if err != nil {
+		return fmt.Errorf("load target shared backends: %w", err)
+	}
+	if err := validatePortableBackends(p.portableBackends, backends); err != nil {
+		return err
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(p.Raw, &root); err != nil {
+		return err
+	}
+	attachBackends(&root, backends)
+	effective, err := marshalNode(&root)
+	if err != nil {
+		return err
+	}
+	if _, err := config.ParseStrict(effective); err != nil {
+		if missingSharedBackendError(err) {
+			return fmt.Errorf("target config store is missing a shared backend required by this project; configure it at fleet scope before plan/apply: %w", err)
+		}
+		return err
+	}
+	return nil
+}
+
+func loadBackendsTx(ctx context.Context, tx *sql.Tx) (map[string]*yaml.Node, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT name, definition_yaml FROM backends ORDER BY name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[string]*yaml.Node{}
+	for rows.Next() {
+		var name, data string
+		if err := rows.Scan(&name, &data); err != nil {
+			return nil, err
+		}
+		var doc yaml.Node
+		if err := yaml.Unmarshal([]byte(data), &doc); err != nil {
+			return nil, fmt.Errorf("parse backend %s: %w", name, err)
+		}
+		out[name] = documentValue(&doc)
+	}
+	return out, rows.Err()
 }
 
 func existingRowTx(ctx context.Context, tx *sql.Tx, name string) (*ExistingRow, error) {

--- a/internal/configstore/genesis_test.go
+++ b/internal/configstore/genesis_test.go
@@ -20,6 +20,18 @@ management_home:
   vault_path: Dev/Areas/maestro
 `
 
+const genesisSharedBackendYAML = genesisYAML + `model:
+  default: claude
+  fallback_backends: [codex]
+  backends:
+    claude:
+      cmd: claude
+      prompt_mode: arg
+    codex:
+      cmd: codex
+      prompt_mode: stdin
+`
+
 func TestPrepareProjectValid(t *testing.T) {
 	p, err := PrepareProject("portable.yaml", []byte(genesisYAML))
 	if err != nil {
@@ -135,6 +147,213 @@ func TestPrepareProjectSurfacesDeliveryWarnings(t *testing.T) {
 	if containsSubstr(q.Warnings, "deploy_cmd is deprecated") || containsSubstr(q.Warnings, "delivery.mode: automatic") {
 		t.Fatalf("approval_required delivery must not emit a delivery deprecation/automatic warning; warnings=%v", q.Warnings)
 	}
+}
+
+func TestPrepareProjectAgainstSharedBackends(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("raw stored YAML", func(t *testing.T) {
+		store := openTestStore(t)
+		seedGenesisSharedBackends(t, store)
+		raw := storedProjectYAML(t, store, "befeast-maestro")
+		desired := strings.Replace(raw, "/srv/example-src/maestro", "/srv/updated-src/maestro", 1)
+
+		if _, err := PrepareProject("raw.yaml", []byte(desired)); err == nil || !strings.Contains(err.Error(), "fallback_backends") {
+			t.Fatalf("standalone prepare err = %v, want unresolved fallback backend", err)
+		}
+		p, err := store.PrepareProject(ctx, "raw.yaml", []byte(desired))
+		if err != nil {
+			t.Fatalf("store-aware PrepareProject: %v", err)
+		}
+		plan, err := store.PlanProject(ctx, p)
+		if err != nil {
+			t.Fatalf("PlanProject: %v", err)
+		}
+		if plan.Effect != EffectUpdate || plan.Wrote {
+			t.Fatalf("plan = %+v, want update+!wrote", plan)
+		}
+	})
+
+	t.Run("exported YAML with matching definitions", func(t *testing.T) {
+		store := openTestStore(t)
+		seedGenesisSharedBackends(t, store)
+		exported, err := store.ExportProject(ctx, "befeast-maestro")
+		if err != nil {
+			t.Fatalf("ExportProject: %v", err)
+		}
+		desired := strings.Replace(string(exported), "/srv/example-src/maestro", "/srv/updated-src/maestro", 1)
+
+		if _, err := PrepareProject("exported.yaml", []byte(desired)); err == nil || !strings.Contains(err.Error(), "must not define shared model.backends") {
+			t.Fatalf("standalone prepare err = %v, want portable backend rejection", err)
+		}
+		p, err := store.PrepareProject(ctx, "exported.yaml", []byte(desired))
+		if err != nil {
+			t.Fatalf("store-aware PrepareProject: %v", err)
+		}
+		if strings.Contains(string(p.Raw), "\n  backends:") {
+			t.Fatalf("prepared project retained shared backend definitions:\n%s", p.Raw)
+		}
+		plan, err := store.PlanProject(ctx, p)
+		if err != nil {
+			t.Fatalf("PlanProject: %v", err)
+		}
+		if plan.Effect != EffectUpdate {
+			t.Fatalf("plan effect = %q, want update", plan.Effect)
+		}
+	})
+
+	t.Run("missing target definition", func(t *testing.T) {
+		store := openTestStore(t)
+		seedGenesisSharedBackends(t, store)
+		exported, err := store.ExportProject(ctx, "befeast-maestro")
+		if err != nil {
+			t.Fatalf("ExportProject: %v", err)
+		}
+		raw := storedProjectYAML(t, store, "befeast-maestro")
+		if _, err := store.db.ExecContext(ctx, `DELETE FROM backends WHERE name = 'codex'`); err != nil {
+			t.Fatalf("delete codex fixture: %v", err)
+		}
+
+		_, err = store.PrepareProject(ctx, "raw.yaml", []byte(raw))
+		if err == nil || !strings.Contains(err.Error(), "target config store is missing") || !strings.Contains(err.Error(), "codex") {
+			t.Fatalf("raw missing-definition err = %v, want actionable codex error", err)
+		}
+		_, err = store.PrepareProject(ctx, "exported.yaml", exported)
+		if err == nil || !strings.Contains(err.Error(), "model.backends.codex") || !strings.Contains(err.Error(), "target config store") {
+			t.Fatalf("export missing-definition err = %v, want target-store error", err)
+		}
+	})
+
+	t.Run("divergent exported definition", func(t *testing.T) {
+		store := openTestStore(t)
+		seedGenesisSharedBackends(t, store)
+		exported, err := store.ExportProject(ctx, "befeast-maestro")
+		if err != nil {
+			t.Fatalf("ExportProject: %v", err)
+		}
+		divergent := strings.Replace(string(exported), "cmd: codex", "cmd: other-codex", 1)
+		_, err = store.PrepareProject(ctx, "exported.yaml", []byte(divergent))
+		if err == nil || !strings.Contains(err.Error(), "model.backends.codex diverges") || !strings.Contains(err.Error(), "cannot be redefined") {
+			t.Fatalf("divergent-definition err = %v, want fail-closed redefinition error", err)
+		}
+	})
+}
+
+func TestApplyProjectSharedBackendUpdatePreservesFleetTableAndIdentity(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	seedGenesisSharedBackends(t, store)
+	before := backendTableSnapshot(t, store)
+	exported, err := store.ExportProject(ctx, "befeast-maestro")
+	if err != nil {
+		t.Fatalf("ExportProject: %v", err)
+	}
+	desired := strings.Replace(string(exported), "/srv/example-src/maestro", "/srv/updated-src/maestro", 1)
+	p, err := store.PrepareProject(ctx, "exported.yaml", []byte(desired))
+	if err != nil {
+		t.Fatalf("PrepareProject: %v", err)
+	}
+	plan, err := store.PlanProject(ctx, p)
+	if err != nil {
+		t.Fatalf("PlanProject: %v", err)
+	}
+	report, err := store.ApplyProject(ctx, p, p.ProjectID, p.Fingerprint, plan.BaselineFingerprint)
+	if err != nil {
+		t.Fatalf("ApplyProject: %v", err)
+	}
+	if report.Effect != EffectUpdate || !report.Wrote {
+		t.Fatalf("apply = %+v, want update+wrote", report)
+	}
+	if after := backendTableSnapshot(t, store); !reflect.DeepEqual(after, before) {
+		t.Fatalf("genesis update changed shared backend table:\nbefore=%v\nafter=%v", before, after)
+	}
+	cfg, err := store.Load(ctx, "befeast-maestro")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.ProjectID != "3f2504e0-4f89-41d3-9a0c-0305e82c3301" {
+		t.Fatalf("project identity changed to %q", cfg.ProjectID)
+	}
+	if cfg.LocalPath != "/srv/updated-src/maestro" {
+		t.Fatalf("local_path = %q, want updated value", cfg.LocalPath)
+	}
+	if got := cfg.Model.Backends["codex"].Cmd; got != "codex" {
+		t.Fatalf("shared codex backend cmd = %q, want codex", got)
+	}
+}
+
+func TestApplyProjectRejectsSharedBackendDriftSinceExport(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	seedGenesisSharedBackends(t, store)
+	exported, err := store.ExportProject(ctx, "befeast-maestro")
+	if err != nil {
+		t.Fatalf("ExportProject: %v", err)
+	}
+	desired := strings.Replace(string(exported), "/srv/example-src/maestro", "/srv/updated-src/maestro", 1)
+	p, err := store.PrepareProject(ctx, "exported.yaml", []byte(desired))
+	if err != nil {
+		t.Fatalf("PrepareProject: %v", err)
+	}
+	plan, err := store.PlanProject(ctx, p)
+	if err != nil {
+		t.Fatalf("PlanProject: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `UPDATE backends SET definition_yaml = 'cmd: other-codex' WHERE name = 'codex'`); err != nil {
+		t.Fatalf("change shared backend fixture: %v", err)
+	}
+
+	report, err := store.ApplyProject(ctx, p, p.ProjectID, p.Fingerprint, plan.BaselineFingerprint)
+	if err == nil || !strings.Contains(err.Error(), "model.backends.codex diverges") {
+		t.Fatalf("ApplyProject err = %v, want shared-backend drift refusal", err)
+	}
+	if report != nil {
+		t.Fatalf("drifted apply report = %+v, want validation failure before evaluation", report)
+	}
+	cfg, err := store.Load(ctx, "befeast-maestro")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.LocalPath != "/srv/example-src/maestro" {
+		t.Fatalf("drifted apply changed project local_path to %q", cfg.LocalPath)
+	}
+}
+
+func seedGenesisSharedBackends(t *testing.T, store *Store) {
+	t.Helper()
+	if err := store.UpsertProject(context.Background(), "befeast-maestro", genesisSharedBackendYAML); err != nil {
+		t.Fatalf("seed shared-backend project: %v", err)
+	}
+}
+
+func storedProjectYAML(t *testing.T, store *Store, name string) string {
+	t.Helper()
+	var data string
+	if err := store.db.QueryRow(`SELECT config_yaml FROM project WHERE name = ?`, name).Scan(&data); err != nil {
+		t.Fatalf("query stored project YAML: %v", err)
+	}
+	return data
+}
+
+func backendTableSnapshot(t *testing.T, store *Store) map[string][2]string {
+	t.Helper()
+	rows, err := store.db.Query(`SELECT name, definition_yaml, updated_at FROM backends ORDER BY name`)
+	if err != nil {
+		t.Fatalf("query backend table: %v", err)
+	}
+	defer rows.Close()
+	out := map[string][2]string{}
+	for rows.Next() {
+		var name, definition, updatedAt string
+		if err := rows.Scan(&name, &definition, &updatedAt); err != nil {
+			t.Fatalf("scan backend table: %v", err)
+		}
+		out[name] = [2]string{definition, updatedAt}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate backend table: %v", err)
+	}
+	return out
 }
 
 func containsSubstr(ss []string, sub string) bool {

--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -673,7 +673,33 @@ func upsertProjectTx(ctx context.Context, tx *sql.Tx, name, configYAML string) e
 	if err := upsertSharedBackendsTx(ctx, tx, backends, now); err != nil {
 		return err
 	}
-	projectYAML, err := marshalNode(&root)
+	return upsertProjectRootTx(ctx, tx, name, &root, now)
+}
+
+// upsertPreparedProjectTx writes a project document that genesis already
+// strict-validated against the target store in the same transaction. Genesis
+// never owns fleet backend values, so an attached backend block is an internal
+// error rather than something this path may detach and upsert.
+func upsertPreparedProjectTx(ctx context.Context, tx *sql.Tx, name, configYAML string) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("project name is required")
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(configYAML), &root); err != nil {
+		return err
+	}
+	if backends := detachBackends(&root); len(backends) > 0 {
+		return errors.New("internal: prepared project still contains model.backends")
+	}
+	if err := enforceImmutableProjectID(ctx, tx, name, &root); err != nil {
+		return err
+	}
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	return upsertProjectRootTx(ctx, tx, name, &root, now)
+}
+
+func upsertProjectRootTx(ctx context.Context, tx *sql.Tx, name string, root *yaml.Node, now string) error {
+	projectYAML, err := marshalNode(root)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Refs #883

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR enables project updates that reference fleet-shared backends. The main changes are:

- Store-aware validation for project plan and apply.
- Read-only backend resolution during planning.
- Transactional backend drift checks during apply.
- Backend-free project writes that preserve fleet-owned definitions.
- Tests for raw YAML, exports, drift, identity, and SQLite file stability.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to compile the baseline parent implementation against the overlaid focused tests but the compile failed because Store.PrepareProject did not exist.
- T-Rex ran the changed tree through focused configstore and CLI tests uncached, and the tests completed with exit code 0, demonstrating the new path and refusal behavior.
- T-Rex verified through assertions that update and write occurred, the backend table remained unchanged, the project ID and backend data were retained, the project path was updated, drift refusal did not mutate state, and SQLite database/WAL/SHM remained unchanged during planning.
- T-Rex captured and prepared artifacts to support review, including logs and a shellscript artifact.

<a href="https://app.greptile.com/trex/runs/15424685/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cmd/maestro/project.go | Plan and apply now prepare project files against an existing target store through a read-only path. |
| internal/configstore/genesis.go | Project preparation now resolves shared backends and repeats backend validation inside the apply transaction. |
| internal/configstore/store.go | Genesis writes now update only project-owned YAML and reject attached shared backend definitions. |
| cmd/maestro/project_test.go | Command coverage verifies shared-backend planning does not modify active SQLite files. |
| internal/configstore/genesis_test.go | Tests cover stored and exported YAML, backend mismatch and drift, identity preservation, and fleet-table preservation. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-1113-8..."](https://github.com/befeast/maestro/commit/7cc4a17d2c1b5020187d7c030b0a653994f746bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46335982)</sub>

<!-- /greptile_comment -->