### PR TITLE
Application factory SLA: queues + hands-off fill (not issue-loop cosplay)

### DIFF
--- a/docs/fleet-mission-control-runbook.md
+++ b/docs/fleet-mission-control-runbook.md
@@ -244,6 +244,15 @@ Dynamic wave policy:
 
 Fleet cards surface `open`, `eligible`, `excluded`, `held/meta`, `blocked-deps`, `non_runnable_project_status`, selected candidate, and top skipped reason so operators can tell whether the queue is empty, held by parent/meta policy, blocked by dependencies, or waiting on project status.
 
+Fleet capacity contention is product-first. The shared spawn limiter treats the
+`BeFeast/maestro` dogfood project as background work: it defers a dogfood spawn
+while the fleet is below `fleet.min_live_workers` and another registered
+project has runnable supervisor backlog, and also when such a product queue has
+no live worker. The signal comes from fresh persisted queue analysis and
+durable issue claims. Empty, stale, locally capacity-blocked, or fully claimed
+product queues do not suppress dogfood, and the policy never preempts a running
+worker.
+
 The Settings view also surfaces the effective model route as provider lanes, a
 flattened backend order, and its exact source (`provider_lanes`,
 `explicit_backend_chain`, or `model_default_only`). Worker drawers show the

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -631,7 +631,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	for i := range projects {
 		if cfg := projects[i].Cfg(); cfg != nil {
 			if d.spawnLimiter != nil {
-				d.spawnLimiter.RegisterStateDir(cfg.StateDir)
+				d.spawnLimiter.RegisterProject(cfg.StateDir, cfg.Repo, d.opts.SuperviseInterval)
 			}
 		}
 	}

--- a/internal/daemon/fleet_concurrency.go
+++ b/internal/daemon/fleet_concurrency.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/state"
@@ -21,6 +22,11 @@ type fleetSpawnReservation struct {
 	slot     string
 }
 
+type fleetProjectRegistration struct {
+	repo              string
+	queueSignalMaxAge time.Duration
+}
+
 // fleetSpawnLimiter serializes capacity checks across every project flow. A
 // successful spawn remains reserved until its running slot is visible in the
 // authoritative state file, closing both the concurrent-flow race and the
