### PR TITLE
S8: Outcome hold must prefer backlog label/spawn (F8) + fleet min/max live workers

### DIFF
--- a/cmd/maestro/settings.go
+++ b/cmd/maestro/settings.go
@@ -98,6 +98,17 @@ func openSettingsStore(dbPath string) *configstore.Store {
 	return store
 }
 
+func rejectFleetOnlyProjectSetting(key, project string) error {
+	if strings.TrimSpace(project) == "" {
+		return nil
+	}
+	spec, ok := config.FleetSettingSpecByKey(key)
+	if ok && spec.FleetOnly {
+		return fmt.Errorf("setting %q is fleet-only; omit --project", key)
+	}
+	return nil
+}
+
 func settingsList(args []string) {
 	fs := flag.NewFlagSet("settings list", flag.ExitOnError)
 	dbPath := configStoreDBFlag(fs)
@@ -115,12 +126,14 @@ func settingsList(args []string) {
 			log.Fatalf("settings list: %v", err)
 		}
 		fmt.Fprintln(tw, "KEY\tFLEET DEFAULT")
-		for _, key := range config.FleetSettingKeys() {
-			v, ok := fleet[key]
-			if !ok {
+		for _, spec := range config.FleetSettingSpecs() {
+			v, stored := config.FleetSettingDisplayValue(spec, fleet)
+			if !stored && !spec.FleetOnly {
 				v = "— (built-in)"
+			} else if !stored {
+				v += " (built-in)"
 			}
-			fmt.Fprintf(tw, "%s\t%s\n", key, v)
+			fmt.Fprintf(tw, "%s\t%s\n", spec.Key, v)
 		}
 		tw.Flush()
 		return
@@ -130,8 +143,21 @@ func settingsList(args []string) {
 	if err != nil {
 		log.Fatalf("settings list: %v", err)
 	}
+	fleet, err := store.FleetSettings(ctx)
+	if err != nil {
+		log.Fatalf("settings list: %v", err)
+	}
 	fmt.Fprintln(tw, "KEY\tVALUE\tSOURCE")
 	for _, spec := range config.FleetSettingSpecs() {
+		if spec.FleetOnly {
+			v, stored := config.FleetSettingDisplayValue(spec, fleet)
+			src := config.SettingSourceBuiltin
+			if stored {
+				src = config.SettingSourceFleet
+			}
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", spec.Key, v, src)
+			continue
+		}
 		src := cfg.SettingsSources[spec.Key]
 		if src == "" {
 			src = config.SettingSourceBuiltin
@@ -155,6 +181,9 @@ func settingsGet(args []string) {
 	if _, ok := config.FleetSettingSpecByKey(key); !ok {
 		log.Fatalf("settings get: unknown key %q (known: %s)", key, strings.Join(config.FleetSettingKeys(), ", "))
 	}
+	if err := rejectFleetOnlyProjectSetting(key, *project); err != nil {
+		log.Fatalf("settings get: %v", err)
+	}
 
 	ctx := context.Background()
 	store := openSettingsStore(*dbPath)
@@ -165,8 +194,11 @@ func settingsGet(args []string) {
 		if err != nil {
 			log.Fatalf("settings get: %v", err)
 		}
+		spec, _ := config.FleetSettingSpecByKey(key)
 		if v, ok := fleet[key]; ok {
 			fmt.Printf("%s = %s (fleet default)\n", key, v)
+		} else if spec.FleetOnly {
+			fmt.Printf("%s = %s (built-in)\n", key, spec.Default)
 		} else {
 			fmt.Printf("%s: unset — the built-in default applies\n", key)
 		}
@@ -201,6 +233,9 @@ func settingsSet(args []string) {
 	if _, ok := config.FleetSettingSpecByKey(key); !ok {
 		log.Fatalf("settings set: unknown key %q (known: %s)", key, strings.Join(config.FleetSettingKeys(), ", "))
 	}
+	if err := rejectFleetOnlyProjectSetting(key, *project); err != nil {
+		log.Fatalf("settings set: %v", err)
+	}
 
 	ctx := context.Background()
 	store := openSettingsStore(*dbPath)
@@ -234,6 +269,9 @@ func settingsRm(args []string) {
 	key := strings.TrimSpace(rest[0])
 	if _, ok := config.FleetSettingSpecByKey(key); !ok {
 		log.Fatalf("settings rm: unknown key %q (known: %s)", key, strings.Join(config.FleetSettingKeys(), ", "))
+	}
+	if err := rejectFleetOnlyProjectSetting(key, *project); err != nil {
+		log.Fatalf("settings rm: %v", err)
 	}
 
 	ctx := context.Background()

--- a/cmd/maestro/settings_test.go
+++ b/cmd/maestro/settings_test.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/befeast/maestro/internal/config"
 )
 
 func TestSplitSettingsArgs(t *testing.T) {
@@ -61,5 +64,17 @@ func TestSettingsActor(t *testing.T) {
 	t.Setenv("USER", "")
 	if got := settingsActor(""); got != "cli:unknown" {
 		t.Errorf("empty-user actor = %q, want cli:unknown", got)
+	}
+}
+
+func TestRejectFleetOnlyProjectSetting(t *testing.T) {
+	if err := rejectFleetOnlyProjectSetting(config.FleetMaxLiveWorkersKey, "project-a"); err == nil || !strings.Contains(err.Error(), "fleet-only") {
+		t.Fatalf("error = %v, want fleet-only rejection", err)
+	}
+	if err := rejectFleetOnlyProjectSetting(config.FleetMaxLiveWorkersKey, ""); err != nil {
+		t.Fatalf("fleet scope rejected: %v", err)
+	}
+	if err := rejectFleetOnlyProjectSetting("worker_max_tokens", "project-a"); err != nil {
+		t.Fatalf("project setting rejected: %v", err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2269,6 +2269,11 @@ type Config struct {
 	// configstore.Load; nil for file-loaded configs. Not serialized and ignored
 	// by config equality — it is display provenance for effective_config only.
 	SettingsSources map[string]string `yaml:"-" json:"-"`
+	// FleetOnlySettings carries the resolved values of daemon/control-plane
+	// settings that have no project-YAML field. Config-store loads populate it
+	// for Mission Control display; file-loaded configs leave it nil and use the
+	// registered built-in defaults.
+	FleetOnlySettings map[string]string `yaml:"-" json:"-"`
 }
 
 // LoadFrom loads config from a specific path.

--- a/internal/config/fleet_concurrency_settings_test.go
+++ b/internal/config/fleet_concurrency_settings_test.go
@@ -1,0 +1,54 @@
+package config
+
+import "testing"
+
+func TestResolveFleetConcurrencySettingsDefaults(t *testing.T) {
+	got, err := ResolveFleetConcurrencySettings(nil)
+	if err != nil {
+		t.Fatalf("ResolveFleetConcurrencySettings: %v", err)
+	}
+	if got.MinLiveWorkers != 5 || got.MaxLiveWorkers != 10 {
+		t.Fatalf("settings = %+v, want min=5 max=10", got)
+	}
+}
+
+func TestResolveFleetConcurrencySettingsStoredValues(t *testing.T) {
+	got, err := ResolveFleetConcurrencySettings(map[string]string{
+		FleetMinLiveWorkersKey: "3",
+		FleetMaxLiveWorkersKey: "8",
+	})
+	if err != nil {
+		t.Fatalf("ResolveFleetConcurrencySettings: %v", err)
+	}
+	if got.MinLiveWorkers != 3 || got.MaxLiveWorkers != 8 {
+		t.Fatalf("settings = %+v, want min=3 max=8", got)
+	}
+}
+
+func TestResolveFleetConcurrencySettingsRejectsInvalidBand(t *testing.T) {
+	_, err := ResolveFleetConcurrencySettings(map[string]string{
+		FleetMinLiveWorkersKey: "11",
+		FleetMaxLiveWorkersKey: "10",
+	})
+	if err == nil {
+		t.Fatal("expected min > max to be rejected")
+	}
+}
+
+func TestFleetConcurrencySettingsAreFleetOnly(t *testing.T) {
+	for _, key := range []string{FleetMinLiveWorkersKey, FleetMaxLiveWorkersKey} {
+		spec, ok := FleetSettingSpecByKey(key)
+		if !ok {
+			t.Fatalf("missing setting %q", key)
+		}
+		if !spec.FleetOnly || spec.Kind != SettingKindInt || spec.Default == "" {
+			t.Fatalf("spec = %+v, want fleet-only int with default", spec)
+		}
+	}
+}
+
+func TestNormalizeFleetConcurrencySettingRejectsNegative(t *testing.T) {
+	if _, err := NormalizeSettingValue(FleetMaxLiveWorkersKey, "-1"); err == nil {
+		t.Fatal("expected negative fleet max to be rejected")
+	}
+}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -38,12 +38,16 @@ const (
 // CLI / audit identifier), the path to it in a project YAML document (used by
 // the config store to detect a per-project override and to inject a fleet
 // default), its value kind (validation + scalar tag), and an accessor that
-// returns the resolved value as a display string.
+// returns the resolved value as a display string. FleetOnly specs live solely
+// in the settings table: they have no YAMLPath or project Config accessor, and
+// their registered Default is used when the fleet row is absent.
 type FleetSettingSpec struct {
-	Key      string
-	YAMLPath []string
-	Kind     string
-	Value    func(*Config) string
+	Key       string
+	YAMLPath  []string
+	Kind      string
+	FleetOnly bool
+	Default   string
+	Value     func(*Config) string
 }
 
 // FleetSettingSpecs returns the ordered registry of fleet-controllable settings.
@@ -138,6 +142,18 @@ func FleetSettingSpecs() []FleetSettingSpec {
 			Value:    func(c *Config) string { return strconv.Itoa(c.WorkerMaxTokens) },
 		},
 		{
+			Key:       FleetMinLiveWorkersKey,
+			Kind:      SettingKindInt,
+			FleetOnly: true,
+			Default:   strconv.Itoa(DefaultFleetMinLiveWorkers),
+		},
+		{
+			Key:       FleetMaxLiveWorkersKey,
+			Kind:      SettingKindInt,
+			FleetOnly: true,
+			Default:   strconv.Itoa(DefaultFleetMaxLiveWorkers),
+		},
+		{
 			Key:      "stalled_progress_watchdog.enabled",
 			YAMLPath: []string{"stalled_progress_watchdog", "enabled"},
 			Kind:     SettingKindBool,
@@ -201,6 +217,9 @@ func NormalizeSettingValue(key, value string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("setting %q wants an integer, got %q", key, value)
 		}
+		if spec.FleetOnly && n < 0 {
+			return "", fmt.Errorf("setting %q wants a non-negative integer, got %q", key, value)
+		}
 		return strconv.Itoa(n), nil
 	case SettingKindJSON:
 		var lanes []ProviderLane
@@ -239,4 +258,65 @@ func NormalizeSettingValue(key, value string) (string, error) {
 	default:
 		return v, nil
 	}
+}
+
+const (
+	FleetMinLiveWorkersKey = "fleet.min_live_workers"
+	FleetMaxLiveWorkersKey = "fleet.max_live_workers"
+
+	DefaultFleetMinLiveWorkers = 5
+	DefaultFleetMaxLiveWorkers = 10
+)
+
+// FleetConcurrencySettings is the daemon-wide live-worker band. The minimum is
+// a soft operating target; the maximum is a hard spawn ceiling shared by every
+// project flow. A stored zero disables that side of the band.
+type FleetConcurrencySettings struct {
+	MinLiveWorkers int
+	MaxLiveWorkers int
+}
+
+// ResolveFleetConcurrencySettings applies built-in defaults to missing keys and
+// validates the stored fleet-only values. Settings writes already normalize
+// values, but this read-side validation keeps the daemon fail-closed if the DB
+// was edited out of band.
+func ResolveFleetConcurrencySettings(settings map[string]string) (FleetConcurrencySettings, error) {
+	resolved := FleetConcurrencySettings{
+		MinLiveWorkers: DefaultFleetMinLiveWorkers,
+		MaxLiveWorkers: DefaultFleetMaxLiveWorkers,
+	}
+	for key, target := range map[string]*int{
+		FleetMinLiveWorkersKey: &resolved.MinLiveWorkers,
+		FleetMaxLiveWorkersKey: &resolved.MaxLiveWorkers,
+	} {
+		raw, ok := settings[key]
+		if !ok {
+			continue
+		}
+		norm, err := NormalizeSettingValue(key, raw)
+		if err != nil {
+			return FleetConcurrencySettings{}, err
+		}
+		n, err := strconv.Atoi(norm)
+		if err != nil {
+			return FleetConcurrencySettings{}, err
+		}
+		*target = n
+	}
+	if resolved.MinLiveWorkers > 0 && resolved.MaxLiveWorkers > 0 && resolved.MinLiveWorkers > resolved.MaxLiveWorkers {
+		return FleetConcurrencySettings{}, fmt.Errorf("%s (%d) cannot exceed %s (%d)", FleetMinLiveWorkersKey, resolved.MinLiveWorkers, FleetMaxLiveWorkersKey, resolved.MaxLiveWorkers)
+	}
+	return resolved, nil
+}
+
+// FleetSettingDisplayValue returns a stored fleet setting or its built-in
+// fleet-only default. The boolean reports whether the value came from the DB.
+func FleetSettingDisplayValue(spec FleetSettingSpec, settings map[string]string) (string, bool) {
+	if value, ok := settings[spec.Key]; ok {
+		return value, true
+	}
+	if spec.FleetOnly {
+		return spec.Default, false
+	}
+	return "", false
 }

--- a/internal/configstore/settings.go
+++ b/internal/configstore/settings.go
@@ -51,12 +51,26 @@ func (s *Store) FleetSettings(ctx context.Context) (map[string]string, error) {
 	return out, rows.Err()
 }
 
+// FleetConcurrencySettings resolves the daemon-only live-worker band from the
+// fleet settings table, applying built-in defaults to missing keys.
+func (s *Store) FleetConcurrencySettings(ctx context.Context) (config.FleetConcurrencySettings, error) {
+	settings, err := s.FleetSettings(ctx)
+	if err != nil {
+		return config.FleetConcurrencySettings{}, err
+	}
+	return config.ResolveFleetConcurrencySettings(settings)
+}
+
 // SetFleetSetting writes (or replaces) a fleet-level default for key and
 // journals the change. key must be a known fleet setting and value must match
 // its kind (config.NormalizeSettingValue). actor is the RFC3339-journaled
 // identity of who made the change. The settings row and its audit entry are
 // written in one transaction.
 func (s *Store) SetFleetSetting(ctx context.Context, key, value, actor string) error {
+	spec, ok := config.FleetSettingSpecByKey(key)
+	if !ok {
+		return fmt.Errorf("unknown setting %q", key)
+	}
 	norm, err := config.NormalizeSettingValue(key, value)
 	if err != nil {
 		return err
@@ -70,6 +84,11 @@ func (s *Store) SetFleetSetting(ctx context.Context, key, value, actor string) e
 	old, _, err := fleetSettingTx(ctx, tx, key)
 	if err != nil {
 		return err
+	}
+	if spec.FleetOnly {
+		if err := validateFleetConcurrencyBandTx(ctx, tx, key, &norm); err != nil {
+			return err
+		}
 	}
 	changedAt, err := writeSettingsAuditTx(ctx, tx, key, scopeFleet, old, norm, actor)
 	if err != nil {
@@ -90,7 +109,8 @@ ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.upd
 // no-op — no row and no audit entry — so it does not spuriously advance the
 // fingerprint.
 func (s *Store) DeleteFleetSetting(ctx context.Context, key, actor string) error {
-	if _, ok := config.FleetSettingSpecByKey(key); !ok {
+	spec, ok := config.FleetSettingSpecByKey(key)
+	if !ok {
 		return fmt.Errorf("unknown setting %q", key)
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
@@ -105,6 +125,11 @@ func (s *Store) DeleteFleetSetting(ctx context.Context, key, actor string) error
 	}
 	if !present {
 		return tx.Commit()
+	}
+	if spec.FleetOnly {
+		if err := validateFleetConcurrencyBandTx(ctx, tx, key, nil); err != nil {
+			return err
+		}
 	}
 	if _, err := writeSettingsAuditTx(ctx, tx, key, scopeFleet, old, "", actor); err != nil {
 		return err
@@ -124,6 +149,9 @@ func (s *Store) SetProjectSetting(ctx context.Context, project, key, value, acto
 	spec, ok := config.FleetSettingSpecByKey(key)
 	if !ok {
 		return fmt.Errorf("unknown setting %q", key)
+	}
+	if spec.FleetOnly {
+		return fmt.Errorf("setting %q is fleet-only; omit --project", key)
 	}
 	norm, err := config.NormalizeSettingValue(key, value)
 	if err != nil {
@@ -166,6 +194,9 @@ func (s *Store) DeleteProjectSetting(ctx context.Context, project, key, actor st
 	spec, ok := config.FleetSettingSpecByKey(key)
 	if !ok {
 		return fmt.Errorf("unknown setting %q", key)
+	}
+	if spec.FleetOnly {
+		return fmt.Errorf("setting %q is fleet-only; omit --project", key)
 	}
 	exported, err := s.ExportProject(ctx, project)
 	if err != nil {
@@ -286,6 +317,26 @@ func fleetSettingTx(ctx context.Context, tx *sql.Tx, key string) (value string, 
 	return value, true, nil
 }
 
+func validateFleetConcurrencyBandTx(ctx context.Context, tx *sql.Tx, changedKey string, changedValue *string) error {
+	settings := make(map[string]string, 2)
+	for _, key := range []string{config.FleetMinLiveWorkersKey, config.FleetMaxLiveWorkersKey} {
+		value, present, err := fleetSettingTx(ctx, tx, key)
+		if err != nil {
+			return err
+		}
+		if present {
+			settings[key] = value
+		}
+	}
+	if changedValue == nil {
+		delete(settings, changedKey)
+	} else {
+		settings[changedKey] = *changedValue
+	}
+	_, err := config.ResolveFleetConcurrencySettings(settings)
+	return err
+}
+
 // applyFleetDefaults folds the fleet-level defaults into a project's YAML and
 // returns the merged document plus the per-key source map. Precedence per key:
 // a value already present in the project YAML wins (source "project"); else a
@@ -300,6 +351,14 @@ func applyFleetDefaults(projectYAML []byte, fleet map[string]string) ([]byte, ma
 	sources := make(map[string]string, len(config.FleetSettingSpecs()))
 	changed := false
 	for _, spec := range config.FleetSettingSpecs() {
+		if spec.FleetOnly {
+			if _, ok := fleet[spec.Key]; ok {
+				sources[spec.Key] = config.SettingSourceFleet
+			} else {
+				sources[spec.Key] = config.SettingSourceBuiltin
+			}
+			continue
+		}
 		if nodeAtPath(&root, spec.YAMLPath) != nil {
 			sources[spec.Key] = config.SettingSourceProject
 			continue
@@ -530,9 +589,9 @@ func importFleetSettingsTx(ctx context.Context, tx *sql.Tx, data []byte, actor s
 INSERT INTO settings(key, value, updated_at)
 VALUES(?, ?, ?)
 ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
-`, key, norm, changedAt); err != nil {
+		`, key, norm, changedAt); err != nil {
 			return err
 		}
 	}
-	return nil
+	return validateFleetConcurrencyBandTx(ctx, tx, "", nil)
 }

--- a/internal/configstore/settings_test.go
+++ b/internal/configstore/settings_test.go
@@ -349,6 +349,46 @@ func TestSettingValidation(t *testing.T) {
 	}
 }
 
+func TestFleetConcurrencySettingsStoredAtFleetScopeOnly(t *testing.T) {
+	ctx := context.Background()
+	store := openTestStore(t)
+	seedProject(t, store, "p")
+
+	if err := store.SetFleetSetting(ctx, config.FleetMaxLiveWorkersKey, "10", "tester"); err != nil {
+		t.Fatalf("SetFleetSetting: %v", err)
+	}
+	if err := store.SetFleetSetting(ctx, config.FleetMaxLiveWorkersKey, "4", "tester"); err == nil {
+		t.Fatal("expected fleet max below the default min to be rejected")
+	}
+	settings, err := store.FleetConcurrencySettings(ctx)
+	if err != nil {
+		t.Fatalf("FleetConcurrencySettings: %v", err)
+	}
+	if settings.MinLiveWorkers != config.DefaultFleetMinLiveWorkers || settings.MaxLiveWorkers != 10 {
+		t.Fatalf("settings = %+v", settings)
+	}
+	if err := store.SetProjectSetting(ctx, "p", config.FleetMaxLiveWorkersKey, "7", "tester"); err == nil || !strings.Contains(err.Error(), "fleet-only") {
+		t.Fatalf("SetProjectSetting error = %v, want fleet-only rejection", err)
+	}
+	if err := store.DeleteProjectSetting(ctx, "p", config.FleetMaxLiveWorkersKey, "tester"); err == nil || !strings.Contains(err.Error(), "fleet-only") {
+		t.Fatalf("DeleteProjectSetting error = %v, want fleet-only rejection", err)
+	}
+
+	cfg, err := store.Load(ctx, "p")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := cfg.SettingsSources[config.FleetMaxLiveWorkersKey]; !ok {
+		t.Fatalf("settings sources = %#v, want fleet-only provenance", cfg.SettingsSources)
+	}
+	if got := cfg.FleetOnlySettings[config.FleetMaxLiveWorkersKey]; got != "10" {
+		t.Fatalf("fleet-only max = %q, want 10", got)
+	}
+	if got := cfg.FleetOnlySettings[config.FleetMinLiveWorkersKey]; got != "5" {
+		t.Fatalf("fleet-only min = %q, want builtin 5", got)
+	}
+}
+
 // config-store export writes the fleet settings file; a fresh store re-imports it.
 func TestExportImportRoundTripsFleetSettings(t *testing.T) {
 	ctx := context.Background()

--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -382,6 +382,14 @@ func (s *Store) Load(ctx context.Context, name string) (*config.Config, error) {
 		return nil, err
 	}
 	cfg.SettingsSources = sources
+	cfg.FleetOnlySettings = make(map[string]string)
+	for _, spec := range config.FleetSettingSpecs() {
+		if !spec.FleetOnly {
+			continue
+		}
+		value, _ := config.FleetSettingDisplayValue(spec, fleet)
+		cfg.FleetOnlySettings[spec.Key] = value
+	}
 	if strings.TrimSpace(sourcePath) == "" {
 		// No originating file (write-API row): report the store row itself so
 		// path consumers surface "store:<name>" instead of inventing a

--- a/internal/configstore/store_test.go
+++ b/internal/configstore/store_test.go
@@ -69,7 +69,8 @@ supervisor:
 	}
 	fromYAML.SourcePath = ""
 	fromStore.SourcePath = ""
-	fromStore.SettingsSources = nil // provenance map is set by Load, absent from Parse
+	fromStore.SettingsSources = nil   // provenance map is set by Load, absent from Parse
+	fromStore.FleetOnlySettings = nil // daemon-only settings are set by Load, absent from Parse
 	if !reflect.DeepEqual(fromStore, fromYAML) {
 		t.Fatalf("store config differs from yaml\nstore=%#v\nyaml=%#v", fromStore.Model, fromYAML.Model)
 	}

--- a/internal/configstore/store_write_test.go
+++ b/internal/configstore/store_write_test.go
@@ -56,7 +56,8 @@ func TestUpsertProjectLoadAllRoundTrip(t *testing.T) {
 	}
 	want.SourcePath = ""
 	got.SourcePath = ""
-	got.SettingsSources = nil // provenance map is set by Load, absent from Parse
+	got.SettingsSources = nil   // provenance map is set by Load, absent from Parse
+	got.FleetOnlySettings = nil // daemon-only settings are set by Load, absent from Parse
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("round-trip config differs\n got=%#v\nwant=%#v", got.Model, want.Model)
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -321,6 +321,10 @@ type Daemon struct {
 	emergencyState    emergencystore.State
 	emergencyNotifier *notify.Notifier
 
+	// spawnLimiter owns the daemon-wide live-worker budget. It is shared by all
+	// project orchestrators so concurrent flows reserve against one atomic max.
+	spawnLimiter *fleetSpawnLimiter
+
 	// tmpfsHygiene owns the host-level scheduled sweep and latest Fleet-facing
 	// summary. It is independent of per-project flow state.
 	tmpfsHygiene *tmpfsHygieneRuntime
@@ -410,9 +414,10 @@ func New(store ConfigLoader, opts Options) *Daemon {
 		opts.DrainTimeout = DefaultDrainTimeout
 	}
 	d := &Daemon{
-		store: store,
-		opts:  opts,
-		flows: make(map[string]*projectFlow),
+		store:        store,
+		opts:         opts,
+		flows:        make(map[string]*projectFlow),
+		spawnLimiter: newFleetSpawnLimiter(store),
 	}
 	d.tmpfsHygiene = newTmpfsHygieneRuntime(d)
 	if opts.WatchStore {
@@ -623,6 +628,13 @@ func (d *Daemon) Run(ctx context.Context) error {
 		return err
 	}
 
+	for i := range projects {
+		if cfg := projects[i].Cfg(); cfg != nil {
+			if d.spawnLimiter != nil {
+				d.spawnLimiter.RegisterStateDir(cfg.StateDir)
+			}
+		}
+	}
 	for i := range projects {
 		flow := d.startFlow(ctx, storeNames[i], projects[i])
 		log.Printf("[daemon] started flow %q (repo=%s state_dir=%s)", flow.name, flow.cfg.Repo, flow.cfg.StateDir)

--- a/internal/daemon/fleet_concurrency.go
+++ b/internal/daemon/fleet_concurrency.go
@@ -1,0 +1,203 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+type fleetConcurrencySettingsLoader interface {
+	FleetConcurrencySettings(context.Context) (config.FleetConcurrencySettings, error)
+}
+
+type fleetSpawnReservation struct {
+	stateDir string
+	slot     string
+}
+
+// fleetSpawnLimiter serializes capacity checks across every project flow. A
+// successful spawn remains reserved until its running slot is visible in the
+// authoritative state file, closing both the concurrent-flow race and the
+// single-flow batch overshoot window.
+type fleetSpawnLimiter struct {
+	mu           sync.Mutex
+	settings     fleetConcurrencySettingsLoader
+	stateDirs    map[string]struct{}
+	reservations map[uint64]fleetSpawnReservation
+	nextID       uint64
+	loadState    func(string) (*state.State, error)
+}
+
+func newFleetSpawnLimiter(store ConfigLoader) *fleetSpawnLimiter {
+	loader, _ := store.(fleetConcurrencySettingsLoader)
+	return &fleetSpawnLimiter{
+		settings:     loader,
+		stateDirs:    make(map[string]struct{}),
+		reservations: make(map[uint64]fleetSpawnReservation),
+		loadState:    state.Load,
+	}
+}
+
+func (l *fleetSpawnLimiter) RegisterStateDir(stateDir string) {
+	if l == nil || strings.TrimSpace(stateDir) == "" {
+		return
+	}
+	l.mu.Lock()
+	l.stateDirs[stateDir] = struct{}{}
+	l.mu.Unlock()
+}
+
+func (l *fleetSpawnLimiter) UnregisterStateDir(stateDir string) {
+	if l == nil || strings.TrimSpace(stateDir) == "" {
+		return
+	}
+	l.mu.Lock()
+	delete(l.stateDirs, stateDir)
+	for id, reservation := range l.reservations {
+		if reservation.stateDir == stateDir {
+			delete(l.reservations, id)
+		}
+	}
+	l.mu.Unlock()
+}
+
+func (l *fleetSpawnLimiter) settingsLocked() (config.FleetConcurrencySettings, error) {
+	if l.settings == nil {
+		return config.ResolveFleetConcurrencySettings(nil)
+	}
+	return l.settings.FleetConcurrencySettings(context.Background())
+}
+
+func fleetWorkerKey(stateDir, slot string) string {
+	return stateDir + "\x00" + slot
+}
+
+func (l *fleetSpawnLimiter) liveLocked() (int, error) {
+	dirs := make([]string, 0, len(l.stateDirs))
+	for dir := range l.stateDirs {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+
+	running := make(map[string]struct{})
+	for _, dir := range dirs {
+		st, err := l.loadState(dir)
+		if err != nil {
+			return 0, fmt.Errorf("load fleet state %s: %w", dir, err)
+		}
+		for slot, sess := range st.Sessions {
+			if sess != nil && sess.Status == state.StatusRunning {
+				running[fleetWorkerKey(dir, slot)] = struct{}{}
+			}
+		}
+	}
+
+	// Once a committed reservation appears as a running state session, the
+	// durable state count replaces it. Pending or not-yet-persisted commits stay
+	// reserved, so no other flow can consume the same global slot.
+	for id, reservation := range l.reservations {
+		if reservation.slot == "" {
+			continue
+		}
+		if _, ok := running[fleetWorkerKey(reservation.stateDir, reservation.slot)]; ok {
+			delete(l.reservations, id)
+		}
+	}
+	return len(running) + len(l.reservations), nil
+}
+
+func (l *fleetSpawnLimiter) CeilingReached() bool {
+	if l == nil {
+		return false
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	settings, err := l.settingsLocked()
+	if err != nil {
+		log.Printf("[daemon] fleet spawn ceiling fail-closed: settings unavailable: %v", err)
+		return true
+	}
+	if settings.MaxLiveWorkers == 0 {
+		return false
+	}
+	live, err := l.liveLocked()
+	if err != nil {
+		log.Printf("[daemon] fleet spawn ceiling fail-closed: live-worker count unavailable: %v", err)
+		return true
+	}
+	if live >= settings.MaxLiveWorkers {
+		log.Printf("[daemon] fleet spawn ceiling reached: live=%d min=%d max=%d", live, settings.MinLiveWorkers, settings.MaxLiveWorkers)
+		return true
+	}
+	return false
+}
+
+func (l *fleetSpawnLimiter) Reserve(stateDir string) (commit func(string), release func(), ok bool) {
+	if l == nil {
+		return func(string) {}, func() {}, true
+	}
+	l.mu.Lock()
+	settings, err := l.settingsLocked()
+	if err != nil {
+		l.mu.Unlock()
+		log.Printf("[daemon] fleet spawn reservation fail-closed: settings unavailable: %v", err)
+		return nil, nil, false
+	}
+	if settings.MaxLiveWorkers == 0 {
+		l.mu.Unlock()
+		return func(string) {}, func() {}, true
+	}
+	if strings.TrimSpace(stateDir) == "" {
+		l.mu.Unlock()
+		log.Printf("[daemon] fleet spawn reservation fail-closed: project state_dir is empty")
+		return nil, nil, false
+	}
+	l.stateDirs[stateDir] = struct{}{}
+	live, err := l.liveLocked()
+	if err != nil {
+		l.mu.Unlock()
+		log.Printf("[daemon] fleet spawn reservation fail-closed: live-worker count unavailable: %v", err)
+		return nil, nil, false
+	}
+	if live >= settings.MaxLiveWorkers {
+		l.mu.Unlock()
+		return nil, nil, false
+	}
+	l.nextID++
+	id := l.nextID
+	l.reservations[id] = fleetSpawnReservation{stateDir: stateDir}
+	l.mu.Unlock()
+
+	commit = func(slot string) {
+		l.mu.Lock()
+		reservation, exists := l.reservations[id]
+		if exists {
+			reservation.slot = strings.TrimSpace(slot)
+			l.reservations[id] = reservation
+		}
+		l.mu.Unlock()
+	}
+	release = func() {
+		l.mu.Lock()
+		delete(l.reservations, id)
+		l.mu.Unlock()
+	}
+	return commit, release, true
+}
+
+func (d *Daemon) fleetSpawnCeilingReached() bool {
+	return d.spawnLimiter != nil && d.spawnLimiter.CeilingReached()
+}
+
+func (d *Daemon) reserveFleetSpawn(stateDir string) (func(string), func(), bool) {
+	if d.spawnLimiter == nil {
+		return func(string) {}, func() {}, true
+	}
+	return d.spawnLimiter.Reserve(stateDir)
+}

--- a/internal/daemon/fleet_concurrency_test.go
+++ b/internal/daemon/fleet_concurrency_test.go
@@ -1,0 +1,99 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+type fleetConcurrencyTestStore struct {
+	settings config.FleetConcurrencySettings
+	err      error
+}
+
+func (s *fleetConcurrencyTestStore) LoadAll(context.Context) ([]*config.Config, error) {
+	return nil, nil
+}
+
+func (s *fleetConcurrencyTestStore) FleetConcurrencySettings(context.Context) (config.FleetConcurrencySettings, error) {
+	if s.err != nil {
+		return config.FleetConcurrencySettings{}, s.err
+	}
+	return s.settings, nil
+}
+
+func saveFleetRunningState(t *testing.T, dir string, running int) {
+	t.Helper()
+	st := state.NewState()
+	for i := 0; i < running; i++ {
+		slot := fmt.Sprintf("slot-%d", i+1)
+		st.Sessions[slot] = &state.Session{Status: state.StatusRunning, IssueNumber: i + 1}
+	}
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+}
+
+func TestFleetSpawnLimiterReservationPreventsBatchAndCrossFlowOvershoot(t *testing.T) {
+	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 5, MaxLiveWorkers: 10}}
+	limiter := newFleetSpawnLimiter(store)
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	saveFleetRunningState(t, dirA, 9)
+	saveFleetRunningState(t, dirB, 0)
+	limiter.RegisterStateDir(dirA)
+	limiter.RegisterStateDir(dirB)
+
+	commit, _, ok := limiter.Reserve(dirB)
+	if !ok {
+		t.Fatal("first reservation should consume the final fleet slot")
+	}
+	commit("slot-new")
+	if _, _, ok := limiter.Reserve(dirA); ok {
+		t.Fatal("second reservation exceeded fleet.max_live_workers")
+	}
+	if !limiter.CeilingReached() {
+		t.Fatal("ceiling should include a successful spawn not yet visible on disk")
+	}
+}
+
+func TestFleetSpawnLimiterReconcilesCommittedReservationWithState(t *testing.T) {
+	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 1, MaxLiveWorkers: 2}}
+	limiter := newFleetSpawnLimiter(store)
+	dir := t.TempDir()
+	saveFleetRunningState(t, dir, 0)
+	limiter.RegisterStateDir(dir)
+
+	commit, _, ok := limiter.Reserve(dir)
+	if !ok {
+		t.Fatal("reservation failed")
+	}
+	commit("slot-1")
+	saveFleetRunningState(t, dir, 1)
+
+	_, release, ok := limiter.Reserve(dir)
+	if !ok {
+		t.Fatal("persisted worker was double-counted with its committed reservation")
+	}
+	release()
+}
+
+func TestFleetSpawnLimiterFailsClosedWhenStateCannotBeCounted(t *testing.T) {
+	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 5, MaxLiveWorkers: 10}}
+	limiter := newFleetSpawnLimiter(store)
+	limiter.RegisterStateDir(t.TempDir())
+	limiter.loadState = func(string) (*state.State, error) {
+		return nil, errors.New("state unavailable")
+	}
+
+	if !limiter.CeilingReached() {
+		t.Fatal("uncertain fleet state must close the fast gate")
+	}
+	if _, _, ok := limiter.Reserve("state-dir"); ok {
+		t.Fatal("uncertain fleet state must reject atomic reservations")
+	}
+}

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -48,6 +48,9 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 	cfg := proj.Cfg()
 	if cfg != nil {
 		cfg.RuntimeSuperviseIntervalSeconds = runtimeIntervalSeconds(d.opts.SuperviseInterval)
+		if d.spawnLimiter != nil {
+			d.spawnLimiter.RegisterStateDir(cfg.StateDir)
+		}
 	}
 	fctx, cancel := context.WithCancel(parent)
 	flow := &projectFlow{
@@ -171,11 +174,16 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 		// its own — e.g. a panic that recoverFlow cancelled — does not linger in
 		// the registry reporting as live. Guarded against a restart that reused
 		// the same key (stopFlow may have already removed and replaced it).
+		removed := false
 		d.mu.Lock()
 		if d.flows[flow.key] == flow {
 			delete(d.flows, flow.key)
+			removed = true
 		}
 		d.mu.Unlock()
+		if removed && d.spawnLimiter != nil && flow.cfg != nil {
+			d.spawnLimiter.UnregisterStateDir(flow.cfg.StateDir)
+		}
 	}()
 
 	return flow
@@ -196,6 +204,9 @@ func (d *Daemon) stopFlow(key string) {
 	}
 	flow.cancel()
 	<-flow.done
+	if d.spawnLimiter != nil && flow.cfg != nil {
+		d.spawnLimiter.UnregisterStateDir(flow.cfg.StateDir)
+	}
 	log.Printf("[daemon] stopped flow %q", flow.name)
 }
 
@@ -427,6 +438,10 @@ func (d *Daemon) runOrchestrator(ctx context.Context, cfg *config.Config, opts O
 	// within one poll interval. nil emergency store (open failed / test loader)
 	// leaves the closure reading a permanently-normal cache, i.e. inert.
 	orch.SetEmergencyHalt(d.emergencySpawnHalt)
+	orch.SetFleetSpawnCeiling(d.fleetSpawnCeilingReached)
+	orch.SetFleetSpawnReserve(func() (func(string), func(), bool) {
+		return d.reserveFleetSpawn(orchCfg.StateDir)
+	})
 	// Mirror-first reads (#826): serve the orchestrator's high-volume poll reads
 	// from the shared mirror when github_mirror.source is mirror-first, falling
 	// back to the API on a miss/stale. The closure reads &orchCfg — the live,

--- a/internal/orchestrator/fleet_spawn_ceiling_test.go
+++ b/internal/orchestrator/fleet_spawn_ceiling_test.go
@@ -1,0 +1,60 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestStartNewWorkers_FleetSpawnCeilingBlocksBeforeGitHubList(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	issues := []github.Issue{makeIssue(1081, "ready issue")}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	listed := false
+	o.listOpenIssuesFn = func(labels []string) ([]github.Issue, error) {
+		listed = true
+		return issues, nil
+	}
+	o.SetFleetSpawnCeiling(func() bool { return true })
+
+	o.startNewWorkers(state.NewState(), 5)
+
+	if listed {
+		t.Fatal("startNewWorkers listed GitHub issues after the fleet ceiling closed")
+	}
+	if len(*started) != 0 {
+		t.Fatalf("started = %v, want no workers", *started)
+	}
+}
+
+func TestStartNewWorkers_FleetReservationCapsBatch(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	issues := []github.Issue{
+		makeIssue(1081, "first"),
+		makeIssue(1082, "second"),
+		makeIssue(1083, "third"),
+	}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	remaining := 1
+	o.SetFleetSpawnReserve(func() (func(string), func(), bool) {
+		if remaining == 0 {
+			return nil, nil, false
+		}
+		remaining--
+		done := false
+		commit := func(string) { done = true }
+		release := func() {
+			if !done {
+				remaining++
+			}
+		}
+		return commit, release, true
+	})
+
+	o.startNewWorkers(state.NewState(), 5)
+
+	if len(*started) != 1 || (*started)[0] != 1081 {
+		t.Fatalf("started = %v, want only the one reserved worker", *started)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -155,6 +155,13 @@ type Orchestrator struct {
 	// restart. In-flight workers are unaffected — this gate only refuses NEW work.
 	emergencyHaltFn func() bool
 
+	// fleetSpawnCeilingFn is the daemon-wide fast gate checked before issue
+	// listing. fleetSpawnReserveFn is the atomic per-worker backstop: concurrent
+	// project flows and one flow's batch dispatch must each reserve one shared
+	// slot before a worker process starts.
+	fleetSpawnCeilingFn func() bool
+	fleetSpawnReserveFn func() (commit func(slot string), release func(), ok bool)
+
 	// Restart-required signal. Some config fields (currently routing.*) cannot be
 	// hot-applied because their runtime components are built once at startup. When
 	// such a field changes during a config reload we do not apply it; instead we raise this
@@ -267,6 +274,56 @@ func (o *Orchestrator) SetReadSource(src githubReadSource) {
 // claims no new issues and spawns no new workers. Passing nil clears the gate.
 func (o *Orchestrator) SetEmergencyHalt(fn func() bool) {
 	o.emergencyHaltFn = fn
+}
+
+// SetFleetSpawnCeiling wires the daemon-wide pre-list spawn ceiling. Passing
+// nil disables the gate for legacy single-project callers and tests.
+func (o *Orchestrator) SetFleetSpawnCeiling(fn func() bool) {
+	o.fleetSpawnCeilingFn = fn
+}
+
+// SetFleetSpawnReserve wires the daemon's atomic one-worker reservation. The
+// returned commit callback receives the started slot; release is used whenever
+// dispatch aborts before a worker starts.
+func (o *Orchestrator) SetFleetSpawnReserve(fn func() (commit func(slot string), release func(), ok bool)) {
+	o.fleetSpawnReserveFn = fn
+}
+
+type fleetSpawnPermit struct {
+	commitFn  func(string)
+	releaseFn func()
+	done      bool
+}
+
+func (o *Orchestrator) reserveFleetSpawn() (*fleetSpawnPermit, bool) {
+	if o.fleetSpawnReserveFn == nil {
+		return &fleetSpawnPermit{}, true
+	}
+	commit, release, ok := o.fleetSpawnReserveFn()
+	if !ok {
+		return nil, false
+	}
+	return &fleetSpawnPermit{commitFn: commit, releaseFn: release}, true
+}
+
+func (p *fleetSpawnPermit) Commit(slot string) {
+	if p == nil || p.done {
+		return
+	}
+	p.done = true
+	if p.commitFn != nil {
+		p.commitFn(slot)
+	}
+}
+
+func (p *fleetSpawnPermit) Release() {
+	if p == nil || p.done {
+		return
+	}
+	p.done = true
+	if p.releaseFn != nil {
+		p.releaseFn()
+	}
 }
 
 // SetApprovalStore configures which approval store the orchestrator's standing
@@ -2631,6 +2688,14 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 		// The current issue read is authoritative: a previously persisted hold
 		// has cleared, so this exact canonical retry may proceed in place.
 		sess.RetryHoldReason = ""
+		permit, permitOK := o.reserveFleetSpawn()
+		if !permitOK {
+			retryAt := time.Now().UTC().Add(time.Minute)
+			sess.NextRetryAt = &retryAt
+			log.Printf("[orch] worker %s retry deferred until %s: fleet live-worker ceiling reached",
+				slotName, retryAt.Format(time.RFC3339))
+			return
+		}
 
 		promptBase := o.selectPrompt(issue)
 
@@ -2690,6 +2755,7 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 						retryAt = earliest.UTC()
 					}
 					sess.NextRetryAt = &retryAt
+					permit.Release()
 					log.Printf("[orch] worker %s retry deferred until %s: backend %s blocked (%s) and no healthy fallback is available",
 						slotName, retryAt.Format(time.RFC3339), respawnBackend, blockedBy)
 					continue
@@ -2745,6 +2811,7 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 
 		respawnErr := o.respawnPreservingWorktreeWithConfig(respawnCfg, slotName, sess, issue, promptBase, respawnBackend)
 		if respawnErr != nil {
+			permit.Release()
 			log.Printf("[orch] respawn worker %s: %v — marking as failed", slotName, respawnErr)
 			sess.Status = state.StatusFailed
 			now := time.Now().UTC()
@@ -2754,6 +2821,7 @@ func (o *Orchestrator) respawnDueRetries(s *state.State, slots int) {
 				slotName, sess.IssueNumber, sess.IssueTitle, respawnErr)
 			continue
 		}
+		permit.Commit(slotName)
 
 		o.notifier.Sendf("🔄 maestro: retrying worker %s for issue #%d: %s (attempt %d)",
 			slotName, sess.IssueNumber, sess.IssueTitle, sess.RetryCount)
@@ -9728,6 +9796,10 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		log.Printf("[orch] EMERGENCY STOP active: not spawning new workers (running=%d)", s.RunningSessionCount())
 		return
 	}
+	if o.fleetSpawnCeilingFn != nil && o.fleetSpawnCeilingFn() {
+		log.Printf("[orch] fleet live-worker ceiling reached: not listing or spawning new work (local_running=%d)", s.RunningSessionCount())
+		return
+	}
 	// Graceful drain (#541): while a drain is requested, refuse to claim new
 	// issues or spawn new workers. In-flight workers keep running; the
 	// operator runs `maestro drain` before a restart so a `systemctl restart`
@@ -9912,14 +9984,22 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			}
 			log.Printf("[orch] allowing repair worker for issue #%d despite open PR because supervisor selected spawn_repair_worker", issue.Number)
 		}
+		permit, permitOK := o.reserveFleetSpawn()
+		if !permitOK {
+			log.Printf("[orch] fleet live-worker ceiling reached before routing issue #%d", issue.Number)
+			return
+		}
 
 		// A classic repair is a same-session maintenance operation, not a fresh
 		// issue dispatch. Resolve and revalidate the durable reservation before
 		// any backend routing or slot allocation can create a second worktree.
 		if repairDispatch := o.resolveSpawnRepairDispatch(s, issue.Number); repairDispatch != nil {
 			if o.dispatchSpawnRepairWorker(s, issue, repairDispatch) {
+				permit.Commit(repairDispatch.target.Session)
 				markSupervisorWorkerRecommendationMaterialized(s, issue.Number, time.Now().UTC())
 				started++
+			} else {
+				permit.Release()
 			}
 			continue
 		}
@@ -9948,6 +10028,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		reviewRepair, repairTarget, reviewRepairApprovalID := o.resolveReviewRepairDispatch(s, issue.Number)
 		if reviewRepair != nil && repairTarget != nil {
 			if !o.tryClaimReviewRepairSlot(s, repairTarget, reviewRepair) {
+				permit.Release()
 				continue
 			}
 			backendName = reviewRepair.Backend
@@ -9976,6 +10057,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			// auth failure / provider limit (#695).
 			decision, dispatchable, retryAt := o.resolveDispatchBackend(s, issue, time.Now().UTC())
 			if !dispatchable {
+				permit.Release()
 				if !dispatchPauseLogged {
 					expiry := "no cooldown expiry recorded"
 					if retryAt != nil {
@@ -10035,10 +10117,12 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			claimedAt := time.Now().UTC()
 			claim, acquired, claimErr := o.claimFreshDispatch(s, issue, claimedAt)
 			if claimErr != nil {
+				permit.Release()
 				log.Printf("[orch] claim fresh dispatch for issue #%d: %v", issue.Number, claimErr)
 				continue
 			}
 			if !acquired {
+				permit.Release()
 				if claim != nil && claim.Slot != "" {
 					log.Printf("[orch] skipping duplicate fresh dispatch for issue #%d: canonical startup lease is %s (generation=%d)", issue.Number, claim.Slot, claim.LeaseGeneration)
 				}
@@ -10055,6 +10139,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			slotName, err = o.startWorker(workerCfg, s, issue, promptBase, backendName)
 		}
 		if err != nil {
+			permit.Release()
 			log.Printf("[orch] start worker for issue #%d: %v", issue.Number, err)
 			o.notifier.Sendf("❌ maestro: failed to start worker for issue #%d (%s): %v",
 				issue.Number, issue.Title, err)
@@ -10067,6 +10152,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			}
 			continue
 		}
+		permit.Commit(slotName)
 		markSupervisorWorkerRecommendationMaterialized(s, issue.Number, time.Now().UTC())
 
 		if longRunning {

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -4418,9 +4418,15 @@ func buildFleetSettingSources(cfg *config.Config) []fleetSettingSource {
 		if src == "" {
 			src = config.SettingSourceBuiltin
 		}
+		value := ""
+		if spec.FleetOnly {
+			value, _ = config.FleetSettingDisplayValue(spec, cfg.FleetOnlySettings)
+		} else {
+			value = spec.Value(cfg)
+		}
 		out = append(out, fleetSettingSource{
 			Key:       spec.Key,
-			Value:     spec.Value(cfg),
+			Value:     value,
 			Source:    src,
 			IsDefault: src == config.SettingSourceBuiltin,
 		})

--- a/internal/server/fleet_test.go
+++ b/internal/server/fleet_test.go
@@ -660,9 +660,11 @@ func TestFleetEffectiveConfigSettingsSource(t *testing.T) {
 		WorkerMaxTokens: 250000,
 		Supervisor:      config.SupervisorConfig{Enabled: false},
 		SettingsSources: map[string]string{
-			"supervisor.enabled": config.SettingSourceProject,
-			"worker_max_tokens":  config.SettingSourceFleet,
+			"supervisor.enabled":          config.SettingSourceProject,
+			"worker_max_tokens":           config.SettingSourceFleet,
+			config.FleetMaxLiveWorkersKey: config.SettingSourceFleet,
 		},
+		FleetOnlySettings: map[string]string{config.FleetMaxLiveWorkersKey: "7"},
 	}
 	srv := NewFleet([]FleetProject{NewFleetProject("Settings", "/tmp/settings.yaml", "", cfg)}, "127.0.0.1", 8786, true)
 
@@ -688,6 +690,12 @@ func TestFleetEffectiveConfigSettingsSource(t *testing.T) {
 	}
 	if s := byKey["worker_max_tokens"]; s.Source != config.SettingSourceFleet || s.Value != "250000" || s.IsDefault {
 		t.Fatalf("worker_max_tokens = %+v", s)
+	}
+	if s := byKey[config.FleetMaxLiveWorkersKey]; s.Source != config.SettingSourceFleet || s.Value != "7" || s.IsDefault {
+		t.Fatalf("fleet.max_live_workers = %+v", s)
+	}
+	if s := byKey[config.FleetMinLiveWorkersKey]; s.Source != config.SettingSourceBuiltin || s.Value != "5" || !s.IsDefault {
+		t.Fatalf("fleet.min_live_workers = %+v", s)
 	}
 	// An unmapped key falls back to builtin + is_default.
 	if s := byKey["poll_interval_seconds"]; s.Source != config.SettingSourceBuiltin || !s.IsDefault {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -799,22 +799,6 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		}
 	}
 
-	if stuck := noOutcomeProgressStuckState(stuckStates); stuck != nil && len(st.ActiveSessions()) == 0 {
-		reasons := appendReasons(baseReasons,
-			stuck.Summary,
-			fmt.Sprintf("Open PRs observed: %d; PR presence does not prove the live outcome is fixed", len(prs)),
-			"Supervisor remains read-only; it recommends outcome verification but does not run deploy or runtime commands",
-		)
-		decision := e.decision(st, now, projectState, ActionCheckOutcomeHealth,
-			"Verify outcome health before starting more issue work.",
-			RiskSafe, 0.86, nil, PolicyRuleRuntimeState, reasons)
-		decision.StuckStates = stuckStates
-		if st.OutcomeHealth != nil && st.OutcomeHealth.State == outcome.HealthFailing {
-			decision.QueueAnalysis = e.dispatchBlockerQueueAnalysis(st)
-		}
-		return decision, nil
-	}
-
 	issues, err := e.reader.ListOpenIssues(nil)
 	if err != nil {
 		return state.SupervisorDecision{}, fmt.Errorf("list open issues: %w", err)
@@ -1014,6 +998,10 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 		}
 	}
 
+	if decision, ok := e.noBacklogOutcomeDecision(st, now, projectState, baseReasons, prs, stuckStates); ok {
+		return withAnalysis(decision), nil
+	}
+
 	reasons := appendReasons(baseReasons,
 		fmt.Sprintf("Checked %d open issue(s)", len(issues)),
 		"No worker is running, no PR needs attention, and no eligible issue is ready",
@@ -1108,6 +1096,9 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 	}
 
 	if len(candidates) == 0 {
+		if decision, ok := e.noBacklogOutcomeDecision(st, now, projectState, baseReasons, prs, stuckStates); ok {
+			return withAnalysis(decision), nil
+		}
 		reasons := appendReasons(baseReasons,
 			fmt.Sprintf("Dynamic wave checked %d open issue(s)", len(issues)),
 			fmt.Sprintf("Dynamic wave found %d eligible candidate(s), %d excluded issue(s), %d held/meta issue(s), %d blocked-by-dependency issue(s), and %d issue(s) in non-runnable project status", analysis.EligibleCandidates, analysis.ExcludedIssues, analysis.HeldIssues, analysis.BlockedByDependencyIssues, analysis.NonRunnableProjectStatusCount),
@@ -1219,6 +1210,9 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 	}
 
 	if !matchesRequiredLabels(issue, e.requiredIssueLabels()) {
+		if decision, ok := e.noBacklogOutcomeDecision(st, now, projectState, baseReasons, prs, stuckStates); ok {
+			return withAnalysis(decision), nil
+		}
 		reasons := appendReasons(baseReasons,
 			fmt.Sprintf("Dynamic wave selected issue #%d", issue.Number),
 			"Selected issue is waiting for a ready label mutation to appear in GitHub issue data",
@@ -1277,6 +1271,29 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 		fmt.Sprintf("Start a worker for issue #%d: %s", issue.Number, issue.Title),
 		RiskMutating, 0.84, &state.SupervisorTarget{Issue: issue.Number}, PolicyRuleDynamicWave, reasons)
 	return withAnalysis(decision), nil
+}
+
+// noBacklogOutcomeDecision preserves the runtime-health recommendation only
+// after queue handling has had a chance to label or dispatch actionable work.
+// Previously this check ran before ListOpenIssues, so a failing/unknown outcome
+// plus zero active sessions starved both add_ready_label and spawn_worker and
+// could leave the whole fleet at zero workers until an operator intervened.
+func (e *Engine) noBacklogOutcomeDecision(st *state.State, now time.Time, projectState state.SupervisorProjectState, baseReasons []string, prs []github.PR, stuckStates []state.SupervisorStuckState) (state.SupervisorDecision, bool) {
+	stuck := noOutcomeProgressStuckState(stuckStates)
+	if stuck == nil || len(st.ActiveSessions()) != 0 {
+		return state.SupervisorDecision{}, false
+	}
+	reasons := appendReasons(baseReasons,
+		stuck.Summary,
+		fmt.Sprintf("Open PRs observed: %d; PR presence does not prove the live outcome is fixed", len(prs)),
+		"No actionable backlog remains after queue policy evaluation",
+		"Supervisor remains read-only; it recommends outcome verification but does not run deploy or runtime commands",
+	)
+	decision := e.decision(st, now, projectState, ActionCheckOutcomeHealth,
+		"Verify outcome health before starting more issue work.",
+		RiskSafe, 0.86, nil, PolicyRuleRuntimeState, reasons)
+	decision.StuckStates = stuckStates
+	return decision, true
 }
 
 func (e *Engine) decision(st *state.State, now time.Time, ps state.SupervisorProjectState, action, summary, risk string, confidence float64, target *state.SupervisorTarget, policyRule string, reasons []string) state.SupervisorDecision {
@@ -2215,62 +2232,6 @@ func (e *Engine) policyCandidateIssues(st *state.State, issues []github.Issue) (
 		return e.dynamicWaveCandidateIssues(st, issues, skipped)
 	}
 	return policyCandidateResult{skipped: skipped, policyRule: PolicyRuleOrderedQueue}, nil
-}
-
-// dispatchBlockerQueueAnalysis keeps the per-issue decision plane populated
-// when the supervisor returns early for a top-level failing outcome gate. It is
-// best-effort: the red outcome finding remains more important than a transient
-// issue-list/guard read failure, so the last queue analysis is retained when a
-// fresh snapshot cannot be built.
-func (e *Engine) dispatchBlockerQueueAnalysis(st *state.State) *state.SupervisorQueueAnalysis {
-	previous := func() *state.SupervisorQueueAnalysis {
-		if st == nil {
-			return nil
-		}
-		if latest := st.LatestSupervisorDecision(); latest != nil {
-			return cloneSupervisorQueueAnalysis(latest.QueueAnalysis)
-		}
-		return nil
-	}
-	issues, err := e.reader.ListOpenIssues(nil)
-	if err != nil {
-		log.Printf("[supervisor] dispatch blocker queue snapshot: list open issues: %v", err)
-		return previous()
-	}
-	result, err := e.policyCandidateIssues(st, issues)
-	if err != nil {
-		log.Printf("[supervisor] dispatch blocker queue snapshot: classify candidates: %v", err)
-		return previous()
-	}
-	if result.dynamicWave && result.analysis != nil {
-		return cloneSupervisorQueueAnalysis(result.analysis)
-	}
-	eligible, skipped, err := e.eligibleIssues(st, result.candidates, true)
-	if err != nil {
-		log.Printf("[supervisor] dispatch blocker queue snapshot: evaluate guards: %v", err)
-		return previous()
-	}
-	skipped = append(result.skipped, skipped...)
-	return supervisorQueueAnalysis(result.policyRule, len(issues), eligible, skipped)
-}
-
-func cloneSupervisorQueueAnalysis(src *state.SupervisorQueueAnalysis) *state.SupervisorQueueAnalysis {
-	if src == nil {
-		return nil
-	}
-	cp := *src
-	if src.SelectedCandidate != nil {
-		selected := *src.SelectedCandidate
-		selected.Labels = append([]string(nil), src.SelectedCandidate.Labels...)
-		cp.SelectedCandidate = &selected
-	}
-	cp.SkippedReasons = append([]string(nil), src.SkippedReasons...)
-	cp.EligibleRanked = append([]state.SupervisorIssueCandidate(nil), src.EligibleRanked...)
-	for i := range cp.EligibleRanked {
-		cp.EligibleRanked[i].Labels = append([]string(nil), src.EligibleRanked[i].Labels...)
-	}
-	cp.SkippedCandidates = append([]state.SupervisorSkippedCandidate(nil), src.SkippedCandidates...)
-	return &cp
 }
 
 func (e *Engine) dynamicWaveCandidateIssues(st *state.State, issues []github.Issue, prefixSkipped []string) (policyCandidateResult, error) {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1916,12 +1916,12 @@ func TestDecide_NoOutcomeProgressRecommendsRuntimeCheck(t *testing.T) {
 	if !strings.Contains(stuck.Summary, "Hosted app responds to users") || !strings.Contains(stuck.Summary, "unknown") {
 		t.Fatalf("stuck summary = %q, want outcome and unknown health", stuck.Summary)
 	}
-	if reader.issueCalls != 0 {
-		t.Fatalf("ListOpenIssues called %d time(s), want runtime check before more issue throughput", reader.issueCalls)
+	if reader.issueCalls != 1 {
+		t.Fatalf("ListOpenIssues called %d time(s), want one backlog evaluation before the runtime check", reader.issueCalls)
 	}
 }
 
-func TestDecide_FailingOutcomeImmediatelyBlocksFalseGreen(t *testing.T) {
+func TestDecide_FailingOutcomeWithReadyIssueSpawnsWorker(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.Outcome = outcome.Brief{
 		DesiredOutcome: "Hosted app responds to users",
@@ -1946,8 +1946,11 @@ func TestDecide_FailingOutcomeImmediatelyBlocksFalseGreen(t *testing.T) {
 		t.Fatalf("Decide: %v", err)
 	}
 
-	if decision.RecommendedAction != ActionCheckOutcomeHealth {
-		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionCheckOutcomeHealth)
+	if decision.RecommendedAction != ActionSpawnWorker {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionSpawnWorker)
+	}
+	if decision.Target == nil || decision.Target.Issue != 1023 {
+		t.Fatalf("target = %#v, want ready issue #1023", decision.Target)
 	}
 	stuck := requireStuckState(t, decision, state.StuckNoOutcomeProgress)
 	if stuck.Severity != SeverityBlocked {
@@ -1957,14 +1960,97 @@ func TestDecide_FailingOutcomeImmediatelyBlocksFalseGreen(t *testing.T) {
 		t.Fatalf("stuck summary = %q, want failing outcome", stuck.Summary)
 	}
 	if reader.issueCalls != 1 {
-		t.Fatalf("ListOpenIssues called %d time(s), want one blocker-panel snapshot read", reader.issueCalls)
+		t.Fatalf("ListOpenIssues called %d time(s), want one backlog evaluation", reader.issueCalls)
 	}
 	if decision.QueueAnalysis == nil || decision.QueueAnalysis.EligibleCandidates != 1 || len(decision.QueueAnalysis.EligibleRanked) != 1 || decision.QueueAnalysis.EligibleRanked[0].Number != 1023 {
-		t.Fatalf("queue analysis = %#v, want ready issue #1023 preserved behind the outcome hold", decision.QueueAnalysis)
+		t.Fatalf("queue analysis = %#v, want ready issue #1023 selected despite the outcome hold", decision.QueueAnalysis)
+	}
+	if decision.Outcome == nil || decision.Outcome.HealthState != outcome.HealthFailing {
+		t.Fatalf("outcome = %#v, want failing health retained on spawn decision", decision.Outcome)
+	}
+}
+
+func TestDecide_FailingOutcomeWithLabelableIssueAddsReadyLabel(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel}
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome: "Hosted app responds to users",
+		HealthcheckURL: "https://app.example.com/healthz",
+	}
+	reader := &fakeReader{issues: []github.Issue{testIssue(1024, "label next repair step")}}
+	st := state.NewState()
+	st.OutcomeHealth = &outcome.HealthCheckResult{State: outcome.HealthFailing, Summary: "GET returned 500"}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionLabelIssueReady {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionLabelIssueReady)
+	}
+	if decision.Target == nil || decision.Target.Issue != 1024 {
+		t.Fatalf("target = %#v, want labelable issue #1024", decision.Target)
+	}
+	if len(decision.Mutations) != 1 || decision.Mutations[0].Type != MutationAddReadyLabel {
+		t.Fatalf("mutations = %#v, want add_ready_label", decision.Mutations)
+	}
+}
+
+func TestDecide_FailingOutcomeDynamicWaveAddsReadyLabel(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.IssueLabels = []string{"maestro-ready"}
+	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel}
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome: "Hosted app responds to users",
+		HealthcheckURL: "https://app.example.com/healthz",
+	}
+	enableDynamicWave(cfg)
+	reader := &fakeReader{issues: []github.Issue{testIssue(1025, "dynamic repair step", "p0")}}
+	st := state.NewState()
+	st.OutcomeHealth = &outcome.HealthCheckResult{State: outcome.HealthFailing, Summary: "GET returned 500"}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionLabelIssueReady {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionLabelIssueReady)
+	}
+	if decision.Target == nil || decision.Target.Issue != 1025 {
+		t.Fatalf("target = %#v, want dynamic-wave issue #1025", decision.Target)
+	}
+}
+
+func TestDecide_FailingOutcomeWithEmptyBacklogStillChecksHealth(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Outcome = outcome.Brief{
+		DesiredOutcome: "Hosted app responds to users",
+		RuntimeTarget:  "https://app.example.com",
+		HealthcheckURL: "https://app.example.com/healthz",
+	}
+	reader := &fakeReader{}
+	st := state.NewState()
+	st.OutcomeHealth = &outcome.HealthCheckResult{
+		CheckedAt: time.Now().UTC(),
+		Signal:    "healthcheck_url",
+		State:     outcome.HealthFailing,
+		Summary:   "GET returned 500",
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionCheckOutcomeHealth {
+		t.Fatalf("action = %q, want %q", decision.RecommendedAction, ActionCheckOutcomeHealth)
+	}
+	if decision.QueueAnalysis == nil || decision.QueueAnalysis.OpenIssues != 0 || decision.QueueAnalysis.EligibleCandidates != 0 {
+		t.Fatalf("queue analysis = %#v, want empty backlog", decision.QueueAnalysis)
 	}
 	reasons := strings.Join(decision.Reasons, "\n")
-	if !strings.Contains(reasons, "Open PRs observed: 1") {
-		t.Fatalf("reasons = %q, want open PRs to be treated as insufficient proof", reasons)
+	if !strings.Contains(reasons, "No actionable backlog remains") {
+		t.Fatalf("reasons = %q, want empty-backlog outcome rationale", reasons)
 	}
 }
 


### PR DESCRIPTION
Refs #1081

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds fleet-wide worker controls and changes supervisor queue ordering. The main changes are:

- Fleet-only minimum and maximum live-worker settings.
- A shared daemon limiter for atomic worker-spawn reservations.
- CLI and Mission Control display of fleet-only settings.
- Backlog labeling and spawning before outcome-health fallback.

<h3>Confidence Score: 4/5</h3>

The fleet minimum setting needs runtime scheduling behavior before merging.

The maximum worker cap is enforced through shared reservations. The minimum is accepted and displayed but does not replenish workers. Supervisor backlog ordering preserves the health fallback when no actionable work remains.

internal/config/settings.go and the daemon or supervisor scheduling path that should consume MinLiveWorkers

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the minimum-target behavior by running a focused Go test overlay against the unchanged daemon package with min\_live\_workers=5, max\_live\_workers=10, and zero running workers in the persisted state.
- Observed via runtime tracing that the limiter resolved min\_live\_workers=5 and counted zero live workers, but created zero replenishment reservations.
- Confirmed that the five-replenishment expectation did not occur, showing the configured minimum produced no scheduling action.
- Performed a before-change comparison that failed the ready-work case by returning check\_outcome\_health instead of spawn\_worker (exit 1).
- Performed the after-change validation that passed all three requested scenarios with exit code 0, indicating backlog dispatch/labeling is evaluated before the outcome-health hold even when the backlog is empty.

<a href="https://app.greptile.com/trex/runs/15425709/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/settings.go | Adds fleet-only worker-band settings, defaults, normalization, and validation; the minimum lacks a runtime consumer. |
| internal/configstore/settings.go | Adds fleet-only scope checks and transactional validation for worker-band writes, deletes, and imports. |
| internal/daemon/fleet_concurrency.go | Adds shared live-worker counting and atomic reservations that enforce the configured maximum. |
| internal/orchestrator/orchestrator.go | Adds fleet permit handling to fresh dispatch, repair, and retry worker paths. |
| internal/supervisor/supervisor.go | Moves outcome-health fallback behind actionable backlog evaluation. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/config/settings.go:285
**Minimum Target Has No Effect**

When `fleet.min_live_workers` is changed, the daemon persists and displays the value but never uses `MinLiveWorkers` to replenish the fleet. The limiter only enforces `MaxLiveWorkers`, so a configured minimum of 5 can still leave the fleet at zero workers with no scheduling action.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-1111-1..."](https://github.com/befeast/maestro/commit/472ac3f4da18657e2b1f263f19df884b83e5c5d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46339787)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->