### PR TITLE
fix: stop IssueDone / merged-PR leases starving ready queue

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4674,6 +4674,24 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						if !o.reconcileClosedIssueSession(s, slotName, sess, now) {
 							remoteReconcileFailed = true
 						}
+					} else if !sess.ReleasedForRedispatch {
+						// #1103: PR finished but the GitHub issue is still open.
+						// Holding terminal_reconcile forever makes the issue look
+						// "in progress" with zero live workers and starves the
+						// ready queue. After a short grace for close-issue to land,
+						// release so hands-off fill can redispatch or move on.
+						const terminalReconcileGrace = 15 * time.Minute
+						if now.Sub(sess.FinishedAt.UTC()) >= terminalReconcileGrace {
+							merged, mErr := o.isPRMerged(sess.PRNumber)
+							if mErr != nil {
+								remoteReconcileFailed = true
+								log.Printf("[orch] terminal claim merge check for PR #%d: %v", sess.PRNumber, mErr)
+							} else if merged {
+								o.releaseDoneMergedOpenIssueForRedispatch(s, sess,
+									fmt.Sprintf("issue #%d still open after merged PR #%d past %s grace — released for redispatch",
+										sess.IssueNumber, sess.PRNumber, terminalReconcileGrace))
+							}
+						}
 					}
 				}
 			}
