### PR TITLE
feat: hold-on-cooldown — wait out quota cooldowns instead of cascading the fallback chain

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -385,6 +385,41 @@ type ModelConfig struct {
 	// project override. Otherwise lanes compose in declaration order, with each
 	// provider's default followed by its local fallbacks before the next provider.
 	ProviderLanes []ProviderLane `yaml:"provider_lanes,omitempty"`
+	// HoldOnCooldown makes quota-class backend cooldowns a wait, not a cascade:
+	// when the routed backend is cooling down with a known reset inside the
+	// configured window, dispatch/retry hold for that reset instead of walking
+	// the fallback chain. See HoldOnCooldownConfig.
+	HoldOnCooldown HoldOnCooldownConfig `yaml:"hold_on_cooldown,omitempty"`
+}
+
+// HoldOnCooldownConfig controls hold-vs-cascade semantics for quota-class
+// backend cooldowns (provider_limit, usage_limit, model_cooldown,
+// model_overloaded, quota_pressure). Off, a cooling backend cascades work onto
+// the next fallback rung immediately — under a fleet-wide primary cooldown
+// that dumps every project onto one fallback seat (2026-07 live: an Anthropic
+// cooldown pushed ~80% of the week's tokens through the single ChatGPT seat).
+// On, a cooldown whose RetryAfter lands within max_wait_minutes holds the work
+// for the reset; only unknown or beyond-window resets (weekly caps), and
+// non-quota failures (auth_failure, model_unavailable, disabled), still
+// cascade.
+type HoldOnCooldownConfig struct {
+	Enabled bool `yaml:"enabled"`
+	// MaxWaitMinutes bounds how long a hold may wait for a stated reset.
+	// 0 means the default (360 = 6h, covering a 5-hour subscription window);
+	// resets further out than this cascade to the next rung as before.
+	MaxWaitMinutes int `yaml:"max_wait_minutes,omitempty"`
+}
+
+// defaultHoldOnCooldownMaxWait covers a full 5-hour subscription window with
+// slack; a stated reset beyond it (e.g. a weekly cap) is not worth idling for.
+const defaultHoldOnCooldownMaxWait = 360 * time.Minute
+
+// MaxWait returns the bounded hold window as a duration.
+func (h HoldOnCooldownConfig) MaxWait() time.Duration {
+	if h.MaxWaitMinutes > 0 {
+		return time.Duration(h.MaxWaitMinutes) * time.Minute
+	}
+	return defaultHoldOnCooldownMaxWait
 }
 
 // VersioningConfig controls automatic version bumping on PR merge.
@@ -2656,6 +2691,9 @@ func parse(data []byte) (*Config, error) {
 		if def.NonAgentic {
 			return nil, fmt.Errorf("config: model.fallback_backends includes %q which is marked non_agentic; the fallback chain is the worker chain — a non-agentic entry would produce fake-PR sessions when paid backends are exhausted. Remove %q from fallback_backends and use it only for supervisor sub-tasks", fb, fb)
 		}
+	}
+	if cfg.Model.HoldOnCooldown.MaxWaitMinutes < 0 {
+		return nil, fmt.Errorf("config: model.hold_on_cooldown.max_wait_minutes = %d; want >= 0 (0 uses the default window)", cfg.Model.HoldOnCooldown.MaxWaitMinutes)
 	}
 	// #704: quota calibration sanity. Capacities must be non-negative and
 	// the dispatch threshold a fraction in (0, 1]; a percent-style value

--- a/internal/config/hold_on_cooldown_test.go
+++ b/internal/config/hold_on_cooldown_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// model.hold_on_cooldown parses, defaults max_wait to 6h, and rejects a
+// negative window.
+func TestParse_HoldOnCooldown(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: claude
+  hold_on_cooldown:
+    enabled: true
+  backends:
+    claude:
+      cmd: claude
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	hold := cfg.Model.HoldOnCooldown
+	if !hold.Enabled {
+		t.Fatal("hold_on_cooldown.enabled should parse true")
+	}
+	if got := hold.MaxWait(); got != 360*time.Minute {
+		t.Fatalf("MaxWait() = %v, want default 6h", got)
+	}
+}
+
+func TestParse_HoldOnCooldownExplicitWindow(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: claude
+  hold_on_cooldown:
+    enabled: true
+    max_wait_minutes: 90
+  backends:
+    claude:
+      cmd: claude
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.Model.HoldOnCooldown.MaxWait(); got != 90*time.Minute {
+		t.Fatalf("MaxWait() = %v, want 90m", got)
+	}
+}
+
+func TestParse_HoldOnCooldownRejectsNegativeWindow(t *testing.T) {
+	yaml := `
+repo: owner/repo
+model:
+  default: claude
+  hold_on_cooldown:
+    max_wait_minutes: -5
+  backends:
+    claude:
+      cmd: claude
+`
+	_, err := parse([]byte(yaml))
+	if err == nil || !strings.Contains(err.Error(), "hold_on_cooldown.max_wait_minutes") {
+		t.Fatalf("err = %v, want max_wait_minutes rejection", err)
+	}
+}

