### PR TITLE
fix: CRITICAL floor alert + stop token_budget project freezes

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -685,6 +685,22 @@ func (d *Daemon) Run(ctx context.Context) error {
 			<-emergencyDone
 		}
 	}
+	// #1106: CRITICAL floor breach watch — live < fleet.min_live_workers must
+	// ntfy the operator without waiting for a status poll.
+	var stopFloorWatch func()
+	if d.spawnLimiter != nil {
+		fctx, floorCancel := context.WithCancel(ctx)
+		floorDone := make(chan struct{})
+		go func() {
+			defer close(floorDone)
+			d.watchFloorBreachLoop(fctx, DefaultFloorWatchInterval)
+		}()
+		log.Printf("[daemon] floor breach watch enabled — poll every %s (CRITICAL when live < min)", DefaultFloorWatchInterval)
+		stopFloorWatch = func() {
+			floorCancel()
+			<-floorDone
+		}
+	}
 	// Protect-aware /tmp sweep: one host-level apply loop for the single daemon,
 	// not one per project. The first run occurs after one interval, avoiding a
 	// surprise startup prune while still bounding abandoned residue to 10m past
@@ -709,6 +725,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 		if stopEmergencyWatch != nil {
 			stopEmergencyWatch()
+		}
+		if stopFloorWatch != nil {
+			stopFloorWatch()
 		}
 		if stopTmpfsHygiene != nil {
 			stopTmpfsHygiene()

--- a/internal/daemon/fleet_concurrency.go
+++ b/internal/daemon/fleet_concurrency.go
@@ -138,6 +138,28 @@ func (l *fleetSpawnLimiter) CeilingReached() bool {
 	return false
 }
 
+// FloorStatus reports current live worker count against fleet.min_live_workers.
+// below=true means live < min (CRITICAL floor breach, #1106).
+func (l *fleetSpawnLimiter) FloorStatus() (live, min, max int, below bool, err error) {
+	if l == nil {
+		return 0, 0, 0, false, nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	settings, err := l.settingsLocked()
+	if err != nil {
+		return 0, 0, 0, false, err
+	}
+	live, err = l.liveLocked()
+	if err != nil {
+		return 0, settings.MinLiveWorkers, settings.MaxLiveWorkers, false, err
+	}
+	min = settings.MinLiveWorkers
+	max = settings.MaxLiveWorkers
+	below = min > 0 && live < min
+	return live, min, max, below, nil
+}
+
 func (l *fleetSpawnLimiter) Reserve(stateDir string) (commit func(string), release func(), ok bool) {
 	if l == nil {
 		return func(string) {}, func() {}, true

--- a/internal/daemon/floor_watch.go
+++ b/internal/daemon/floor_watch.go
@@ -1,0 +1,76 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/befeast/maestro/internal/notify"
+)
+
+// DefaultFloorWatchInterval is how often the daemon re-checks live workers
+// against fleet.min_live_workers (#1106).
+const DefaultFloorWatchInterval = 30 * time.Second
+
+// floorBreachConfirmSamples is how many consecutive below-floor samples must
+// fire before CRITICAL alert. At 30s interval this is ~1 minute — long enough
+// to ignore a brief drain/restart, short enough that operators are not waiting
+// on a status poll.
+const floorBreachConfirmSamples = 2
+
+// watchFloorBreachLoop emits CRITICAL ntfy when fleet live workers stay below
+// fleet.min_live_workers. Dedup is owned by notify.Alert (body-stable).
+func (d *Daemon) watchFloorBreachLoop(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = DefaultFloorWatchInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	belowStreak := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.evaluateFloorBreach(&belowStreak)
+		}
+	}
+}
+
+func (d *Daemon) evaluateFloorBreach(belowStreak *int) {
+	if d == nil || d.spawnLimiter == nil || belowStreak == nil {
+		return
+	}
+	live, min, max, below, err := d.spawnLimiter.FloorStatus()
+	if err != nil {
+		log.Printf("[daemon] floor watch: %v", err)
+		return
+	}
+	if !below {
+		if *belowStreak > 0 {
+			log.Printf("[daemon] floor recovered: live=%d min=%d max=%d", live, min, max)
+		}
+		*belowStreak = 0
+		return
+	}
+	*belowStreak++
+	if *belowStreak < floorBreachConfirmSamples {
+		log.Printf("[daemon] floor breach pending confirm: live=%d min=%d sample=%d/%d",
+			live, min, *belowStreak, floorBreachConfirmSamples)
+		return
+	}
+	body := fmt.Sprintf(
+		"CRITICAL: fleet live workers below floor — live=%d min=%d max=%d. Hands-off fill is failing; investigate spawn/supervisor freezes immediately.",
+		live, min, max,
+	)
+	log.Printf("[daemon] %s", body)
+	n := d.emergencyNotifier
+	if n == nil {
+		return
+	}
+	if err := n.Alert(notify.AlertFloorBreach, "fleet:floor_breach", "maestro CRITICAL: live below min", body); err != nil {
+		log.Printf("[daemon] floor breach ntfy failed: %v", err)
+	}
+}

--- a/internal/daemon/floor_watch_test.go
+++ b/internal/daemon/floor_watch_test.go
@@ -1,0 +1,60 @@
+package daemon
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func TestEvaluateFloorBreach_ConfirmsThenRecovers(t *testing.T) {
+	dir := t.TempDir()
+	if err := state.Save(dir, state.NewState()); err != nil {
+		t.Fatal(err)
+	}
+	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 5, MaxLiveWorkers: 10}}
+	limiter := newFleetSpawnLimiter(store)
+	limiter.RegisterStateDir(dir)
+
+	d := &Daemon{spawnLimiter: limiter}
+	streak := 0
+	d.evaluateFloorBreach(&streak)
+	if streak != 1 {
+		t.Fatalf("streak after first sample = %d, want 1", streak)
+	}
+	d.evaluateFloorBreach(&streak)
+	if streak != 2 {
+		t.Fatalf("streak after confirm = %d, want 2", streak)
+	}
+
+	running := state.NewState()
+	for i := 1; i <= 5; i++ {
+		running.Sessions[fmt.Sprintf("sup-%d", i)] = &state.Session{IssueNumber: i, Status: state.StatusRunning, StartedAt: time.Now().UTC()}
+	}
+	if err := state.Save(dir, running); err != nil {
+		t.Fatal(err)
+	}
+	d.evaluateFloorBreach(&streak)
+	if streak != 0 {
+		t.Fatalf("streak after recover = %d, want 0", streak)
+	}
+}
+
+func TestFloorStatus_BelowMin(t *testing.T) {
+	dir := t.TempDir()
+	if err := state.Save(dir, state.NewState()); err != nil {
+		t.Fatal(err)
+	}
+	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 5, MaxLiveWorkers: 10}}
+	limiter := newFleetSpawnLimiter(store)
+	limiter.RegisterStateDir(dir)
+	live, min, max, below, err := limiter.FloorStatus()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live != 0 || min != 5 || max != 10 || !below {
+		t.Fatalf("FloorStatus = live=%d min=%d max=%d below=%v", live, min, max, below)
+	}
+}