@@ -7267,6 +7285,29 @@ func (o *Orchestrator) releaseCodeLandedForRedispatch(s *state.State, sess *stat
 	if strings.TrimSpace(o.cfg.StateDir) != "" {
 		if err := state.Save(o.cfg.StateDir, s); err != nil {
 			log.Printf("[orch] release for redispatch: state save failed for issue #%d: %v", sess.IssueNumber, err)
+		}
+	}
+}
+
+// releaseDoneMergedOpenIssueForRedispatch drops the terminal_reconcile claim on
+// a StatusDone session whose PR merged but whose GitHub issue stayed open.
+// Keeps history; marks ReleasedForRedispatch so dynamic wave can fill again (#1103).
+func (o *Orchestrator) releaseDoneMergedOpenIssueForRedispatch(s *state.State, sess *state.Session, reason string) {
+	if sess == nil || sess.ReleasedForRedispatch {
+		return
+	}
+	sess.ReleasedForRedispatch = true
+	if strings.TrimSpace(sess.WorkerOutcome) == "" {
+		sess.WorkerOutcome = "merged_pr_issue_still_open"
+	}
+	o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
+	log.Printf("[orch] merged_pr_issue_still_open: %s", reason)
+	if o.notifier != nil {
+		o.notifier.Sendf("♻️ maestro: PR #%d merged but issue #%d is still open — released terminal claim for redispatch", sess.PRNumber, sess.IssueNumber)
+	}
+	if strings.TrimSpace(o.cfg.StateDir) != "" {
+		if err := state.Save(o.cfg.StateDir, s); err != nil {
+			log.Printf("[orch] release done+merged open issue: state save failed for issue #%d: %v", sess.IssueNumber, err)
 		}
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -5023,10 +5023,23 @@ func (s *State) IssueInProgress(issueNum int) bool {
 	return ok
 }
 
-// IssueDone returns true if the given issue already has a completed session.
+// IssueDone returns true only when forge reconciliation has closed the issue
+// on a completed session. Historical StatusDone rows (duplicate_dispatch,
+// abandoned attempts, docs-only merges that left the GitHub issue open) must
+// NOT permanently starve dynamic-wave eligibility — that was the live path to
+// eligible=0 / live=0 while *-ready backlog still existed (#1103).
+//
+// The merge→close race is owned by sessionIssueClaim's terminal_reconcile
+// lease (done+PR, not yet ReleasedForRedispatch), not by this helper.
 func (s *State) IssueDone(issueNum int) bool {
 	for _, sess := range s.Sessions {
-		if sess.IssueNumber == issueNum && sess.Status == StatusDone {
+		if sess == nil || sess.IssueNumber != issueNum || sess.Status != StatusDone {
+			continue
+		}
+		if sess.ReleasedForRedispatch {
+			continue
+		}
+		if sess.IssueClosedAt != nil {
 			return true
 		}
 	}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -117,6 +117,27 @@ func TestDonePRCount(t *testing.T) {
 	}
 }
 
+func TestIssueDone_RequiresForgeClose(t *testing.T) {
+	s := NewState()
+	closedAt := time.Now().UTC()
+	s.Sessions["hist"] = &Session{IssueNumber: 406, Status: StatusDone, WorkerOutcome: "duplicate_dispatch_reconciled"}
+	if s.IssueDone(406) {
+		t.Fatal("historical done without IssueClosedAt must not starve ready redispatch")
+	}
+	s.Sessions["merged-open"] = &Session{IssueNumber: 439, Status: StatusDone, PRNumber: 560, FinishedAt: &closedAt}
+	if s.IssueDone(439) {
+		t.Fatal("done+PR with open forge issue must not report IssueDone (terminal_reconcile owns the lease)")
+	}
+	s.Sessions["closed"] = &Session{IssueNumber: 99, Status: StatusDone, IssueClosedAt: &closedAt}
+	if !s.IssueDone(99) {
+		t.Fatal("forge-closed done session must report IssueDone")
+	}
+	s.Sessions["closed"].ReleasedForRedispatch = true
+	if s.IssueDone(99) {
+		t.Fatal("released session must not report IssueDone")
+	}
+}
+
 func TestProjectStatusSynced(t *testing.T) {
 	s := NewState()
 	if s.ProjectStatusSynced(42, "in_progress") {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1144,6 +1144,11 @@ func tokenBudgetExceededSession(st *state.State) (string, *state.Session, bool) 
 		if sess == nil || sess.WorkerOutcome != worker.TokenBudgetExceededOutcome {
 			continue
 		}
+		// Operator/orchestrator already released this stop for redispatch —
+		// do not keep surfacing ActionNone / freezing fill on a settled budget.
+		if sess.ReleasedForRedispatch {
+			continue
+		}
 		if best == nil || sess.StartedAt.After(best.StartedAt) {
 			bestSlot, best = slot, sess
 		}


### PR DESCRIPTION
## Summary
- `IssueDone` only when forge-closed (`IssueClosedAt`), not every historical `done` row.
- Auto-release `done`+merged-PR terminal claims when the GitHub issue stays open past 15m grace.
- Ignore already-released token-budget sessions in supervisor freeze logic.

Implements #1103

## Test plan
- [x] `go test ./internal/state/ -run IssueDone_RequiresForgeClose`
- [ ] Deploy; confirm open ready issues with old done sessions become eligible
- [ ] Fleet holds `live >= fleet.min_live_workers` without manual state surgery

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how completed and released sessions affect queue eligibility. The main changes are:

- Require forge closure before `IssueDone` reports completion.
- Release merged-PR terminal claims when the issue remains open past a grace period.
- Ignore released token-budget sessions in supervisor freeze decisions.
- Add state tests for forge-closure and redispatch behavior.

<h3>Confidence Score: 4/5</h3>

The terminal reconciliation grace needs to start from the PR merge before this is safe to merge.

- A PR that merges more than 15 minutes after worker completion gets no post-merge close grace.
- The issue can become eligible for duplicate dispatch while its automatic close is still in flight.
- The state and supervisor changes otherwise match the released-session model.

internal/orchestrator/orchestrator.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A focused Go test was run to reproduce the delayed merge skip behavior by exercising the real terminal-reconciliation path with FinishedAt 30 minutes old and an active terminal claim.
- During reconciliation, the forge seam returned an open issue followed by the PR's first observed merged result, and the reconciliation immediately set ReleasedForRedispatch=true and removed the issue claim, showing there is no post-merge close grace.
- The run completed with a runtime result of ok for the internal state package, and the proof log recorded the exact command, working directory, exit code, and captured output.
- Artifacts were created to support inspection: a focused Go test source exercising the delayed first merge observation and the verbose test output showing the forge-call trace and immediate redispatch release.

<a href="https://app.greptile.com/trex/runs/15494477/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Adds release of merged-PR claims for open issues, but measures the close grace from worker completion instead of merge observation. |
| internal/state/state.go | Updates `IssueDone` to require recorded forge closure and to ignore sessions released for redispatch. |
| internal/state/state_test.go | Adds coverage for historical done, merged-open, forge-closed, and released sessions. |
| internal/supervisor/supervisor.go | Excludes released token-budget sessions from supervisor freeze selection. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/orchestrator/orchestrator.go:4684
**Delayed Merge Skips Close Grace**

The deadline starts at `FinishedAt`, although the action being given time to complete is the post-merge issue close. When a worker finishes and its PR merges more than 15 minutes later, the first reconciliation that observes the merge releases the claim immediately, so the issue can be redispatched while merge-triggered closing is still in flight.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: stop IssueDone and merged-PR leases..."](https://github.com/befeast/maestro/commit/161f3034ef7c4851426ff25c9a9bbe49f39e9ceb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46495359)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->