--- a/internal/orchestrator/backend_selector.go
+++ b/internal/orchestrator/backend_selector.go
@@ -27,7 +27,44 @@ const (
 	// or disabled), so the first healthy fallback was substituted instead of
 	// re-burning the retry budget on a dead backend (#805).
 	selectionReasonRetryBlockedFallback = "retry_fallback_blocked_backend"
+	// selectionReasonHoldOnCooldown marks a dispatch/fallover that was HELD
+	// for the routed backend's quota-cooldown reset instead of cascading to
+	// the next fallback rung (model.hold_on_cooldown). The work waits for the
+	// stated RetryAfter; nothing was substituted.
+	selectionReasonHoldOnCooldown = "hold_on_cooldown"
 )
+
+// holdableCooldownReason reports whether a BackendHealth block reason is a
+// quota/capacity cooldown worth waiting out under model.hold_on_cooldown.
+// Auth failures and missing models are excluded: waiting cannot fix them, so
+// they keep cascading to the next rung.
+func holdableCooldownReason(reason string) bool {
+	switch reason {
+	case state.BackendBlockProviderLimit,
+		state.BackendBlockUsageLimit,
+		state.BackendBlockModelCooldown,
+		state.BackendBlockModelOverloaded,
+		state.BackendBlockQuotaPressure:
+		return true
+	}
+	return false
+}
+
+// holdOnCooldownUntil decides whether a blocked backend should be waited for
+// instead of cascaded past. It returns the hold expiry when hold_on_cooldown
+// is enabled, the block is a holdable quota cooldown, and the stated reset
+// lands inside the configured window. A nil RetryAfter (unknown reset) or a
+// reset beyond max_wait (weekly cap) keeps today's cascade behavior.
+func (o *Orchestrator) holdOnCooldownUntil(blockedBy string, retryAfter *time.Time, now time.Time) (*time.Time, bool) {
+	hold := o.cfg.Model.HoldOnCooldown
+	if !hold.Enabled || !holdableCooldownReason(blockedBy) || retryAfter == nil {
+		return nil, false
+	}
+	if !retryAfter.After(now) || retryAfter.After(now.Add(hold.MaxWait())) {
+		return nil, false
+	}
+	return retryAfter, true
+}
 
 // backendFailureCopy holds the reason-dependent strings the dead-worker
 // handlers use to gate a backend and respawn on a fallback (#693/#713). Auth
@@ -261,6 +298,30 @@ func (o *Orchestrator) selectBackendFallback(st *state.State, sess *state.Sessio
 		RouteSelectionReason: o.cfg.Model.ResolvedRoute().SelectionReason,
 		PreviousBackend:      backendName(sess),
 	}
