### PR TITLE
IssueDone(any done session) permanently starves open ready issues → live collapses to 0

### DIFF
--- a/internal/orchestrator/issue_done_redispatch_test.go
+++ b/internal/orchestrator/issue_done_redispatch_test.go
@@ -1,0 +1,140 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestCheckSessionsReleasesDoneMergedOpenIssueAfterGrace(t *testing.T) {
+	cfg := &config.Config{StateDir: t.TempDir()}
+	finished := time.Now().UTC().Add(-terminalReconcileGrace - time.Minute)
+	sess := &state.Session{
+		IssueNumber: 1103,
+		Status:      state.StatusDone,
+		PRNumber:    1104,
+		PRMerged:    true,
+		StartedAt:   finished.Add(-time.Hour),
+		FinishedAt:  &finished,
+	}
+	st := state.NewState()
+	st.Sessions["sup-1103"] = sess
+
+	mergeReads := 0
+	o := &Orchestrator{
+		cfg:           cfg,
+		listOpenPRsFn: func() ([]github.PR, error) { return nil, nil },
+		isIssueClosedFn: func(int) (bool, error) {
+			return false, nil
+		},
+		isPRMergedFn: func(pr int) (bool, error) {
+			mergeReads++
+			return pr == 1104, nil
+		},
+	}
+
+	o.checkSessions(st)
+
+	if mergeReads != 1 {
+		t.Fatalf("merged PR reads = %d, want 1", mergeReads)
+	}
+	if !sess.ReleasedForRedispatch {
+		t.Fatal("done+merged session was not released after the open-issue grace")
+	}
+	if sess.WorkerOutcome != state.WorkerOutcomeMergedPRIssueStillOpen {
+		t.Fatalf("WorkerOutcome = %q, want %q", sess.WorkerOutcome, state.WorkerOutcomeMergedPRIssueStillOpen)
+	}
+	if st.IssueInProgress(1103) {
+		t.Fatal("released terminal session still holds the issue claim")
+	}
+	if st.IssueDone(1103) {
+		t.Fatal("released session for an open issue still reports IssueDone")
+	}
+
+	reloaded, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("load eagerly persisted release: %v", err)
+	}
+	if got := reloaded.Sessions["sup-1103"]; got == nil || !got.ReleasedForRedispatch {
+		t.Fatalf("persisted session = %+v, want ReleasedForRedispatch", got)
+	}
+}
+
+func TestCheckSessionsKeepsDoneMergedClaimDuringCloseGrace(t *testing.T) {
+	finished := time.Now().UTC().Add(-terminalReconcileGrace + time.Minute)
+	sess := &state.Session{
+		IssueNumber: 1103,
+		Status:      state.StatusDone,
+		PRNumber:    1104,
+		PRMerged:    true,
+		StartedAt:   finished.Add(-time.Hour),
+		FinishedAt:  &finished,
+	}
+	st := state.NewState()
+	st.Sessions["sup-1103"] = sess
+
+	mergeReads := 0
+	o := &Orchestrator{
+		cfg:           &config.Config{},
+		listOpenPRsFn: func() ([]github.PR, error) { return nil, nil },
+		isIssueClosedFn: func(int) (bool, error) {
+			return false, nil
+		},
+		isPRMergedFn: func(int) (bool, error) {
+			mergeReads++
+			return true, nil
+		},
+	}
+
+	o.checkSessions(st)
+
+	if mergeReads != 0 {
+		t.Fatalf("merged PR reads = %d, want 0 before grace expires", mergeReads)
+	}
+	if sess.ReleasedForRedispatch {
+		t.Fatal("terminal claim released before close grace expired")
+	}
+	if !st.IssueInProgress(1103) {
+		t.Fatal("done+merged session must retain terminal reconciliation claim during grace")
+	}
+}
+
+func TestReconcileSessionsRetriesTodoForReleasedDoneOpenIssue(t *testing.T) {
+	cfg := &config.Config{
+		GitHubProjects: config.GitHubProjectsConfig{Enabled: true, ProjectNumber: 3},
+	}
+	var gotIssue int
+	var gotStatus github.ProjectStatus
+	o := &Orchestrator{
+		cfg: cfg,
+		rateLimitFn: func() (github.RateLimitStatus, error) {
+			return github.RateLimitStatus{GraphQL: github.RateLimitBucket{Limit: 5000, Remaining: 5000}}, nil
+		},
+		syncProjectFn: func(issue int, status github.ProjectStatus) bool {
+			gotIssue, gotStatus = issue, status
+			return true
+		},
+	}
+	st := state.NewState()
+	st.Sessions["sup-1103"] = &state.Session{
+		IssueNumber:           1103,
+		Status:                state.StatusDone,
+		PRNumber:              1104,
+		ReleasedForRedispatch: true,
+		WorkerOutcome:         state.WorkerOutcomeMergedPRIssueStillOpen,
+	}
+	st.MarkProjectStatusSynced(1103, string(github.ProjectStatusAwaitingClose), time.Now().UTC())
+
+	if !o.reconcileSessionsToProjectBoard(st) {
+		t.Fatal("released done session did not repair its runnable project status")
+	}
+	if gotIssue != 1103 || gotStatus != github.ProjectStatusTodo {
+		t.Fatalf("project sync = issue #%d status %q, want issue #1103 status %q", gotIssue, gotStatus, github.ProjectStatusTodo)
+	}
+	if !st.ProjectStatusSynced(1103, string(github.ProjectStatusTodo)) {
+		t.Fatal("Todo repair was not recorded in durable project sync state")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -47,6 +47,9 @@ const (
 	// observes the authoritative terminal state within the 10-minute SLA even
 	// when the prior check landed immediately after a cycle boundary.
 	terminalReconcileInterval = 9 * time.Minute
+	// Give the normal merge-to-close flow a short window to settle before a
+	// merged session whose issue is still open releases its terminal claim.
+	terminalReconcileGrace = 15 * time.Minute
 	// A fresh dispatch lease spans the slow pre-worker setup window. If its
 	// owner dies, the next cycle renews the same exact slot/worktree/branch;
 	// it never allocates a duplicate identity merely to retry startup.
@@ -2082,6 +2085,15 @@ func projectStatusForSession(sess *state.Session, requiresDeploy bool) (github.P
 		}
 		return codeLandedProjectStatusForSession(sess, requiresDeploy), true
 	case state.StatusDone:
+		// #1103: a merged session released because its issue stayed open did
+		// not settle the issue. Keep a standing Todo mapping so a transient
+		// failure in the edge-triggered release sync cannot strand dynamic wave
+		// behind an Awaiting Close / Done board status. Forge-closed sessions
+		// retain Done even though closed-issue reconciliation releases their
+		// state claim for audit/reopen semantics.
+		if sess.ReleasedForRedispatch && sess.IssueClosedAt == nil {
+			return github.ProjectStatusTodo, true
+		}
 		return github.ProjectStatusDone, true
 	case state.StatusRetryExhausted, state.StatusConflictFailed:
 		return github.ProjectStatusBlocked, true
@@ -4680,7 +4692,6 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 						// "in progress" with zero live workers and starves the
 						// ready queue. After a short grace for close-issue to land,
 						// release so hands-off fill can redispatch or move on.
-						const terminalReconcileGrace = 15 * time.Minute
 						if now.Sub(sess.FinishedAt.UTC()) >= terminalReconcileGrace {
 							merged, mErr := o.isPRMerged(sess.PRNumber)
 							if mErr != nil {
@@ -7298,10 +7309,10 @@ func (o *Orchestrator) releaseDoneMergedOpenIssueForRedispatch(s *state.State, s
 	}
 	sess.ReleasedForRedispatch = true
 	if strings.TrimSpace(sess.WorkerOutcome) == "" {
-		sess.WorkerOutcome = "merged_pr_issue_still_open"
+		sess.WorkerOutcome = state.WorkerOutcomeMergedPRIssueStillOpen
 	}
 	o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
-	log.Printf("[orch] merged_pr_issue_still_open: %s", reason)
+	log.Printf("[orch] %s: %s", state.WorkerOutcomeMergedPRIssueStillOpen, reason)
 	if o.notifier != nil {
 		o.notifier.Sendf("♻️ maestro: PR #%d merged but issue #%d is still open — released terminal claim for redispatch", sess.PRNumber, sess.IssueNumber)
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -9080,6 +9080,7 @@ func TestDeferProjectBoardSweepDelaysOnlyBroadSweep(t *testing.T) {
 func TestProjectStatusForSession_MirrorsRuntime(t *testing.T) {
 	soon := time.Now().UTC().Add(30 * time.Second)
 	deployed := time.Now().UTC()
+	closed := time.Now().UTC().Add(-time.Minute)
 
 	tests := []struct {
 		name           string
@@ -9096,6 +9097,8 @@ func TestProjectStatusForSession_MirrorsRuntime(t *testing.T) {
 		{name: "code_landed -> deploying when deploy required", sess: &state.Session{IssueNumber: 4, Status: state.StatusCodeLanded, PRNumber: 10}, requiresDeploy: true, want: github.ProjectStatusDeploying, wantOK: true},
 		{name: "code_landed -> live_verification after deploy succeeds", sess: &state.Session{IssueNumber: 4, Status: state.StatusCodeLanded, PRNumber: 10, DeploymentFinishedAt: &deployed}, requiresDeploy: true, want: github.ProjectStatusLiveVerify, wantOK: true},
 		{name: "done -> done", sess: &state.Session{IssueNumber: 5, Status: state.StatusDone}, want: github.ProjectStatusDone, wantOK: true},
+		{name: "done+released open -> todo", sess: &state.Session{IssueNumber: 5, Status: state.StatusDone, ReleasedForRedispatch: true}, want: github.ProjectStatusTodo, wantOK: true},
+		{name: "done+released closed -> done", sess: &state.Session{IssueNumber: 5, Status: state.StatusDone, ReleasedForRedispatch: true, IssueClosedAt: &closed}, want: github.ProjectStatusDone, wantOK: true},
 		{name: "retry_exhausted -> blocked", sess: &state.Session{IssueNumber: 6, Status: state.StatusRetryExhausted}, want: github.ProjectStatusBlocked, wantOK: true},
 		{name: "conflict_failed -> blocked", sess: &state.Session{IssueNumber: 7, Status: state.StatusConflictFailed}, want: github.ProjectStatusBlocked, wantOK: true},
 		{name: "failed -> blocked", sess: &state.Session{IssueNumber: 8, Status: state.StatusFailed}, want: github.ProjectStatusBlocked, wantOK: true},

--- a/internal/state/code_landed.go
+++ b/internal/state/code_landed.go
@@ -20,6 +20,9 @@ const (
 	// but the blocking outcome check the issue targeted stayed failing with the
 	// same fingerprint past the post-merge verification deadline.
 	WorkerOutcomeCodeLandedIneffective = "code_landed_ineffective"
+	// WorkerOutcomeMergedPRIssueStillOpen: the PR merged successfully, but the
+	// linked issue remained open past terminal reconciliation's close grace.
+	WorkerOutcomeMergedPRIssueStillOpen = "merged_pr_issue_still_open"
 )
 
 // OutcomeFailureFingerprint returns a stable identity for a FAILING outcome

--- a/internal/supervisor/issue_done_redispatch_test.go
+++ b/internal/supervisor/issue_done_redispatch_test.go
@@ -1,0 +1,59 @@
+package supervisor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/worker"
+)
+
+func TestDynamicWaveHistoricalDoneSessionRemainsEligible(t *testing.T) {
+	cfg := testConfig(t)
+	enableDynamicWave(cfg)
+	issue := testIssue(1103, "open ready issue", "maestro-ready")
+	st := state.NewState()
+	st.Sessions["historical"] = &state.Session{
+		IssueNumber:   1103,
+		Status:        state.StatusDone,
+		WorkerOutcome: "duplicate_dispatch_reconciled",
+	}
+
+	result, err := testEngine(cfg, &fakeReader{}).dynamicWaveCandidateIssues(st, []github.Issue{issue}, nil)
+	if err != nil {
+		t.Fatalf("dynamicWaveCandidateIssues: %v", err)
+	}
+	if len(result.candidates) != 1 || result.candidates[0].Number != 1103 {
+		t.Fatalf("candidates = %+v, want open issue #1103 eligible", result.candidates)
+	}
+	if result.analysis == nil || result.analysis.EligibleCandidates != 1 {
+		t.Fatalf("queue analysis = %+v, want eligible=1", result.analysis)
+	}
+}
+
+func TestTokenBudgetExceededSessionIgnoresReleasedSessions(t *testing.T) {
+	now := time.Now().UTC()
+	st := state.NewState()
+	st.Sessions["older-active"] = &state.Session{
+		IssueNumber:   1,
+		StartedAt:     now.Add(-time.Hour),
+		WorkerOutcome: worker.TokenBudgetExceededOutcome,
+	}
+	st.Sessions["newer-released"] = &state.Session{
+		IssueNumber:           2,
+		StartedAt:             now,
+		WorkerOutcome:         worker.TokenBudgetExceededOutcome,
+		ReleasedForRedispatch: true,
+	}
+
+	slot, sess, ok := tokenBudgetExceededSession(st)
+	if !ok || slot != "older-active" || sess != st.Sessions["older-active"] {
+		t.Fatalf("selection = (%q, %+v, %v), want only unreleased older-active", slot, sess, ok)
+	}
+
+	st.Sessions["older-active"].ReleasedForRedispatch = true
+	if slot, sess, ok := tokenBudgetExceededSession(st); ok || slot != "" || sess != nil {
+		t.Fatalf("all-released selection = (%q, %+v, %v), want none", slot, sess, ok)
+	}
+}


### PR DESCRIPTION
Refs #1103

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores redispatch for completed sessions whose merged pull requests leave their issues open. The main changes are:

- Adds a grace period before releasing the terminal issue claim.
- Maps released open issues back to Todo during project reconciliation.
- Adds a shared outcome for merged pull requests with open issues.
- Covers durable release, board repair, dynamic-wave eligibility, and token-budget filtering.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code. The updated state, project-status, and supervisor paths consistently treat released open issues as runnable.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the orchestrator command and confirmed it exited with code 0, with all three requested tests passing.
- Ran the supervisor command and confirmed it exited with code 0, with both requested tests passing.
- Compared pre-change orchestrator capture to the current run, noting that the pre-change capture failed due to a released done session repair issue while the current capture passes.
- Confirmed tests ran using in-process hooks and temporary state only, with no external services started.
- Reviewed the validation artifacts to support the observed results, including logs and the shellscript.

<a href="https://app.greptile.com/trex/runs/15514530/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/orchestrator/orchestrator.go | Releases stale terminal claims after a grace period and restores released open issues to Todo. |
| internal/state/code_landed.go | Adds the shared merged-pull-request/open-issue worker outcome. |
| internal/orchestrator/issue_done_redispatch_test.go | Tests grace handling, durable claim release, and project-board repair. |
| internal/orchestrator/orchestrator_test.go | Tests project-status mapping for released open and closed issues. |
| internal/supervisor/issue_done_redispatch_test.go | Tests dynamic-wave eligibility and token-budget filtering for released sessions. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-1116-1..."](https://github.com/befeast/maestro/commit/2a9b91abe5dc74ef064faf2267d61ed9a602912f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46499865)</sub>

<!-- /greptile_comment -->