--- a/internal/notify/alert.go
+++ b/internal/notify/alert.go
@@ -17,6 +17,9 @@ const (
 	// AlertBackendCooldownExhausted: every backend is cooling down / quota-gated
 	// and dispatch has nothing to run.
 	AlertBackendCooldownExhausted AlertClass = "backend_cooldown_exhausted"
+	// AlertFloorBreach: fleet live workers dropped below fleet.min_live_workers.
+	// Priority 5 / CRITICAL — operator must hear this without polling (#1106).
+	AlertFloorBreach AlertClass = "floor_breach"
 	// AlertDeliveryAdvance: a positive event — the delivery/feed advanced.
 	AlertDeliveryAdvance AlertClass = "delivery_advance"
 	// AlertEmergency: notify_red-grade — emergency stop / supervisor degraded.
@@ -38,6 +41,7 @@ var alertRoutes = map[AlertClass]AlertRoute{
 	AlertIdleStall:                {Priority: 4, Tags: []string{"hourglass", "warning"}},
 	AlertFutileRecovery:           {Priority: 4, Tags: []string{"recycle", "warning"}},
 	AlertBackendCooldownExhausted: {Priority: 4, Tags: []string{"battery", "warning"}},
+	AlertFloorBreach:              {Priority: 5, Tags: []string{"rotating_light", "sos", "warning"}},
 	AlertDeliveryAdvance:          {Priority: 3, Tags: []string{"white_check_mark", "rocket"}},
 	AlertEmergency:                {Priority: 5, Tags: []string{"rotating_light", "sos"}},
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4624,6 +4624,10 @@ func (o *Orchestrator) checkSessions(s *state.State) {
 		switch sess.Status {
 		case state.StatusDone, state.StatusCodeLanded, state.StatusDead, state.StatusConflictFailed, state.StatusFailed, state.StatusRetryExhausted:
 			now := time.Now().UTC()
+			// #1106: aged token_budget_exceeded must not hold a permanent issue
+			// claim that freezes redispatch / supervisor attention forever.
+			// After grace, release for redispatch while keeping history.
+			o.releaseAgedTokenBudgetClaim(s, sess, now)
 			remoteReconcileDue := terminalReconcileDue(sess, now)
 			remoteReconcileSucceeded := false
 			remoteReconcileFailed := false
@@ -7319,6 +7323,39 @@ func (o *Orchestrator) releaseDoneMergedOpenIssueForRedispatch(s *state.State, s
 	if strings.TrimSpace(o.cfg.StateDir) != "" {
 		if err := state.Save(o.cfg.StateDir, s); err != nil {
 			log.Printf("[orch] release done+merged open issue: state save failed for issue #%d: %v", sess.IssueNumber, err)
+		}
+	}
+}
+
+// tokenBudgetClaimGrace is how long a deterministic token_budget_exceeded stop
+// may keep an exclusive issue claim before hands-off fill releases it (#1106).
+const tokenBudgetClaimGrace = 30 * time.Minute
+
+func (o *Orchestrator) releaseAgedTokenBudgetClaim(s *state.State, sess *state.Session, now time.Time) {
+	if sess == nil || sess.ReleasedForRedispatch {
+		return
+	}
+	if sess.WorkerOutcome != worker.TokenBudgetExceededOutcome {
+		return
+	}
+	finished := sess.FinishedAt
+	if finished == nil || finished.IsZero() {
+		if sess.StartedAt.IsZero() {
+			return
+		}
+		t := sess.StartedAt.UTC()
+		finished = &t
+	}
+	if now.Sub(finished.UTC()) < tokenBudgetClaimGrace {
+		return
+	}
+	sess.ReleasedForRedispatch = true
+	o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
+	log.Printf("[orch] token_budget_exceeded: issue #%d session aged past %s — released for redispatch",
+		sess.IssueNumber, tokenBudgetClaimGrace)
+	if strings.TrimSpace(o.cfg.StateDir) != "" {
+		if err := state.Save(o.cfg.StateDir, s); err != nil {
+			log.Printf("[orch] release aged token budget: state save failed for issue #%d: %v", sess.IssueNumber, err)
 		}
 	}
 }

--- a/internal/supervisor/hands_off_fill_test.go
+++ b/internal/supervisor/hands_off_fill_test.go
@@ -71,6 +71,40 @@ func TestDecide_TokenBudgetDoesNotStarveSpareSlotBacklog(t *testing.T) {
 	}
 }
 
+func TestDecide_TokenBudgetEmptyQueueIsNotExclusiveFreeze(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.MaxParallel = 4
+	enableDynamicWave(cfg)
+	reader := &fakeReader{issues: nil}
+	st := state.NewState()
+	st.Sessions["sup-old"] = &state.Session{
+		IssueNumber: 1010, IssueTitle: "budgeted out", Status: state.StatusDone,
+		WorkerOutcome: worker.TokenBudgetExceededOutcome,
+		StartedAt:     time.Date(2026, 7, 18, 11, 0, 0, 0, time.UTC),
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionNone {
+		t.Fatalf("action = %q, want none (empty queue)", decision.RecommendedAction)
+	}
+	if decision.Target != nil && decision.Target.Issue == 1010 {
+		t.Fatalf("exclusive budget freeze target leaked: %#v", decision.Target)
+	}
+	found := false
+	for _, stuck := range decision.StuckStates {
+		if stuck.Code == "token_budget_exceeded" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("stuck states = %#v, want token_budget_exceeded note", decision.StuckStates)
+	}
+}
+
 func TestDecide_BlockedOpenPRDoesNotStarveSpareSlotBacklog(t *testing.T) {
 	cfg := testConfig(t)
 	cfg.MaxParallel = 6

--- a/internal/supervisor/llm_short_circuit_test.go
+++ b/internal/supervisor/llm_short_circuit_test.go
@@ -131,9 +131,10 @@ func TestDecideWithLLM_TokenBudgetExceeded_SkipsLLM(t *testing.T) {
 	if llm.calls != 0 {
 		t.Fatalf("LLM calls = %d, want 0 for deterministic token budget state", llm.calls)
 	}
-	if decision.RecommendedAction != ActionNone || decision.Target == nil || decision.Target.Session != "slot-budget" {
-		t.Fatalf("decision = %+v, want action=none targeting slot-budget", decision)
+	if decision.RecommendedAction != ActionNone {
+		t.Fatalf("decision = %+v, want action=none when only a historical budget stop remains", decision)
 	}
+	// #1106: exclusive budget freeze targeting is gone; queue-empty/none is fine.
 }
 
 // TestDecideWithLLM_SpawnCandidate_CallsLLM pins the counterpart AC: a mutating

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -790,25 +790,15 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	}
 
 	if slot, sess, ok := tokenBudgetExceededSession(st); ok {
-		// Hands-off fill (2026-07-22): a historical token-budget stop on one
-		// issue must not freeze the whole project. Only halt immediately when
-		// there is no spare capacity; otherwise continue and only surface the
-		// budget stop if no other backlog remains.
-		if projectState.AvailableSlots <= 0 {
-			reasons := appendReasons(baseReasons,
-				fmt.Sprintf("Session %s for issue #%d stopped deterministically at worker_max_tokens", slot, sess.IssueNumber),
-				"Restarting or re-planning automatically would spend more tokens without an operator budget decision",
-			)
-			decision := e.decision(st, now, projectState, ActionNone,
-				fmt.Sprintf("Issue #%d is stopped at its worker token budget and needs an operator budget decision.", sess.IssueNumber),
-				RiskSafe, 0.99, &state.SupervisorTarget{Issue: sess.IssueNumber, Session: slot}, PolicyRuleRuntimeState, reasons)
-			decision.StuckStates = stuckStates
-			return decision, nil
-		}
+		// Hands-off fill (#1106): a historical token-budget stop on one issue
+		// must never freeze the whole project with exclusive ActionNone. Always
+		// continue; surface the budget stop as a stuck-state note if no other
+		// backlog remains. Capacity-full cases fall through to wait_for_capacity
+		// / monitor_open_pr like any other fill path.
 		deferredBudgetSlot, deferredBudgetSess = slot, sess
 		baseReasons = appendReasons(baseReasons,
 			fmt.Sprintf("Session %s for issue #%d previously hit worker_max_tokens", slot, sess.IssueNumber),
-			"Spare capacity remains — continue backlog fill instead of freezing the project on a budget stop",
+			"Continue backlog fill instead of freezing the project on a budget stop",
 		)
 	}
 
@@ -1098,13 +1088,9 @@ func (e *Engine) decideDeterministic(st *state.State) (state.SupervisorDecision,
 	if deferredOpenPR != nil {
 		return withAnalysis(e.decisionMonitorOpenPR(st, now, projectState, reasons, stuckStates, *deferredOpenPR)), nil
 	}
-	if deferredBudgetSess != nil {
-		decision := e.decision(st, now, projectState, ActionNone,
-			fmt.Sprintf("Issue #%d is stopped at its worker token budget and needs an operator budget decision.", deferredBudgetSess.IssueNumber),
-			RiskSafe, 0.99, &state.SupervisorTarget{Issue: deferredBudgetSess.IssueNumber, Session: deferredBudgetSlot}, PolicyRuleRuntimeState, reasons)
-		decision.StuckStates = stuckStates
-		return withAnalysis(decision), nil
-	}
+	// #1106: historical token_budget with spare slots must stay a stuck-state
+	// note, never an exclusive ActionNone that looks like a project freeze.
+	stuckStates = appendTokenBudgetStuck(stuckStates, deferredBudgetSlot, deferredBudgetSess)
 	decision := e.decision(st, now, projectState, ActionNone,
 		"No action is currently recommended.", RiskSafe, 0.8, nil, policyRule, reasons)
 	decision.StuckStates = stuckStates
@@ -1154,6 +1140,21 @@ func tokenBudgetExceededSession(st *state.State) (string, *state.Session, bool) 
 		}
 	}
 	return bestSlot, best, best != nil
+}
+
+// appendTokenBudgetStuck records a historical token-budget stop as a stuck
+// state without turning it into the exclusive recommended action (#1106).
+func appendTokenBudgetStuck(base []state.SupervisorStuckState, slot string, sess *state.Session) []state.SupervisorStuckState {
+	if sess == nil || sess.IssueNumber <= 0 {
+		return base
+	}
+	return appendStuck(base, stuckState("token_budget_exceeded", SeverityWarning,
+		fmt.Sprintf("Issue #%d previously stopped at worker_max_tokens on session %s; spare capacity must still fill other backlog", sess.IssueNumber, slot),
+		"Continue label/spawn for other eligible issues; raise worker_max_tokens only for intentional redispatch of this issue",
+		false,
+		&state.SupervisorTarget{Issue: sess.IssueNumber, Session: slot},
+		fmt.Sprintf("worker_outcome=%s", sess.WorkerOutcome),
+	))
 }
 
 // deferredOpenPRMonitor holds a non-urgent open-PR monitor decision that is
@@ -1307,16 +1308,13 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 			return withAnalysis(decision), nil
 		}
 
+		stuckStates = appendTokenBudgetStuck(stuckStates, deferredBudgetSlot, deferredBudgetSess)
 		decision := e.decision(st, now, projectState, ActionNone,
 			"No issue is currently eligible under the dynamic wave policy.", RiskSafe, 0.8, nil, PolicyRuleDynamicWave, reasons)
 		if deferredOpenPR != nil {
 			decision = e.decisionMonitorOpenPR(st, now, projectState, reasons, stuckStates, *deferredOpenPR)
-		} else if deferredBudgetSess != nil {
-			decision = e.decision(st, now, projectState, ActionNone,
-				fmt.Sprintf("Issue #%d is stopped at its worker token budget and needs an operator budget decision.", deferredBudgetSess.IssueNumber),
-				RiskSafe, 0.99, &state.SupervisorTarget{Issue: deferredBudgetSess.IssueNumber, Session: deferredBudgetSlot}, PolicyRuleRuntimeState, reasons)
-			decision.StuckStates = stuckStates
 		}
+		decision.StuckStates = stuckStates
 		return withAnalysis(decision), nil
 	}
 
@@ -1440,15 +1438,10 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 	if deferredOpenPR != nil {
 		return withAnalysis(e.decisionMonitorOpenPR(st, now, projectState, baseReasons, stuckStates, *deferredOpenPR)), nil
 	}
-	if deferredBudgetSess != nil {
-		decision := e.decision(st, now, projectState, ActionNone,
-			fmt.Sprintf("Issue #%d is stopped at its worker token budget and needs an operator budget decision.", deferredBudgetSess.IssueNumber),
-			RiskSafe, 0.99, &state.SupervisorTarget{Issue: deferredBudgetSess.IssueNumber, Session: deferredBudgetSlot}, PolicyRuleRuntimeState, baseReasons)
-		decision.StuckStates = stuckStates
-		return withAnalysis(decision), nil
-	}
+	stuckStates = appendTokenBudgetStuck(stuckStates, deferredBudgetSlot, deferredBudgetSess)
 	decision := e.decision(st, now, projectState, ActionNone,
 		"No issue is currently eligible under the dynamic wave policy.", RiskSafe, 0.8, nil, PolicyRuleDynamicWave, baseReasons)
+	decision.StuckStates = stuckStates
 	return withAnalysis(decision), nil
 }
 


