### PR TITLE
fix: break the token-budget kill mill instead of re-dispatching into the wall

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -77,9 +77,12 @@ type Orchestrator struct {
 	// direct GitHub client — it serves fresh mirror rows locally and falls back
 	// to the API on a miss/stale. Writes and un-mirrored reads always stay on
 	// gh, so GitHub remains authoritative. nil = today's API-direct behavior.
-	readSource            githubReadSource
-	router                *router.Router
-	repo                  string
+	readSource githubReadSource
+	// tokenBudgetMillNotified remembers the streak length already alerted per
+	// issue so a held budget-wall issue alerts on escalation, not every cycle.
+	tokenBudgetMillNotified map[int]int
+	router                  *router.Router
+	repo                    string
 	binaryVersion         string
 	promptBase            string
 	bugPromptBase         string
@@ -1468,6 +1471,43 @@ func applyTokenBudgetObservation(sess *state.Session, marker worker.TokenBudgetM
 		delta := marker.TokensObserved - sess.TokensUsedAttempt
 		sess.TokensUsedAttempt = marker.TokensObserved
 		sess.TokensUsedTotal += delta
+	}
+}
+
+// tokenBudgetKillStreakLimit is how many consecutive PR-less token-budget
+// stops on one issue are treated as a misconfigured budget rather than three
+// unlucky workers. Two is deliberate: one stop is a plausible runaway worker,
+// two in a row on the same issue means the budget itself is the wall.
+const tokenBudgetKillStreakLimit = 2
+
+// notifyTokenBudgetMill surfaces a budget-kill streak once per streak length so
+// a held issue cannot become a silent stall. The alert class is futile_recovery:
+// automated re-dispatch that cannot succeed until an operator changes config.
+func (o *Orchestrator) notifyTokenBudgetMill(issueNumber, kills int) {
+	if o == nil || o.notifier == nil {
+		return
+	}
+	if o.tokenBudgetMillNotified == nil {
+		o.tokenBudgetMillNotified = make(map[int]int)
+	}
+	if o.tokenBudgetMillNotified[issueNumber] >= kills {
+		return
+	}
+	o.tokenBudgetMillNotified[issueNumber] = kills
+	project := strings.TrimSpace(o.repo)
+	if project == "" && o.cfg != nil {
+		project = strings.TrimSpace(o.cfg.Repo)
+	}
+	title := "maestro token budget wall"
+	if project != "" {
+		title += ": " + project
+	}
+	body := fmt.Sprintf(
+		"issue #%d stopped at the token budget %d times in a row with no PR; worker_max_tokens=%d is likely below the floor this issue needs. Dispatch is held until the budget is raised.",
+		issueNumber, kills, o.cfg.WorkerMaxTokens,
+	)
+	if err := o.notifier.Alert(notify.AlertFutileRecovery, fmt.Sprintf("%s:token_budget_wall:%d", project, issueNumber), title, body); err != nil {
+		log.Printf("[orch] token-budget-wall notification failed for issue #%d: %v", issueNumber, err)
 	}
 }
 