+	// model.hold_on_cooldown: when the session's own backend is gated by a
+	// quota cooldown that resets inside the hold window, refuse to cascade —
+	// return no selection so every caller takes its existing no-fallback path
+	// (park the retry / mark the budget-preserving dead session) and the work
+	// waits for the reset instead of dumping onto the next rung. The held
+	// backend is recorded as the sole blocked candidate so the audit trail and
+	// earliestCandidateRetry carry the hold expiry.
+	if holdUntil, held := o.sessionBackendHold(st, sess, now); held {
+		provider, model := o.providerModelRouteForSession(sess, "", "")
+		selection.SelectionReason = selectionReasonHoldOnCooldown
+		selection.HoldUntil = holdUntil.UTC().Format(time.RFC3339)
+		selection.CandidateScores = append(selection.CandidateScores, state.BackendCandidate{
+			Backend:    backendName(sess),
+			Provider:   provider,
+			Model:      model,
+			Available:  false,
+			BlockedBy:  o.sessionBackendBlockReason(st, sess),
+			RetryAfter: holdUntil.UTC().Format(time.RFC3339),
+			Fit:        0.5, Policy: 0.5, Final: 0.5,
+		})
+		log.Printf("[orch] hold_on_cooldown: backend %s cooling down until %s — holding instead of falling back (%s)",
+			backendName(sess), holdUntil.UTC().Format(time.RFC3339), selectionReason)
+		return selection
+	}
 	for _, candidate := range o.backendFallbackCandidates(st, sess, selectionReason) {
 		provider, model := o.providerModelRouteForBackend(candidate, "")
 		entry := state.BackendCandidate{Backend: candidate, Provider: provider, Model: model, Fit: 0.5, Policy: 0.5, Final: 0.5}
@@ -327,6 +388,44 @@ func (o *Orchestrator) selectBackendFallback(st *state.State, sess *state.Sessio
 	return selection
 }
 
+// sessionBackendHold reports whether the session's current backend is in a
+// holdable quota cooldown whose reset lands inside the hold_on_cooldown
+// window, checking both the backend-level gate and the provider/model-scoped
+// route gate.
+func (o *Orchestrator) sessionBackendHold(st *state.State, sess *state.Session, now time.Time) (*time.Time, bool) {
+	if st == nil || sess == nil || sess.Backend == "" || !o.cfg.Model.HoldOnCooldown.Enabled {
+		return nil, false
+	}
+	if health, ok := st.BackendHealth[sess.Backend]; ok && health.State == state.BackendHealthCooldown {
+		if holdUntil, held := o.holdOnCooldownUntil(health.Reason, health.RetryAfter, now); held {
+			return holdUntil, true
+		}
+	}
+	provider, model := o.providerModelRouteForSession(sess, "", "")
+	if health, ok := providerModelHealth(st, provider, model); ok && health.State == state.BackendHealthCooldown {
+		if holdUntil, held := o.holdOnCooldownUntil(health.Reason, health.RetryAfter, now); held {
+			return holdUntil, true
+		}
+	}
+	return nil, false
+}
+
+// sessionBackendBlockReason returns the block reason recorded for the
+// session's backend (backend-level first, then the provider/model route).
+func (o *Orchestrator) sessionBackendBlockReason(st *state.State, sess *state.Session) string {
+	if st == nil || sess == nil {
+		return ""
+	}
+	if health, ok := st.BackendHealth[sess.Backend]; ok && health.State == state.BackendHealthCooldown {
+		return health.Reason
+	}
+	provider, model := o.providerModelRouteForSession(sess, "", "")
+	if health, ok := providerModelHealth(st, provider, model); ok && health.State == state.BackendHealthCooldown {
+		return health.Reason
+	}
+	return ""
+}
+
 // resolveDispatchBackend resolves the backend for a fresh dispatch and gates
 // the routed choice on BackendHealth (#695). Without this gate the router's
 // decision never saw cooldowns, so during a credential outage every new
@@ -343,6 +442,15 @@ func (o *Orchestrator) resolveDispatchBackend(st *state.State, issue github.Issu
 	blockedBy, blockedRetry := o.dispatchBackendBlock(st, decision.Backend, decision.Model, now)
 	if blockedBy == "" {
 		return decision, true, nil
+	}
+	// model.hold_on_cooldown: a routed backend gated by a quota cooldown with
+	// a reset inside the hold window is a wait, not a cascade. Report the
+	// dispatch as not-dispatchable with the hold expiry so the caller pauses
+	// this issue until the window reopens instead of substituting the next
+	// rung. Reason marks the hold so the pause log names it.
+	if holdUntil, held := o.holdOnCooldownUntil(blockedBy, blockedRetry, now); held {
+		decision.Reason = selectionReasonHoldOnCooldown
+		return decision, false, holdUntil
 	}
 	earliest := blockedRetry
 	candidates := o.dispatchBackendCandidates(decision.Backend)

--- a/internal/orchestrator/dispatch_visibility.go
+++ b/internal/orchestrator/dispatch_visibility.go
@@ -49,17 +49,25 @@ func (o *Orchestrator) reconcileDispatchVisibility(s *state.State, now time.Time
 	if project == "" {
 		project = strings.TrimSpace(o.cfg.Repo)
 	}
+	// A stall whose cause is backend cooldown routes to the dedicated
+	// backend_cooldown_exhausted class ("battery"), so the operator can tell a
+	// quota wait (self-clears at the stated reset) from a generic idle stall.
+	alertClass := notify.AlertIdleStall
 	title := "maestro idle stall"
+	if reasonClass == state.DispatchHoldBackendsCoolingDown || reasonClass == state.DispatchHoldOnCooldown {
+		alertClass = notify.AlertBackendCooldownExhausted
+		title = "maestro backend cooldown"
+	}
 	if project != "" {
 		title += ": " + project
 	}
 	if err := o.notifier.Alert(
-		notify.AlertIdleStall,
+		alertClass,
 		project+":"+reasonClass,
 		title,
 		body,
 	); err != nil {
-		log.Printf("[orch] idle_stall notification failed for %s: %v", project, err)
+		log.Printf("[orch] %s notification failed for %s: %v", alertClass, project, err)
 		return
 	}
 	s.MarkIdleStallNotified(reasonClass)
@@ -108,6 +116,17 @@ func (o *Orchestrator) dispatchHoldForCycle(s *state.State, capacity state.Capac
 				Active:      true,
 				ReasonClass: state.DispatchHoldBackendsCoolingDown,
 				Detail:      detail,
+			}
+		}
+		if holdUntil, backend, held := o.dispatchHoldOnCooldown(s, now); held {
+			return state.DispatchHold{
+				Active:      true,
+				ReasonClass: state.DispatchHoldOnCooldown,
+				Detail: fmt.Sprintf(
+					"hold_on_cooldown: routed backend %s cooling down; holding for reset at %s instead of cascading",
+					backend,
+					holdUntil.UTC().Format(time.RFC3339),
+				),
 			}
 		}
 		if capacity.GateBound() {
@@ -193,6 +212,31 @@ func containsFold(values []string, want string) bool {
 		}
 	}
 	return false
+}
+
+// dispatchHoldOnCooldown mirrors resolveDispatchBackend's hold gate for the
+// route default so the dashboard names the deliberate wait: the routed backend
+// is in a holdable quota cooldown whose reset lands inside the
+// model.hold_on_cooldown window, so fresh dispatch waits instead of cascading.
+// Per-issue label pins can route elsewhere; the route default is the fleet's
+// dispatch surface and is what the hold visibly parks.
+func (o *Orchestrator) dispatchHoldOnCooldown(s *state.State, now time.Time) (*time.Time, string, bool) {
+	if o == nil || o.cfg == nil || !o.cfg.Model.HoldOnCooldown.Enabled {
+		return nil, "", false
+	}
+	backend := o.cfg.Model.EffectiveDefault()
+	if backend == "" {
+		return nil, "", false
+	}
+	blockedBy, blockedRetry := o.dispatchBackendBlock(s, backend, "", now)
+	if blockedBy == "" {
+		return nil, "", false
+	}
+	holdUntil, held := o.holdOnCooldownUntil(blockedBy, blockedRetry, now)
+	if !held {
+		return nil, "", false
+	}
+	return holdUntil, backend, true
 }
 
 // allDispatchBackendsCoolingDown mirrors the selector's real candidate set and

--- a/internal/orchestrator/hold_on_cooldown_test.go
+++ b/internal/orchestrator/hold_on_cooldown_test.go
@@ -1,0 +1,178 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/router"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func holdTestOrchestrator(enabled bool, maxWaitMinutes int) *Orchestrator {
+	cfg := &config.Config{
+		Repo: "owner/repo",
+		Model: config.ModelConfig{
+			Default:          "claude",
+			FallbackBackends: []string{"sol", "kimi"},
+			Backends: map[string]config.BackendDef{
+				"claude": {Cmd: "claude"},
+				"sol":    {Cmd: "codex"},
+				"kimi":   {Cmd: "kimi"},
+			},
+			HoldOnCooldown: config.HoldOnCooldownConfig{
+				Enabled:        enabled,
+				MaxWaitMinutes: maxWaitMinutes,
+			},
+		},
+	}
+	return &Orchestrator{cfg: cfg, router: router.New(cfg)}
+}
+
+func coolingState(backend, reason string, retryAfter *time.Time, now time.Time) *state.State {
+	s := state.NewState()
+	s.BackendHealth = map[string]state.BackendHealth{
+		backend: {
+			State:      state.BackendHealthCooldown,
+			Reason:     reason,
+			Since:      now.Add(-time.Minute),
+			RetryAfter: retryAfter,
+		},
+	}
+	return s
+}
+
+// A quota cooldown with a reset inside the hold window must hold fresh
+// dispatch — even though later fallback rungs are healthy — and report the
+// hold expiry so the caller can pause until the window reopens.
+func TestResolveDispatchBackend_HoldsForQuotaCooldownWithinWindow(t *testing.T) {
+	now := time.Now().UTC()
+	reset := now.Add(30 * time.Minute)
+	o := holdTestOrchestrator(true, 0)
+	s := coolingState("claude", state.BackendBlockProviderLimit, &reset, now)
+
+	decision, ok, retryAt := o.resolveDispatchBackend(s, makeIssue(1, "hold me"), now)
+	if ok {
+		t.Fatalf("dispatchable = true, want hold (decision=%+v)", decision)
+	}
+	if decision.Reason != selectionReasonHoldOnCooldown {
+		t.Fatalf("reason = %q, want %q", decision.Reason, selectionReasonHoldOnCooldown)
+	}
+	if retryAt == nil || !retryAt.Equal(reset) {
+		t.Fatalf("retryAt = %v, want %v", retryAt, reset)
+	}
+}
+
+// A reset beyond max_wait (weekly cap) must keep today's cascade: the next
+// healthy rung is substituted.
+func TestResolveDispatchBackend_CascadesWhenResetBeyondWindow(t *testing.T) {
+	now := time.Now().UTC()
+	reset := now.Add(48 * time.Hour)
+	o := holdTestOrchestrator(true, 60)
+	s := coolingState("claude", state.BackendBlockProviderLimit, &reset, now)
+
+	decision, ok, _ := o.resolveDispatchBackend(s, makeIssue(1, "cascade"), now)
+	if !ok {
+		t.Fatal("dispatchable = false, want cascade to a healthy rung")
+	}
+	if decision.Backend != "sol" {
+		t.Fatalf("backend = %q, want sol", decision.Backend)
+	}
+	if decision.Reason != selectionReasonDispatchBlockedFallback {
+		t.Fatalf("reason = %q, want %q", decision.Reason, selectionReasonDispatchBlockedFallback)
+	}
+}
+
+// An auth failure is not a quota wait — cascading must proceed even with the
+// hold feature enabled and the reset nearby.
+func TestResolveDispatchBackend_CascadesOnAuthFailure(t *testing.T) {
+	now := time.Now().UTC()
+	reset := now.Add(5 * time.Minute)
+	o := holdTestOrchestrator(true, 0)
+	s := coolingState("claude", state.BackendBlockAuthFailure, &reset, now)
+
+	decision, ok, _ := o.resolveDispatchBackend(s, makeIssue(1, "auth"), now)
+	if !ok || decision.Backend != "sol" {
+		t.Fatalf("decision = %+v ok=%v, want cascade to sol", decision, ok)
+	}
+}
+
+// With the feature disabled the pre-existing cascade behavior is untouched.
+func TestResolveDispatchBackend_FeatureOffKeepsCascade(t *testing.T) {
+	now := time.Now().UTC()
+	reset := now.Add(30 * time.Minute)
+	o := holdTestOrchestrator(false, 0)
+	s := coolingState("claude", state.BackendBlockProviderLimit, &reset, now)
+
+	decision, ok, _ := o.resolveDispatchBackend(s, makeIssue(1, "off"), now)
+	if !ok || decision.Backend != "sol" {
+		t.Fatalf("decision = %+v ok=%v, want cascade to sol with hold disabled", decision, ok)
+	}
+}
+
+// A cooldown with no stated reset cannot be waited for; cascade.
+func TestResolveDispatchBackend_CascadesWhenResetUnknown(t *testing.T) {
+	now := time.Now().UTC()
+	o := holdTestOrchestrator(true, 0)
+	s := coolingState("claude", state.BackendBlockUsageLimit, nil, now)
+
+	decision, ok, _ := o.resolveDispatchBackend(s, makeIssue(1, "unknown"), now)
+	if !ok || decision.Backend != "sol" {
+		t.Fatalf("decision = %+v ok=%v, want cascade when no RetryAfter", decision, ok)
+	}
+}
+
+// The live-failure fallover must hold too: selectBackendFallback returns no
+// selection (callers park / preserve budget) and records the hold expiry.
+func TestSelectBackendFallback_HoldsInsteadOfCascading(t *testing.T) {
+	now := time.Now().UTC()
+	reset := now.Add(90 * time.Minute)
+	o := holdTestOrchestrator(true, 0)
+	s := coolingState("claude", state.BackendBlockUsageLimit, &reset, now)
+	sess := &state.Session{Backend: "claude", IssueNumber: 7}
+
+	selection := o.selectBackendFallback(s, sess, now, selectionReasonUsageLimitFallback)
+	if selection.SelectedBackend != "" {
+		t.Fatalf("SelectedBackend = %q, want empty (hold)", selection.SelectedBackend)
+	}
+	if selection.SelectionReason != selectionReasonHoldOnCooldown {
+		t.Fatalf("SelectionReason = %q, want %q", selection.SelectionReason, selectionReasonHoldOnCooldown)
+	}
+	if selection.HoldUntil != reset.UTC().Format(time.RFC3339) {
+		t.Fatalf("HoldUntil = %q, want %s", selection.HoldUntil, reset.UTC().Format(time.RFC3339))
+	}
+	if earliest := earliestCandidateRetry(selection); earliest == nil || !earliest.Equal(reset.Truncate(time.Second)) {
+		t.Fatalf("earliestCandidateRetry = %v, want %v", earliest, reset.Truncate(time.Second))
+	}
+}
+
+// Feature off: the fallover walks the chain exactly as before.
+func TestSelectBackendFallback_FeatureOffWalksChain(t *testing.T) {
+	now := time.Now().UTC()
+	reset := now.Add(90 * time.Minute)
+	o := holdTestOrchestrator(false, 0)
+	s := coolingState("claude", state.BackendBlockUsageLimit, &reset, now)
+	sess := &state.Session{Backend: "claude", IssueNumber: 7}
+
+	selection := o.selectBackendFallback(s, sess, now, selectionReasonUsageLimitFallback)
+	if selection.SelectedBackend != "sol" {
+		t.Fatalf("SelectedBackend = %q, want sol", selection.SelectedBackend)
+	}
+}
+
+// The dashboard hold surface: dispatchHoldForCycle reports hold_on_cooldown
+// when the route default is held while other rungs stay healthy.
+func TestDispatchHoldForCycle_ReportsHoldOnCooldown(t *testing.T) {
+	now := time.Now().UTC()
+	reset := now.Add(45 * time.Minute)
+	o := holdTestOrchestrator(true, 0)
+	s := coolingState("claude", state.BackendBlockQuotaPressure, &reset, now)
+
+	hold := o.dispatchHoldForCycle(s, state.Capacity{}, 3, now)
+	if !hold.Active || hold.ReasonClass != state.DispatchHoldOnCooldown {
+		t.Fatalf("hold = %+v, want active hold_on_cooldown", hold)
+	}
+}
+
+var _ = github.Issue{} // keep import stable if makeIssue moves

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -10180,7 +10180,11 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 					if retryAt != nil {
 						expiry = "earliest cooldown expires " + retryAt.UTC().Format(time.RFC3339)
 					}