### PR DESCRIPTION
## Summary
- Historical `token_budget_exceeded` never becomes exclusive project `ActionNone` when spare slots exist; recorded as stuck state only.
- Aged token-budget terminal claims auto-release after 30m for redispatch.
- Daemon CRITICAL ntfy (`AlertFloorBreach`, priority 5) when `live < fleet.min_live_workers` for 2 samples (~60s).

Implements #1106

## Test plan
- [x] `go test ./internal/supervisor/ -run TokenBudget`
- [x] `go test ./internal/daemon/ -run Floor`
- [ ] Deploy; confirm floor watch log line and ntfy on below-min
- [ ] Confirm maestro/folio no longer exclusive-freeze on old budget sessions

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes how token-budget stops and fleet floor breaches are handled. The main changes are:

- Treat historical token-budget stops as stuck-state notes instead of exclusive project freezes.
- Release token-budget issue claims after a 30-minute grace period.
- Add a periodic fleet floor watcher and a priority-5 notification route.

<h3>Confidence Score: 4/5</h3>

Alert episode tracking and aged claim ownership need fixes before merging.

State-read errors can satisfy a consecutive-sample alert gate. Body-based dedup can hide a later floor-breach incident. An aged historical session can move an actively owned issue back to Todo.

internal/daemon/floor_watch.go; internal/orchestrator/orchestrator.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I reproduced the breach-streak behavior by running a focused Go test on Daemon.evaluateFloorBreach against a real HTTP notifier, observing the first sample set the streak to 1, a FloorStatus read error keeping it at 1, and a subsequent below-floor success raising the streak to 2 with an AlertFloorBreach POST.
- I attempted a second reproduction fixture to exercise the second-incident scenario, but the run could not proceed to the second 4/5/10 setup because the state persistence merged the recovered worker; the initial 4/5/10 delivery and recovery were observed.
- I verified that historical state can overwrite the current state by running a focused test with a 31-minute-old token\_budget\_exceeded session and a replacement for issue 1106; the sync hook updated Todo while the replacement session remained active, and reloading showed the historical session released for redispatch.
- I executed the Floor tests with go test ./internal/daemon/ -run Floor -count=1 -v; the tests passed with exit code 0 and no source changes.