@@ -29,6 +35,7 @@ type fleetSpawnLimiter struct {
 	mu           sync.Mutex
 	settings     fleetConcurrencySettingsLoader
 	stateDirs    map[string]struct{}
+	projects     map[string]fleetProjectRegistration
 	reservations map[uint64]fleetSpawnReservation
 	nextID       uint64
 	loadState    func(string) (*state.State, error)
@@ -39,17 +46,30 @@ func newFleetSpawnLimiter(store ConfigLoader) *fleetSpawnLimiter {
 	return &fleetSpawnLimiter{
 		settings:     loader,
 		stateDirs:    make(map[string]struct{}),
+		projects:     make(map[string]fleetProjectRegistration),
 		reservations: make(map[uint64]fleetSpawnReservation),
 		loadState:    state.Load,
 	}
 }
 
 func (l *fleetSpawnLimiter) RegisterStateDir(stateDir string) {
+	l.RegisterProject(stateDir, "", DefaultSuperviseInterval)
+}
+
+func (l *fleetSpawnLimiter) RegisterProject(stateDir, repo string, superviseInterval time.Duration) {
 	if l == nil || strings.TrimSpace(stateDir) == "" {
 		return
 	}
+	stateDir = strings.TrimSpace(stateDir)
+	if superviseInterval <= 0 {
+		superviseInterval = DefaultSuperviseInterval
+	}
 	l.mu.Lock()
 	l.stateDirs[stateDir] = struct{}{}
+	l.projects[stateDir] = fleetProjectRegistration{
+		repo:              strings.TrimSpace(repo),
+		queueSignalMaxAge: 2*superviseInterval + time.Minute,
+	}
 	l.mu.Unlock()
 }
 
@@ -59,6 +79,7 @@ func (l *fleetSpawnLimiter) UnregisterStateDir(stateDir string) {
 	}
 	l.mu.Lock()
 	delete(l.stateDirs, stateDir)
+	delete(l.projects, stateDir)
 	for id, reservation := range l.reservations {
 		if reservation.stateDir == stateDir {
 			delete(l.reservations, id)
@@ -191,6 +212,17 @@ func (l *fleetSpawnLimiter) Reserve(stateDir string) (commit func(string), relea
 		l.mu.Unlock()
 		return nil, nil, false
 	}
+	deferReason, err := l.dogfoodDeferralReasonLocked(stateDir, settings, live)
+	if err != nil {
+		l.mu.Unlock()
+		log.Printf("[daemon] fleet spawn reservation fail-closed: product queue state unavailable: %v", err)
+		return nil, nil, false
+	}
+	if deferReason != "" {
+		l.mu.Unlock()
+		log.Printf("[daemon] fleet spawn reservation deferred for %s: %s", factoryDogfoodRepo, deferReason)
+		return nil, nil, false
+	}
 	l.nextID++
 	id := l.nextID
 	l.reservations[id] = fleetSpawnReservation{stateDir: stateDir}
@@ -211,6 +243,100 @@ func (l *fleetSpawnLimiter) Reserve(stateDir string) (commit func(string), relea
 		l.mu.Unlock()
 	}
 	return commit, release, true
+}
+
+const factoryDogfoodRepo = "BeFeast/maestro"
+
+// dogfoodDeferralReasonLocked keeps the Maestro dogfood project in the
+// background when product work can use the same fleet slot. It is deliberately
+// narrow: no new priority scheduler or operator knob, and no preemption. The
+// existing persisted supervisor decision supplies the runnable-backlog signal.
+func (l *fleetSpawnLimiter) dogfoodDeferralReasonLocked(stateDir string, settings config.FleetConcurrencySettings, live int) (string, error) {
+	registration, ok := l.projects[stateDir]
+	if !ok || !strings.EqualFold(registration.repo, factoryDogfoodRepo) {
+		return "", nil
+	}
+
+	dirs := make([]string, 0, len(l.projects))
+	for dir, project := range l.projects {
+		if dir == stateDir || strings.TrimSpace(project.repo) == "" || strings.EqualFold(project.repo, factoryDogfoodRepo) {
+			continue
+		}
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+
+	for _, dir := range dirs {
+		project := l.projects[dir]
+		st, err := l.loadState(dir)
+		if err != nil {
+			return "", fmt.Errorf("load product state %s: %w", dir, err)
+		}
+		decision := st.LatestSupervisorDecision()
+		if !freshSupervisorQueueSignal(decision, project.queueSignalMaxAge, time.Now().UTC()) ||
+			!productQueueCanDispatch(st, decision) || !hasUnclaimedRunnableCandidate(st, decision) {
+			continue
+		}
+		productLive := st.RunningSessionCount()
+		if settings.MinLiveWorkers > 0 && live < settings.MinLiveWorkers {
+			return fmt.Sprintf("fleet is below floor (live=%d min=%d) and product %s has runnable backlog", live, settings.MinLiveWorkers, project.repo), nil
+		}
+		if productLive == 0 {
+			return fmt.Sprintf("product %s has runnable backlog and no live worker", project.repo), nil
+		}
+	}
+	return "", nil
+}
+
+func freshSupervisorQueueSignal(decision *state.SupervisorDecision, maxAge time.Duration, now time.Time) bool {
+	if decision == nil || decision.RecommendationDropped() || maxAge <= 0 {
+		return false
+	}
+	observedAt := decision.CreatedAt
+	if decision.LastSeenAt.After(observedAt) {
+		observedAt = decision.LastSeenAt
+	}
+	if observedAt.IsZero() {
+		return false
+	}
+	return !now.After(observedAt.UTC().Add(maxAge))
+}
+
+func productQueueCanDispatch(st *state.State, decision *state.SupervisorDecision) bool {
+	if st == nil || decision == nil {
+		return false
+	}
+	if st.PauseActive() || st.DrainActive() || decision.RequiresApproval {
+		return false
+	}
+	if st.DispatchHold.Active && st.DispatchHold.ReasonClass != state.DispatchHoldAwaitingDispatch {
+		return false
+	}
+	if decision.ProjectState.AvailableSlots > 0 {
+		return true
+	}
+	// A decision recorded at local capacity becomes dispatchable after one of
+	// those workers exits, even before the next supervisor cycle refreshes it.
+	return st.RunningSessionCount() < decision.ProjectState.Running
+}
+
+func hasUnclaimedRunnableCandidate(st *state.State, decision *state.SupervisorDecision) bool {
+	if st == nil || decision == nil || decision.QueueAnalysis == nil || decision.QueueAnalysis.EligibleCandidates <= 0 {
+		return false
+	}
+	analysis := decision.QueueAnalysis
+	candidates := analysis.EligibleRanked
+	if len(candidates) == 0 && analysis.SelectedCandidate != nil {
+		candidates = []state.SupervisorIssueCandidate{*analysis.SelectedCandidate}
+	}
+	for _, candidate := range candidates {
+		if candidate.Number > 0 && !st.IssueInProgress(candidate.Number) && !st.IssueDone(candidate.Number) {
+			return true
+		}
+	}
+	// EligibleRanked is bounded. A larger aggregate means unlisted runnable
+	// candidates remain even when every persisted identity is already claimed.
+	return analysis.EligibleCandidates > len(candidates)
 }
 
 func (d *Daemon) fleetSpawnCeilingReached() bool {

--- a/internal/daemon/fleet_concurrency_test.go
+++ b/internal/daemon/fleet_concurrency_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/state"
@@ -33,6 +34,34 @@ func saveFleetRunningState(t *testing.T, dir string, running int) {
 		slot := fmt.Sprintf("slot-%d", i+1)
 		st.Sessions[slot] = &state.Session{Status: state.StatusRunning, IssueNumber: i + 1}
 	}
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+}
+
+func saveFleetQueueState(t *testing.T, dir string, running, availableSlots int, candidates ...int) {
+	t.Helper()
+	st := state.NewState()
+	for i := 0; i < running; i++ {
+		issue := 1000 + i
+		st.Sessions[fmt.Sprintf("slot-%d", i+1)] = &state.Session{Status: state.StatusRunning, IssueNumber: issue}
+	}
+	ranked := make([]state.SupervisorIssueCandidate, 0, len(candidates))
+	for _, issue := range candidates {
+		ranked = append(ranked, state.SupervisorIssueCandidate{Number: issue})
+	}
+	decision := state.SupervisorDecision{
+		CreatedAt: time.Now().UTC(),
+		ProjectState: state.SupervisorProjectState{
+			Running:        running,
+			AvailableSlots: availableSlots,
+		},
+		QueueAnalysis: &state.SupervisorQueueAnalysis{
+			EligibleCandidates: len(ranked),
+			EligibleRanked:     ranked,
+		},
+	}
+	st.SupervisorDecisions = append(st.SupervisorDecisions, decision)
 	if err := state.Save(dir, st); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -96,4 +125,137 @@ func TestFleetSpawnLimiterFailsClosedWhenStateCannotBeCounted(t *testing.T) {
 	if _, _, ok := limiter.Reserve("state-dir"); ok {
 		t.Fatal("uncertain fleet state must reject atomic reservations")
 	}
+}
+
+func TestFleetSpawnLimiterDefersDogfoodBelowFloorForRunnableProductBacklog(t *testing.T) {
+	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 5, MaxLiveWorkers: 10}}
+	limiter := newFleetSpawnLimiter(store)
+	dogfoodDir := t.TempDir()
+	productDir := t.TempDir()
+	saveFleetRunningState(t, dogfoodDir, 0)
+	saveFleetQueueState(t, productDir, 0, 2, 394)
+	limiter.RegisterProject(dogfoodDir, factoryDogfoodRepo, time.Minute)
+	limiter.RegisterProject(productDir, "BeFeast/ok-player", time.Minute)
+
+	if _, _, ok := limiter.Reserve(dogfoodDir); ok {
+		t.Fatal("dogfood reservation should defer to runnable product backlog below the fleet floor")
+	}
+	_, release, ok := limiter.Reserve(productDir)
+	if !ok {
+		t.Fatal("product reservation should consume the protected slot")
+	}
+	release()
+}
+
+func TestFleetSpawnLimiterDefersDogfoodForStarvedProductAtFloor(t *testing.T) {
+	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 2, MaxLiveWorkers: 4}}
+	limiter := newFleetSpawnLimiter(store)
+	dogfoodDir := t.TempDir()
+	busyProductDir := t.TempDir()
+	starvedProductDir := t.TempDir()
+	saveFleetRunningState(t, dogfoodDir, 0)
+	saveFleetRunningState(t, busyProductDir, 2)
+	saveFleetQueueState(t, starvedProductDir, 0, 1, 264)
+	limiter.RegisterProject(dogfoodDir, factoryDogfoodRepo, time.Minute)
+	limiter.RegisterProject(busyProductDir, "example/busy-product", time.Minute)
+	limiter.RegisterProject(starvedProductDir, "BeFeast/ok-folio", time.Minute)
+
+	if _, _, ok := limiter.Reserve(dogfoodDir); ok {
+		t.Fatal("dogfood reservation should defer when a runnable product queue has no live worker")
+	}
+}
+
+func TestFleetSpawnLimiterAllowsDogfoodWhenProductQueueCannotDispatch(t *testing.T) {
+	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 5, MaxLiveWorkers: 10}}
+	limiter := newFleetSpawnLimiter(store)
+	dogfoodDir := t.TempDir()
+	productDir := t.TempDir()
+	saveFleetRunningState(t, dogfoodDir, 0)
+	saveFleetQueueState(t, productDir, 0, 0, 394)
+	limiter.RegisterProject(dogfoodDir, factoryDogfoodRepo, time.Minute)
+	limiter.RegisterProject(productDir, "BeFeast/ok-player", time.Minute)
+
+	_, release, ok := limiter.Reserve(dogfoodDir)
+	if !ok {
+		t.Fatal("dogfood should fill spare capacity when the product queue has no local dispatch slot")
+	}
+	release()
+}
+
+func TestFleetSpawnLimiterAllowsDogfoodWhenProductCandidateIsAlreadyClaimed(t *testing.T) {
+	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 5, MaxLiveWorkers: 10}}
+	limiter := newFleetSpawnLimiter(store)
+	dogfoodDir := t.TempDir()
+	productDir := t.TempDir()
+	saveFleetRunningState(t, dogfoodDir, 0)
+	saveFleetQueueState(t, productDir, 0, 1, 394)
+	productState, err := state.Load(productDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	productState.Sessions["ok-player-1"] = &state.Session{Status: state.StatusRunning, IssueNumber: 394}
+	if err := state.Save(productDir, productState); err != nil {
+		t.Fatal(err)
+	}
+	limiter.RegisterProject(dogfoodDir, factoryDogfoodRepo, time.Minute)
+	limiter.RegisterProject(productDir, "BeFeast/ok-player", time.Minute)
+
+	_, release, ok := limiter.Reserve(dogfoodDir)
+	if !ok {
+		t.Fatal("a stale product queue candidate should not suppress dogfood after it has a durable claim")
+	}
+	release()
+}
+
+func TestFleetSpawnLimiterAllowsDogfoodWhenProductDispatchIsHeld(t *testing.T) {
+	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 5, MaxLiveWorkers: 10}}
+	limiter := newFleetSpawnLimiter(store)
+	dogfoodDir := t.TempDir()
+	productDir := t.TempDir()
+	saveFleetRunningState(t, dogfoodDir, 0)
+	saveFleetQueueState(t, productDir, 0, 1, 394)
+	productState, err := state.Load(productDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	productState.DispatchHold = state.DispatchHold{
+		Active:      true,
+		ReasonClass: state.DispatchHoldBackendsCoolingDown,
+	}
+	if err := state.Save(productDir, productState); err != nil {
+		t.Fatal(err)
+	}
+	limiter.RegisterProject(dogfoodDir, factoryDogfoodRepo, time.Minute)
+	limiter.RegisterProject(productDir, "BeFeast/ok-player", time.Minute)
+
+	_, release, ok := limiter.Reserve(dogfoodDir)
+	if !ok {
+		t.Fatal("backend-held product work is not runnable and should not suppress dogfood fill")
+	}
+	release()
+}
+
+func TestFleetSpawnLimiterAllowsDogfoodWhenProductQueueSignalIsStale(t *testing.T) {
+	store := &fleetConcurrencyTestStore{settings: config.FleetConcurrencySettings{MinLiveWorkers: 5, MaxLiveWorkers: 10}}
+	limiter := newFleetSpawnLimiter(store)
+	dogfoodDir := t.TempDir()
+	productDir := t.TempDir()
+	saveFleetRunningState(t, dogfoodDir, 0)
+	saveFleetQueueState(t, productDir, 0, 1, 394)
+	productState, err := state.Load(productDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	productState.SupervisorDecisions[0].CreatedAt = time.Now().UTC().Add(-10 * time.Minute)
+	if err := state.Save(productDir, productState); err != nil {
+		t.Fatal(err)
+	}
+	limiter.RegisterProject(dogfoodDir, factoryDogfoodRepo, time.Minute)
+	limiter.RegisterProject(productDir, "BeFeast/ok-player", time.Minute)
+
+	_, release, ok := limiter.Reserve(dogfoodDir)
+	if !ok {
+		t.Fatal("historical queue analysis must not become a new dogfood freeze")
+	}
+	release()
 }

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -49,7 +49,7 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 	if cfg != nil {
 		cfg.RuntimeSuperviseIntervalSeconds = runtimeIntervalSeconds(d.opts.SuperviseInterval)
 		if d.spawnLimiter != nil {
-			d.spawnLimiter.RegisterStateDir(cfg.StateDir)
+			d.spawnLimiter.RegisterProject(cfg.StateDir, cfg.Repo, d.opts.SuperviseInterval)
 		}
 	}
 	fctx, cancel := context.WithCancel(parent)


### PR DESCRIPTION
Refs #1109

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gives product queues priority over Maestro dogfood work when fleet capacity is contested. The main changes are:

- Registers repository and queue-freshness metadata with the shared spawn limiter.
- Defers dogfood reservations for fresh, runnable, unclaimed product work.
- Preserves dogfood fill when product work is stale, held, claimed, or locally blocked.
- Adds scheduling tests and documents the new fleet policy.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

No blocking issues found in the changed code.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex confirmed that the parent implementation rejects the new policy surface at compile time, as captured in fleet-limiter-01-before.log.
- T-Rex validated the current runtime behavior, showing global reservation and ceiling checks pass, the fresh backlog defers dogfood, and locally blocked, claimed, held, and stale product queues allow dogfood, as shown in fleet-limiter-02-after.log.
- T-Rex executed the focused race test suite and confirmed it passes when run with -race, as recorded in fleet-limiter-race.log.
- T-Rex performed 100 repetitions of the reservation/overshoot guard in a stress test and all runs succeeded, as documented in fleet-limiter-stress.log.
- T-Rex reviewed all fleet limiter logs to corroborate the results and ensure consistency across tests.

<a href="https://app.greptile.com/trex/runs/15556838/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/daemon/fleet_concurrency.go | Adds project-aware dogfood deferral using fresh queue state, dispatch capacity, and durable issue claims. |
| internal/daemon/daemon.go | Registers project repository metadata and supervision timing during daemon startup. |
| internal/daemon/flow.go | Registers project metadata when each flow starts. |
| internal/daemon/fleet_concurrency_test.go | Covers product prioritization, claimed work, dispatch holds, local capacity, and stale queue signals. |
| docs/fleet-mission-control-runbook.md | Documents product-first fleet contention and the conditions that allow dogfood fill. |

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;main&#39; into feat/sup-1118-1..."](https://github.com/befeast/maestro/commit/1ae93062bbddc79babe3f76390494af327f4104d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46618256)</sub>

<!-- /greptile_comment -->