-					log.Printf("[orch] dispatch paused: all backends blocked or cooling down (%s) — not spawning fresh workers this cycle", expiry)
+					if decision.Reason == selectionReasonHoldOnCooldown {
+						log.Printf("[orch] dispatch hold: routed backend %s cooling down (%s) — hold_on_cooldown waits for the reset instead of cascading to fallback rungs", decision.Backend, expiry)
+					} else {
+						log.Printf("[orch] dispatch paused: all backends blocked or cooling down (%s) — not spawning fresh workers this cycle", expiry)
+					}
 					dispatchPauseLogged = true
 				}
 				continue

--- a/internal/state/dispatch_hold.go
+++ b/internal/state/dispatch_hold.go
@@ -13,10 +13,14 @@ const (
 const (
 	DispatchHoldBlockingOutcomeCheck = "blocking_outcome_check"
 	DispatchHoldBackendsCoolingDown  = "all_backends_cooling_down"
-	DispatchHoldPRGateCapacity       = "capacity_blocked_by_pr_gates"
-	DispatchHoldPaused               = "paused"
-	DispatchHoldAwaitingDispatch     = "awaiting_dispatch"
-	DispatchHoldQueueEmpty           = "queue_empty"
+	// DispatchHoldOnCooldown: model.hold_on_cooldown is deliberately waiting
+	// out the routed backend's quota-cooldown reset instead of cascading work
+	// onto the remaining fallback rungs (which may be healthy).
+	DispatchHoldOnCooldown       = "hold_on_cooldown"
+	DispatchHoldPRGateCapacity   = "capacity_blocked_by_pr_gates"
+	DispatchHoldPaused           = "paused"
+	DispatchHoldAwaitingDispatch = "awaiting_dispatch"
+	DispatchHoldQueueEmpty       = "queue_empty"
 )
 
 // DispatchHold is the bounded, command/output-free explanation for why fresh

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -190,6 +190,9 @@ type BackendSelection struct {
 	CandidateScores      []BackendCandidate `json:"candidate_scores,omitempty"`
 	HardPin              bool               `json:"hard_pin,omitempty"`
 	PreviousBackend      string             `json:"previous_backend,omitempty"`
+	// HoldUntil (RFC3339) is set when hold_on_cooldown suppressed a fallback
+	// cascade: no backend was selected and the work waits for this instant.
+	HoldUntil string `json:"hold_until,omitempty"`
 
 	// Task-aware policy routing observability (#783, RFC §2.7). Tier is the
 	// strength tier the policy resolved to; Effort/Model are the per-tier

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -53,6 +53,12 @@ type LLMClient interface {
 
 type backendLLMClient struct {
 	cfg *config.Config
+	// backendHealth is an optional per-cycle snapshot of the project's
+	// BackendHealth gates. When present, candidates in an active cooldown are
+	// skipped instead of re-tried every supervise tick — without it the walk
+	// re-burned the whole chain down to the last rung (live 2026-07: opencode
+	// every cycle while the primaries cooled).
+	backendHealth map[string]state.BackendHealth
 }
 
 const (
@@ -64,8 +70,15 @@ func NewBackendLLMClient(cfg *config.Config) LLMClient {
 	return &backendLLMClient{cfg: cfg}
 }
 
+// withBackendHealth returns a copy of the client carrying the cycle's
+// BackendHealth snapshot, so a concurrent Complete on the shared engine client
+// never observes a mutated map.
+func (c *backendLLMClient) withBackendHealth(health map[string]state.BackendHealth) *backendLLMClient {
+	return &backendLLMClient{cfg: c.cfg, backendHealth: health}
+}
+
 func (c *backendLLMClient) Complete(prompt string) (string, error) {
-	candidates, err := supervisorBackendCandidates(c.cfg)
+	candidates, err := supervisorBackendCandidates(c.cfg, c.backendHealth, time.Now().UTC())
 	if err != nil {
 		return "", err
 	}
@@ -120,7 +133,7 @@ type supervisorBackendCandidate struct {
 	def  config.BackendDef
 }
 
-func supervisorBackendCandidates(cfg *config.Config) ([]supervisorBackendCandidate, error) {
+func supervisorBackendCandidates(cfg *config.Config, health map[string]state.BackendHealth, now time.Time) ([]supervisorBackendCandidate, error) {
 	primary, def, err := supervisorBackend(cfg)
 	if err != nil {
 		return nil, err
@@ -128,6 +141,7 @@ func supervisorBackendCandidates(cfg *config.Config) ([]supervisorBackendCandida
 	names := append([]string{primary}, cfg.Model.FallbackBackends...)
 	seen := make(map[string]struct{}, len(names))
 	out := make([]supervisorBackendCandidate, 0, len(names))
+	var cooling []string
 	for _, name := range names {
 		name = strings.TrimSpace(name)
 		if name == "" {
@@ -141,13 +155,29 @@ func supervisorBackendCandidates(cfg *config.Config) ([]supervisorBackendCandida
 		if !ok || !candidate.IsEnabled() {
 			continue
 		}
+		// Skip candidates in an active BackendHealth cooldown instead of
+		// re-proving the outage with a live call every tick. The gate clears
+		// itself: ReconcileBackendHealth drops elapsed entries, and an entry
+		// whose RetryAfter has passed is eligible again here.
+		if gate, gated := health[name]; gated && gate.State == state.BackendHealthCooldown {
+			if gate.RetryAfter == nil || now.Before(*gate.RetryAfter) {
+				cooling = append(cooling, name)
+				continue
+			}
+		}
 		if name == primary {
 			candidate = def
 		}
 		out = append(out, supervisorBackendCandidate{name: name, def: candidate})
 	}
 	if len(out) == 0 {
+		if len(cooling) > 0 {
+			return nil, fmt.Errorf("supervisor backend candidates all cooling down (%s); skipping LLM this cycle", strings.Join(cooling, ", "))
+		}
 		return nil, fmt.Errorf("supervisor has no enabled backend candidates")
+	}
+	if len(cooling) > 0 {
+		log.Printf("[supervisor] skipping cooling-down backend candidate(s) %s for this cycle", strings.Join(cooling, ", "))
 	}
 	return out, nil
 }
@@ -241,6 +271,12 @@ func (e *Engine) decideWithLLM(st *state.State) (state.SupervisorDecision, error
 	client := e.llm
 	if client == nil {
 		client = NewBackendLLMClient(e.cfg)
+	}
+	// Thread the cycle's BackendHealth gates into the backend walk so a
+	// cooling-down candidate is skipped, not re-tried per tick. Custom LLM
+	// clients (tests, remote implementations) pass through unchanged.
+	if backendClient, ok := client.(*backendLLMClient); ok {
+		client = backendClient.withBackendHealth(st.BackendHealth)
 	}
 	output, err := client.Complete(prompt)
 	if err != nil {

--- a/internal/supervisor/llm_cooldown_test.go
+++ b/internal/supervisor/llm_cooldown_test.go
@@ -1,0 +1,74 @@
+package supervisor
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func cooldownCandidatesConfig() *config.Config {
+	return &config.Config{Model: config.ModelConfig{
+		Default:          "claude",
+		FallbackBackends: []string{"sol", "opencode"},
+		Backends: map[string]config.BackendDef{
+			"claude":   {Cmd: "claude"},
+			"sol":      {Cmd: "codex"},
+			"opencode": {Cmd: "opencode"},
+		},
+	}}
+}
+
+// A candidate in active BackendHealth cooldown is skipped for the cycle
+// instead of re-proving the outage with a live call (the pre-fix walk landed
+// on the last rung — opencode — every supervise tick while primaries cooled).
+func TestSupervisorBackendCandidates_SkipsCoolingBackends(t *testing.T) {
+	now := time.Now().UTC()
+	retry := now.Add(30 * time.Minute)
+	health := map[string]state.BackendHealth{
+		"claude": {State: state.BackendHealthCooldown, Reason: state.BackendBlockProviderLimit, RetryAfter: &retry},
+	}
+
+	candidates, err := supervisorBackendCandidates(cooldownCandidatesConfig(), health, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 2 || candidates[0].name != "sol" || candidates[1].name != "opencode" {
+		t.Fatalf("candidates = %+v, want [sol opencode]", candidates)
+	}
+}
+
+// An elapsed cooldown no longer blocks the candidate.
+func TestSupervisorBackendCandidates_ElapsedCooldownIsEligible(t *testing.T) {
+	now := time.Now().UTC()
+	retry := now.Add(-time.Minute)
+	health := map[string]state.BackendHealth{
+		"claude": {State: state.BackendHealthCooldown, Reason: state.BackendBlockProviderLimit, RetryAfter: &retry},
+	}
+
+	candidates, err := supervisorBackendCandidates(cooldownCandidatesConfig(), health, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 3 || candidates[0].name != "claude" {
+		t.Fatalf("candidates = %+v, want claude first", candidates)
+	}
+}
+
+// All candidates cooling → a distinct error so decideWithLLM degrades to the
+// deterministic guardrail without burning a walk down the chain.
+func TestSupervisorBackendCandidates_AllCoolingSkipsCycle(t *testing.T) {
+	now := time.Now().UTC()
+	retry := now.Add(30 * time.Minute)
+	health := map[string]state.BackendHealth{}
+	for _, name := range []string{"claude", "sol", "opencode"} {
+		health[name] = state.BackendHealth{State: state.BackendHealthCooldown, Reason: state.BackendBlockUsageLimit, RetryAfter: &retry}
+	}
+
+	_, err := supervisorBackendCandidates(cooldownCandidatesConfig(), health, now)
+	if err == nil || !strings.Contains(err.Error(), "cooling down") {
+		t.Fatalf("err = %v, want all-cooling-down skip", err)
+	}
+}

--- a/internal/supervisor/llm_timeout_test.go
+++ b/internal/supervisor/llm_timeout_test.go
@@ -33,7 +33,7 @@ func TestSupervisorBackendCandidatesUsesOrderedFallbacks(t *testing.T) {
 			"gpt55":  {Enabled: &disabled, Cmd: "codex"},
 		},
 	}}
-	candidates, err := supervisorBackendCandidates(cfg)
+	candidates, err := supervisorBackendCandidates(cfg, nil, time.Now().UTC())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Problem

Last week an Anthropic cooldown cascaded the whole fleet onto the single ChatGPT seat: 109 `claude→sol` fallback transitions, ~80% of the week's tokens through one subscription, 38.5k rate-limit journal lines, and the supervisor walked its chain down to `opencode` on every tick (2,754 lines / 7 days). A quota cooldown with a known reset is a *wait*, not a reason to dump work onto the next seat.

## Change

New `model.hold_on_cooldown {enabled, max_wait_minutes}` (default window 360m ≈ a 5-hour subscription window; **off by default** — zero behavior change until enabled per project row):

- **Fresh dispatch** (`resolveDispatchBackend`): a routed backend gated by a quota-class cooldown (`provider_limit`, `usage_limit`, `model_cooldown`, `model_overloaded`, `quota_pressure`) with a stated reset inside the window **holds** the issue for the reset instead of substituting the next rung. Auth failures, unknown resets, and beyond-window resets (weekly caps) cascade exactly as before.
- **Live-failure / retry fallover** (`selectBackendFallback`): same gate — returns no selection so every caller takes its existing budget-preserving no-fallback path; `BackendSelection.HoldUntil` records the audit trail and `earliestCandidateRetry` carries the reset.
- **Supervisor chain-walk** is now `BackendHealth`-aware: candidates in an active cooldown are skipped for the cycle (ends the opencode-every-tick walks); an all-cooling chain degrades to the deterministic guardrail.
- **Visibility**: new `DispatchHold` reason `hold_on_cooldown`; the previously-defined-but-never-emitted `backend_cooldown_exhausted` alert class now fires via the existing two-cycle idle-stall debounce for both cooldown hold classes.

## Tests

8 orchestrator + 3 supervisor + 3 config tests; full `go test ./...` green (umask-022 environment).

Context: planning note `Dev/Areas/maestro/planning/fallback-chain-and-subscription-restructure-2026-07-24.md` (two-layer fallback: CLIProxyAPI credential rotation = Layer 1, this chain + hold = Layer 2).