<a href="https://app.greptile.com/trex/runs/15548139/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/daemon/floor_watch.go | Adds floor-breach sampling and alerts, but error handling and body-based dedup can report the wrong incident state. |
| internal/daemon/fleet_concurrency.go | Adds a locked snapshot of live workers and configured fleet limits. |
| internal/daemon/daemon.go | Starts and synchronously stops the floor watcher with the daemon lifecycle. |
| internal/notify/alert.go | Registers the floor-breach alert with critical notification priority. |
| internal/orchestrator/orchestrator.go | Releases aged token-budget claims, but does not verify current issue ownership before updating shared project state. |
| internal/supervisor/supervisor.go | Makes token-budget history non-exclusive while retaining it in supervisor stuck-state output. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
internal/daemon/floor_watch.go:46-50
**Errors Preserve The Breach Streak**

When `FloorStatus` succeeds below the floor, then fails, then succeeds below the floor again, the error path preserves the first sample and the next success triggers the alert. The two samples are not consecutive, so a transient state-read failure can violate the documented confirmation window.

```suggestion
	live, min, max, below, err := d.spawnLimiter.FloorStatus()
	if err != nil {
		*belowStreak = 0
		log.Printf("[daemon] floor watch: %v", err)
		return
	}
```

### Issue 2 of 3
internal/daemon/floor_watch.go:64-73
**Body Dedup Hides New Incidents**

`Notifier.Alert` deduplicates this fixed class and key by exact body, but recovery does not clear that state. If the fleet breaches at `live=4,min=5,max=10`, recovers, and later reaches the same counts, the second incident has the same body and no notification is sent; changing the live count during one incident can instead send another notification.

### Issue 3 of 3
internal/orchestrator/orchestrator.go:7352-7353
**Historical Claim Overwrites Current State**

An old token-budget session remains in history after a replacement session starts. When the old session reaches 30 minutes, this helper releases it and unconditionally moves the shared issue to `Todo`, even if the replacement currently owns the issue, so the project board can advertise active work as dispatchable and allow duplicate dispatch.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: CRITICAL floor-breach alert; stop t..."](https://github.com/befeast/maestro/commit/5f6a703c9ccd505de1e0a706d618ed2787a460bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46604090)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->