### PR TITLE
fix(tmpfs-hygiene): stop blanket no-op sweeps and reap leaked native libs

### DIFF
--- a/internal/tmpfshygiene/sweeper.go
+++ b/internal/tmpfshygiene/sweeper.go
@@ -36,6 +36,14 @@ type policy struct {
 // daemon. It is intentionally not configurable at runtime: broadening the
 // deletion surface requires a reviewed code-and-test change.
 var defaultPolicies = []policy{
+	// Bun/Zig-compiled CLIs (opencode) extract a ~5.6MB embedded native
+	// library to $TMPDIR/.<hex>-00000000.so on every invocation and never
+	// delete it (plus an empty .hm marker). Supervisor backend probes mint
+	// these around the clock; on the RAM-backed /tmp this leaked ~10.5GB
+	// across 1978 copies before the 2026-07-23 overload. Deleting a mapped
+	// .so is safe on Linux: the inode survives until the mapping is gone.
+	{Category: "native_lib_leak", Pattern: ".*-00000000.so", MinAge: time.Hour},
+	{Category: "native_lib_leak", Pattern: ".*-00000000.hm", MinAge: time.Hour},
 	{Category: "outcome_snapshot", Pattern: "tmp.*", MinAge: time.Hour},
 	{Category: "browser_profile", Pattern: "playwright-*", MinAge: 2 * time.Hour},
 	{Category: "browser_profile", Pattern: "playwright_chromiumdev_profile-*", MinAge: 2 * time.Hour},
@@ -169,16 +177,24 @@ func Sweep(ctx context.Context, opts Options) (Summary, error) {
 		nameSet[item.name] = struct{}{}
 	}
 
-	procProtect, scanErrors, err := collectProcessProtects(opts.ProcRoot, opts.Root, nameSet, opts.processID())
+	procProtect, procScan, err := collectProcessProtects(opts.ProcRoot, opts.Root, nameSet, opts.processID())
 	if err != nil {
 		return fail(fmt.Errorf("build process protect set: %w", err))
 	}
-	summary.ProcScanErrors = scanErrors
+	summary.ProcScanErrors = procScan.errors
+	summary.ProcPermissionSkips = procScan.permissionSkips
 	for i := range candidates {
 		for reason := range procProtect[candidates[i].name] {
 			candidates[i].protects[reason] = struct{}{}
 		}
-		if scanErrors > 0 {
+		// Unexpected scan failures blanket-protect the whole sweep, but
+		// permission-denied reads of other users' /proc entries are the normal
+		// state on any multi-user host (the daemon is not root). Treating them
+		// as scan errors made every sweep a permanent no-op (2026-07-23 RCA):
+		// protected==matched, deleted==0, while /tmp filled RAM. A foreign-uid
+		// process can hold a candidate open, but deletion of same-uid entries
+		// is still safe on Linux — the inode outlives the unlink.
+		if procScan.errors > 0 {
 			candidates[i].protects["proc_scan_error"] = struct{}{}
 		}
 	}
@@ -271,8 +287,9 @@ func Sweep(ctx context.Context, opts Options) (Summary, error) {
 				// path; cmdlines can still contain the former public path, so both top-
 				// level names are mapped back to this candidate.
 				freshNames := map[string]struct{}{item.name: {}, quarantine.name: {}}
-				freshProtect, freshScanErrors, scanErr := collectProcessProtects(opts.ProcRoot, opts.Root, freshNames, opts.processID())
-				summary.ProcScanErrors += freshScanErrors
+				freshProtect, freshScan, scanErr := collectProcessProtects(opts.ProcRoot, opts.Root, freshNames, opts.processID())
+				summary.ProcScanErrors += freshScan.errors
+				summary.ProcPermissionSkips += freshScan.permissionSkips
 				if scanErr != nil {
 					if restoreErr := quarantine.restore(rootFD, item.name); restoreErr != nil {
 						scanErr = fmt.Errorf("%w; also failed to restore isolated candidate: %v", scanErr, restoreErr)
@@ -285,7 +302,7 @@ func Sweep(ctx context.Context, opts Options) (Summary, error) {
 						item.protects[reason] = struct{}{}
 					}
 				}
-				if freshScanErrors > 0 {
+				if freshScan.errors > 0 {
 					item.protects["proc_scan_error"] = struct{}{}
 				}
 				if len(item.protects) > 0 {
@@ -554,13 +571,22 @@ func pathWithin(path, base string) bool {
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
-func collectProcessProtects(procRoot, tmpRoot string, candidates map[string]struct{}, ignoredPID int) (map[string]map[string]struct{}, int, error) {
+// procScanResult splits /proc scan outcomes: errors are unexpected failures
+// that blanket-protect the sweep; permissionSkips are EACCES reads of other
+// users' processes, which are routine for a non-root sweeper and must not
+// disable deletion (2026-07-23 RCA: they froze every apply sweep into a no-op).
+type procScanResult struct {
+	errors          int
+	permissionSkips int
+}
+
+func collectProcessProtects(procRoot, tmpRoot string, candidates map[string]struct{}, ignoredPID int) (map[string]map[string]struct{}, procScanResult, error) {
 	protected := make(map[string]map[string]struct{})
+	var scan procScanResult
 	entries, err := os.ReadDir(procRoot)
 	if err != nil {
-		return nil, 0, err
+		return nil, scan, err
 	}
-	scanErrors := 0
 	add := func(value, reason string) {
 		for _, name := range candidateNamesFromValue(value, tmpRoot) {
 			if _, ok := candidates[name]; !ok {
@@ -586,32 +612,43 @@ func collectProcessProtects(procRoot, tmpRoot string, candidates map[string]stru
 		processDir := filepath.Join(procRoot, entry.Name())
 		if cwd, err := os.Readlink(filepath.Join(processDir, "cwd")); err == nil {
 			add(trimDeletedSuffix(cwd), "process_cwd")
-		} else if !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, fs.ErrPermission) {
-			scanErrors++
 		} else if errors.Is(err, fs.ErrPermission) {
-			scanErrors++
+			// Another user's process: /proc/<pid>/cwd is unreadable for a
+			// non-root sweeper. Routine on every multi-user host — count it
+			// separately so it never blanket-protects the sweep. cmdline
+			// below is still world-readable, so foreign processes that name
+			// a candidate path on their command line stay protected.
+			scan.permissionSkips++
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			scan.errors++
 		}
 
 		fdEntries, err := os.ReadDir(filepath.Join(processDir, "fd"))
 		if err != nil {
-			if !errors.Is(err, fs.ErrNotExist) {
-				scanErrors++
+			if errors.Is(err, fs.ErrPermission) {
+				scan.permissionSkips++
+			} else if !errors.Is(err, fs.ErrNotExist) {
+				scan.errors++
 			}
 		} else {
 			for _, fd := range fdEntries {
 				target, err := os.Readlink(filepath.Join(processDir, "fd", fd.Name()))
 				if err == nil {
 					add(trimDeletedSuffix(target), "process_fd")
+				} else if errors.Is(err, fs.ErrPermission) {
+					scan.permissionSkips++
 				} else if !errors.Is(err, fs.ErrNotExist) {
-					scanErrors++
+					scan.errors++
 				}
 			}
 		}
 
 		cmdline, err := os.ReadFile(filepath.Join(processDir, "cmdline"))
 		if err != nil {
-			if !errors.Is(err, fs.ErrNotExist) {
-				scanErrors++
+			if errors.Is(err, fs.ErrPermission) {
+				scan.permissionSkips++
+			} else if !errors.Is(err, fs.ErrNotExist) {
+				scan.errors++
 			}
 			continue
 		}
@@ -619,7 +656,7 @@ func collectProcessProtects(procRoot, tmpRoot string, candidates map[string]stru
 			add(arg, "process_cmdline")
 		}
 	}
-	return protected, scanErrors, nil
+	return protected, scan, nil
 }
 
 func trimDeletedSuffix(path string) string {

--- a/internal/tmpfshygiene/sweeper.go
+++ b/internal/tmpfshygiene/sweeper.go
@@ -15,6 +15,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -30,7 +31,19 @@ type policy struct {
 	Category string
 	Pattern  string
 	MinAge   time.Duration
+	// GeneratedName, when set, must also match the entry basename. The glob
+	// alone is far too loose for the leak categories: `.*-00000000.so` happily
+	// matches an unrelated `.my-plugin-00000000.so`. RegularOnly additionally
+	// refuses directories, which the same glob matched. Without both, every
+	// apply sweep recursively deleted foreign entries that merely shared the
+	// suffix.
+	GeneratedName *regexp.Regexp
+	RegularOnly   bool
 }
+
+// nativeLibLeakName pins the documented generated basename: a hex stem, the
+// fixed -00000000 discriminator, and the extension the extractor writes.
+var nativeLibLeakName = regexp.MustCompile(`^\.[0-9a-f]+-00000000\.(so|hm)$`)
 
 // defaultPolicies is the compiled policy table used by both the CLI and
 // daemon. It is intentionally not configurable at runtime: broadening the
@@ -42,8 +55,8 @@ var defaultPolicies = []policy{
 	// these around the clock; on the RAM-backed /tmp this leaked ~10.5GB
 	// across 1978 copies before the 2026-07-23 overload. Deleting a mapped
 	// .so is safe on Linux: the inode survives until the mapping is gone.
-	{Category: "native_lib_leak", Pattern: ".*-00000000.so", MinAge: time.Hour},
-	{Category: "native_lib_leak", Pattern: ".*-00000000.hm", MinAge: time.Hour},
+	{Category: "native_lib_leak", Pattern: ".*-00000000.so", MinAge: time.Hour, GeneratedName: nativeLibLeakName, RegularOnly: true},
+	{Category: "native_lib_leak", Pattern: ".*-00000000.hm", MinAge: time.Hour, GeneratedName: nativeLibLeakName, RegularOnly: true},
 	{Category: "outcome_snapshot", Pattern: "tmp.*", MinAge: time.Hour},
 	{Category: "browser_profile", Pattern: "playwright-*", MinAge: 2 * time.Hour},
 	{Category: "browser_profile", Pattern: "playwright_chromiumdev_profile-*", MinAge: 2 * time.Hour},
@@ -126,7 +139,7 @@ func Sweep(ctx context.Context, opts Options) (Summary, error) {
 	candidates := make([]candidate, 0)
 	nameSet := make(map[string]struct{})
 	for _, entry := range entries {
-		policy, matched := matchPolicy(entry.Name())
+		policy, matched := matchPolicy(entry.Name(), entry)
 		if !matched {
 			continue
 		}
@@ -460,14 +473,45 @@ func InspectLinuxMount(root string) (MountUsage, error) {
 	}, nil
 }
 
-func matchPolicy(name string) (policy, bool) {
+func matchPolicy(name string, entry fs.DirEntry) (policy, bool) {
 	for _, policy := range defaultPolicies {
 		matched, err := filepath.Match(policy.Pattern, name)
-		if err == nil && matched {
-			return policy, true
+		if err != nil || !matched {
+			continue
 		}
+		if policy.GeneratedName != nil && !policy.GeneratedName.MatchString(name) {
+			continue
+		}
+		if policy.RegularOnly && entry != nil && !entry.Type().IsRegular() {
+			continue
+		}
+		return policy, true
 	}
 	return policy{}, false
+}
+
+// procOwnerIsSelf reports whether /proc/<pid> belongs to the sweeper's own UID.
+//
+// EACCES on /proc/<pid>/cwd does not prove the process belongs to another
+// user: Linux denies the same read for a same-UID process that cleared
+// PR_SET_DUMPABLE. Counting that as a routine foreign-process skip would let
+// the sweep quarantine and delete a tree such a process is actively sitting
+// in, so same-UID denials stay fail-closed.
+// procOwnerIsSelf is a variable so tests can simulate a foreign-owned
+// /proc entry: without root they cannot chown the fixture, and ownership is
+// the only thing separating the two EACCES cases.
+var procOwnerIsSelf = defaultProcOwnerIsSelf
+
+func defaultProcOwnerIsSelf(processDir string) bool {
+	info, err := os.Stat(processDir)
+	if err != nil {
+		return false
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return false
+	}
+	return int(stat.Uid) == os.Getuid()
 }
 
 func alwaysKeepTopLevel(name string) bool {
@@ -618,7 +662,11 @@ func collectProcessProtects(procRoot, tmpRoot string, candidates map[string]stru
 			// separately so it never blanket-protects the sweep. cmdline
 			// below is still world-readable, so foreign processes that name
 			// a candidate path on their command line stay protected.
-			scan.permissionSkips++
+			if procOwnerIsSelf(processDir) {
+				scan.errors++
+			} else {
+				scan.permissionSkips++
+			}
 		} else if !errors.Is(err, fs.ErrNotExist) {
 			scan.errors++
 		}
@@ -626,7 +674,11 @@ func collectProcessProtects(procRoot, tmpRoot string, candidates map[string]stru
 		fdEntries, err := os.ReadDir(filepath.Join(processDir, "fd"))
 		if err != nil {
 			if errors.Is(err, fs.ErrPermission) {
-				scan.permissionSkips++
+				if procOwnerIsSelf(processDir) {
+					scan.errors++
+				} else {
+					scan.permissionSkips++
+				}
 			} else if !errors.Is(err, fs.ErrNotExist) {
 				scan.errors++
 			}
@@ -636,7 +688,11 @@ func collectProcessProtects(procRoot, tmpRoot string, candidates map[string]stru
 				if err == nil {
 					add(trimDeletedSuffix(target), "process_fd")
 				} else if errors.Is(err, fs.ErrPermission) {
-					scan.permissionSkips++
+					if procOwnerIsSelf(processDir) {
+						scan.errors++
+					} else {
+						scan.permissionSkips++
+					}
 				} else if !errors.Is(err, fs.ErrNotExist) {
 					scan.errors++
 				}
@@ -646,7 +702,11 @@ func collectProcessProtects(procRoot, tmpRoot string, candidates map[string]stru
 		cmdline, err := os.ReadFile(filepath.Join(processDir, "cmdline"))
 		if err != nil {
 			if errors.Is(err, fs.ErrPermission) {
-				scan.permissionSkips++
+				if procOwnerIsSelf(processDir) {
+					scan.errors++
+				} else {
+					scan.permissionSkips++
+				}
 			} else if !errors.Is(err, fs.ErrNotExist) {
 				scan.errors++
 			}

--- a/internal/tmpfshygiene/sweeper_test.go
+++ b/internal/tmpfshygiene/sweeper_test.go
@@ -321,6 +321,12 @@ func TestSweepIgnoresForeignProcessPermissionDenials(t *testing.T) {
 	}
 	root, proc, now := fakeRoots(t)
 	stale := oldDir(t, root, "tmp.stale", now, 3*time.Hour, "stale")
+	// The fixture cannot chown itself to another UID without root, and
+	// ownership is what separates a foreign process from a same-UID one that
+	// cleared PR_SET_DUMPABLE, so state the foreign ownership explicitly.
+	restoreOwner := procOwnerIsSelf
+	procOwnerIsSelf = func(string) bool { return false }
+	t.Cleanup(func() { procOwnerIsSelf = restoreOwner })
 	// A foreign process whose /proc internals are unreadable (EACCES), like
 	// every other user's process on a shared host. It must not freeze the
 	// sweep: before the 2026-07-23 fix this blanket-protected every candidate.
@@ -620,4 +626,81 @@ func assertMissing(t *testing.T, path string) {
 	if _, err := os.Lstat(path); !os.IsNotExist(err) {
 		t.Fatalf("expected %s to be absent, err=%v", path, err)
 	}
+}
+
+// Codex review catch (P1): the `.*-00000000.so` glob enforces neither the
+// documented hex stem nor a regular-file type, so an unrelated plugin file —
+// or a directory that merely ends the same way — was recursively deleted by
+// every apply sweep.
+func TestSweepLeavesNonGeneratedNativeLibLookalikes(t *testing.T) {
+	root, proc, now := fakeRoots(t)
+	old := now.Add(-3 * time.Hour)
+
+	// Not a hex stem: a real plugin that happens to share the suffix.
+	foreignFile := filepath.Join(root, ".my-plugin-00000000.so")
+	if err := os.WriteFile(foreignFile, []byte("elf"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A directory the glob also matched.
+	foreignDir := filepath.Join(root, ".bcddfd9eb5fdb63f-00000000.so.d")
+	if err := os.MkdirAll(foreignDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(foreignDir, "keep"), []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A genuine leak, to prove the policy still fires.
+	leaked := filepath.Join(root, ".18c737bd3e5dfeff-00000000.so")
+	if err := os.WriteFile(leaked, []byte("elf"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{foreignFile, foreignDir, leaked} {
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := Sweep(context.Background(), fakeOptions(root, proc, now, ModeApply, 40, true)); err != nil {
+		t.Fatal(err)
+	}
+	assertExists(t, foreignFile)
+	assertExists(t, filepath.Join(foreignDir, "keep"))
+	assertMissing(t, leaked)
+}
+
+// Codex review catch (P1): EACCES does not prove the process belongs to
+// another user — Linux denies the same read for a same-UID process that
+// cleared PR_SET_DUMPABLE. Downgrading that to a routine skip let the sweep
+// delete a tree such a process was sitting in.
+func TestSweepFailsClosedOnSameUIDPermissionDenial(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission denials cannot be simulated as root")
+	}
+	root, proc, now := fakeRoots(t)
+	stale := oldDir(t, root, "tmp.stale", now, 3*time.Hour, "stale")
+
+	processDir := filepath.Join(proc, "655")
+	if err := os.MkdirAll(processDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fdDir := filepath.Join(processDir, "fd")
+	if err := os.MkdirAll(fdDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(fdDir, 0o755) })
+	if err := os.WriteFile(filepath.Join(processDir, "cmdline"), []byte("dumpable-off\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := Sweep(context.Background(), fakeOptions(root, proc, now, ModeApply, 40, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.ProcScanErrors == 0 {
+		t.Fatalf("summary = %+v, want a scan error for a same-UID denial", summary)
+	}
+	if summary.DeletedEntries != 0 {
+		t.Fatalf("summary = %+v, want no deletion while the scan is incomplete", summary)
+	}
+	assertExists(t, stale)
 }

--- a/internal/tmpfshygiene/sweeper_test.go
+++ b/internal/tmpfshygiene/sweeper_test.go
@@ -232,12 +232,12 @@ func TestCollectProcessProtectsSkipsSweeperProcess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	protected, scanErrors, err := collectProcessProtects(proc, root, map[string]struct{}{"tmp.self": {}}, 789)
+	protected, scan, err := collectProcessProtects(proc, root, map[string]struct{}{"tmp.self": {}}, 789)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if scanErrors != 0 || len(protected) != 0 {
-		t.Fatalf("protected = %#v, scanErrors = %d", protected, scanErrors)
+	if scan.errors != 0 || len(protected) != 0 {
+		t.Fatalf("protected = %#v, scan = %+v", protected, scan)
 	}
 }
 
@@ -256,7 +256,7 @@ func TestCollectProcessProtectsMapsIsolatedCandidatePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	protected, scanErrors, err := collectProcessProtects(
+	protected, scan, err := collectProcessProtects(
 		proc,
 		root,
 		map[string]struct{}{quarantineName: {}},
@@ -265,12 +265,89 @@ func TestCollectProcessProtectsMapsIsolatedCandidatePath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if scanErrors != 0 {
-		t.Fatalf("scanErrors = %d", scanErrors)
+	if scan.errors != 0 {
+		t.Fatalf("scan = %+v", scan)
 	}
 	if _, ok := protected[quarantineName]["process_cwd"]; !ok {
 		t.Fatalf("protected = %#v, want isolated cwd hit", protected)
 	}
+}
+
+func TestSweepDeletesLeakedNativeLibsAndKeepsMappedOnes(t *testing.T) {
+	root, proc, now := fakeRoots(t)
+	leakedSo := filepath.Join(root, ".bcddfd9eb5fdb63f-00000000.so")
+	leakedHm := filepath.Join(root, ".18c737bd3e5dfeff-00000000.hm")
+	mappedSo := filepath.Join(root, ".bcddfddebceffe6f-00000000.so")
+	for _, path := range []string{leakedSo, leakedHm, mappedSo} {
+		if err := os.WriteFile(path, []byte("elf"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		old := now.Add(-3 * time.Hour)
+		if err := os.Chtimes(path, old, old); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A live process holds the third copy open through an fd link.
+	processDir := filepath.Join(proc, "321")
+	if err := os.MkdirAll(filepath.Join(processDir, "fd"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(mappedSo, filepath.Join(processDir, "fd", "3")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(processDir, "cmdline"), []byte("opencode\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := Sweep(context.Background(), fakeOptions(root, proc, now, ModeApply, 40, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.DeletedEntries != 2 {
+		t.Fatalf("summary = %+v, want the two unreferenced leak files deleted", summary)
+	}
+	stats := summary.Categories["native_lib_leak"]
+	if stats.Candidates != 3 || stats.Deleted != 2 || stats.Protected != 1 {
+		t.Fatalf("native_lib_leak stats = %+v", stats)
+	}
+	assertMissing(t, leakedSo)
+	assertMissing(t, leakedHm)
+	assertExists(t, mappedSo)
+}
+
+func TestSweepIgnoresForeignProcessPermissionDenials(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission denials cannot be simulated as root")
+	}
+	root, proc, now := fakeRoots(t)
+	stale := oldDir(t, root, "tmp.stale", now, 3*time.Hour, "stale")
+	// A foreign process whose /proc internals are unreadable (EACCES), like
+	// every other user's process on a shared host. It must not freeze the
+	// sweep: before the 2026-07-23 fix this blanket-protected every candidate.
+	processDir := filepath.Join(proc, "654")
+	if err := os.MkdirAll(processDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fdDir := filepath.Join(processDir, "fd")
+	if err := os.MkdirAll(fdDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chmod(fdDir, 0o755) })
+	if err := os.WriteFile(filepath.Join(processDir, "cmdline"), []byte("foreign\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	summary, err := Sweep(context.Background(), fakeOptions(root, proc, now, ModeApply, 40, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.ProcScanErrors != 0 || summary.ProcPermissionSkips == 0 {
+		t.Fatalf("summary = %+v, want permission skips counted without scan errors", summary)
+	}
+	if summary.ProtectHits["proc_scan_error"] != 0 || summary.DeletedEntries != 1 {
+		t.Fatalf("summary = %+v, want stale candidate deleted despite foreign EACCES", summary)
+	}
+	assertMissing(t, stale)
 }
 
 func TestSweepRevalidatesAgeImmediatelyBeforeApply(t *testing.T) {

--- a/internal/tmpfshygiene/types.go
+++ b/internal/tmpfshygiene/types.go
@@ -57,7 +57,12 @@ type Summary struct {
 	Categories       map[string]CategoryStats `json:"categories"`
 	ProtectHits      map[string]int           `json:"protect_hits"`
 	ProcScanErrors   int                      `json:"proc_scan_errors,omitempty"`
-	Error            string                   `json:"error,omitempty"`
+	// ProcPermissionSkips counts /proc entries the sweeper could not inspect
+	// because they belong to other users (EACCES). These are expected on any
+	// multi-user host and never blanket-protect candidates; they are surfaced
+	// for observability only.
+	ProcPermissionSkips int    `json:"proc_permission_skips,omitempty"`
+	Error               string `json:"error,omitempty"`
 }
 
 type removalResult struct {


### PR DESCRIPTION
## Problem

During the 2026-07-23 host overload (load 129, 34 oom-kills, /tmp tmpfs 15G/16G) the daemon hygiene sweep was a permanent no-op: `matched=252 protected=252 deleted=0`, while the actual 10.5GB leak pattern was not even matchable.

Two defects:

1. **EACCES blanket-protect.** `collectProcessProtects` counted permission-denied reads of other users' `/proc` entries as scan errors, and any scan error > 0 protects every candidate. On a multi-user host that is the steady state, so every apply sweep froze. Now EACCES is counted separately as `proc_permission_skips` (surfaced in the summary) and does not disable deletion; genuine unexpected errors still blanket-protect.

2. **No policy for the real leak.** Bun/Zig-built CLIs (opencode) extract a ~5.6MB embedded native lib to `/tmp/.<hex>-00000000.so` (plus an empty `.hm`) on every invocation and never delete it. Supervisor backend probes mint them 24/7, so 1978 copies (~10.5GB RAM) accumulated. New `native_lib_leak` category reaps them after 1h; copies held open by a live process remain protected by the existing fd scan.

## Testing

- New `TestSweepDeletesLeakedNativeLibsAndKeepsMappedOnes` — deletes stale .so/.hm, keeps the mapped one.
- New `TestSweepIgnoresForeignProcessPermissionDenials` — EACCES on foreign /proc does not freeze the sweep.
- Full `go test ./...` green except pre-existing `TestBuildWorkerCmd_CodexPromptFileIsValidUTF8` (fails identically on clean main; umask-dependent, unrelated).

## Context

Incident RCA: vault `Dev/Areas/maestro/handovers/2026-07-23-cpu-overload-tmpfs-so-leak-rca.md`. Host-side backstop `/etc/tmpfiles.d/maestro-build-debris.conf` already installed; this makes the daemon-side sweep actually work. Deployed as break-fix by operator request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates tmpfs hygiene cleanup for leaked native library files and foreign `/proc` permission denials. The main changes are:

- Adds `native_lib_leak` policies for stale `.<hex>-00000000.so` and `.hm` files.
- Separates expected EACCES `/proc` reads into `proc_permission_skips`.
- Keeps unexpected `/proc` scan errors as blanket-protection events.
- Adds tests for stale native library deletion and foreign-process permission skips.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The change is narrowly scoped to tmpfs hygiene and preserves the existing protections for live paths and unexpected scan failures. Targeted tests cover both new cleanup behavior and the EACCES handling change. No blocking correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The targeted contract validation confirms that TestSweepDeletesLeakedNativeLibsAndKeepsMappedOnes and TestSweepIgnoresForeignProcessPermissionDenials PASS in the targeted log.
- The package contract validation confirms that all internal tmpfshygiene tests PASS in the package log.
- The proofs confirm that both logs include the exact command, working directory, verbose test output, and exit code, ensuring the logs are complete for review.

<a href="https://app.greptile.com/trex/runs/15623429/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/tmpfshygiene/sweeper.go | Adds native library leak cleanup policies and separates expected `/proc` permission skips from real scan errors without weakening existing candidate protection logic. |
| internal/tmpfshygiene/sweeper_test.go | Updates process-protection tests and adds coverage for stale native library cleanup and foreign-process EACCES handling. |
| internal/tmpfshygiene/types.go | Extends sweep summaries with `proc_permission_skips` observability for expected foreign process permission denials. |

<sub>Reviews (1): Last reviewed commit: ["fix(tmpfs-hygiene): stop blanket no-op s..."](https://github.com/befeast/maestro/commit/6773837233d690064a2a13d40968053b3adf1821) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46760067)</sub>

<!-- /greptile_comment -->