### PR TITLE
P0: live < min_live_workers must CRITICAL-alert; historical token_budget must not freeze projects

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -320,6 +320,9 @@ type Daemon struct {
 	emergencyMu       sync.RWMutex
 	emergencyState    emergencystore.State
 	emergencyNotifier *notify.Notifier
+	// floorNotifier is selected independently of the emergency switch store so
+	// an unavailable safety DB cannot silence the fleet-capacity CRITICAL alert.
+	floorNotifier *notify.Notifier
 
 	// spawnLimiter owns the daemon-wide live-worker budget. It is shared by all
 	// project orchestrators so concurrent flows reserve against one atomic max.
@@ -582,6 +585,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// the daemon logs it loudly and comes up without ingestion (the fleet keeps
 	// polling), rather than aborting startup over an unreadable secret.
 	d.configureWebhookIngestion(fleet)
+	// The fleet floor is daemon-wide and must retain an ntfy route even if the
+	// independent emergency-switch store cannot be opened.
+	d.floorNotifier = fleetFloorNotifierFor(importCfgs)
 
 	// #840: open the fleet-wide EMERGENCY STOP switch, seed the gate cache from
 	// the current value (so a switch set while the daemon was down is honored on

--- a/internal/daemon/fleet_concurrency.go
+++ b/internal/daemon/fleet_concurrency.go
@@ -78,7 +78,7 @@ func fleetWorkerKey(stateDir, slot string) string {
 	return stateDir + "\x00" + slot
 }
 
-func (l *fleetSpawnLimiter) liveLocked() (int, error) {
+func (l *fleetSpawnLimiter) runningLocked() (map[string]struct{}, error) {
 	dirs := make([]string, 0, len(l.stateDirs))
 	for dir := range l.stateDirs {
 		dirs = append(dirs, dir)
@@ -89,7 +89,7 @@ func (l *fleetSpawnLimiter) liveLocked() (int, error) {
 	for _, dir := range dirs {
 		st, err := l.loadState(dir)
 		if err != nil {
-			return 0, fmt.Errorf("load fleet state %s: %w", dir, err)
+			return nil, fmt.Errorf("load fleet state %s: %w", dir, err)
 		}
 		for slot, sess := range st.Sessions {
 			if sess != nil && sess.Status == state.StatusRunning {
@@ -97,7 +97,10 @@ func (l *fleetSpawnLimiter) liveLocked() (int, error) {
 			}
 		}
 	}
+	return running, nil
+}
 
+func (l *fleetSpawnLimiter) reconcileReservationsLocked(running map[string]struct{}) {
 	// Once a committed reservation appears as a running state session, the
 	// durable state count replaces it. Pending or not-yet-persisted commits stay
 	// reserved, so no other flow can consume the same global slot.
@@ -109,6 +112,14 @@ func (l *fleetSpawnLimiter) liveLocked() (int, error) {
 			delete(l.reservations, id)
 		}
 	}
+}
+
+func (l *fleetSpawnLimiter) liveLocked() (int, error) {
+	running, err := l.runningLocked()
+	if err != nil {
+		return 0, err
+	}
+	l.reconcileReservationsLocked(running)
 	return len(running) + len(l.reservations), nil
 }
 
@@ -138,8 +149,9 @@ func (l *fleetSpawnLimiter) CeilingReached() bool {
 	return false
 }
 
-// FloorStatus reports current live worker count against fleet.min_live_workers.
-// below=true means live < min (CRITICAL floor breach, #1106).
+// FloorStatus reports the durable StatusRunning count against
+// fleet.min_live_workers. Pending spawn reservations still protect the hard
+// ceiling but are not live workers and cannot mask a CRITICAL floor breach.
 func (l *fleetSpawnLimiter) FloorStatus() (live, min, max int, below bool, err error) {
 	if l == nil {
 		return 0, 0, 0, false, nil
@@ -150,10 +162,12 @@ func (l *fleetSpawnLimiter) FloorStatus() (live, min, max int, below bool, err e
 	if err != nil {
 		return 0, 0, 0, false, err
 	}
-	live, err = l.liveLocked()
+	running, err := l.runningLocked()
 	if err != nil {
 		return 0, settings.MinLiveWorkers, settings.MaxLiveWorkers, false, err
 	}
+	l.reconcileReservationsLocked(running)
+	live = len(running)
 	min = settings.MinLiveWorkers
 	max = settings.MaxLiveWorkers
 	below = min > 0 && live < min

--- a/internal/daemon/floor_watch.go
+++ b/internal/daemon/floor_watch.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/notify"
 )
 
@@ -19,8 +20,16 @@ const DefaultFloorWatchInterval = 30 * time.Second
 // on a status poll.
 const floorBreachConfirmSamples = 2
 
-// watchFloorBreachLoop emits CRITICAL ntfy when fleet live workers stay below
-// fleet.min_live_workers. Dedup is owned by notify.Alert (body-stable).
+type floorBreachState struct {
+	streak   int
+	notified bool
+	episode  uint64
+}
+
+// watchFloorBreachLoop emits one CRITICAL ntfy per sustained below-floor
+// episode. Recovery resets the debounce and increments the next episode's
+// identity so notify.Alert can deliver a later recurrence even at the same
+// live/min/max values.
 func (d *Daemon) watchFloorBreachLoop(ctx context.Context, interval time.Duration) {
 	if interval <= 0 {
 		interval = DefaultFloorWatchInterval
@@ -28,19 +37,19 @@ func (d *Daemon) watchFloorBreachLoop(ctx context.Context, interval time.Duratio
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
-	belowStreak := 0
+	var breach floorBreachState
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			d.evaluateFloorBreach(&belowStreak)
+			d.evaluateFloorBreach(&breach)
 		}
 	}
 }
 
-func (d *Daemon) evaluateFloorBreach(belowStreak *int) {
-	if d == nil || d.spawnLimiter == nil || belowStreak == nil {
+func (d *Daemon) evaluateFloorBreach(breach *floorBreachState) {
+	if d == nil || d.spawnLimiter == nil || breach == nil {
 		return
 	}
 	live, min, max, below, err := d.spawnLimiter.FloorStatus()
@@ -49,28 +58,56 @@ func (d *Daemon) evaluateFloorBreach(belowStreak *int) {
 		return
 	}
 	if !below {
-		if *belowStreak > 0 {
+		if breach.streak > 0 {
 			log.Printf("[daemon] floor recovered: live=%d min=%d max=%d", live, min, max)
 		}
-		*belowStreak = 0
+		breach.streak = 0
+		breach.notified = false
 		return
 	}
-	*belowStreak++
-	if *belowStreak < floorBreachConfirmSamples {
+	if breach.streak == 0 {
+		breach.episode++
+	}
+	breach.streak++
+	if breach.streak < floorBreachConfirmSamples {
 		log.Printf("[daemon] floor breach pending confirm: live=%d min=%d sample=%d/%d",
-			live, min, *belowStreak, floorBreachConfirmSamples)
+			live, min, breach.streak, floorBreachConfirmSamples)
+		return
+	}
+	if breach.notified {
 		return
 	}
 	body := fmt.Sprintf(
-		"CRITICAL: fleet live workers below floor — live=%d min=%d max=%d. Hands-off fill is failing; investigate spawn/supervisor freezes immediately.",
-		live, min, max,
+		"CRITICAL: fleet live workers below floor — live=%d min=%d max=%d for %d consecutive samples "+
+			"(breach episode %d). Hands-off fill is failing; investigate spawn/supervisor freezes immediately.",
+		live, min, max, breach.streak, breach.episode,
 	)
 	log.Printf("[daemon] %s", body)
-	n := d.emergencyNotifier
+	n := d.floorNotifier
 	if n == nil {
+		breach.notified = true
 		return
 	}
 	if err := n.Alert(notify.AlertFloorBreach, "fleet:floor_breach", "maestro CRITICAL: live below min", body); err != nil {
 		log.Printf("[daemon] floor breach ntfy failed: %v", err)
+		return
 	}
+	breach.notified = true
+}
+
+// fleetFloorNotifierFor selects an ntfy-capable route directly. A Telegram-only
+// project is skipped so a later project's configured ntfy topic cannot be
+// shadowed by the emergency channel selection order.
+func fleetFloorNotifierFor(cfgs []*config.Config) *notify.Notifier {
+	for _, cfg := range cfgs {
+		if cfg == nil || !cfg.Notify.Ntfy.Enabled() {
+			continue
+		}
+		n := notify.NewWithToken(
+			cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL,
+		)
+		n.WithNtfy(cfg.Notify.Ntfy.BaseURL, cfg.Notify.Ntfy.Topic, cfg.Notify.Ntfy.Token())
+		return n
+	}
+	return nil
 }

--- a/internal/daemon/floor_watch_test.go
+++ b/internal/daemon/floor_watch_test.go
@@ -1,60 +1,113 @@
 package daemon
 
 import (
-	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
-	"time"
 
 	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/notify"
 	"github.com/befeast/maestro/internal/state"
 )
 
-func TestEvaluateFloorBreach_ConfirmsThenRecovers(t *testing.T) {
+func TestEvaluateFloorBreach_AlertsOncePerEpisodeAtPriorityFive(t *testing.T) {
+	var mu sync.Mutex
+	var priorities []string
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		priorities = append(priorities, r.Header.Get("Priority"))
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
 	dir := t.TempDir()
-	if err := state.Save(dir, state.NewState()); err != nil {
-		t.Fatal(err)
-	}
+	saveFleetRunningState(t, dir, 1)
 	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 5, MaxLiveWorkers: 10}}
 	limiter := newFleetSpawnLimiter(store)
 	limiter.RegisterStateDir(dir)
 
-	d := &Daemon{spawnLimiter: limiter}
-	streak := 0
-	d.evaluateFloorBreach(&streak)
-	if streak != 1 {
-		t.Fatalf("streak after first sample = %d, want 1", streak)
+	d := &Daemon{
+		spawnLimiter:  limiter,
+		floorNotifier: (&notify.Notifier{}).WithNtfy(srv.URL, "fleet", ""),
 	}
-	d.evaluateFloorBreach(&streak)
-	if streak != 2 {
-		t.Fatalf("streak after confirm = %d, want 2", streak)
+	var breach floorBreachState
+	d.evaluateFloorBreach(&breach)
+	if breach.streak != 1 {
+		t.Fatalf("streak after first sample = %d, want 1", breach.streak)
+	}
+	d.evaluateFloorBreach(&breach)
+	d.evaluateFloorBreach(&breach)
+	mu.Lock()
+	if len(priorities) != 1 || priorities[0] != "5" {
+		mu.Unlock()
+		t.Fatalf("first breach priorities = %v, want one priority 5 post", priorities)
+	}
+	firstBody := bodies[0]
+	mu.Unlock()
+	if !strings.Contains(firstBody, "live=1 min=5 max=10") {
+		t.Fatalf("first alert body = %q", firstBody)
 	}
 
-	running := state.NewState()
-	for i := 1; i <= 5; i++ {
-		running.Sessions[fmt.Sprintf("sup-%d", i)] = &state.Session{IssueNumber: i, Status: state.StatusRunning, StartedAt: time.Now().UTC()}
+	// Recovery resets the local debounce. A later identical floor condition is
+	// a new episode and must bypass notify.Alert's prior body dedup.
+	saveFleetRunningState(t, dir, 5)
+	d.evaluateFloorBreach(&breach)
+	if breach.streak != 0 || breach.notified {
+		t.Fatalf("state after recovery = %+v, want reset", breach)
 	}
-	if err := state.Save(dir, running); err != nil {
-		t.Fatal(err)
-	}
-	d.evaluateFloorBreach(&streak)
-	if streak != 0 {
-		t.Fatalf("streak after recover = %d, want 0", streak)
+	limiter.UnregisterStateDir(dir)
+	rebreachDir := t.TempDir()
+	saveFleetRunningState(t, rebreachDir, 1)
+	limiter.RegisterStateDir(rebreachDir)
+	d.evaluateFloorBreach(&breach)
+	d.evaluateFloorBreach(&breach)
+	mu.Lock()
+	defer mu.Unlock()
+	if len(priorities) != 2 || priorities[1] != "5" {
+		t.Fatalf("posts after recovery and rebreach = %v, want two priority 5 posts", priorities)
 	}
 }
 
-func TestFloorStatus_BelowMin(t *testing.T) {
+func TestFloorStatus_BelowMinExcludesPendingReservations(t *testing.T) {
 	dir := t.TempDir()
 	if err := state.Save(dir, state.NewState()); err != nil {
 		t.Fatal(err)
 	}
-	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 5, MaxLiveWorkers: 10}}
+	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 1, MaxLiveWorkers: 1}}
 	limiter := newFleetSpawnLimiter(store)
 	limiter.RegisterStateDir(dir)
+	commit, release, ok := limiter.Reserve(dir)
+	if !ok {
+		t.Fatal("reservation failed")
+	}
+	defer release()
+	commit("slot-pending")
+
 	live, min, max, below, err := limiter.FloorStatus()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if live != 0 || min != 5 || max != 10 || !below {
+	if live != 0 || min != 1 || max != 1 || !below {
 		t.Fatalf("FloorStatus = live=%d min=%d max=%d below=%v", live, min, max, below)
+	}
+	if !limiter.CeilingReached() {
+		t.Fatal("pending reservation stopped protecting the hard ceiling")
+	}
+}
+
+func TestFleetFloorNotifierForSkipsTelegramOnlyConfig(t *testing.T) {
+	n := fleetFloorNotifierFor([]*config.Config{
+		{Telegram: config.TelegramConfig{Target: "telegram-only"}},
+		{Notify: config.NotifyConfig{Ntfy: config.NtfyConfig{BaseURL: "https://ntfy.example", Topic: "fleet"}}},
+	})
+	if n == nil || !n.NtfyConfigured() || n.NtfyTopic != "fleet" {
+		t.Fatalf("floor notifier = %+v, want configured ntfy route", n)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7349,6 +7349,12 @@ func (o *Orchestrator) releaseAgedTokenBudgetClaim(s *state.State, sess *state.S
 	if now.Sub(finished.UTC()) < tokenBudgetClaimGrace {
 		return
 	}
+	// A legacy cycle may already have promoted this deterministic budget stop to
+	// retry_exhausted. Normalize it before release so IssueRetryExhausted cannot
+	// outlive the claim and keep selectors blocked forever.
+	if sess.Status == state.StatusRetryExhausted {
+		sess.Status = state.StatusFailed
+	}
 	sess.ReleasedForRedispatch = true
 	o.syncProject(sess.IssueNumber, github.ProjectStatusTodo)
 	log.Printf("[orch] token_budget_exceeded: issue #%d session aged past %s — released for redispatch",

--- a/internal/orchestrator/token_budget_redispatch_test.go
+++ b/internal/orchestrator/token_budget_redispatch_test.go
@@ -1,0 +1,44 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/worker"
+)
+
+func TestReleaseAgedTokenBudgetClaimClearsRetryBlockAndKeepsHistory(t *testing.T) {
+	now := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	finished := now.Add(-tokenBudgetClaimGrace - time.Minute)
+	st := state.NewState()
+	sess := &state.Session{
+		IssueNumber:   1006,
+		Status:        state.StatusRetryExhausted,
+		StartedAt:     finished.Add(-time.Hour),
+		FinishedAt:    &finished,
+		WorkerOutcome: worker.TokenBudgetExceededOutcome,
+	}
+	st.Sessions["aged"] = sess
+
+	o := &Orchestrator{cfg: &config.Config{}}
+	o.releaseAgedTokenBudgetClaim(st, sess, now)
+
+	if !sess.ReleasedForRedispatch {
+		t.Fatal("aged token-budget session was not released")
+	}
+	if sess.Status != state.StatusFailed || sess.WorkerOutcome != worker.TokenBudgetExceededOutcome {
+		t.Fatalf("released audit history = %+v, want failed + token_budget_exceeded", sess)
+	}
+	if _, claimed := st.IssueClaimFor(1006); claimed {
+		t.Fatal("aged token-budget issue still has a terminal claim")
+	}
+	if st.IssueRetryExhausted(1006) || st.FailedAttemptsForIssue(1006) != 0 {
+		t.Fatal("released token-budget issue still consumes or reports an exhausted retry budget")
+	}
+	if status, ok := projectStatusForSession(sess, false); !ok || status != github.ProjectStatusTodo {
+		t.Fatalf("released session board status = %q, %v; want Todo", status, ok)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1012,6 +1012,9 @@ const (
 	// surfaced as evidence. NEVER a silent dead-end (#565).
 	StuckReviewRepairExhausted = "review_repair_exhausted"
 	StuckSearchGuardrailTrip   = "search_guardrail_trip"
+	// StuckTokenBudgetExceeded keeps an issue-scoped budget stop visible without
+	// turning historical worker spend into a project-wide dispatch hold.
+	StuckTokenBudgetExceeded = "token_budget_exceeded"
 	// StuckSupervisorMeteredBackend is emitted when the supervisor LLM path is
 	// refused because supervisor.backend (or its model.default fallback) resolves
 	// to a metered (per-token) backend and supervisor.allow_metered_backend is not
@@ -5050,15 +5053,16 @@ func (s *State) IssueDone(issueNum int) bool {
 // without producing a PR (dead, failed, or retry_exhausted).
 //
 // Sessions marked as backend-blocked (RateLimitHit — provider capacity limit
-// or backend auth failure) are NOT counted as failed attempts: a transient
-// backend block must not consume the per-issue retry budget.
+// or backend auth failure) and deterministic token-budget stops are NOT counted
+// as failed attempts: neither condition proves the implementation itself failed,
+// and both must remain runnable after their independent hold/release policy.
 // See #432 / #458 / #466 / #693.
 func (s *State) FailedAttemptsForIssue(issueNum int) int {
 	count := 0
 	for _, sess := range s.Sessions {
 		if sess.IssueNumber == issueNum && sess.PRNumber == 0 &&
 			(sess.Status == StatusDead || sess.Status == StatusFailed || sess.Status == StatusRetryExhausted) &&
-			!sess.RateLimitHit {
+			!sess.RateLimitHit && sess.WorkerOutcome != string(DisplayTokenBudgetExceeded) {
 			count++
 		}
 	}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1135,6 +1135,10 @@ func TestFailedAttemptsForIssue(t *testing.T) {
 	s.Sessions["slot-7"] = &Session{IssueNumber: 42, Status: StatusRunning, PRNumber: 0, StartedAt: now}  // running — not counted
 	s.Sessions["slot-8"] = &Session{IssueNumber: 42, Status: StatusConflictFailed, PRNumber: 0}           // conflict — not counted
 	s.Sessions["slot-9"] = &Session{IssueNumber: 42, Status: StatusDead, PRNumber: 0, RateLimitHit: true} // rate-limited — not counted (#466)
+	s.Sessions["slot-10"] = &Session{
+		IssueNumber: 42, Status: StatusFailed, PRNumber: 0,
+		WorkerOutcome: string(DisplayTokenBudgetExceeded),
+	} // budget stop — not counted
 
 	if got := s.FailedAttemptsForIssue(42); got != 3 {
 		t.Errorf("FailedAttemptsForIssue(42) = %d, want 3", got)

--- a/internal/supervisor/hands_off_fill_test.go
+++ b/internal/supervisor/hands_off_fill_test.go
@@ -69,6 +69,33 @@ func TestDecide_TokenBudgetDoesNotStarveSpareSlotBacklog(t *testing.T) {
 	if decision.Target == nil || decision.Target.Issue != 30 {
 		t.Fatalf("target = %#v, want issue #30", decision.Target)
 	}
+	requireStuckState(t, decision, state.StuckTokenBudgetExceeded)
+}
+
+func TestDecide_ReleasedTokenBudgetIssueCanRedispatchAtRetryLimit(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.MaxParallel = 2
+	cfg.MaxRetriesPerIssue = 1
+	cfg.IssueLabels = []string{"maestro-ready"}
+	reader := &fakeReader{issues: []github.Issue{testIssue(9, "retry with raised budget", "maestro-ready")}}
+	st := state.NewState()
+	finished := time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC)
+	st.Sessions["sup-old"] = &state.Session{
+		IssueNumber:           9,
+		Status:                state.StatusFailed,
+		WorkerOutcome:         worker.TokenBudgetExceededOutcome,
+		StartedAt:             finished.Add(-time.Hour),
+		FinishedAt:            &finished,
+		ReleasedForRedispatch: true,
+	}
+
+	decision, err := testEngine(cfg, reader).Decide(st)
+	if err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	if decision.RecommendedAction != ActionSpawnWorker || decision.Target == nil || decision.Target.Issue != 9 {
+		t.Fatalf("decision = %+v, want released budget issue #9 redispatched despite max_retries_per_issue=1", decision)
+	}
 }
 
 func TestDecide_TokenBudgetEmptyQueueIsNotExclusiveFreeze(t *testing.T) {

--- a/internal/supervisor/llm_short_circuit_test.go
+++ b/internal/supervisor/llm_short_circuit_test.go
@@ -131,10 +131,10 @@ func TestDecideWithLLM_TokenBudgetExceeded_SkipsLLM(t *testing.T) {
 	if llm.calls != 0 {
 		t.Fatalf("LLM calls = %d, want 0 for deterministic token budget state", llm.calls)
 	}
-	if decision.RecommendedAction != ActionNone {
-		t.Fatalf("decision = %+v, want action=none when only a historical budget stop remains", decision)
+	if decision.RecommendedAction != ActionNone || decision.Target != nil {
+		t.Fatalf("decision = %+v, want untargeted action=none when only historical budget history remains", decision)
 	}
-	// #1106: exclusive budget freeze targeting is gone; queue-empty/none is fine.
+	requireStuckState(t, decision, state.StuckTokenBudgetExceeded)
 }
 
 // TestDecideWithLLM_SpawnCandidate_CallsLLM pins the counterpart AC: a mutating

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1148,7 +1148,12 @@ func appendTokenBudgetStuck(base []state.SupervisorStuckState, slot string, sess
 	if sess == nil || sess.IssueNumber <= 0 {
 		return base
 	}
-	return appendStuck(base, stuckState("token_budget_exceeded", SeverityWarning,
+	for _, existing := range base {
+		if existing.Code == state.StuckTokenBudgetExceeded && existing.Target != nil && existing.Target.Session == slot {
+			return base
+		}
+	}
+	return appendStuck(base, stuckState(state.StuckTokenBudgetExceeded, SeverityWarning,
 		fmt.Sprintf("Issue #%d previously stopped at worker_max_tokens on session %s; spare capacity must still fill other backlog", sess.IssueNumber, slot),
 		"Continue label/spawn for other eligible issues; raise worker_max_tokens only for intentional redispatch of this issue",
 		false,
@@ -1910,6 +1915,13 @@ func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time, cache *
 				fmt.Sprintf("Issue #%d exhausted its retry budget.", sess.IssueNumber),
 				"Review the failed attempts, adjust the issue or retry budget, then restart intentionally.", false, target,
 				fmt.Sprintf("Session %s status=retry_exhausted retry_count=%d", slot, sess.RetryCount)))
+		}
+
+		if sess.WorkerOutcome == worker.TokenBudgetExceededOutcome && !sess.ReleasedForRedispatch {
+			findings = append(findings, stuckState(state.StuckTokenBudgetExceeded, SeverityWarning,
+				fmt.Sprintf("Issue #%d previously stopped at worker_max_tokens on session %s.", sess.IssueNumber, slot),
+				"Continue label/spawn for other eligible issues; raise worker_max_tokens only for intentional redispatch of this issue.", false, target,
+				fmt.Sprintf("worker_outcome=%s", sess.WorkerOutcome)))
 		}
 
 		if sess.PreviousAttemptFeedbackKind == state.RetryReasonReviewFeedback && e.staleReviewFeedbackNeedsAttention(sess) {


### PR DESCRIPTION
Refs #1106

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves fleet-floor alerting and token-budget recovery. The main changes are:

- Counts only durable running workers when checking the fleet floor.
- Sends one CRITICAL ntfy alert per sustained breach episode.
- Releases aged token-budget claims without consuming retry capacity.
- Adds tests for floor alerts, reservations, and token-budget redispatch.

<h3>Confidence Score: 4/5</h3>

The live project-update path can leave the required floor-alert route stale or unset.

Worker counting and token-budget release preserve their intended state rules.

Runtime project additions and notification changes do not refresh the new notifier. A breach can therefore be recorded without sending its CRITICAL alert.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A focused Go test through the production Daemon.Run and live store-watch reconciliation was executed starting with an empty fleet and an ntfy-enabled project to reproduce the stale alert route.
- The test observed that the live project appeared in the fleet while floorNotifier remained nil, confirming the stale alert route condition.
- Two production evaluateFloorBreach samples advanced the breach to streak 2 and marked it notified.
- The local httptest ntfy endpoint recorded zero CRITICAL requests, and the focused test ended in failure with the reproduced condition.
- A post-change comparison of token-budget recovery harness runs showed the after-change execution exiting cleanly (0) with zero retries, while the before-change run exited with failures; temporary harness sources were included to trace the comparison.

<a href="https://app.greptile.com/trex/runs/15551213/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/daemon/daemon.go | Adds a separate floor notifier, but initializes it only from startup project configs. |
| internal/daemon/fleet_concurrency.go | Separates durable running-worker counts from reservations while preserving reservation-based capacity control. |
| internal/daemon/floor_watch.go | Adds per-episode breach tracking, alert retry behavior, and direct ntfy route selection. |
| internal/orchestrator/orchestrator.go | Normalizes and releases aged token-budget sessions for redispatch. |
| internal/state/state.go | Excludes token-budget stops from failed-attempt accounting and adds a shared stuck-state code. |
| internal/supervisor/supervisor.go | Reports token-budget history without blocking other eligible work. |

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
internal/daemon/daemon.go:590
**Live Config Leaves Alert Route Stale**

The notifier is selected only from the startup project list. If the store-watch path later adds the first ntfy-enabled project or changes the selected route, floor breaches keep using the old value; when it remains nil, `evaluateFloorBreach` marks the episode notified and no CRITICAL alert is sent until recovery and restart.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: harden fleet floor alerts"](https://github.com/befeast/maestro/commit/674fd9b2837ae7afd056e3e56e1340037bc81dbe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46610253)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->