### PR TITLE
feat(supervisor): configurable consult timeouts + per-backend failure memory

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -151,6 +151,13 @@ type BackendDef struct {
 	// false backend gating. Validated to compile at config parse.
 	UsageLimitPatterns []string `yaml:"usage_limit_patterns,omitempty"`
 
+	// SupervisorAttemptTimeoutSeconds overrides supervisor.attempt_timeout_seconds
+	// for this backend when it serves a supervisor consult. Set it on slow
+	// print-mode carriers (claude CLI at high effort ≈ 180) so the walk gives
+	// them a real chance instead of billing a generation and killing it at the
+	// 45s default. Workers are unaffected — this is a supervisor-only knob.
+	SupervisorAttemptTimeoutSeconds int `yaml:"supervisor_attempt_timeout_seconds,omitempty"`
+
 	// SubagentHint steers an orchestrating backend (e.g. Claude Code) to
 	// delegate grunt subtasks to cheaper sub-agent models instead of
 	// reusing the expensive orchestrator model for everything (#706). When
@@ -934,6 +941,18 @@ type SupervisorConfig struct {
 	ApprovalRequiredActions []string                        `yaml:"approval_required_actions" json:"approval_required_actions,omitempty"`
 	PolicyPath              string                          `yaml:"-" json:"policy_path,omitempty"`
 	LessonProposalsEnabled  *bool                           `yaml:"lesson_proposals_enabled" json:"lesson_proposals_enabled,omitempty"`
+	// AttemptTimeoutSeconds bounds ONE supervisor LLM backend attempt. Default
+	// 45s — calibrated for fast print-mode backends (codex/sol). A slow carrier
+	// (claude CLI at high effort through a proxy) needs more; give it a
+	// per-backend override (model.backends.<name>.supervisor_attempt_timeout_seconds)
+	// instead of raising this global. Burn RCA 2026-07-24: a chain of three
+	// claude-binary candidates under the 45s default produced ~365
+	// paid-and-discarded generations in 4.5h — every attempt billed
+	// server-side, then killed client-side before the answer arrived.
+	AttemptTimeoutSeconds int `yaml:"attempt_timeout_seconds" json:"attempt_timeout_seconds,omitempty"`
+	// TotalTimeoutSeconds bounds the whole candidate walk for one consult so a
+	// slow chain can never overrun the supervise interval. Default 180s.
+	TotalTimeoutSeconds int `yaml:"total_timeout_seconds" json:"total_timeout_seconds,omitempty"`
 	// AlwaysConsultLLM restores the pre-#837 behavior of calling the supervisor
 	// LLM on every enabled cycle, even when the deterministic guardrail already
 	// decided a safe, mutation-free action (action=none / wait_* / monitor_open_pr).
@@ -2694,6 +2713,17 @@ func parse(data []byte) (*Config, error) {
 	}
 	if cfg.Model.HoldOnCooldown.MaxWaitMinutes < 0 {
 		return nil, fmt.Errorf("config: model.hold_on_cooldown.max_wait_minutes = %d; want >= 0 (0 uses the default window)", cfg.Model.HoldOnCooldown.MaxWaitMinutes)
+	}
+	if cfg.Supervisor.AttemptTimeoutSeconds < 0 {
+		return nil, fmt.Errorf("config: supervisor.attempt_timeout_seconds = %d; want >= 0 (0 uses the 45s default)", cfg.Supervisor.AttemptTimeoutSeconds)
+	}
+	if cfg.Supervisor.TotalTimeoutSeconds < 0 {
+		return nil, fmt.Errorf("config: supervisor.total_timeout_seconds = %d; want >= 0 (0 uses the 180s default)", cfg.Supervisor.TotalTimeoutSeconds)
+	}
+	for name, def := range cfg.Model.Backends {
+		if def.SupervisorAttemptTimeoutSeconds < 0 {
+			return nil, fmt.Errorf("config: model.backends.%s.supervisor_attempt_timeout_seconds = %d; want >= 0", name, def.SupervisorAttemptTimeoutSeconds)
+		}
 	}
 	// #704: quota calibration sanity. Capacities must be non-negative and
 	// the dispatch threshold a fraction in (0, 1]; a percent-style value

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
@@ -59,22 +60,112 @@ type backendLLMClient struct {
 	// re-burned the whole chain down to the last rung (live 2026-07: opencode
 	// every cycle while the primaries cooled).
 	backendHealth map[string]state.BackendHealth
+	// memory tracks consecutive per-backend failures across consults (shared
+	// by all withBackendHealth copies). A backend that keeps failing — e.g. a
+	// carrier that cannot answer within its attempt timeout — gets skipped for
+	// a window instead of billing another doomed generation every cycle. Burn
+	// RCA 2026-07-24: without this, a 100%-failing chain was re-walked on every
+	// consult for 4.5h.
+	memory *supervisorBackendMemory
 }
 
 const (
 	supervisorBackendAttemptTimeout = 45 * time.Second
 	supervisorBackendTotalTimeout   = 3 * time.Minute
+	// supervisorBackendFailureThreshold consecutive failures put a candidate
+	// into a skip window; a success resets the count.
+	supervisorBackendFailureThreshold = 3
+	// supervisorBackendFailureSkipWindow is how long a repeatedly-failing
+	// candidate is skipped before it may be probed again.
+	supervisorBackendFailureSkipWindow = 10 * time.Minute
 )
 
+// supervisorBackendMemory is the supervisor-local failure memory. It is
+// deliberately NOT written to state.BackendHealth: a print-mode consult
+// timing out says nothing about the backend's fitness for long-form worker
+// runs, so it must not gate dispatch.
+type supervisorBackendMemory struct {
+	mu        sync.Mutex
+	failures  map[string]int
+	skipUntil map[string]time.Time
+}
+
+func newSupervisorBackendMemory() *supervisorBackendMemory {
+	return &supervisorBackendMemory{failures: map[string]int{}, skipUntil: map[string]time.Time{}}
+}
+
+// shouldSkip reports whether the candidate is inside an active skip window.
+func (m *supervisorBackendMemory) shouldSkip(name string, now time.Time) (time.Time, bool) {
+	if m == nil {
+		return time.Time{}, false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	until, ok := m.skipUntil[name]
+	if !ok || now.After(until) {
+		return time.Time{}, false
+	}
+	return until, true
+}
+
+// recordFailure bumps the candidate's consecutive-failure count and opens a
+// skip window at the threshold. Returns the window expiry when one opened.
+func (m *supervisorBackendMemory) recordFailure(name string, now time.Time) (time.Time, bool) {
+	if m == nil {
+		return time.Time{}, false
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.failures[name]++
+	if m.failures[name] < supervisorBackendFailureThreshold {
+		return time.Time{}, false
+	}
+	m.failures[name] = 0
+	until := now.Add(supervisorBackendFailureSkipWindow)
+	m.skipUntil[name] = until
+	return until, true
+}
+
+func (m *supervisorBackendMemory) recordSuccess(name string) {
+	if m == nil {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.failures, name)
+	delete(m.skipUntil, name)
+}
+
+// supervisorAttemptTimeoutFor resolves the attempt budget for one candidate:
+// per-backend override, then supervisor.attempt_timeout_seconds, then the 45s
+// default.
+func supervisorAttemptTimeoutFor(cfg *config.Config, def config.BackendDef) time.Duration {
+	if def.SupervisorAttemptTimeoutSeconds > 0 {
+		return time.Duration(def.SupervisorAttemptTimeoutSeconds) * time.Second
+	}
+	if cfg != nil && cfg.Supervisor.AttemptTimeoutSeconds > 0 {
+		return time.Duration(cfg.Supervisor.AttemptTimeoutSeconds) * time.Second
+	}
+	return supervisorBackendAttemptTimeout
+}
+
+func supervisorTotalTimeoutFor(cfg *config.Config) time.Duration {
+	if cfg != nil && cfg.Supervisor.TotalTimeoutSeconds > 0 {
+		return time.Duration(cfg.Supervisor.TotalTimeoutSeconds) * time.Second
+	}
+	return supervisorBackendTotalTimeout
+}
+
 func NewBackendLLMClient(cfg *config.Config) LLMClient {
-	return &backendLLMClient{cfg: cfg}
+	return &backendLLMClient{cfg: cfg, memory: newSupervisorBackendMemory()}
 }
 
 // withBackendHealth returns a copy of the client carrying the cycle's
 // BackendHealth snapshot, so a concurrent Complete on the shared engine client
-// never observes a mutated map.
+// never observes a mutated map. The failure memory pointer is shared — it must
+// survive across cycles.
 func (c *backendLLMClient) withBackendHealth(health map[string]state.BackendHealth) *backendLLMClient {
-	return &backendLLMClient{cfg: c.cfg, backendHealth: health}
+	return &backendLLMClient{cfg: c.cfg, backendHealth: health, memory: c.memory}
 }
 
 func (c *backendLLMClient) Complete(prompt string) (string, error) {
@@ -104,26 +195,43 @@ func (c *backendLLMClient) Complete(prompt string) (string, error) {
 	if strings.TrimSpace(worktree) == "" {
 		worktree = "."
 	}
-	deadline := time.Now().Add(supervisorBackendTotalTimeout)
+	deadline := time.Now().Add(supervisorTotalTimeoutFor(c.cfg))
 	var failed []string
+	var skipped []string
 	for _, candidate := range candidates {
+		now := time.Now()
+		if until, skip := c.memory.shouldSkip(candidate.name, now); skip {
+			skipped = append(skipped, candidate.name)
+			log.Printf("[supervisor] skipping backend %s: %d consecutive failures, retry allowed after %s",
+				candidate.name, supervisorBackendFailureThreshold, until.UTC().Format(time.RFC3339))
+			continue
+		}
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
 			break
 		}
-		attemptTimeout := supervisorBackendAttemptTimeout
+		attemptTimeout := supervisorAttemptTimeoutFor(c.cfg, candidate.def)
 		if remaining < attemptTimeout {
 			attemptTimeout = remaining
 		}
 		out, runErr := completeSupervisorBackend(candidate.name, candidate.def, c.cfg, promptPath, worktree, attemptTimeout)
 		if runErr == nil {
+			c.memory.recordSuccess(candidate.name)
 			if len(failed) > 0 {
 				log.Printf("[supervisor] backend fallback selected %s after %s failed", candidate.name, strings.Join(failed, ", "))
 			}
 			return strings.TrimSpace(string(out)), nil
 		}
 		failed = append(failed, candidate.name)
-		log.Printf("[supervisor] backend %s unavailable for this cycle; trying configured fallback", candidate.name)
+		if until, opened := c.memory.recordFailure(candidate.name, time.Now()); opened {
+			log.Printf("[supervisor] backend %s unavailable for this cycle (%v); %d consecutive failures — skipping it until %s",
+				candidate.name, runErr, supervisorBackendFailureThreshold, until.UTC().Format(time.RFC3339))
+		} else {
+			log.Printf("[supervisor] backend %s unavailable for this cycle (%v); trying configured fallback", candidate.name, runErr)
+		}
+	}
+	if len(failed) == 0 && len(skipped) > 0 {
+		return "", fmt.Errorf("run supervisor backends: all candidates inside failure-memory skip windows (%s); deterministic guardrail proceeds", strings.Join(skipped, ", "))
 	}
 	return "", fmt.Errorf("run supervisor backends: all bounded candidates failed (%s)", strings.Join(failed, ", "))
 }

--- a/internal/supervisor/llm_failure_memory_test.go
+++ b/internal/supervisor/llm_failure_memory_test.go
@@ -1,0 +1,83 @@
+package supervisor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// Per-backend override wins, then the supervisor-level knob, then the 45s
+// default.
+func TestSupervisorAttemptTimeoutResolution(t *testing.T) {
+	cfg := &config.Config{}
+	if got := supervisorAttemptTimeoutFor(cfg, config.BackendDef{}); got != 45*time.Second {
+		t.Fatalf("default = %v, want 45s", got)
+	}
+	cfg.Supervisor.AttemptTimeoutSeconds = 90
+	if got := supervisorAttemptTimeoutFor(cfg, config.BackendDef{}); got != 90*time.Second {
+		t.Fatalf("global = %v, want 90s", got)
+	}
+	def := config.BackendDef{SupervisorAttemptTimeoutSeconds: 180}
+	if got := supervisorAttemptTimeoutFor(cfg, def); got != 180*time.Second {
+		t.Fatalf("per-backend = %v, want 180s", got)
+	}
+	if got := supervisorTotalTimeoutFor(cfg); got != 3*time.Minute {
+		t.Fatalf("total default = %v, want 3m", got)
+	}
+	cfg.Supervisor.TotalTimeoutSeconds = 300
+	if got := supervisorTotalTimeoutFor(cfg); got != 300*time.Second {
+		t.Fatalf("total = %v, want 300s", got)
+	}
+}
+
+// Three consecutive failures open a skip window; a success resets everything;
+// an expired window re-allows probing.
+func TestSupervisorBackendMemoryLifecycle(t *testing.T) {
+	m := newSupervisorBackendMemory()
+	now := time.Now()
+
+	for i := 0; i < supervisorBackendFailureThreshold-1; i++ {
+		if _, opened := m.recordFailure("claude-fable", now); opened {
+			t.Fatalf("skip window opened after %d failures, want threshold %d", i+1, supervisorBackendFailureThreshold)
+		}
+	}
+	if _, skip := m.shouldSkip("claude-fable", now); skip {
+		t.Fatal("skipping before threshold reached")
+	}
+	until, opened := m.recordFailure("claude-fable", now)
+	if !opened {
+		t.Fatal("threshold failure did not open a skip window")
+	}
+	if want := now.Add(supervisorBackendFailureSkipWindow); !until.Equal(want) {
+		t.Fatalf("window until = %v, want %v", until, want)
+	}
+	if _, skip := m.shouldSkip("claude-fable", now.Add(time.Minute)); !skip {
+		t.Fatal("not skipping inside the window")
+	}
+	if _, skip := m.shouldSkip("claude-fable", now.Add(supervisorBackendFailureSkipWindow+time.Second)); skip {
+		t.Fatal("still skipping after the window expired")
+	}
+
+	// Success resets both the counter and any window.
+	m.recordFailure("sol", now)
+	m.recordFailure("sol", now)
+	m.recordSuccess("sol")
+	for i := 0; i < supervisorBackendFailureThreshold-1; i++ {
+		if _, opened := m.recordFailure("sol", now); opened {
+			t.Fatal("success did not reset the consecutive-failure count")
+		}
+	}
+}
+
+// A nil memory (custom clients) is inert.
+func TestSupervisorBackendMemoryNilSafe(t *testing.T) {
+	var m *supervisorBackendMemory
+	if _, skip := m.shouldSkip("x", time.Now()); skip {
+		t.Fatal("nil memory must not skip")
+	}
+	if _, opened := m.recordFailure("x", time.Now()); opened {
+		t.Fatal("nil memory must not open windows")
+	}
+	m.recordSuccess("x")
+}


### PR DESCRIPTION
Burn RCA 2026-07-24: hardcoded 45s consult timeout + no failure memory = ~365 paid-and-discarded generations in 4.5h (60% of the Anthropic 5h window, 1 success). Adds supervisor.attempt_timeout_seconds / total_timeout_seconds knobs (defaults unchanged), per-backend model.backends.<name>.supervisor_attempt_timeout_seconds for slow carriers (claude ~ 180s), and supervisor-local failure memory: 3 consecutive fails -> 10m skip window, success resets; deliberately NOT BackendHealth so consult timeouts never gate worker dispatch. Binary v1.4.2+g497faccd already installed manually on the fleet host (daemon down); this PR is the mainline record. Context: handovers/2026-07-24-resume-burn-supervisor-fable-timeout-rca.md