### PR TITLE
Release fresh_dispatch lease when worker start fails (zombie claimed leases → 0 workers)

### DIFF
--- a/internal/orchestrator/fresh_dispatch_claim_test.go
+++ b/internal/orchestrator/fresh_dispatch_claim_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"errors"
 	"path/filepath"
 	"sync/atomic"
 	"testing"
@@ -226,5 +227,75 @@ func TestFreshDispatchClaim_PreventsConcurrentDuplicateBeforeSessionRegistration
 	}
 	if loaded.NextSlot != 2 {
 		t.Fatalf("next_slot = %d, want 2 (no duplicate allocation)", loaded.NextSlot)
+	}
+}
+
+func TestFreshDispatchClaim_StartFailureSupersedesLease(t *testing.T) {
+	dir := t.TempDir()
+	cfg := cfgWithBackends("claude", "claude")
+	cfg.StateDir = dir
+	cfg.WorktreeBase = filepath.Join(dir, "worktrees")
+	cfg.SessionPrefix = "ok-player"
+	if err := state.Save(dir, state.NewState()); err != nil {
+		t.Fatal(err)
+	}
+	issue := makeIssue(394, "release failed startup", "maestro-ready")
+	orch, _, _ := newStartWorkersOrchestrator(cfg, []github.Issue{issue})
+	orch.workerStartFn = nil
+	var attemptedSlots []string
+	orch.workerStartClaimedFn = func(_ *config.Config, _ *state.State, _ string, _ github.Issue, _ string, _ string, slot string) (string, error) {
+		attemptedSlots = append(attemptedSlots, slot)
+		return "", errors.New("base checkout blocked")
+	}
+
+	cycle, err := state.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	orch.startNewWorkers(cycle, 1)
+	if _, active := cycle.FreshDispatchClaimFor(394); active {
+		t.Fatal("failed startup remained active in cycle state")
+	}
+	if err := state.Save(dir, cycle); err != nil {
+		t.Fatalf("post-failure cycle save: %v", err)
+	}
+
+	loaded, err := state.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim := loaded.FreshDispatchClaims[394]
+	if claim == nil || claim.Status != state.FreshDispatchClaimStatusSuperseded || claim.TerminalReason != "start_failed" {
+		t.Fatalf("failed startup claim = %+v", claim)
+	}
+	if !claim.LeaseExpiresAt.IsZero() || claim.CompletedAt.IsZero() {
+		t.Fatalf("failed startup claim retained lease = %+v", claim)
+	}
+	if len(loaded.Sessions) != 0 {
+		t.Fatalf("sessions after pre-launch failure = %+v, want none", loaded.Sessions)
+	}
+	if loaded.NextSlot != 2 {
+		t.Fatalf("next_slot = %d, want 2", loaded.NextSlot)
+	}
+
+	firstBranch := claim.Branch
+	firstWorktree := claim.Worktree
+	orch.startNewWorkers(loaded, 1)
+	if err := state.Save(dir, loaded); err != nil {
+		t.Fatalf("post-retry cycle save: %v", err)
+	}
+	retried, err := state.Load(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim = retried.FreshDispatchClaims[394]
+	if len(attemptedSlots) != 2 || attemptedSlots[0] != "ok-player-1" || attemptedSlots[1] != attemptedSlots[0] {
+		t.Fatalf("failed startup slots = %v, want the reserved slot reused", attemptedSlots)
+	}
+	if claim == nil || claim.Status != state.FreshDispatchClaimStatusSuperseded || claim.TerminalReason != "start_failed" || claim.LeaseGeneration != 2 {
+		t.Fatalf("retried failed startup claim = %+v", claim)
+	}
+	if claim.Branch != firstBranch || claim.Worktree != firstWorktree || retried.NextSlot != 2 {
+		t.Fatalf("retry changed reserved identity: claim=%+v next_slot=%d", claim, retried.NextSlot)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -9785,29 +9785,26 @@ func (o *Orchestrator) completeFreshDispatch(s *state.State, claim *state.FreshD
 	return nil
 }
 
-func (o *Orchestrator) releaseFreshDispatch(s *state.State, claim *state.FreshDispatchClaim, reason string) {
-	if claim == nil || !o.durableFreshDispatchClaimsEnabled() {
-		return
+func (o *Orchestrator) supersedeFreshDispatch(s *state.State, claim *state.FreshDispatchClaim, terminalReason string, now time.Time) error {
+	if claim == nil {
+		return nil
 	}
-	now := time.Now().UTC()
+	var superseded state.FreshDispatchClaim
 	if err := state.Update(o.cfg.StateDir, func(latest *state.State) error {
-		return latest.SupersedeFreshDispatch(claim.IssueNumber, claim.LeaseID, reason, now)
+		if err := latest.SupersedeFreshDispatch(claim.IssueNumber, claim.LeaseID, terminalReason, now); err != nil {
+			return err
+		}
+		superseded = *latest.FreshDispatchClaims[claim.IssueNumber]
+		return nil
 	}); err != nil {
-		log.Printf("[orch] release fresh dispatch for issue #%d: %v", claim.IssueNumber, err)
-		return
+		return err
 	}
 	if s.FreshDispatchClaims == nil {
-		return
+		s.FreshDispatchClaims = make(map[int]*state.FreshDispatchClaim)
 	}
-	copy := *claim
-	copy.Status = state.FreshDispatchClaimStatusSuperseded
-	copy.UpdatedAt = now
-	copy.LeaseExpiresAt = time.Time{}
-	if strings.TrimSpace(reason) == "" {
-		reason = "start_failed"
-	}
-	copy.TerminalReason = reason
+	copy := superseded
 	s.FreshDispatchClaims[claim.IssueNumber] = &copy
+	return nil
 }
 
 func (o *Orchestrator) reconcileFreshDispatchClaims(s *state.State, now time.Time) {
@@ -10207,14 +10204,17 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		if err != nil {
 			permit.Release()
 			log.Printf("[orch] start worker for issue #%d: %v", issue.Number, err)
+			// #1100: release the pre-spawn lease immediately so a failed start
+			// cannot leave the issue claimed with no worker. The next dispatch
+			// reuses this exact reserved slot, branch, and worktree, preventing
+			// repeated setup failures from leaking a new worktree each cycle.
+			if freshClaim != nil {
+				if supersedeErr := o.supersedeFreshDispatch(s, freshClaim, "start_failed", time.Now().UTC()); supersedeErr != nil {
+					log.Printf("[orch] supersede failed fresh dispatch for issue #%d on %s: %v (lease remains authoritative)", issue.Number, freshClaim.Slot, supersedeErr)
+				}
+			}
 			o.notifier.Sendf("❌ maestro: failed to start worker for issue #%d (%s): %v",
 				issue.Number, issue.Title, err)
-			// #1100: release the pre-spawn lease immediately so a failed start
-			// (dirty base, worktree create, hooks, …) does not leave status=claimed
-			// for freshDispatchLeaseDuration and starve the issue as "in progress".
-			if freshClaim != nil {
-				o.releaseFreshDispatch(s, freshClaim, "start_failed")
-			}
 			// #874: a review-repair dispatch claimed a (pr,head) attempt via
 			// tryClaimReviewRepairSlot BEFORE this start; release it so a failed
 			// start does not burn a slot from the bounded repair budget and leave

--- a/internal/state/issue_claim.go
+++ b/internal/state/issue_claim.go
@@ -201,8 +201,9 @@ func (s *State) IssueHasNonFreshClaim(issueNumber int) bool {
 
 // ClaimFreshDispatch atomically reserves or renews one exact fresh-worker
 // identity. An unexpired lease records contention and refuses a second owner.
-// An expired lease is renewed in place on the same slot/branch/worktree; it
-// never allocates a replacement identity merely to retry startup.
+// An expired lease, or a lease superseded after a failed start, is renewed in
+// place on the same slot/branch/worktree; it never allocates a replacement
+// identity merely to retry startup.
 //
 // The caller may fill Branch and Worktree on a newly returned claim before the
 // enclosing State.Update callback returns.
@@ -232,6 +233,20 @@ func (s *State) ClaimFreshDispatch(issueNumber int, slotPrefix, leaseID string, 
 	}
 	if s.IssueHasNonFreshClaim(issueNumber) {
 		return nil, false, nil
+	}
+	if existing := s.FreshDispatchClaims[issueNumber]; existing != nil &&
+		existing.Status == FreshDispatchClaimStatusSuperseded &&
+		existing.TerminalReason == "start_failed" {
+		existing.Status = FreshDispatchClaimStatusClaimed
+		existing.LeaseID = leaseID
+		existing.LeaseGeneration++
+		existing.ClaimedAt = now
+		existing.UpdatedAt = now
+		existing.LeaseExpiresAt = now.Add(leaseDuration)
+		existing.CompletedAt = time.Time{}
+		existing.SessionStartedAt = time.Time{}
+		existing.TerminalReason = ""
+		return existing, true, nil
 	}
 	claim := &FreshDispatchClaim{
 		IssueNumber:     issueNumber,
@@ -277,29 +292,24 @@ func (s *State) CompleteFreshDispatch(issueNumber int, leaseID string, sess *Ses
 	return nil
 }
 
-// SupersedeFreshDispatch marks a pre-spawn lease terminal without a Session.
-// Call this when worker start fails after ClaimFreshDispatch so the issue does
-// not stay status=claimed for the full lease window and block re-dispatch
-// (zombie leases → "already in progress" with zero live workers).
-func (s *State) SupersedeFreshDispatch(issueNumber int, leaseID, reason string, now time.Time) error {
-	if s == nil || issueNumber <= 0 {
-		return nil
-	}
+// SupersedeFreshDispatch releases an exact pre-spawn lease after its worker
+// fails to start. The lease ID guard prevents a stale startup owner from
+// releasing a newer generation acquired by another orchestrator process.
+func (s *State) SupersedeFreshDispatch(issueNumber int, leaseID, terminalReason string, now time.Time) error {
 	claim, ok := s.FreshDispatchClaimFor(issueNumber)
-	if !ok {
-		return nil
-	}
-	if strings.TrimSpace(leaseID) != "" && claim.LeaseID != leaseID {
+	if !ok || strings.TrimSpace(leaseID) == "" || claim.LeaseID != leaseID {
 		return fmt.Errorf("fresh dispatch lease changed")
+	}
+	terminalReason = strings.TrimSpace(terminalReason)
+	if terminalReason == "" {
+		return fmt.Errorf("fresh dispatch terminal reason is required")
 	}
 	now = now.UTC()
 	claim.Status = FreshDispatchClaimStatusSuperseded
 	claim.UpdatedAt = now
+	claim.CompletedAt = now
 	claim.LeaseExpiresAt = time.Time{}
-	if strings.TrimSpace(reason) == "" {
-		reason = "start_failed"
-	}
-	claim.TerminalReason = reason
+	claim.TerminalReason = terminalReason
 	return nil
 }
 
@@ -358,7 +368,7 @@ func mergeFreshDispatchClaims(current, ours map[int]*FreshDispatchClaim) map[int
 		prior := merged[issue]
 		if prior == nil || candidate.UpdatedAt.After(prior.UpdatedAt) ||
 			(candidate.UpdatedAt.Equal(prior.UpdatedAt) && candidate.LeaseGeneration > prior.LeaseGeneration) ||
-			(candidate.UpdatedAt.Equal(prior.UpdatedAt) && candidate.LeaseGeneration == prior.LeaseGeneration && candidate.Status == FreshDispatchClaimStatusCompleted) {
+			(candidate.UpdatedAt.Equal(prior.UpdatedAt) && candidate.LeaseGeneration == prior.LeaseGeneration && candidate.LeaseID == prior.LeaseID && freshDispatchClaimStatusRank(candidate.Status) > freshDispatchClaimStatusRank(prior.Status)) {
 			chosen := copyClaim(candidate)
 			if prior != nil {
 				if prior.ContentionCount > chosen.ContentionCount {
@@ -379,6 +389,17 @@ func mergeFreshDispatchClaims(current, ours map[int]*FreshDispatchClaim) map[int
 		}
 	}
 	return merged
+}
+
+func freshDispatchClaimStatusRank(status string) int {
+	switch status {
+	case FreshDispatchClaimStatusCompleted:
+		return 2
+	case FreshDispatchClaimStatusSuperseded:
+		return 1
+	default:
+		return 0
+	}
 }
 
 // IssueClaimFor returns the first durable claim for issueNumber.

--- a/internal/state/issue_claim_test.go
+++ b/internal/state/issue_claim_test.go
@@ -202,6 +202,71 @@ func TestFreshDispatchClaim_CompletionCreatesSessionAndRetainsEvidence(t *testin
 	}
 }
 
+func TestFreshDispatchClaim_SupersedeReleasesExactLease(t *testing.T) {
+	s := NewState()
+	now := time.Date(2026, 7, 21, 21, 0, 0, 0, time.UTC)
+	claim, acquired, err := s.ClaimFreshDispatch(394, "ok-player", "lease-a", 10*time.Minute, now)
+	if err != nil || !acquired {
+		t.Fatalf("claim: acquired=%t err=%v", acquired, err)
+	}
+	claim.Branch = "feat/ok-player-1-394-canonical"
+	claim.Worktree = filepath.Join("/worktrees", claim.Slot)
+
+	if err := s.SupersedeFreshDispatch(394, "stale-lease", "start_failed", now.Add(time.Minute)); err == nil {
+		t.Fatal("stale lease owner superseded the active claim")
+	}
+	if claim.Status != FreshDispatchClaimStatusClaimed {
+		t.Fatalf("claim status after stale supersede = %q, want claimed", claim.Status)
+	}
+
+	completedAt := now.Add(2 * time.Minute)
+	if err := s.SupersedeFreshDispatch(394, "lease-a", "start_failed", completedAt); err != nil {
+		t.Fatal(err)
+	}
+	if _, active := s.FreshDispatchClaimFor(394); active {
+		t.Fatal("superseded claim remained active")
+	}
+	if _, claimed := s.IssueClaimFor(394); claimed {
+		t.Fatal("superseded lease still appeared as an active issue claim")
+	}
+	if claim.Status != FreshDispatchClaimStatusSuperseded || claim.TerminalReason != "start_failed" {
+		t.Fatalf("superseded claim = %+v", claim)
+	}
+	if !claim.CompletedAt.Equal(completedAt) || !claim.UpdatedAt.Equal(completedAt) || !claim.LeaseExpiresAt.IsZero() {
+		t.Fatalf("superseded timestamps = %+v", claim)
+	}
+
+	next, acquired, err := s.ClaimFreshDispatch(394, "ok-player", "lease-b", 10*time.Minute, completedAt.Add(time.Minute))
+	if err != nil || !acquired {
+		t.Fatalf("redispatch claim: acquired=%t err=%v", acquired, err)
+	}
+	if next != claim || next.Slot != "ok-player-1" || next.Branch != "feat/ok-player-1-394-canonical" || next.Worktree != filepath.Join("/worktrees", "ok-player-1") {
+		t.Fatalf("redispatch identity changed = %+v", next)
+	}
+	if next.Status != FreshDispatchClaimStatusClaimed || next.LeaseID != "lease-b" || next.LeaseGeneration != 2 || s.NextSlot != 2 {
+		t.Fatalf("redispatch lease = %+v next_slot=%d", next, s.NextSlot)
+	}
+	if !next.CompletedAt.IsZero() || !next.SessionStartedAt.IsZero() || next.TerminalReason != "" {
+		t.Fatalf("redispatch retained terminal evidence = %+v", next)
+	}
+}
+
+func TestFreshDispatchClaim_StaleOwnerCannotSupersedeRenewedLease(t *testing.T) {
+	s := NewState()
+	now := time.Date(2026, 7, 21, 21, 0, 0, 0, time.UTC)
+	claim, _, _ := s.ClaimFreshDispatch(394, "ok-player", "lease-a", time.Minute, now)
+	renewed, acquired, err := s.ClaimFreshDispatch(394, "ok-player", "lease-b", time.Minute, now.Add(2*time.Minute))
+	if err != nil || !acquired {
+		t.Fatalf("renew claim: acquired=%t err=%v", acquired, err)
+	}
+	if err := s.SupersedeFreshDispatch(394, "lease-a", "start_failed", now.Add(3*time.Minute)); err == nil {
+		t.Fatal("stale owner superseded renewed lease")
+	}
+	if renewed.Status != FreshDispatchClaimStatusClaimed || renewed.LeaseID != "lease-b" || renewed.LeaseGeneration != 2 {
+		t.Fatalf("renewed lease changed = %+v (initial %+v)", renewed, claim)
+	}
+}
+
 func TestFreshDispatchClaim_ConcurrentSaveKeepsContentionAndCompletion(t *testing.T) {
 	dir := t.TempDir()
 	now := time.Date(2026, 7, 21, 21, 0, 0, 0, time.UTC)
@@ -238,6 +303,40 @@ func TestFreshDispatchClaim_ConcurrentSaveKeepsContentionAndCompletion(t *testin
 	}
 }
 
+func TestFreshDispatchClaim_ConcurrentSaveKeepsSupersededAtEqualTimestamp(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 7, 21, 21, 0, 0, 0, time.UTC)
+	seed := NewState()
+	if _, acquired, err := seed.ClaimFreshDispatch(394, "ok-player", "lease-a", 10*time.Minute, now); err != nil || !acquired {
+		t.Fatalf("seed claim: acquired=%t err=%v", acquired, err)
+	}
+	if err := Save(dir, seed); err != nil {
+		t.Fatal(err)
+	}
+
+	owner, _ := Load(dir)
+	contender, _ := Load(dir)
+	terminalAt := now.Add(time.Minute)
+	if err := owner.SupersedeFreshDispatch(394, "lease-a", "start_failed", terminalAt); err != nil {
+		t.Fatal(err)
+	}
+	if _, acquired, err := contender.ClaimFreshDispatch(394, "ok-player", "lease-b", 10*time.Minute, terminalAt); err != nil || acquired {
+		t.Fatalf("contender: acquired=%t err=%v", acquired, err)
+	}
+	if err := Save(dir, contender); err != nil {
+		t.Fatal(err)
+	}
+	if err := Save(dir, owner); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, _ := Load(dir)
+	claim := loaded.FreshDispatchClaims[394]
+	if claim.Status != FreshDispatchClaimStatusSuperseded || claim.TerminalReason != "start_failed" || claim.ContentionCount != 1 {
+		t.Fatalf("merged superseded evidence = %+v", claim)
+	}
+}
+
 func TestFreshDispatchClaim_ReconcilesCrashAfterSessionSave(t *testing.T) {
 	s := NewState()
 	now := time.Date(2026, 7, 21, 21, 0, 0, 0, time.UTC)
@@ -256,39 +355,5 @@ func TestFreshDispatchClaim_ReconcilesCrashAfterSessionSave(t *testing.T) {
 	}
 	if claim.Status != FreshDispatchClaimStatusCompleted || claim.TerminalReason != "session_persisted" || claim.SessionStartedAt.IsZero() {
 		t.Fatalf("reconciled claim = %+v", claim)
-	}
-}
-
-func TestFreshDispatchClaim_SupersedeReleasesIssueForRedispatch(t *testing.T) {
-	s := NewState()
-	now := time.Date(2026, 7, 22, 20, 0, 0, 0, time.UTC)
-	claim, acquired, err := s.ClaimFreshDispatch(505, "ok-player", "lease-a", 10*time.Minute, now)
-	if err != nil || !acquired {
-		t.Fatalf("claim: acquired=%t err=%v", acquired, err)
-	}
-	claim.Branch = "feat/ok-player-1-505"
-	claim.Worktree = filepath.Join("/worktrees", claim.Slot)
-
-	if err := s.SupersedeFreshDispatch(505, "lease-a", "start_failed", now.Add(time.Minute)); err != nil {
-		t.Fatal(err)
-	}
-	if _, active := s.FreshDispatchClaimFor(505); active {
-		t.Fatal("superseded claim remained active")
-	}
-	evidence := s.FreshDispatchClaims[505]
-	if evidence == nil || evidence.Status != FreshDispatchClaimStatusSuperseded || evidence.TerminalReason != "start_failed" {
-		t.Fatalf("superseded evidence = %+v", evidence)
-	}
-	if _, ok := s.IssueClaimFor(505); ok {
-		t.Fatal("superseded lease still appears in ActiveIssueClaims")
-	}
-
-	// A new owner can claim a fresh identity after supersede (not renew-in-place).
-	next, acquired, err := s.ClaimFreshDispatch(505, "ok-player", "lease-b", 10*time.Minute, now.Add(2*time.Minute))
-	if err != nil || !acquired {
-		t.Fatalf("reclaim after supersede: acquired=%t err=%v", acquired, err)
-	}
-	if next.Slot == claim.Slot || next.LeaseGeneration != 1 {
-		t.Fatalf("expected new identity after supersede, got %+v (prior slot %s)", next, claim.Slot)
 	}
 }

--- a/internal/worker/syncbase.go
+++ b/internal/worker/syncbase.go
@@ -76,8 +76,8 @@ func SyncBaseBranch(localPath, branch string) error {
 	if strings.TrimSpace(head) == branch {
 		// Base branch is checked out: refuse a dirty *tracked* tree, then
 		// fast-forward merge. Untracked agent harness dirs (.claude/.codex/…)
-		// must not block sync — merge --ff-only does not touch them, and
-		// workers commonly leave those dirs in the shared base checkout (#1100).
+		// normally do not affect an ff-only merge and commonly live in the shared
+		// base checkout, so they must not freeze fleet spawn (#1100).
 		if dirty, err := baseCheckoutBlockingDirt(localPath); err != nil {
 			return fmt.Errorf("sync base branch %q: %w", branch, err)
 		} else if dirty != "" {

--- a/internal/worker/syncbase_test.go
+++ b/internal/worker/syncbase_test.go
@@ -1,7 +1,6 @@
 package worker
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -118,32 +117,40 @@ func TestSyncBaseBranch_IgnoresUntrackedAgentHarnessDirs(t *testing.T) {
 	_, local, seed := setupOriginAndClone(t)
 	advanceOrigin(t, seed, "v2\n")
 
-	for _, dir := range []string{".claude", ".codex", ".cursor", ".entire"} {
-		if err := os.MkdirAll(filepath.Join(local, dir), 0o755); err != nil {
-			t.Fatalf("mkdir %s: %v", dir, err)
-		}
-		writeTestFile(t, filepath.Join(local, dir), "junk.txt", "agent junk\n")
+	harnessFiles := map[string]string{
+		".claude/settings.json": "{}\n",
+		".codex/session.json":   "{}\n",
+		".cursor/rules.md":      "local rules\n",
+		".entire/state.json":    "{}\n",
+	}
+	for path, content := range harnessFiles {
+		writeTestFile(t, local, path, content)
 	}
 
 	if err := SyncBaseBranch(local, "main"); err != nil {
-		t.Fatalf("SyncBaseBranch with agent junk: %v", err)
+		t.Fatalf("SyncBaseBranch with agent harness dirs: %v", err)
 	}
 	if got, want := revParse(t, local, "main"), revParse(t, local, "origin/main"); got != want {
 		t.Fatalf("local main = %s, want origin/main %s", got, want)
 	}
+	for path, want := range harnessFiles {
+		if got := readTestFile(t, local, path); got != want {
+			t.Fatalf("harness file %s = %q, want preserved %q", path, got, want)
+		}
+	}
 }
 
-func TestSyncBaseBranch_UntrackedNonAgentStillBlocks(t *testing.T) {
+func TestSyncBaseBranch_UnrelatedUntrackedFileStillFails(t *testing.T) {
 	_, local, seed := setupOriginAndClone(t)
 	advanceOrigin(t, seed, "v2\n")
+	writeTestFile(t, local, "scratch.txt", "local scratch\n")
 
-	writeTestFile(t, local, "mystery-untracked.txt", "nope\n")
 	err := SyncBaseBranch(local, "main")
 	if err == nil {
-		t.Fatal("expected error for non-agent untracked dirt")
+		t.Fatal("expected error for unrelated untracked file")
 	}
-	if !strings.Contains(err.Error(), "dirty") {
-		t.Fatalf("expected dirty error, got: %v", err)
+	if !strings.Contains(err.Error(), "dirty") || !strings.Contains(err.Error(), "scratch.txt") {
+		t.Fatalf("expected dirty scratch.txt error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Refs #1100

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR releases fresh-dispatch leases when worker startup fails. The main changes are:

- Marks failed startup claims as superseded with exact lease ownership checks.
- Reuses the reserved slot, branch, and worktree on retry.
- Preserves terminal claim state during concurrent saves.
- Expands tests for retries, stale owners, and untracked harness files.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

Failed starts now release the durable lease without allowing stale owners to supersede newer claims. Retry and concurrent-save behavior are covered by tests.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before the change, the parent revision released the lease but retried as ok-player-2, changed branch/worktree, and advanced next\_slot to 3, and the comparison harness failed as expected.
- After the change, the same harness passed and showed a durable superseded state with zero sessions, followed by reuse of ok-player-1 and the same branch/worktree.
- Additional focused orchestrator and persistence tests completed with exit code 0.

<a href="https://app.greptile.com/trex/runs/15495184/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Persists lease supersession after worker startup failure and updates the in-memory cycle state. |
| internal/state/issue_claim.go | Adds guarded supersession, in-place retry of failed claims, and terminal-status merge ordering. |
| internal/orchestrator/fresh_dispatch_claim_test.go | Covers lease release and reserved worker identity reuse after startup failure. |
| internal/state/issue_claim_test.go | Covers exact lease ownership, stale-owner rejection, retries, and concurrent state merging. |
| internal/worker/syncbase.go | Clarifies the existing handling of untracked agent harness directories. |
| internal/worker/syncbase_test.go | Checks that harness files are preserved while unrelated untracked files still block synchronization. |

<sub>Reviews (2): Last reviewed commit: ["fix: reuse failed fresh dispatch reserva..."](https://github.com/befeast/maestro/commit/bea8118923b8dd8d0d617b36a4cae7cd943b5202) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46445911)</sub>

<!-- /greptile_comment -->