### PR TITLE
fix: release fresh_dispatch lease on failed worker start

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -9744,6 +9744,31 @@ func (o *Orchestrator) completeFreshDispatch(s *state.State, claim *state.FreshD
 	return nil
 }
 
+func (o *Orchestrator) releaseFreshDispatch(s *state.State, claim *state.FreshDispatchClaim, reason string) {
+	if claim == nil || !o.durableFreshDispatchClaimsEnabled() {
+		return
+	}
+	now := time.Now().UTC()
+	if err := state.Update(o.cfg.StateDir, func(latest *state.State) error {
+		return latest.SupersedeFreshDispatch(claim.IssueNumber, claim.LeaseID, reason, now)
+	}); err != nil {
+		log.Printf("[orch] release fresh dispatch for issue #%d: %v", claim.IssueNumber, err)
+		return
+	}
+	if s.FreshDispatchClaims == nil {
+		return
+	}
+	copy := *claim
+	copy.Status = state.FreshDispatchClaimStatusSuperseded
+	copy.UpdatedAt = now
+	copy.LeaseExpiresAt = time.Time{}
+	if strings.TrimSpace(reason) == "" {
+		reason = "start_failed"
+	}
+	copy.TerminalReason = reason
+	s.FreshDispatchClaims[claim.IssueNumber] = &copy
+}
+
 func (o *Orchestrator) reconcileFreshDispatchClaims(s *state.State, now time.Time) {
 	if !o.durableFreshDispatchClaimsEnabled() || s == nil {
 		return
@@ -10143,6 +10168,12 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 			log.Printf("[orch] start worker for issue #%d: %v", issue.Number, err)
 			o.notifier.Sendf("❌ maestro: failed to start worker for issue #%d (%s): %v",
 				issue.Number, issue.Title, err)
+			// #1100: release the pre-spawn lease immediately so a failed start
+			// (dirty base, worktree create, hooks, …) does not leave status=claimed
+			// for freshDispatchLeaseDuration and starve the issue as "in progress".
+			if freshClaim != nil {
+				o.releaseFreshDispatch(s, freshClaim, "start_failed")
+			}
 			// #874: a review-repair dispatch claimed a (pr,head) attempt via
 			// tryClaimReviewRepairSlot BEFORE this start; release it so a failed
 			// start does not burn a slot from the bounded repair budget and leave

--- a/internal/state/issue_claim.go
+++ b/internal/state/issue_claim.go
@@ -277,6 +277,32 @@ func (s *State) CompleteFreshDispatch(issueNumber int, leaseID string, sess *Ses
 	return nil
 }
 
+// SupersedeFreshDispatch marks a pre-spawn lease terminal without a Session.
+// Call this when worker start fails after ClaimFreshDispatch so the issue does
+// not stay status=claimed for the full lease window and block re-dispatch
+// (zombie leases → "already in progress" with zero live workers).
+func (s *State) SupersedeFreshDispatch(issueNumber int, leaseID, reason string, now time.Time) error {
+	if s == nil || issueNumber <= 0 {
+		return nil
+	}
+	claim, ok := s.FreshDispatchClaimFor(issueNumber)
+	if !ok {
+		return nil
+	}
+	if strings.TrimSpace(leaseID) != "" && claim.LeaseID != leaseID {
+		return fmt.Errorf("fresh dispatch lease changed")
+	}
+	now = now.UTC()
+	claim.Status = FreshDispatchClaimStatusSuperseded
+	claim.UpdatedAt = now
+	claim.LeaseExpiresAt = time.Time{}
+	if strings.TrimSpace(reason) == "" {
+		reason = "start_failed"
+	}
+	claim.TerminalReason = reason
+	return nil
+}
+
 // ReconcileFreshDispatchClaims makes a pre-spawn lease terminal when its exact
 // Session was persisted by a later compatible save. This is the
 // crash-after-launch repair: it preserves the worker identity already present

--- a/internal/state/issue_claim_test.go
+++ b/internal/state/issue_claim_test.go
@@ -258,3 +258,37 @@ func TestFreshDispatchClaim_ReconcilesCrashAfterSessionSave(t *testing.T) {
 		t.Fatalf("reconciled claim = %+v", claim)
 	}
 }
+
+func TestFreshDispatchClaim_SupersedeReleasesIssueForRedispatch(t *testing.T) {
+	s := NewState()
+	now := time.Date(2026, 7, 22, 20, 0, 0, 0, time.UTC)
+	claim, acquired, err := s.ClaimFreshDispatch(505, "ok-player", "lease-a", 10*time.Minute, now)
+	if err != nil || !acquired {
+		t.Fatalf("claim: acquired=%t err=%v", acquired, err)
+	}
+	claim.Branch = "feat/ok-player-1-505"
+	claim.Worktree = filepath.Join("/worktrees", claim.Slot)
+
+	if err := s.SupersedeFreshDispatch(505, "lease-a", "start_failed", now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	if _, active := s.FreshDispatchClaimFor(505); active {
+		t.Fatal("superseded claim remained active")
+	}
+	evidence := s.FreshDispatchClaims[505]
+	if evidence == nil || evidence.Status != FreshDispatchClaimStatusSuperseded || evidence.TerminalReason != "start_failed" {
+		t.Fatalf("superseded evidence = %+v", evidence)
+	}
+	if _, ok := s.IssueClaimFor(505); ok {
+		t.Fatal("superseded lease still appears in ActiveIssueClaims")
+	}
+
+	// A new owner can claim a fresh identity after supersede (not renew-in-place).
+	next, acquired, err := s.ClaimFreshDispatch(505, "ok-player", "lease-b", 10*time.Minute, now.Add(2*time.Minute))
+	if err != nil || !acquired {
+		t.Fatalf("reclaim after supersede: acquired=%t err=%v", acquired, err)
+	}
+	if next.Slot == claim.Slot || next.LeaseGeneration != 1 {
+		t.Fatalf("expected new identity after supersede, got %+v (prior slot %s)", next, claim.Slot)
+	}
+}

--- a/internal/worker/syncbase.go
+++ b/internal/worker/syncbase.go
@@ -74,8 +74,11 @@ func SyncBaseBranch(localPath, branch string) error {
 
 	head, _ := runGit(localPath, "symbolic-ref", "--quiet", "--short", "HEAD")
 	if strings.TrimSpace(head) == branch {
-		// Base branch is checked out: refuse a dirty tree, then fast-forward merge.
-		if dirty, err := worktreeDirty(localPath); err != nil {
+		// Base branch is checked out: refuse a dirty *tracked* tree, then
+		// fast-forward merge. Untracked agent harness dirs (.claude/.codex/…)
+		// must not block sync — merge --ff-only does not touch them, and
+		// workers commonly leave those dirs in the shared base checkout (#1100).
+		if dirty, err := baseCheckoutBlockingDirt(localPath); err != nil {
 			return fmt.Errorf("sync base branch %q: %w", branch, err)
 		} else if dirty != "" {
 			return fmt.Errorf("base branch %q checkout at %s is dirty; cannot fast-forward to %s:\n%s",
@@ -93,6 +96,57 @@ func SyncBaseBranch(localPath, branch string) error {
 		return fmt.Errorf("fast-forward base branch %q to %s: %w", branch, remoteRef, err)
 	}
 	return nil
+}
+
+// ignorableBaseUntrackedPrefixes are untracked top-level paths workers and
+// agent harnesses commonly leave in the shared local_path checkout. They do
+// not block git merge --ff-only and must not freeze fleet spawn (#1100).
+var ignorableBaseUntrackedPrefixes = []string{
+	".claude/",
+	".codex/",
+	".cursor/",
+	".entire/",
+	".agents/",
+	".windsurf/",
+	".clinerules",
+}
+
+// baseCheckoutBlockingDirt returns porcelain lines that should block SyncBaseBranch.
+// Tracked modifications always block. Untracked agent harness dirs are ignored.
+func baseCheckoutBlockingDirt(localPath string) (string, error) {
+	out, err := worktreeDirty(localPath)
+	if err != nil {
+		return "", err
+	}
+	if out == "" {
+		return "", nil
+	}
+	var blocking []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "?? ") {
+			path := strings.TrimPrefix(line, "?? ")
+			if isIgnorableBaseUntracked(path) {
+				continue
+			}
+		}
+		blocking = append(blocking, line)
+	}
+	return strings.Join(blocking, "\n"), nil
+}
+
+func isIgnorableBaseUntracked(path string) bool {
+	path = strings.TrimSpace(path)
+	path = strings.ReplaceAll(path, "\\", "/")
+	for _, prefix := range ignorableBaseUntrackedPrefixes {
+		if path == strings.TrimSuffix(prefix, "/") || strings.HasPrefix(path, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // addWorktreeFromBase creates worktreePath as a fresh checkout on branchName,

--- a/internal/worker/syncbase_test.go
+++ b/internal/worker/syncbase_test.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -107,6 +108,39 @@ func TestSyncBaseBranch_DirtyCheckoutFailsLoudly(t *testing.T) {
 	err := SyncBaseBranch(local, "main")
 	if err == nil {
 		t.Fatal("expected error for dirty base checkout")
+	}
+	if !strings.Contains(err.Error(), "dirty") {
+		t.Fatalf("expected dirty error, got: %v", err)
+	}
+}
+
+func TestSyncBaseBranch_IgnoresUntrackedAgentHarnessDirs(t *testing.T) {
+	_, local, seed := setupOriginAndClone(t)
+	advanceOrigin(t, seed, "v2\n")
+
+	for _, dir := range []string{".claude", ".codex", ".cursor", ".entire"} {
+		if err := os.MkdirAll(filepath.Join(local, dir), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+		writeTestFile(t, filepath.Join(local, dir), "junk.txt", "agent junk\n")
+	}
+
+	if err := SyncBaseBranch(local, "main"); err != nil {
+		t.Fatalf("SyncBaseBranch with agent junk: %v", err)
+	}
+	if got, want := revParse(t, local, "main"), revParse(t, local, "origin/main"); got != want {
+		t.Fatalf("local main = %s, want origin/main %s", got, want)
+	}
+}
+
+func TestSyncBaseBranch_UntrackedNonAgentStillBlocks(t *testing.T) {
+	_, local, seed := setupOriginAndClone(t)
+	advanceOrigin(t, seed, "v2\n")
+
+	writeTestFile(t, local, "mystery-untracked.txt", "nope\n")
+	err := SyncBaseBranch(local, "main")
+	if err == nil {
+		t.Fatal("expected error for non-agent untracked dirt")
 	}
 	if !strings.Contains(err.Error(), "dirty") {
 		t.Fatalf("expected dirty error, got: %v", err)


### PR DESCRIPTION
## Summary
- Supersede `fresh_dispatch` lease immediately when `startClaimedWorker` fails so issues are not stuck "in progress" for 10 minutes with no session.
- Ignore untracked agent harness dirs (`.claude`/`.codex`/`.cursor`/`.entire`/…) in `SyncBaseBranch` dirty checks — they were freezing all ok-player spawns.

Implements #1100

## Test plan
- [x] `go test ./internal/state/ -run FreshDispatchClaim`
- [x] `go test ./internal/worker/ -run SyncBaseBranch`
- [x] Deployed binary `bc0eb708` to host; live recovered from 0 → 4–5; no zombie claimed leases
- [ ] Fleet live stays in [5,10] without manual state.json surgery

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR releases failed worker-start leases sooner and relaxes base-checkout dirt checks. The main changes are:

- Supersede `fresh_dispatch` claims when worker startup fails.
- Preserve lease ownership checks during release.
- Ignore selected untracked agent-harness paths during base sync.
- Add coverage for lease reuse and dirty-check filtering.

<h3>Confidence Score: 4/5</h3>

The base-sync conflict path needs a fix before merging.

Lease release checks the current lease ID and does not supersede a newer owner. An allowed untracked harness file can still make the subsequent fast-forward fail when the remote branch begins tracking the same path. Existing tests do not cover that collision.

internal/worker/syncbase.go and internal/worker/syncbase_test.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- - The focused Go test using the real SyncBaseBranch reproduced the untracked .claude/settings.local.json scenario that blocks a fast-forward merge.
- - The merge attempt failed with git merge --ff-only because the untracked working-tree file would be overwritten, preventing synchronization.
- - The startup trace shows the claim being active, followed by a failure that supersedes it, and a redispatch producing a new claim slot trex-2.
- - The focused state and orchestrator commands exited 0 on the changed revision, indicating a clean post-change run.

<a href="https://app.greptile.com/trex/runs/15478278/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Releases the fresh-dispatch lease after a claimed worker fails to start. |
| internal/state/issue_claim.go | Adds an ownership-checked terminal transition for fresh-dispatch claims. |
| internal/state/issue_claim_test.go | Covers claim superseding, inactive-claim behavior, and acquisition of a new lease identity. |
| internal/worker/syncbase.go | Allows selected untracked harness paths during base sync, but does not account for conflicts with paths newly tracked by the remote branch. |
| internal/worker/syncbase_test.go | Covers ordinary harness directories and unrelated untracked files, but not remote path conflicts. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/worker/syncbase.go:81
**Ignored Path Blocks Fast-Forward**

When `origin/<branch>` starts tracking a file that already exists untracked under an allowed harness directory, this check permits the sync but `git merge --ff-only` rejects the conflicting file. Worker spawning remains blocked until that harness content is removed or relocated.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: release fresh\_dispatch lease on fai..."](https://github.com/befeast/maestro/commit/bc0eb708021a5d761f5fc140b208a9c8576c0e5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46442787)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->