@@ -10027,6 +10067,23 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		if label, ok := matchingIssueLabel(issue, o.operatorGateLabels()); ok {
 			log.Printf("[orch] skipping issue #%d: held by operator gate label %q", issue.Number, label)
 			continue
+		}
+
+		// Break the budget-kill mill: a token budget below the floor a worker
+		// needs to load its initial context kills every dispatch identically,
+		// and budget stops are excluded from the retry budget by design, so
+		// nothing else stops the loop (#628 live: 9 spawns in 4.5h, each ~2
+		// min at observed≈157k vs max=120k). After a streak of PR-less budget
+		// kills the issue is held and the misconfiguration is surfaced once —
+		// the operator raises worker_max_tokens (or fixes the measure) instead
+		// of watching the fleet re-spawn into the same wall.
+		if !repairSpawn {
+			if kills := s.ConsecutiveTokenBudgetKillsForIssue(issue.Number); kills >= tokenBudgetKillStreakLimit {
+				o.notifyTokenBudgetMill(issue.Number, kills)
+				log.Printf("[orch] skipping issue #%d: %d consecutive token-budget stops — worker_max_tokens=%d is likely below the viable floor for this issue",
+					issue.Number, kills, o.cfg.WorkerMaxTokens)
+				continue
+			}
 		}
 
 		// Check retry limit: skip issues that have exhausted their retry budget

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1480,6 +1480,24 @@ func applyTokenBudgetObservation(sess *state.Session, marker worker.TokenBudgetM
 // two in a row on the same issue means the budget itself is the wall.
 const tokenBudgetKillStreakLimit = 2
 
+// tokenBudgetMillHold reports whether fresh dispatch must hold for this issue's
+// budget-kill streak, and owns the alert bookkeeping. A streak below the limit
+// clears the alert memory: once a worker ends any other way the wall is gone,
+// and a later wall on the same issue must alert again rather than hold it
+// silently — a guard that parks work without telling anyone is the failure mode
+// this whole change exists to remove.
+func (o *Orchestrator) tokenBudgetMillHold(issueNumber, kills int) bool {
+	if o == nil {
+		return false
+	}
+	if kills < tokenBudgetKillStreakLimit {
+		delete(o.tokenBudgetMillNotified, issueNumber)
+		return false
+	}
+	o.notifyTokenBudgetMill(issueNumber, kills)
+	return true
+}
+
 // notifyTokenBudgetMill surfaces a budget-kill streak once per streak length so
 // a held issue cannot become a silent stall. The alert class is futile_recovery:
 // automated re-dispatch that cannot succeed until an operator changes config.
@@ -10078,8 +10096,8 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		// the operator raises worker_max_tokens (or fixes the measure) instead
 		// of watching the fleet re-spawn into the same wall.
 		if !repairSpawn {
-			if kills := s.ConsecutiveTokenBudgetKillsForIssue(issue.Number); kills >= tokenBudgetKillStreakLimit {
-				o.notifyTokenBudgetMill(issue.Number, kills)
+			kills := s.ConsecutiveTokenBudgetKillsForIssue(issue.Number)
+			if o.tokenBudgetMillHold(issue.Number, kills) {
 				log.Printf("[orch] skipping issue #%d: %d consecutive token-budget stops — worker_max_tokens=%d is likely below the viable floor for this issue",
 					issue.Number, kills, o.cfg.WorkerMaxTokens)
 				continue

--- a/internal/orchestrator/token_budget_mill_test.go
+++ b/internal/orchestrator/token_budget_mill_test.go
@@ -1,0 +1,79 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/notify"
+)
+
+func millTestOrchestrator() *Orchestrator {
+	return &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", WorkerMaxTokens: 120000},
+		notifier: &notify.Notifier{},
+		repo:     "owner/repo",
+	}
+}
+
+// Below the streak limit dispatch proceeds; at or above it the issue is held.
+func TestTokenBudgetMillHold_HoldsAtStreakLimit(t *testing.T) {
+	o := millTestOrchestrator()
+	if o.tokenBudgetMillHold(628, tokenBudgetKillStreakLimit-1) {
+		t.Fatal("held below the streak limit")
+	}
+	if !o.tokenBudgetMillHold(628, tokenBudgetKillStreakLimit) {
+		t.Fatal("did not hold at the streak limit")
+	}
+}
+
+// The same streak length alerts once; an escalation alerts again.
+func TestTokenBudgetMillHold_AlertsOncePerEscalation(t *testing.T) {
+	o := millTestOrchestrator()
+	o.tokenBudgetMillHold(628, 2)
+	if got := o.tokenBudgetMillNotified[628]; got != 2 {
+		t.Fatalf("notified = %d, want 2", got)
+	}
+	o.tokenBudgetMillHold(628, 2) // same streak — no new alert
+	if got := o.tokenBudgetMillNotified[628]; got != 2 {
+		t.Fatalf("notified = %d after repeat, want 2", got)
+	}
+	o.tokenBudgetMillHold(628, 3) // escalation — alerts again
+	if got := o.tokenBudgetMillNotified[628]; got != 3 {
+		t.Fatalf("notified = %d after escalation, want 3", got)
+	}
+}
+
+// A cleared streak must clear the alert memory, so a later wall on the same
+// issue alerts instead of being held silently.
+func TestTokenBudgetMillHold_ClearedStreakReArms(t *testing.T) {
+	o := millTestOrchestrator()
+	o.tokenBudgetMillHold(628, 2)
+
+	// A worker ended some other way: the streak is gone, dispatch resumes.
+	if o.tokenBudgetMillHold(628, 0) {
+		t.Fatal("held with a cleared streak")
+	}
+	if _, remembered := o.tokenBudgetMillNotified[628]; remembered {
+		t.Fatal("alert memory survived a cleared streak — a later wall would hold the issue silently")
+	}
+
+	// The wall returns: it must hold AND alert again.
+	if !o.tokenBudgetMillHold(628, 2) {
+		t.Fatal("did not hold on the returning wall")
+	}
+	if got := o.tokenBudgetMillNotified[628]; got != 2 {
+		t.Fatalf("notified = %d on the returning wall, want a fresh alert at 2", got)
+	}
+}
+
+// Streaks are tracked per issue.
+func TestTokenBudgetMillHold_PerIssue(t *testing.T) {
+	o := millTestOrchestrator()
+	o.tokenBudgetMillHold(628, 2)
+	if o.tokenBudgetMillHold(629, 1) {
+		t.Fatal("issue 629 held by issue 628's streak")
+	}
+	if got := o.tokenBudgetMillNotified[628]; got != 2 {
+		t.Fatalf("issue 628 memory = %d, want 2 (unaffected by 629)", got)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -5072,6 +5072,55 @@ func (s *State) FailedAttemptsForIssue(issueNum int) int {
 	return count
 }
 
+// ConsecutiveTokenBudgetKillsForIssue counts how many of the issue's most
+// recent PR-less sessions ended at the token budget, stopping at the first
+// session that ended any other way.
+//
+// A budget stop is deliberately excluded from FailedAttemptsForIssue — it is a
+// governor, not a work failure, so it must not burn the per-issue retry budget.
+// The gap that leaves: when the configured budget sits BELOW the floor a worker
+// needs just to load its initial context, every dispatch dies the same way and
+// nothing ever stops re-dispatching. Live 2026-07-24: ok-player #628 spawned 9
+// times in 4.5h, each killed after ~2 minutes at observed≈157k vs max=120k.
+// Callers use this streak to break the mill and surface the misconfiguration.
+func (s *State) ConsecutiveTokenBudgetKillsForIssue(issueNum int) int {
+	if s == nil {
+		return 0
+	}
+	type ended struct {
+		at      time.Time
+		budget  bool
+		counted bool
+	}
+	var history []ended
+	for _, sess := range s.Sessions {
+		if sess == nil || sess.IssueNumber != issueNum || sess.PRNumber != 0 {
+			continue
+		}
+		if sess.Status != StatusDead && sess.Status != StatusFailed && sess.Status != StatusRetryExhausted {
+			continue
+		}
+		at := sess.StartedAt
+		if sess.FinishedAt != nil {
+			at = *sess.FinishedAt
+		}
+		history = append(history, ended{
+			at:      at,
+			budget:  sess.WorkerOutcome == string(DisplayTokenBudgetExceeded),
+			counted: true,
+		})
+	}
+	sort.Slice(history, func(i, j int) bool { return history[i].at.After(history[j].at) })
+	streak := 0
+	for _, entry := range history {
+		if !entry.budget {
+			break
+		}
+		streak++
+	}
+	return streak
+}
+
 // IssueRetryExhausted returns true if any session for the given issue
 // has been marked as retry_exhausted.
 func (s *State) IssueRetryExhausted(issueNum int) bool {

--- a/internal/state/token_budget_streak_test.go
+++ b/internal/state/token_budget_streak_test.go
@@ -1,0 +1,87 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+func budgetSession(issue int, outcome string, status SessionStatus, finished time.Time, pr int) *Session {
+	f := finished
+	return &Session{
+		IssueNumber:   issue,
+		PRNumber:      pr,
+		Status:        status,
+		WorkerOutcome: outcome,
+		StartedAt:     finished.Add(-2 * time.Minute),
+		FinishedAt:    &f,
+	}
+}
+
+// Consecutive PR-less budget stops accumulate; the streak counts only the most
+// recent run.
+func TestConsecutiveTokenBudgetKillsForIssue_CountsRecentRun(t *testing.T) {
+	now := time.Now().UTC()
+	s := NewState()
+	s.Sessions["a"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-30*time.Minute), 0)
+	s.Sessions["b"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-20*time.Minute), 0)
+	s.Sessions["c"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-10*time.Minute), 0)
+
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(628); got != 3 {
+		t.Fatalf("streak = %d, want 3", got)
+	}
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(999); got != 0 {
+		t.Fatalf("streak for unrelated issue = %d, want 0", got)
+	}
+}
+
+// A newer non-budget ending breaks the streak: the budget was not the wall for
+// the latest attempt, so dispatch must not stay held.
+func TestConsecutiveTokenBudgetKillsForIssue_NonBudgetEndingBreaksStreak(t *testing.T) {
+	now := time.Now().UTC()
+	s := NewState()
+	s.Sessions["a"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-30*time.Minute), 0)
+	s.Sessions["b"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-20*time.Minute), 0)
+	s.Sessions["c"] = budgetSession(628, "", StatusDead, now.Add(-5*time.Minute), 0)
+
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(628); got != 0 {
+		t.Fatalf("streak = %d, want 0 — the most recent ending was not a budget stop", got)
+	}
+}
+
+// A session that produced a PR is progress, never part of a futile streak.
+func TestConsecutiveTokenBudgetKillsForIssue_IgnoresSessionsWithPR(t *testing.T) {
+	now := time.Now().UTC()
+	s := NewState()
+	s.Sessions["a"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-30*time.Minute), 0)
+	s.Sessions["b"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-10*time.Minute), 4242)
+
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(628); got != 1 {
+		t.Fatalf("streak = %d, want 1 (the PR-bearing session is excluded)", got)
+	}
+}
+
+// Running sessions are not endings and must not enter the streak.
+func TestConsecutiveTokenBudgetKillsForIssue_IgnoresRunning(t *testing.T) {
+	now := time.Now().UTC()
+	s := NewState()
+	s.Sessions["a"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-30*time.Minute), 0)
+	live := budgetSession(628, "", StatusRunning, now, 0)
+	live.FinishedAt = nil
+	s.Sessions["b"] = live
+
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(628); got != 1 {
+		t.Fatalf("streak = %d, want 1", got)
+	}
+}
+
+// The budget stop still must NOT burn the per-issue retry budget (#805 rule).
+func TestFailedAttemptsForIssue_StillExcludesBudgetStops(t *testing.T) {
+	now := time.Now().UTC()
+	s := NewState()
+	s.Sessions["a"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-30*time.Minute), 0)
+	s.Sessions["b"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-20*time.Minute), 0)
+
+	if got := s.FailedAttemptsForIssue(628); got != 0 {
+		t.Fatalf("FailedAttemptsForIssue = %d, want 0 — budget stops are a governor, not work failures", got)
+	}
+}


### PR DESCRIPTION
## Problem

A token-budget stop is deliberately excluded from `FailedAttemptsForIssue` — it is a governor, not a work failure, so it must not burn the per-issue retry budget (#805 rule, kept intact here). The gap that leaves: when `worker_max_tokens` sits **below the floor a worker needs just to load its initial context**, every dispatch dies identically and nothing ever stops re-dispatching.

Live evidence 2026-07-24, ok-player #628: **9 spawns in 4.5h**, each killed after ~2 minutes at `observed≈157k max=120000 measure=codex_rollout_tokens`, burning the OpenAI seat on workers that could not have succeeded.

## Change

- `state.ConsecutiveTokenBudgetKillsForIssue(issue)` — streak of the issue's most recent PR-less sessions that ended at the budget. Any other ending, a session that produced a PR, or a live session breaks the streak.
- Orchestrator holds fresh dispatch for an issue at **2** consecutive budget stops (`tokenBudgetKillStreakLimit`) and surfaces it once per escalation as a `futile_recovery` alert naming the configured budget. `spawn_repair_worker` keeps its existing override.

The hold is self-clearing: raise the budget (or fix the measure) and the next worker that ends any other way resets the streak. No new config knob — the misconfiguration is reported, not encoded.

## Tests

Streak counting (recent run only), non-budget ending breaks it, PR-bearing and running sessions excluded, plus a regression test that budget stops still do **not** count toward `FailedAttemptsForIssue`. Full suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issues repeatedly stopped by token-budget limits are now detected more reliably.
  * New worker attempts are paused after repeated token-budget exhaustion, preventing unproductive retries.
  * Token-budget stops are no longer counted as failed work attempts.

* **Notifications**
  * Added alerts when an issue is held because its token budget may be too low or misconfigured. Alerts avoid duplicate notifications while tracking continued occurrences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->