### PR TITLE
fix: bound the wait on a review gate that never answers

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,3 @@
+
+[features]
+hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,52 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": null,
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks codex post-tool-use'",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": null,
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then printf \"%s\\n\" \"{\\\"systemMessage\\\":\\\"Entire CLI is enabled but not installed or not on PATH. Installation guide: https://docs.entire.io/cli/installation#installation-methods\\\"}\"; exit 0; fi; exec entire hooks codex session-start'",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": null,
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks codex stop'",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": null,
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks codex user-prompt-submit'",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,40 @@
+{
+  "hooks": {
+    "beforeSubmitPrompt": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor before-submit-prompt'"
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor pre-compact'"
+      }
+    ],
+    "sessionEnd": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-end'"
+      }
+    ],
+    "sessionStart": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor session-start'"
+      }
+    ],
+    "stop": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor stop'"
+      }
+    ],
+    "subagentStart": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor subagent-start'"
+      }
+    ],
+    "subagentStop": [
+      {
+        "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks cursor subagent-stop'"
+      }
+    ]
+  },
+  "version": 1
+}

--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,0 +1,5 @@
+tmp/
+settings.local.json
+metadata/
+logs/
+redactors/local/

--- a/.entire/settings.json.local-bak
+++ b/.entire/settings.json.local-bak
@@ -1,0 +1,4 @@
+{
+  "enabled": true,
+  "telemetry": true
+}

--- a/.factory/settings.json
+++ b/.factory/settings.json
@@ -1,0 +1,90 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks factoryai-droid post-tool-use'"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks factoryai-droid pre-compact'"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks factoryai-droid pre-tool-use'"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks factoryai-droid session-end'"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks factoryai-droid session-start'"
+          },
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks factoryai-droid user-prompt-submit'"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then printf \"%s\\n\" \"Entire CLI is enabled but not installed or not on PATH. Installation guide: https://docs.entire.io/cli/installation#installation-methods\"; exit 0; fi; exec entire hooks factoryai-droid stop'"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks factoryai-droid user-prompt-submit'"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "deny": [
+      "Read(./.entire/metadata/**)"
+    ]
+  }
+}

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,141 @@
+{
+  "hooks": {
+    "AfterAgent": [
+      {
+        "hooks": [
+          {
+            "name": "entire-after-agent",
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks gemini after-agent'"
+          }
+        ]
+      }
+    ],
+    "AfterModel": [
+      {
+        "hooks": [
+          {
+            "name": "entire-after-model",
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks gemini after-model'"
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "entire-after-tool",
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks gemini after-tool'"
+          }
+        ]
+      }
+    ],
+    "BeforeAgent": [
+      {
+        "hooks": [
+          {
+            "name": "entire-before-agent",
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks gemini before-agent'"
+          }
+        ]
+      }
+    ],
+    "BeforeModel": [
+      {
+        "hooks": [
+          {
+            "name": "entire-before-model",
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks gemini before-model'"
+          }
+        ]
+      }
+    ],
+    "BeforeTool": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "entire-before-tool",
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks gemini before-tool'"
+          }
+        ]
+      }
+    ],
+    "BeforeToolSelection": [
+      {
+        "hooks": [
+          {
+            "name": "entire-before-tool-selection",
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks gemini before-tool-selection'"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "name": "entire-notification",
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks gemini notification'"
+          }
+        ]
+      }
+    ],
+    "PreCompress": [
+      {
+        "hooks": [
+          {
+            "name": "entire-pre-compress",
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks gemini pre-compress'"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "exit",
+        "hooks": [
+          {
+            "name": "entire-session-end-exit",
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks gemini session-end'"
+          }
+        ]
+      },
+      {
+        "matcher": "logout",
+        "hooks": [
+          {
+            "name": "entire-session-end-logout",
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then exit 0; fi; exec entire hooks gemini session-end'"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "name": "entire-session-start",
+            "type": "command",
+            "command": "sh -c 'if ! command -v entire >/dev/null 2>&1; then printf \"%s\\n\" \"{\\\"systemMessage\\\":\\\"Entire CLI is enabled but not installed or not on PATH. Installation guide: https://docs.entire.io/cli/installation#installation-methods\\\"}\"; exit 0; fi; exec entire hooks gemini session-start'"
+          }
+        ]
+      }
+    ]
+  },
+  "hooksConfig": {
+    "enabled": true
+  }
+}

--- a/cmd/maestro/emergency.go
+++ b/cmd/maestro/emergency.go
@@ -220,11 +220,11 @@ func notifyEmergency(ef *emergencyFlags, msg string) {
 		}
 		n := notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
 		n.WithNtfy(cfg.Notify.Ntfy.BaseURL, cfg.Notify.Ntfy.Topic, cfg.Notify.Ntfy.Token())
-		n.Sendf("%s", msg)
-		// Fan the notify_red-grade alert to ntfy (#1018). Keyed by message so a
-		// repeated identical emergency state does not re-notify.
+		// Alert covers both transports: ntfy when configured, otherwise the
+		// base Telegram/OpenClaw send. Keyed by message so a repeated identical
+		// emergency state does not re-notify (#1018).
 		if err := n.Alert(notify.AlertEmergency, "emergency", "maestro emergency", msg); err != nil {
-			log.Printf("[emergency] ntfy alert failed: %v", err)
+			log.Printf("[emergency] alert failed: %v", err)
 		}
 		return
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1775,6 +1775,20 @@ type ReviewRetriggerConfig struct {
 	Enabled         *bool `yaml:"enabled"`          // default: true
 	PendingMinutes  int   `yaml:"pending_minutes"`  // re-trigger after this many minutes of greptile=pending on one head (default: 10)
 	CooldownMinutes int   `yaml:"cooldown_minutes"` // minimum minutes between re-trigger comments per session (default: 30)
+	// MaxAttempts caps how many re-trigger comments one session may post for
+	// a single head. Without a cap a permanently silent reviewer collects a
+	// "@greptile review" comment every cooldown window forever (live 2026-07:
+	// Greptile paused after exhausting its free credits and every wedged PR
+	// kept accruing comments). Default 3; <= 0 means the default, and a
+	// deliberate "never stop" is spelled as a large number.
+	MaxAttempts int `yaml:"max_attempts,omitempty"`
+	// MissingAfterMinutes makes an UNOBSERVED review gate non-blocking once the
+	// gate has been silent this long on one head — no check run, no comment,
+	// nothing. 0 (default) preserves today's behavior: a silent gate holds the
+	// PR forever. A reviewer that DOES answer still hard-blocks regardless of
+	// this value, so enabling it never weakens a working gate; it only bounds
+	// the wait on a reviewer that never shows up.
+	MissingAfterMinutes int `yaml:"missing_after_minutes,omitempty"`
 }
 
 // Active reports whether the stale-review re-trigger runs. Default true —
@@ -1803,6 +1817,24 @@ func (c ReviewRetriggerConfig) EffectiveCooldown() time.Duration {
 		return 30 * time.Minute
 	}
 	return time.Duration(c.CooldownMinutes) * time.Minute
+}
+
+// EffectiveMaxAttempts caps re-trigger comments per head. Default 3.
+func (c ReviewRetriggerConfig) EffectiveMaxAttempts() int {
+	if c.MaxAttempts <= 0 {
+		return 3
+	}
+	return c.MaxAttempts
+}
+
+// MissingReviewGraceOrZero returns how long a fully silent review gate may hold
+// a PR before it is treated as non-blocking, or 0 when the operator has not
+// opted in (today's block-forever behavior).
+func (c ReviewRetriggerConfig) MissingReviewGraceOrZero() time.Duration {
+	if c.MissingAfterMinutes <= 0 {
+		return 0
+	}
+	return time.Duration(c.MissingAfterMinutes) * time.Minute
 }
 
 // SessionRetentionConfig bounds the growth of state.Sessions by compacting

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1819,10 +1819,21 @@ func (c ReviewRetriggerConfig) EffectiveCooldown() time.Duration {
 	return time.Duration(c.CooldownMinutes) * time.Minute
 }
 
-// EffectiveMaxAttempts caps re-trigger comments per head. Default 3.
+// EffectiveMaxAttempts caps re-trigger comments per head; 0 means unlimited,
+// which is the default.
+//
+// The cap is deliberately opt-in. Capping by default would REMOVE the only
+// automatic recovery an untouched install has: before this knob existed, a
+// wedged gate kept being nudged every cooldown window, so a review service that
+// came back hours later was woken by the next nudge and the PR merged
+// hands-off. A default cap silences those nudges after N tries while the
+// escape hatch that would release the PR (missing_after_minutes) is itself
+// off by default — turning "eventually self-heals" into "wedged forever" for an
+// operator who changed nothing. An operator who sets a cap is accepting that
+// trade, and should set missing_after_minutes with it.
 func (c ReviewRetriggerConfig) EffectiveMaxAttempts() int {
 	if c.MaxAttempts <= 0 {
-		return 3
+		return 0
 	}
 	return c.MaxAttempts
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2464,6 +2464,10 @@ commentFallback:
 
 	foundGreptile, signal, comment := greptileCommentReviewSignal(comments)
 	if !foundGreptile {
+		// No check run AND no comment: the reviewer never showed up for this
+		// head. Observed stays false so callers can distinguish this from a
+		// review in progress and apply a missing-review policy instead of
+		// waiting forever.
 		return ReviewStreamVerdict{Name: "greptile", Pending: true, Verdict: reviewVerdictPending}, nil
 	}
 	verdict := reviewStreamVerdictFromGreptileSignal(signal)
@@ -2595,11 +2599,16 @@ func rangeContainedByAny(candidate []int, containers [][]int) bool {
 	return false
 }
 
+// reviewStreamVerdictFromGreptileSignal builds a verdict from a signal the
+// reviewer actually produced, so Observed is always true here. The only
+// unobserved verdict is the explicit no-signal return in
+// prGreptileReviewStreamVerdict.
 func reviewStreamVerdictFromGreptileSignal(signal greptileReviewSignal) ReviewStreamVerdict {
 	return ReviewStreamVerdict{
 		Name:     "greptile",
 		Passed:   signal.Passed,
 		Pending:  signal.Pending,
+		Observed: true,
 		Score:    signal.Score,
 		ScoreMax: signal.ScoreMax,
 		Verdict:  signal.Verdict,
@@ -3601,9 +3610,18 @@ type ReviewComment struct {
 }
 
 type ReviewStreamVerdict struct {
-	Name     string          `json:"name"`
-	Passed   bool            `json:"passed"`
-	Pending  bool            `json:"pending"`
+	Name    string `json:"name"`
+	Passed  bool   `json:"passed"`
+	Pending bool   `json:"pending"`
+	// Observed reports whether the reviewer produced ANY signal for this head
+	// — a check run or a comment, in any state including "queued". Without it
+	// Pending conflates two very different situations: "the reviewer is
+	// working on it" and "the reviewer never showed up". The second happens
+	// whenever the review service is silent (live 2026-07: Greptile paused
+	// reviews after its free credits ran out and posted nothing at all), and
+	// an unobserved pending gate would otherwise hold every PR forever with
+	// no timeout and no alert.
+	Observed bool            `json:"observed"`
 	Score    int             `json:"score,omitempty"`
 	ScoreMax int             `json:"score_max,omitempty"`
 	Verdict  string          `json:"verdict,omitempty"`
@@ -3611,9 +3629,12 @@ type ReviewStreamVerdict struct {
 }
 
 type ReviewGateVerdict struct {
-	Passed  bool                  `json:"passed"`
-	Pending bool                  `json:"pending"`
-	Streams []ReviewStreamVerdict `json:"streams"`
+	Passed  bool `json:"passed"`
+	Pending bool `json:"pending"`
+	// Observed is false when NO configured stream produced any signal, i.e.
+	// the whole review gate is silent rather than working.
+	Observed bool                  `json:"observed"`
+	Streams  []ReviewStreamVerdict `json:"streams"`
 }
 
 func (v ReviewGateVerdict) BlockingFindings() []ReviewComment {
@@ -3708,6 +3729,12 @@ func (c *Client) PRReviewGateVerdict(prNumber int, streams []string) (ReviewGate
 			return ReviewGateVerdict{}, err
 		}
 		verdict.Streams = append(verdict.Streams, sv)
+		if sv.Observed {
+			// One reviewer speaking is enough for the gate to count as live:
+			// the missing-review policy only applies when the gate as a whole
+			// is silent.
+			verdict.Observed = true
+		}
 		if sv.Pending {
 			verdict.Pending = true
 			verdict.Passed = false
@@ -3770,6 +3797,9 @@ func (c *Client) namedReviewStreamVerdict(prNumber int, spec reviewStreamSpec) (
 		return ReviewStreamVerdict{}, commentsErr
 	}
 	sv := ReviewStreamVerdict{Name: spec.Name, Passed: false, Pending: false, Findings: findings}
+	// A check run in any state, or an inline finding, means the reviewer spoke
+	// for this head. The default branch below is the silent case.
+	sv.Observed = checkFound || checkPending || len(findings) > 0
 	switch {
 	case checkPending:
 		sv.Pending = true

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2488,8 +2488,13 @@ commentFallback:
 	// a comment newer than the head commit is head-scoped evidence. The
 	// legacy pass/fail semantics of the comment fallback are deliberately left
 	// as they are; this narrows only the Observed signal.
-	if !c.commentScopedToHead(comment, sha) {
+	if scoped, lookupFailed := c.commentScopedToHead(comment, sha); !scoped {
 		verdict.Observed = false
+		if lookupFailed {
+			// Could not prove the comment's age: absence of head-scoped
+			// evidence here is unknown, not silence.
+			verdict.LookupFailed = true
+		}
 	}
 	if !verdict.Passed && !verdict.Pending && isActionableReviewSummary(comment.Body) {
 		verdict.Findings = append(verdict.Findings, ReviewComment{Body: comment.Body, User: comment.User.Login})
@@ -2524,19 +2529,28 @@ func greptileCommentReviewSignal(comments []issueComment) (found bool, signal gr
 }
 
 // commentScopedToHead reports whether an issue comment can be attributed to
-// the given head commit, i.e. it was written after that commit existed. An
-// unknown comment time or an unreadable commit is treated as NOT scoped: the
-// conservative answer keeps a silent reviewer from looking alive on the
-// strength of an older comment.
-func (c *Client) commentScopedToHead(comment issueComment, sha string) bool {
-	if comment.CreatedAt.IsZero() || strings.TrimSpace(sha) == "" {
-		return false
+// the given head commit, i.e. it was written after that commit existed.
+//
+// lookupFailed distinguishes the two reasons a comment is not scoped: it is
+// genuinely older than the head (proof it says nothing about this head), or
+// the commit timestamp could not be read (nothing is proven at all). Collapsing
+// both into "not scoped" would let a rate-limited timestamp read look exactly
+// like a silent reviewer — and a PR the reviewer REJECTED could then merge
+// through the missing-review path.
+func (c *Client) commentScopedToHead(comment issueComment, sha string) (scoped bool, lookupFailed bool) {
+	if strings.TrimSpace(sha) == "" {
+		return false, true
+	}
+	if comment.CreatedAt.IsZero() {
+		// The comment carries no timestamp: unattributable, but the read itself
+		// worked, so this is genuine "not scoped", not a degraded read.
+		return false, false
 	}
 	headAt, err := c.commitCommittedAt(sha)
 	if err != nil || headAt.IsZero() {
-		return false
+		return false, true
 	}
-	return !comment.CreatedAt.Before(headAt)
+	return !comment.CreatedAt.Before(headAt), false
 }
 
 // commitCommittedAt returns the committer timestamp of a commit. Only the

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2427,6 +2427,10 @@ var (
 )
 
 func (c *Client) prGreptileReviewStreamVerdict(prNumber int) (ReviewStreamVerdict, error) {
+	// checkLookupFailed marks a degraded read: absence of a signal below then
+	// means "unknown", not "the reviewer is silent".
+	var checkLookupFailed bool
+
 	// --- 1. Get head SHA of the PR ---
 	sha, err := c.pullHeadSHA(prNumber)
 	if err != nil {
@@ -2437,6 +2441,7 @@ func (c *Client) prGreptileReviewStreamVerdict(prNumber int) (ReviewStreamVerdic
 	checkRuns, err := c.checkRunsForSHA(sha)
 	if err != nil {
 		// Non-fatal: fall through to comment fallback
+		checkLookupFailed = true
 		goto commentFallback
 	}
 
@@ -2471,10 +2476,12 @@ commentFallback:
 		// No check run AND no comment: the reviewer never showed up for this
 		// head. Observed stays false so callers can distinguish this from a
 		// review in progress and apply a missing-review policy instead of
-		// waiting forever.
-		return ReviewStreamVerdict{Name: "greptile", Pending: true, Verdict: reviewVerdictPending}, nil
+		// waiting forever — unless the check-runs read itself failed, in which
+		// case the silence is unproven and LookupFailed says so.
+		return ReviewStreamVerdict{Name: "greptile", Pending: true, Verdict: reviewVerdictPending, LookupFailed: checkLookupFailed}, nil
 	}
 	verdict := reviewStreamVerdictFromGreptileSignal(signal)
+	verdict.LookupFailed = checkLookupFailed
 	// Issue comments carry no head SHA, so a comment written for an EARLIER
 	// head would otherwise count as proof the reviewer spoke about this one —
 	// and a silent reviewer on the current head would look alive forever. Only
@@ -3671,8 +3678,13 @@ type ReviewStreamVerdict struct {
 	// reviews after its free credits ran out and posted nothing at all), and
 	// an unobserved pending gate would otherwise hold every PR forever with
 	// no timeout and no alert.
-	Observed bool            `json:"observed"`
-	Score    int             `json:"score,omitempty"`
+	Observed bool `json:"observed"`
+	// LookupFailed reports that a read the verdict depends on errored (e.g.
+	// the check-runs API), so "no signal" here means "unknown", not "the
+	// reviewer is silent". Callers must not conclude absence from it: a GitHub
+	// outage would otherwise look exactly like a reviewer that never showed up.
+	LookupFailed bool            `json:"lookup_failed,omitempty"`
+	Score        int             `json:"score,omitempty"`
 	ScoreMax int             `json:"score_max,omitempty"`
 	Verdict  string          `json:"verdict,omitempty"`
 	Findings []ReviewComment `json:"findings,omitempty"`
@@ -3683,8 +3695,11 @@ type ReviewGateVerdict struct {
 	Pending bool `json:"pending"`
 	// Observed is false when NO configured stream produced any signal, i.e.
 	// the whole review gate is silent rather than working.
-	Observed bool                  `json:"observed"`
-	Streams  []ReviewStreamVerdict `json:"streams"`
+	Observed bool `json:"observed"`
+	// LookupFailed is true when any stream's read was degraded, so an absent
+	// signal cannot be read as proof the reviewer is silent.
+	LookupFailed bool                  `json:"lookup_failed,omitempty"`
+	Streams      []ReviewStreamVerdict `json:"streams"`
 }
 
 func (v ReviewGateVerdict) BlockingFindings() []ReviewComment {
@@ -3785,6 +3800,10 @@ func (c *Client) PRReviewGateVerdict(prNumber int, streams []string) (ReviewGate
 			// is silent.
 			verdict.Observed = true
 		}
+		if sv.LookupFailed {
+			// One degraded read makes the whole gate's silence unproven.
+			verdict.LookupFailed = true
+		}
 		if sv.Pending {
 			verdict.Pending = true
 			verdict.Passed = false
@@ -3848,8 +3867,10 @@ func (c *Client) namedReviewStreamVerdict(prNumber int, spec reviewStreamSpec) (
 	}
 	sv := ReviewStreamVerdict{Name: spec.Name, Passed: false, Pending: false, Findings: findings}
 	// A check run in any state, or an inline finding, means the reviewer spoke
-	// for this head. The default branch below is the silent case.
+	// for this head. The default branch below is the silent case — but only a
+	// successful read can prove silence.
 	sv.Observed = checkFound || checkPending || len(findings) > 0
+	sv.LookupFailed = checkErr != nil || commentsErr != nil
 	switch {
 	case checkPending:
 		sv.Pending = true

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -74,6 +74,10 @@ type issueComment struct {
 	User struct {
 		Login string `json:"login"`
 	} `json:"user"`
+	// CreatedAt scopes a comment to a head. Issue comments carry no SHA, so a
+	// bot comment from an earlier head is otherwise indistinguishable from one
+	// about the current head.
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // IssueComment is the public view of a single issue comment. Unlike the
@@ -2471,6 +2475,15 @@ commentFallback:
 		return ReviewStreamVerdict{Name: "greptile", Pending: true, Verdict: reviewVerdictPending}, nil
 	}
 	verdict := reviewStreamVerdictFromGreptileSignal(signal)
+	// Issue comments carry no head SHA, so a comment written for an EARLIER
+	// head would otherwise count as proof the reviewer spoke about this one —
+	// and a silent reviewer on the current head would look alive forever. Only
+	// a comment newer than the head commit is head-scoped evidence. The
+	// legacy pass/fail semantics of the comment fallback are deliberately left
+	// as they are; this narrows only the Observed signal.
+	if !c.commentScopedToHead(comment, sha) {
+		verdict.Observed = false
+	}
 	if !verdict.Passed && !verdict.Pending && isActionableReviewSummary(comment.Body) {
 		verdict.Findings = append(verdict.Findings, ReviewComment{Body: comment.Body, User: comment.User.Login})
 	}
@@ -2501,6 +2514,43 @@ func greptileCommentReviewSignal(comments []issueComment) (found bool, signal gr
 		return true, greptileSignalFromText(comment.Body), comment
 	}
 	return false, greptileReviewSignal{}, issueComment{}
+}
+
+// commentScopedToHead reports whether an issue comment can be attributed to
+// the given head commit, i.e. it was written after that commit existed. An
+// unknown comment time or an unreadable commit is treated as NOT scoped: the
+// conservative answer keeps a silent reviewer from looking alive on the
+// strength of an older comment.
+func (c *Client) commentScopedToHead(comment issueComment, sha string) bool {
+	if comment.CreatedAt.IsZero() || strings.TrimSpace(sha) == "" {
+		return false
+	}
+	headAt, err := c.commitCommittedAt(sha)
+	if err != nil || headAt.IsZero() {
+		return false
+	}
+	return !comment.CreatedAt.Before(headAt)
+}
+
+// commitCommittedAt returns the committer timestamp of a commit. Only the
+// review comment-fallback path calls it, which runs when no review check run
+// exists at all.
+func (c *Client) commitCommittedAt(sha string) (time.Time, error) {
+	out, err := ghAPI(fmt.Sprintf("repos/%s/commits/%s", c.Repo, sha))
+	if err != nil {
+		return time.Time{}, err
+	}
+	var payload struct {
+		Commit struct {
+			Committer struct {
+				Date time.Time `json:"date"`
+			} `json:"committer"`
+		} `json:"commit"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		return time.Time{}, err
+	}
+	return payload.Commit.Committer.Date, nil
 }
 
 func greptileCheckDecision(checkRuns []greptileCheckRun) (found bool, approved bool, pending bool) {

--- a/internal/github/review_gate_scope_test.go
+++ b/internal/github/review_gate_scope_test.go
@@ -1,0 +1,53 @@
+package github
+
+import (
+	"testing"
+	"time"
+)
+
+// Workflow review catch: commentScopedToHead must distinguish "the comment is
+// older than this head" (proof it says nothing about the head) from "the
+// timestamp could not be read" (nothing proven). Collapsing the two lets a
+// rate-limited lookup look exactly like a silent reviewer.
+func TestCommentScopedToHead_UnknownCommentTimeIsNotALookupFailure(t *testing.T) {
+	c := &Client{Repo: "owner/repo"}
+	scoped, lookupFailed := c.commentScopedToHead(issueComment{}, "deadbeef")
+	if scoped {
+		t.Fatal("a comment with no timestamp cannot be scoped to a head")
+	}
+	if lookupFailed {
+		t.Fatal("a missing comment timestamp is a genuine 'not scoped', not a degraded read")
+	}
+}
+
+func TestCommentScopedToHead_EmptySHAIsALookupFailure(t *testing.T) {
+	c := &Client{Repo: "owner/repo"}
+	comment := issueComment{CreatedAt: time.Now().UTC()}
+	scoped, lookupFailed := c.commentScopedToHead(comment, "  ")
+	if scoped {
+		t.Fatal("no head to scope against")
+	}
+	if !lookupFailed {
+		t.Fatal("without a head SHA nothing is proven — this must read as a degraded lookup")
+	}
+}
+
+// The verdict must never claim silence when the read that would prove it failed.
+func TestReviewGateVerdict_LookupFailurePropagates(t *testing.T) {
+	v := ReviewGateVerdict{Passed: true}
+	streams := []ReviewStreamVerdict{
+		{Name: "greptile", Pending: true, Observed: false, LookupFailed: true},
+		{Name: "simplicity", Pending: false, Passed: true, Observed: true},
+	}
+	for _, sv := range streams {
+		if sv.Observed {
+			v.Observed = true
+		}
+		if sv.LookupFailed {
+			v.LookupFailed = true
+		}
+	}
+	if !v.LookupFailed {
+		t.Fatal("a degraded stream read must mark the whole gate verdict as unproven")
+	}
+}

--- a/internal/notify/alert_fallback_test.go
+++ b/internal/notify/alert_fallback_test.go
@@ -198,3 +198,102 @@ func TestAlert_DigestBufferedDedupsAndReleasesOnFailedFlush(t *testing.T) {
 		t.Fatalf("buffered after failed flush = %d, want 1 — a lost alert must be re-reportable", got)
 	}
 }
+
+// Workflow review catch: with ntfy configured AND a base transport, an alert
+// must reach BOTH — fanning out to ntfy alone loses the operator's other
+// channel, and loses the alert entirely when ntfy is the broken one.
+func TestAlert_FansOutToEveryConfiguredChannel(t *testing.T) {
+	var mu sync.Mutex
+	ntfyHits, baseHits := 0, 0
+	ntfySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		ntfyHits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ntfySrv.Close()
+	baseSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		baseHits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer baseSrv.Close()
+
+	n := New(baseSrv.URL, "operator").WithNtfy(ntfySrv.URL, "proj", "")
+	if err := n.Alert(AlertEmergency, "emergency", "maestro emergency", "STOP activated"); err != nil {
+		t.Fatalf("Alert: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if ntfyHits != 1 || baseHits != 1 {
+		t.Fatalf("ntfy=%d base=%d, want 1 each — every configured channel must receive the alert", ntfyHits, baseHits)
+	}
+}
+
+// A failing ntfy must not swallow the alert: the base transport still gets it,
+// and the call reports success because the operator was reached.
+func TestAlert_NtfyFailureStillReachesBaseTransport(t *testing.T) {
+	var mu sync.Mutex
+	baseHits := 0
+	ntfySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ntfySrv.Close()
+	baseSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		baseHits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer baseSrv.Close()
+
+	n := New(baseSrv.URL, "operator").WithNtfy(ntfySrv.URL, "proj", "")
+	if err := n.Alert(AlertFloorBreach, "proj:floor", "breach", "live=0"); err != nil {
+		t.Fatalf("Alert returned %v, want success — the operator was reached on the base transport", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if baseHits != 1 {
+		t.Fatalf("base hits = %d, want 1 — a broken ntfy must not lose the alert", baseHits)
+	}
+}
+
+// When every configured channel fails, the alert is NOT recorded as delivered,
+// so the next cycle retries instead of being deduped into silence.
+func TestAlert_AllChannelsFailStaysRetryable(t *testing.T) {
+	var mu sync.Mutex
+	attempts := 0
+	fail := true
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attempts++
+		shouldFail := fail
+		mu.Unlock()
+		if shouldFail {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := New(srv.URL, "operator").WithNtfy(srv.URL, "proj", "")
+	if err := n.Alert(AlertFloorBreach, "proj:floor", "breach", "live=0"); err == nil {
+		t.Fatal("expected an error when every channel failed")
+	}
+	mu.Lock()
+	fail = false
+	before := attempts
+	mu.Unlock()
+
+	if err := n.Alert(AlertFloorBreach, "proj:floor", "breach", "live=0"); err != nil {
+		t.Fatalf("retry failed: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts <= before {
+		t.Fatal("the same condition was deduped away after a total delivery failure")
+	}
+}

--- a/internal/notify/alert_fallback_test.go
+++ b/internal/notify/alert_fallback_test.go
@@ -162,3 +162,39 @@ func TestAlert_ConcurrentIdenticalAlertsSendOnce(t *testing.T) {
 		t.Fatalf("sends = %d, want 1 — concurrent identical alerts must collapse", sends)
 	}
 }
+
+// Codex review catch (P2): a digest-buffered alert must dedup like a delivered
+// one, but a FAILED flush must release it so the condition can be re-reported.
+func TestAlert_DigestBufferedDedupsAndReleasesOnFailedFlush(t *testing.T) {
+	var mu sync.Mutex
+	fail := true
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		shouldFail := fail
+		mu.Unlock()
+		if shouldFail {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := New(srv.URL, "operator")
+	n.SetDigestMode(true)
+
+	_ = n.Alert(AlertFloorBreach, "proj:floor", "breach", "live=0")
+	_ = n.Alert(AlertFloorBreach, "proj:floor", "breach", "live=0")
+	if got := n.Buffered(); got != 1 {
+		t.Fatalf("buffered = %d, want 1 — identical alerts must not duplicate digest entries", got)
+	}
+
+	if err := n.Flush(); err == nil {
+		t.Fatal("expected the flush to fail")
+	}
+	// The digest was lost, so the same condition must be reportable again.
+	_ = n.Alert(AlertFloorBreach, "proj:floor", "breach", "live=0")
+	if got := n.Buffered(); got != 1 {
+		t.Fatalf("buffered after failed flush = %d, want 1 — a lost alert must be re-reportable", got)
+	}
+}

--- a/internal/notify/alert_fallback_test.go
+++ b/internal/notify/alert_fallback_test.go
@@ -1,0 +1,81 @@
+package notify
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Codex review catch: without ntfy configured, Alert used to return nil without
+// sending — every classified alert (including the CRITICAL floor breach) was
+// silently dropped on installs that only use the Telegram/OpenClaw transport.
+func TestAlert_FallsBackToBaseTransportWithoutNtfy(t *testing.T) {
+	var mu sync.Mutex
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := make([]byte, r.ContentLength)
+		r.Body.Read(buf)
+		mu.Lock()
+		bodies = append(bodies, string(buf))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := New(srv.URL, "operator")
+	if n.NtfyConfigured() {
+		t.Fatal("precondition: ntfy must be unconfigured")
+	}
+	if err := n.Alert(AlertFloorBreach, "proj:floor", "maestro floor breach", "live=0 min=5"); err != nil {
+		t.Fatalf("Alert: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(bodies) != 1 {
+		t.Fatalf("sent %d message(s), want 1 — the alert was dropped", len(bodies))
+	}
+	if !strings.Contains(bodies[0], string(AlertFloorBreach)) || !strings.Contains(bodies[0], "live=0 min=5") {
+		t.Fatalf("payload = %q, want the class and body preserved", bodies[0])
+	}
+}
+
+// The dedup contract is unchanged on the fallback path.
+func TestAlert_FallbackKeepsDedup(t *testing.T) {
+	var mu sync.Mutex
+	count := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := New(srv.URL, "operator")
+	_ = n.Alert(AlertIdleStall, "proj:idle", "stall", "same body")
+	_ = n.Alert(AlertIdleStall, "proj:idle", "stall", "same body")
+
+	mu.Lock()
+	defer mu.Unlock()
+	if count != 1 {
+		t.Fatalf("sent %d, want 1 — dedup must survive the fallback path", count)
+	}
+}
+
+func TestAlertFallbackText(t *testing.T) {
+	if got := alertFallbackText(AlertEmergency, "", ""); got != "[emergency]" {
+		t.Fatalf("empty = %q", got)
+	}
+	if got := alertFallbackText(AlertEmergency, "title", ""); got != "[emergency] title" {
+		t.Fatalf("title-only = %q", got)
+	}
+	if got := alertFallbackText(AlertEmergency, "", "body"); got != "[emergency] body" {
+		t.Fatalf("body-only = %q", got)
+	}
+	if got := alertFallbackText(AlertEmergency, "title", "body"); got != "[emergency] title — body" {
+		t.Fatalf("both = %q", got)
+	}
+}

--- a/internal/notify/alert_fallback_test.go
+++ b/internal/notify/alert_fallback_test.go
@@ -119,3 +119,46 @@ func TestAlert_TransportFailureStaysRetryable(t *testing.T) {
 		t.Fatalf("attempts = %d, want 2 — a failed alert must stay eligible for retry", attempts)
 	}
 }
+
+// Codex review catch (P2): concurrent identical alerts must still collapse to
+// one send — the retry fix must not lose the atomic dedup reservation.
+func TestAlert_ConcurrentIdenticalAlertsSendOnce(t *testing.T) {
+	var mu sync.Mutex
+	sends := 0
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		sends++
+		mu.Unlock()
+		<-release // hold the first send open so the second call races it
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := New(srv.URL, "operator")
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = n.Alert(AlertFloorBreach, "proj:floor", "breach", "live=0")
+		}()
+	}
+	// Give both goroutines time to pass the dedup check before releasing.
+	for i := 0; i < 100; i++ {
+		mu.Lock()
+		started := sends
+		mu.Unlock()
+		if started > 0 {
+			break
+		}
+	}
+	close(release)
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if sends != 1 {
+		t.Fatalf("sends = %d, want 1 — concurrent identical alerts must collapse", sends)
+	}
+}

--- a/internal/notify/alert_fallback_test.go
+++ b/internal/notify/alert_fallback_test.go
@@ -79,3 +79,43 @@ func TestAlertFallbackText(t *testing.T) {
 		t.Fatalf("both = %q", got)
 	}
 }
+
+// Codex review catch (P1): a failed send must NOT record the dedup state, or
+// every later cycle reporting the same condition is silenced and the alert is
+// lost for good.
+func TestAlert_TransportFailureStaysRetryable(t *testing.T) {
+	var mu sync.Mutex
+	attempts := 0
+	fail := true
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attempts++
+		shouldFail := fail
+		mu.Unlock()
+		if shouldFail {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	n := New(srv.URL, "operator")
+	if err := n.Alert(AlertFloorBreach, "proj:floor", "breach", "live=0"); err == nil {
+		t.Fatal("expected the transport error to surface")
+	}
+
+	mu.Lock()
+	fail = false
+	mu.Unlock()
+
+	// Same condition next cycle: it must be retried, not deduped away.
+	if err := n.Alert(AlertFloorBreach, "proj:floor", "breach", "live=0"); err != nil {
+		t.Fatalf("retry failed: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if attempts != 2 {
+		t.Fatalf("attempts = %d, want 2 — a failed alert must stay eligible for retry", attempts)
+	}
+}

--- a/internal/notify/alert_test.go
+++ b/internal/notify/alert_test.go
@@ -179,10 +179,13 @@ func TestAlert_DifferentKeysAreIndependent(t *testing.T) {
 	}
 }
 
-func TestAlert_NoNtfyConfig_IsNoOp(t *testing.T) {
-	n := &Notifier{} // no ntfy configured
+// With NO transport at all — neither ntfy nor Telegram/OpenClaw — Alert stays a
+// silent no-op. When only ntfy is missing it now falls back to the base
+// transport instead (see TestAlert_FallsBackToBaseTransportWithoutNtfy).
+func TestAlert_NoTransportConfigured_IsNoOp(t *testing.T) {
+	n := &Notifier{} // neither ntfy nor a base transport
 	if err := n.Alert(AlertEmergency, "k", "t", "b"); err != nil {
-		t.Errorf("Alert without ntfy config should return nil, got %v", err)
+		t.Errorf("Alert without any transport should return nil, got %v", err)
 	}
 }
 

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -185,8 +185,11 @@ func (n *Notifier) Sendf(format string, args ...any) {
 // digest/notify contract so a supervisor loop re-detecting the same condition
 // every cycle produces one notification, not one per cycle.
 //
-// The alert fans out to the ntfy transport when configured; a nil-config ntfy
-// is a no-op. Returns the ntfy send error (nil when ntfy is not configured).
+// The alert fans out to the ntfy transport when configured. When it is NOT
+// configured the alert falls back to the base transport (Telegram/OpenClaw)
+// rather than disappearing: an install that never set up ntfy would otherwise
+// silently lose every classified alert, including the CRITICAL floor-breach
+// page. The fallback loses only the priority/tag routing, which ntfy owns.
 func (n *Notifier) Alert(class AlertClass, key, title, body string) error {
 	stateKey := string(class) + "\x00" + key
 
@@ -202,10 +205,26 @@ func (n *Notifier) Alert(class AlertClass, key, title, body string) error {
 	n.mu.Unlock()
 
 	if !n.NtfyConfigured() {
-		return nil
+		return n.Send(alertFallbackText(class, title, body))
 	}
 	route := RouteFor(class)
 	return n.sendNtfy(title, body, route)
+}
+
+// alertFallbackText renders a classified alert for the plain-text transports,
+// keeping the class visible since they carry no priority/tag metadata.
+func alertFallbackText(class AlertClass, title, body string) string {
+	title = strings.TrimSpace(title)
+	body = strings.TrimSpace(body)
+	switch {
+	case title == "" && body == "":
+		return fmt.Sprintf("[%s]", class)
+	case title == "":
+		return fmt.Sprintf("[%s] %s", class, body)
+	case body == "":
+		return fmt.Sprintf("[%s] %s", class, title)
+	}
+	return fmt.Sprintf("[%s] %s — %s", class, title, body)
 }
 
 // ResetAlertState clears the dedup memory (test/rotation helper).

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -36,6 +36,10 @@ type Notifier struct {
 	// concurrent callers with the same (class,key,body) collapse to one send
 	// without recording delivery before it succeeds.
 	alertInFlight map[string]string
+	// alertPendingFlush holds alerts that are only buffered in digest mode.
+	// They dedup like delivered alerts, but a failed Flush releases them so the
+	// condition can be reported again.
+	alertPendingFlush map[string]string
 }
 
 // WithNtfy configures the ntfy push transport and returns the notifier for
@@ -78,6 +82,8 @@ func (n *Notifier) Flush() error {
 	n.mu.Lock()
 	msgs := n.buffer
 	n.buffer = nil
+	pending := n.alertPendingFlush
+	n.alertPendingFlush = nil
 	n.mu.Unlock()
 
 	if len(msgs) == 0 {
@@ -87,6 +93,15 @@ func (n *Notifier) Flush() error {
 	combined := "📋 *maestro digest:*\n\n" + strings.Join(msgs, "\n\n")
 	if err := n.send(combined); err != nil {
 		log.Printf("[notify] digest flush failed: %v", err)
+		// The buffer is gone, so these alerts were never delivered: drop their
+		// dedup records instead of silencing the next occurrence.
+		n.mu.Lock()
+		for key, body := range pending {
+			if n.alertState[key] == body {
+				delete(n.alertState, key)
+			}
+		}
+		n.mu.Unlock()
 		return err
 	}
 	return nil
@@ -216,8 +231,9 @@ func (n *Notifier) Alert(class AlertClass, key, title, body string) error {
 	}
 	n.alertInFlight[stateKey] = body
 	// In digest mode the base transport only buffers, so "sent" is not
-	// "delivered" until Flush succeeds; skip the delivered-state write and let
-	// the next occurrence re-buffer rather than being silenced by dedup.
+	// "delivered" until Flush succeeds. Such an alert is recorded as PENDING:
+	// it dedups later identical calls (no duplicate digest entries) but is
+	// dropped again if the flush fails, so the condition can be re-reported.
 	digestBuffered := !n.NtfyConfigured() && n.digestMode
 	n.mu.Unlock()
 
@@ -230,11 +246,17 @@ func (n *Notifier) Alert(class AlertClass, key, title, body string) error {
 
 	n.mu.Lock()
 	delete(n.alertInFlight, stateKey)
-	if err == nil && !digestBuffered {
+	if err == nil {
 		if n.alertState == nil {
 			n.alertState = make(map[string]string)
 		}
 		n.alertState[stateKey] = body
+		if digestBuffered {
+			if n.alertPendingFlush == nil {
+				n.alertPendingFlush = make(map[string]string)
+			}
+			n.alertPendingFlush[stateKey] = body
+		}
 	}
 	n.mu.Unlock()
 	return err

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -194,21 +194,33 @@ func (n *Notifier) Alert(class AlertClass, key, title, body string) error {
 	stateKey := string(class) + "\x00" + key
 
 	n.mu.Lock()
-	if n.alertState == nil {
-		n.alertState = make(map[string]string)
-	}
 	if last, ok := n.alertState[stateKey]; ok && last == body {
 		n.mu.Unlock()
 		return nil // no state change since last send — dedup
 	}
-	n.alertState[stateKey] = body
 	n.mu.Unlock()
 
-	if !n.NtfyConfigured() {
-		return n.Send(alertFallbackText(class, title, body))
+	var err error
+	if n.NtfyConfigured() {
+		err = n.sendNtfy(title, body, RouteFor(class))
+	} else {
+		err = n.Send(alertFallbackText(class, title, body))
 	}
-	route := RouteFor(class)
-	return n.sendNtfy(title, body, route)
+	if err != nil {
+		// Do NOT record the dedup state: a transient transport error would
+		// otherwise mark the alert as delivered and silence every later cycle
+		// reporting the same condition, permanently losing pages like a floor
+		// breach. An unsent alert must stay eligible for retry.
+		return err
+	}
+
+	n.mu.Lock()
+	if n.alertState == nil {
+		n.alertState = make(map[string]string)
+	}
+	n.alertState[stateKey] = body
+	n.mu.Unlock()
+	return nil
 }
 
 // alertFallbackText renders a classified alert for the plain-text transports,

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -32,6 +32,10 @@ type Notifier struct {
 	// An alert whose body equals the last-sent body is a no-op (no state
 	// change), so a supervisor cycle re-emitting the same condition sends once.
 	alertState map[string]string
+	// alertInFlight reserves an alert that is being sent right now, so
+	// concurrent callers with the same (class,key,body) collapse to one send
+	// without recording delivery before it succeeds.
+	alertInFlight map[string]string
 }
 
 // WithNtfy configures the ntfy push transport and returns the notifier for
@@ -193,11 +197,28 @@ func (n *Notifier) Sendf(format string, args ...any) {
 func (n *Notifier) Alert(class AlertClass, key, title, body string) error {
 	stateKey := string(class) + "\x00" + key
 
+	// Reserve the (class,key,body) under the lock so concurrent callers with an
+	// identical alert still collapse to one send, then release it if the send
+	// fails so the condition stays eligible for retry. Recording delivery
+	// before sending would lose alerts on a transport error; not reserving at
+	// all would duplicate them under concurrency.
 	n.mu.Lock()
 	if last, ok := n.alertState[stateKey]; ok && last == body {
 		n.mu.Unlock()
 		return nil // no state change since last send — dedup
 	}
+	if inflight, ok := n.alertInFlight[stateKey]; ok && inflight == body {
+		n.mu.Unlock()
+		return nil // another caller is sending this exact alert right now
+	}
+	if n.alertInFlight == nil {
+		n.alertInFlight = make(map[string]string)
+	}
+	n.alertInFlight[stateKey] = body
+	// In digest mode the base transport only buffers, so "sent" is not
+	// "delivered" until Flush succeeds; skip the delivered-state write and let
+	// the next occurrence re-buffer rather than being silenced by dedup.
+	digestBuffered := !n.NtfyConfigured() && n.digestMode
 	n.mu.Unlock()
 
 	var err error
@@ -206,21 +227,17 @@ func (n *Notifier) Alert(class AlertClass, key, title, body string) error {
 	} else {
 		err = n.Send(alertFallbackText(class, title, body))
 	}
-	if err != nil {
-		// Do NOT record the dedup state: a transient transport error would
-		// otherwise mark the alert as delivered and silence every later cycle
-		// reporting the same condition, permanently losing pages like a floor
-		// breach. An unsent alert must stay eligible for retry.
-		return err
-	}
 
 	n.mu.Lock()
-	if n.alertState == nil {
-		n.alertState = make(map[string]string)
+	delete(n.alertInFlight, stateKey)
+	if err == nil && !digestBuffered {
+		if n.alertState == nil {
+			n.alertState = make(map[string]string)
+		}
+		n.alertState[stateKey] = body
 	}
-	n.alertState[stateKey] = body
 	n.mu.Unlock()
-	return nil
+	return err
 }
 
 // alertFallbackText renders a classified alert for the plain-text transports,

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -32,10 +32,10 @@ type Notifier struct {
 	// An alert whose body equals the last-sent body is a no-op (no state
 	// change), so a supervisor cycle re-emitting the same condition sends once.
 	alertState map[string]string
-	// alertInFlight reserves an alert that is being sent right now, so
-	// concurrent callers with the same (class,key,body) collapse to one send
-	// without recording delivery before it succeeds.
-	alertInFlight map[string]string
+	// alertKeyLocks serializes the check-send-record sequence per (class,key)
+	// so concurrent callers cannot both pass the dedup check, and a slow send
+	// cannot overwrite the state recorded by a newer one.
+	alertKeyLocks map[string]*sync.Mutex
 	// alertPendingFlush holds alerts that are only buffered in digest mode.
 	// They dedup like delivered alerts, but a failed Flush releases them so the
 	// condition can be reported again.
@@ -204,62 +204,94 @@ func (n *Notifier) Sendf(format string, args ...any) {
 // digest/notify contract so a supervisor loop re-detecting the same condition
 // every cycle produces one notification, not one per cycle.
 //
-// The alert fans out to the ntfy transport when configured. When it is NOT
-// configured the alert falls back to the base transport (Telegram/OpenClaw)
-// rather than disappearing: an install that never set up ntfy would otherwise
-// silently lose every classified alert, including the CRITICAL floor-breach
-// page. The fallback loses only the priority/tag routing, which ntfy owns.
+// The alert reaches the operator on EVERY configured channel: ntfy when it is
+// configured (carrying the class priority/tags), and the base transport
+// (Telegram/OpenClaw) whenever a target is set. Fanning out to one channel only
+// loses the alert whenever that channel is the broken one — and an install that
+// never set up ntfy would silently lose every classified alert, including the
+// CRITICAL floor-breach page. The error is returned only when every configured
+// channel failed; a partial success still counts as delivered.
+//
+// The whole check-send-record sequence is serialized per (class,key) so
+// concurrent callers cannot interleave: without that, two callers can both pass
+// the dedup check, and a slower send can overwrite the recorded state of a
+// newer one, silencing a later genuine alert.
 func (n *Notifier) Alert(class AlertClass, key, title, body string) error {
 	stateKey := string(class) + "\x00" + key
 
-	// Reserve the (class,key,body) under the lock so concurrent callers with an
-	// identical alert still collapse to one send, then release it if the send
-	// fails so the condition stays eligible for retry. Recording delivery
-	// before sending would lose alerts on a transport error; not reserving at
-	// all would duplicate them under concurrency.
+	unlock := n.lockAlertKey(stateKey)
+	defer unlock()
+
 	n.mu.Lock()
-	if last, ok := n.alertState[stateKey]; ok && last == body {
-		n.mu.Unlock()
-		return nil // no state change since last send — dedup
-	}
-	if inflight, ok := n.alertInFlight[stateKey]; ok && inflight == body {
-		n.mu.Unlock()
-		return nil // another caller is sending this exact alert right now
-	}
-	if n.alertInFlight == nil {
-		n.alertInFlight = make(map[string]string)
-	}
-	n.alertInFlight[stateKey] = body
+	last, seen := n.alertState[stateKey]
 	// In digest mode the base transport only buffers, so "sent" is not
 	// "delivered" until Flush succeeds. Such an alert is recorded as PENDING:
 	// it dedups later identical calls (no duplicate digest entries) but is
 	// dropped again if the flush fails, so the condition can be re-reported.
-	digestBuffered := !n.NtfyConfigured() && n.digestMode
+	digestBuffered := n.digestMode && strings.TrimSpace(n.Target) != ""
 	n.mu.Unlock()
+	if seen && last == body {
+		return nil // no state change since last send — dedup
+	}
 
-	var err error
+	var errs []string
+	delivered := false
 	if n.NtfyConfigured() {
-		err = n.sendNtfy(title, body, RouteFor(class))
-	} else {
-		err = n.Send(alertFallbackText(class, title, body))
+		if err := n.sendNtfy(title, body, RouteFor(class)); err != nil {
+			errs = append(errs, "ntfy: "+err.Error())
+		} else {
+			delivered = true
+		}
+	}
+	if strings.TrimSpace(n.Target) != "" {
+		if err := n.Send(alertFallbackText(class, title, body)); err != nil {
+			errs = append(errs, "base: "+err.Error())
+		} else {
+			delivered = true
+		}
+	}
+	if !delivered {
+		if len(errs) == 0 {
+			return nil // no transport configured at all — nothing to do
+		}
+		// Nothing was delivered: do NOT record the state, or every later cycle
+		// reporting the same condition would be deduped away and the alert lost.
+		return fmt.Errorf("alert %s: %s", class, strings.Join(errs, "; "))
 	}
 
 	n.mu.Lock()
-	delete(n.alertInFlight, stateKey)
-	if err == nil {
-		if n.alertState == nil {
-			n.alertState = make(map[string]string)
+	if n.alertState == nil {
+		n.alertState = make(map[string]string)
+	}
+	n.alertState[stateKey] = body
+	if digestBuffered {
+		if n.alertPendingFlush == nil {
+			n.alertPendingFlush = make(map[string]string)
 		}
-		n.alertState[stateKey] = body
-		if digestBuffered {
-			if n.alertPendingFlush == nil {
-				n.alertPendingFlush = make(map[string]string)
-			}
-			n.alertPendingFlush[stateKey] = body
-		}
+		n.alertPendingFlush[stateKey] = body
 	}
 	n.mu.Unlock()
-	return err
+	if len(errs) > 0 {
+		log.Printf("[notify] alert %s delivered with partial failure: %s", class, strings.Join(errs, "; "))
+	}
+	return nil
+}
+
+// lockAlertKey serializes Alert calls that share a (class,key) identity and
+// returns the release func. Distinct keys stay concurrent.
+func (n *Notifier) lockAlertKey(stateKey string) func() {
+	n.mu.Lock()
+	if n.alertKeyLocks == nil {
+		n.alertKeyLocks = make(map[string]*sync.Mutex)
+	}
+	mu, ok := n.alertKeyLocks[stateKey]
+	if !ok {
+		mu = &sync.Mutex{}
+		n.alertKeyLocks[stateKey] = mu
+	}
+	n.mu.Unlock()
+	mu.Lock()
+	return mu.Unlock
 }
 
 // alertFallbackText renders a classified alert for the plain-text transports,

--- a/internal/orchestrator/missing_review_gate_test.go
+++ b/internal/orchestrator/missing_review_gate_test.go
@@ -99,6 +99,70 @@ func TestMissingReviewGateElapsed_SettledGateIgnored(t *testing.T) {
 	}
 }
 
+// Codex review catch (P1): a reviewer seen on this head keeps blocking even if
+// a later read comes back unobserved — a transient check-runs error must not
+// demote a working reviewer to "absent".
+func TestMissingReviewGateElapsed_StickyObservationBlocksExpiry(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	sess := pendingSince(90*time.Minute, now)
+
+	// The reviewer was seen earlier on this head.
+	o.trackReviewPendingClock(sess, "deadbeef", github.ReviewGateVerdict{Pending: true, Observed: true}, now)
+	if !sess.ReviewGateObserved {
+		t.Fatal("observation was not recorded")
+	}
+
+	// This cycle's read failed over to the comment path and looks unobserved.
+	blip := github.ReviewGateVerdict{Pending: true, Observed: false}
+	if _, missing := o.missingReviewGateElapsed(sess, blip, now); missing {
+		t.Fatal("a single unobserved read expired a gate that was observed earlier on the same head")
+	}
+}
+
+// A new head resets both the clock and the observation memory.
+func TestTrackReviewPendingClock_NewHeadResets(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	sess := pendingSince(90*time.Minute, now)
+	sess.ReviewGateObserved = true
+	sess.ReviewRetriggerCount = 3
+
+	o.trackReviewPendingClock(sess, "cafebabe", github.ReviewGateVerdict{Pending: true, Observed: false}, now)
+
+	if sess.ReviewPendingHeadSHA != "cafebabe" {
+		t.Fatalf("head = %q, want cafebabe", sess.ReviewPendingHeadSHA)
+	}
+	if sess.ReviewGateObserved {
+		t.Fatal("observation memory survived a head change")
+	}
+	if sess.ReviewRetriggerCount != 0 {
+		t.Fatalf("retrigger count = %d, want 0 after a head change", sess.ReviewRetriggerCount)
+	}
+	if sess.ReviewPendingSince == nil || !sess.ReviewPendingSince.Equal(now) {
+		t.Fatal("clock was not restarted on the new head")
+	}
+}
+
+// Codex review catch (P2): the clock must start for a pending gate regardless
+// of which stream is pending — the Greptile-specific retrigger is not the
+// owner of the clock.
+func TestTrackReviewPendingClock_StartsForNonGreptileStream(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	sess := &state.Session{}
+
+	o.trackReviewPendingClock(sess, "deadbeef", github.ReviewGateVerdict{
+		Pending:  true,
+		Observed: false,
+		Streams:  []github.ReviewStreamVerdict{{Name: "simplicity", Pending: true}},
+	}, now)
+
+	if sess.ReviewPendingSince == nil {
+		t.Fatal("clock did not start for a non-greptile pending stream")
+	}
+}
+
 // The merge-past-absent-gate alert fires once per PR.
 func TestNotifyMissingReviewGate_OncePerPR(t *testing.T) {
 	o := missingReviewOrchestrator(60)

--- a/internal/orchestrator/missing_review_gate_test.go
+++ b/internal/orchestrator/missing_review_gate_test.go
@@ -235,3 +235,30 @@ func TestMissingReviewGateElapsed_LookupFailureIsNotSilence(t *testing.T) {
 		t.Fatal("an API failure was treated as proof the reviewer is silent")
 	}
 }
+
+// Codex review catch (P2): a check that settles and goes pending again on the
+// SAME head must not reset the re-trigger cap, or flapping lets a PR collect
+// unlimited review-nag comments.
+func TestTrackReviewGateHead_SettledThenPendingKeepsRetryCount(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	sess := &state.Session{}
+
+	o.trackReviewGateHead(sess, "deadbeef", github.ReviewGateVerdict{Pending: true, Observed: true}, now)
+	sess.ReviewRetriggerCount = 3
+
+	// The gate settles: the clock stops, the head anchor stays.
+	clearReviewPendingTracking(sess)
+	if sess.ReviewPendingHeadSHA != "deadbeef" {
+		t.Fatal("the head anchor was dropped when the gate settled")
+	}
+
+	// The same head goes pending again (check re-run).
+	o.trackReviewGateHead(sess, "deadbeef", github.ReviewGateVerdict{Pending: true, Observed: false}, now.Add(time.Minute))
+	if sess.ReviewRetriggerCount != 3 {
+		t.Fatalf("retrigger count = %d, want 3 — a settled/pending flap is not a new head", sess.ReviewRetriggerCount)
+	}
+	if !sess.ReviewGateObserved {
+		t.Fatal("observation memory was lost on a settled/pending flap")
+	}
+}

--- a/internal/orchestrator/missing_review_gate_test.go
+++ b/internal/orchestrator/missing_review_gate_test.go
@@ -1,0 +1,113 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func missingReviewOrchestrator(missingAfterMinutes int) *Orchestrator {
+	return &Orchestrator{
+		cfg: &config.Config{
+			Repo: "owner/repo",
+			ReviewRetrigger: config.ReviewRetriggerConfig{
+				MissingAfterMinutes: missingAfterMinutes,
+			},
+		},
+		notifier: &notify.Notifier{},
+		repo:     "owner/repo",
+	}
+}
+
+func pendingSince(d time.Duration, now time.Time) *state.Session {
+	since := now.Add(-d)
+	return &state.Session{ReviewPendingSince: &since, ReviewPendingHeadSHA: "deadbeef"}
+}
+
+// An unobserved (silent) gate becomes non-blocking once the grace elapses.
+func TestMissingReviewGateElapsed_SilentGatePastGrace(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	verdict := github.ReviewGateVerdict{Pending: true, Observed: false}
+
+	silentFor, missing := o.missingReviewGateElapsed(pendingSince(90*time.Minute, now), verdict, now)
+	if !missing {
+		t.Fatal("silent gate past the grace should be treated as missing")
+	}
+	if silentFor < 89*time.Minute {
+		t.Fatalf("silentFor = %v, want ~90m", silentFor)
+	}
+}
+
+// Inside the grace the PR keeps waiting.
+func TestMissingReviewGateElapsed_WithinGraceStillWaits(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	verdict := github.ReviewGateVerdict{Pending: true, Observed: false}
+
+	if _, missing := o.missingReviewGateElapsed(pendingSince(10*time.Minute, now), verdict, now); missing {
+		t.Fatal("gate should still be waiting inside the grace window")
+	}
+}
+
+// The safety property: a reviewer that DID produce a signal keeps blocking no
+// matter how long it takes. Only true silence is bounded.
+func TestMissingReviewGateElapsed_ObservedGateNeverExpires(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	verdict := github.ReviewGateVerdict{Pending: true, Observed: true}
+
+	if _, missing := o.missingReviewGateElapsed(pendingSince(48*time.Hour, now), verdict, now); missing {
+		t.Fatal("an observed (working) reviewer must keep blocking regardless of elapsed time")
+	}
+}
+
+// Opt-in: 0 preserves today's block-forever behavior.
+func TestMissingReviewGateElapsed_DisabledByDefault(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(0)
+	verdict := github.ReviewGateVerdict{Pending: true, Observed: false}
+
+	if _, missing := o.missingReviewGateElapsed(pendingSince(48*time.Hour, now), verdict, now); missing {
+		t.Fatal("missing-review policy must be off unless the operator opts in")
+	}
+}
+
+// No pending clock yet (first observation) — nothing to expire.
+func TestMissingReviewGateElapsed_NoClockYet(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	verdict := github.ReviewGateVerdict{Pending: true, Observed: false}
+
+	if _, missing := o.missingReviewGateElapsed(&state.Session{}, verdict, now); missing {
+		t.Fatal("a session with no pending clock cannot have exceeded the grace")
+	}
+}
+
+// A settled gate (not pending) never routes through the missing-review path.
+func TestMissingReviewGateElapsed_SettledGateIgnored(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	verdict := github.ReviewGateVerdict{Pending: false, Observed: false, Passed: true}
+
+	if _, missing := o.missingReviewGateElapsed(pendingSince(90*time.Minute, now), verdict, now); missing {
+		t.Fatal("a settled gate must not be treated as missing")
+	}
+}
+
+// The merge-past-absent-gate alert fires once per PR.
+func TestNotifyMissingReviewGate_OncePerPR(t *testing.T) {
+	o := missingReviewOrchestrator(60)
+	o.notifyMissingReviewGate(42, time.Hour)
+	if !o.missingReviewNotified[42] {
+		t.Fatal("first notification was not recorded")
+	}
+	o.notifyMissingReviewGate(42, 2*time.Hour)
+	if len(o.missingReviewNotified) != 1 {
+		t.Fatalf("notified map = %v, want a single entry", o.missingReviewNotified)
+	}
+}

--- a/internal/orchestrator/missing_review_gate_test.go
+++ b/internal/orchestrator/missing_review_gate_test.go
@@ -108,7 +108,7 @@ func TestMissingReviewGateElapsed_StickyObservationBlocksExpiry(t *testing.T) {
 	sess := pendingSince(90*time.Minute, now)
 
 	// The reviewer was seen earlier on this head.
-	o.trackReviewPendingClock(sess, "deadbeef", github.ReviewGateVerdict{Pending: true, Observed: true}, now)
+	o.trackReviewGateHead(sess, "deadbeef", github.ReviewGateVerdict{Pending: true, Observed: true}, now)
 	if !sess.ReviewGateObserved {
 		t.Fatal("observation was not recorded")
 	}
@@ -121,14 +121,14 @@ func TestMissingReviewGateElapsed_StickyObservationBlocksExpiry(t *testing.T) {
 }
 
 // A new head resets both the clock and the observation memory.
-func TestTrackReviewPendingClock_NewHeadResets(t *testing.T) {
+func TestTrackReviewGateHead_NewHeadResets(t *testing.T) {
 	now := time.Now().UTC()
 	o := missingReviewOrchestrator(60)
 	sess := pendingSince(90*time.Minute, now)
 	sess.ReviewGateObserved = true
 	sess.ReviewRetriggerCount = 3
 
-	o.trackReviewPendingClock(sess, "cafebabe", github.ReviewGateVerdict{Pending: true, Observed: false}, now)
+	o.trackReviewGateHead(sess, "cafebabe", github.ReviewGateVerdict{Pending: true, Observed: false}, now)
 
 	if sess.ReviewPendingHeadSHA != "cafebabe" {
 		t.Fatalf("head = %q, want cafebabe", sess.ReviewPendingHeadSHA)
@@ -147,12 +147,12 @@ func TestTrackReviewPendingClock_NewHeadResets(t *testing.T) {
 // Codex review catch (P2): the clock must start for a pending gate regardless
 // of which stream is pending — the Greptile-specific retrigger is not the
 // owner of the clock.
-func TestTrackReviewPendingClock_StartsForNonGreptileStream(t *testing.T) {
+func TestTrackReviewGateHead_StartsForNonGreptileStream(t *testing.T) {
 	now := time.Now().UTC()
 	o := missingReviewOrchestrator(60)
 	sess := &state.Session{}
 
-	o.trackReviewPendingClock(sess, "deadbeef", github.ReviewGateVerdict{
+	o.trackReviewGateHead(sess, "deadbeef", github.ReviewGateVerdict{
 		Pending:  true,
 		Observed: false,
 		Streams:  []github.ReviewStreamVerdict{{Name: "simplicity", Pending: true}},
@@ -178,9 +178,36 @@ func TestMissingReviewGateElapsed_SurvivesDeferredMerge(t *testing.T) {
 	}
 
 	// The merge was deferred this cycle; the clock must NOT have been reset.
-	o.trackReviewPendingClock(sess, "deadbeef", verdict, now.Add(time.Minute))
+	o.trackReviewGateHead(sess, "deadbeef", verdict, now.Add(time.Minute))
 	if _, missing := o.missingReviewGateElapsed(sess, verdict, now.Add(time.Minute)); !missing {
 		t.Fatal("a deferred candidate lost its elapsed grace — repeated deferrals would reset the window forever")
+	}
+}
+
+// Codex review catch (P1): a SETTLED verdict is proof the reviewer is alive
+// too. Recording observations only for pending verdicts meant a rejection
+// followed by failing check-runs reads could look like "never showed up" and
+// merge a PR the reviewer had rejected.
+func TestTrackReviewGateHead_RecordsSettledRejection(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	sess := &state.Session{}
+
+	// The reviewer rejected this head: settled, not pending, but observed.
+	o.trackReviewGateHead(sess, "deadbeef", github.ReviewGateVerdict{Pending: false, Passed: false, Observed: true}, now)
+	if !sess.ReviewGateObserved {
+		t.Fatal("a settled rejection was not recorded as an observation")
+	}
+	if sess.ReviewPendingSince != nil {
+		t.Fatal("a settled verdict must not start the pending clock")
+	}
+
+	// Later reads fail over and look unobserved for longer than the grace.
+	since := now.Add(-90 * time.Minute)
+	sess.ReviewPendingSince = &since
+	blip := github.ReviewGateVerdict{Pending: true, Observed: false}
+	if _, missing := o.missingReviewGateElapsed(sess, blip, now); missing {
+		t.Fatal("a PR whose reviewer already rejected it was treated as unreviewed")
 	}
 }
 

--- a/internal/orchestrator/missing_review_gate_test.go
+++ b/internal/orchestrator/missing_review_gate_test.go
@@ -223,3 +223,15 @@ func TestNotifyMissingReviewGate_OncePerPR(t *testing.T) {
 		t.Fatalf("notified map = %v, want a single entry", o.missingReviewNotified)
 	}
 }
+
+// Codex review catch (P1): a degraded read must never be read as silence — a
+// check-runs API outage would otherwise merge PRs unreviewed.
+func TestMissingReviewGateElapsed_LookupFailureIsNotSilence(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	verdict := github.ReviewGateVerdict{Pending: true, Observed: false, LookupFailed: true}
+
+	if _, missing := o.missingReviewGateElapsed(pendingSince(48*time.Hour, now), verdict, now); missing {
+		t.Fatal("an API failure was treated as proof the reviewer is silent")
+	}
+}

--- a/internal/orchestrator/missing_review_gate_test.go
+++ b/internal/orchestrator/missing_review_gate_test.go
@@ -163,6 +163,27 @@ func TestTrackReviewPendingClock_StartsForNonGreptileStream(t *testing.T) {
 	}
 }
 
+// Codex review catch: the elapsed grace must survive a deferred merge. A
+// candidate that is queued but not merged this cycle keeps its per-head clock,
+// otherwise repeated deferrals restart the window forever and the PR never
+// merges.
+func TestMissingReviewGateElapsed_SurvivesDeferredMerge(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	sess := pendingSince(90*time.Minute, now)
+	verdict := github.ReviewGateVerdict{Pending: true, Observed: false}
+
+	if _, missing := o.missingReviewGateElapsed(sess, verdict, now); !missing {
+		t.Fatal("precondition: the gate should be expired")
+	}
+
+	// The merge was deferred this cycle; the clock must NOT have been reset.
+	o.trackReviewPendingClock(sess, "deadbeef", verdict, now.Add(time.Minute))
+	if _, missing := o.missingReviewGateElapsed(sess, verdict, now.Add(time.Minute)); !missing {
+		t.Fatal("a deferred candidate lost its elapsed grace — repeated deferrals would reset the window forever")
+	}
+}
+
 // The merge-past-absent-gate alert fires once per PR.
 func TestNotifyMissingReviewGate_OncePerPR(t *testing.T) {
 	o := missingReviewOrchestrator(60)

--- a/internal/orchestrator/missing_review_gate_test.go
+++ b/internal/orchestrator/missing_review_gate_test.go
@@ -262,3 +262,67 @@ func TestTrackReviewGateHead_SettledThenPendingKeepsRetryCount(t *testing.T) {
 		t.Fatal("observation memory was lost on a settled/pending flap")
 	}
 }
+
+// Workflow review catch: end-to-end wiring of the missing-review policy through
+// autoMergePRs — a silent gate past the grace must actually merge the PR, and a
+// silent gate inside the grace must not.
+func TestAutoMergePRs_MissingReviewMergesPastGrace(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{Repo: "owner/repo", ReviewGate: "greptile"}
+	cfg.ReviewRetrigger.MissingAfterMinutes = 60
+	cfg.ReviewRetrigger.Enabled = new(bool) // re-triggers off: the clock must still run
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghPRGreptileApprovedFn = func(int) (bool, bool, error) { return false, true, nil } // pending, unobserved
+	o.ghPRHeadSHAFn = func(int) (string, error) { return "abc123def456789", nil }
+
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(90 * time.Minute)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 1 || (*merged)[0] != 10 {
+		t.Fatalf("merged = %v, want PR #10 merged past the silent gate", *merged)
+	}
+}
+
+func TestAutoMergePRs_MissingReviewWaitsInsideGrace(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{Repo: "owner/repo", ReviewGate: "greptile"}
+	cfg.ReviewRetrigger.MissingAfterMinutes = 60
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghPRGreptileApprovedFn = func(int) (bool, bool, error) { return false, true, nil }
+	o.ghPRHeadSHAFn = func(int) (string, error) { return "abc123def456789", nil }
+
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(10 * time.Minute)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 0 {
+		t.Fatalf("merged = %v, want none inside the grace window", *merged)
+	}
+}
+
+// The policy stays off unless the operator opts in, end to end.
+func TestAutoMergePRs_MissingReviewDisabledByDefault(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := &config.Config{Repo: "owner/repo", ReviewGate: "greptile"}
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghPRGreptileApprovedFn = func(int) (bool, bool, error) { return false, true, nil }
+	o.ghPRHeadSHAFn = func(int) (string, error) { return "abc123def456789", nil }
+
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(48 * time.Hour)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 0 {
+		t.Fatalf("merged = %v, want none — missing_after_minutes defaults to off", *merged)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -81,6 +81,9 @@ type Orchestrator struct {
 	// tokenBudgetMillNotified remembers the streak length already alerted per
 	// issue so a held budget-wall issue alerts on escalation, not every cycle.
 	tokenBudgetMillNotified map[int]int
+	// missingReviewNotified remembers PRs already reported as merged past an
+	// absent review gate, so the alert fires once per PR.
+	missingReviewNotified map[int]bool
 	router                  *router.Router
 	repo                    string
 	binaryVersion         string
@@ -5594,8 +5597,20 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			addPRGateReviewVerdict(&gateTransition, reviewVerdict)
 			persistGate()
 			if reviewVerdict.Pending {
-				log.Printf("[orch] PR #%d waiting for review gate (%s)", pr.Number, reviewVerdict.Summary())
 				o.maybeRetriggerStalePendingReview(sess, pr, reviewVerdict)
+				// A gate that never produced any signal is not "reviewing" —
+				// it is absent. Past the configured grace the PR proceeds on
+				// its own merits (CI is already green here) instead of waiting
+				// forever on a reviewer that is not coming.
+				if silentFor, missing := o.missingReviewGateElapsed(sess, reviewVerdict, time.Now().UTC()); missing {
+					log.Printf("[orch] PR #%d: review gate produced no signal for %s — treating the missing review as non-blocking (review_retrigger.missing_after_minutes)",
+						pr.Number, silentFor.Round(time.Minute))
+					o.notifyMissingReviewGate(pr.Number, silentFor)
+					clearReviewPendingTracking(sess)
+					ready = append(ready, mergeCandidate{slotName: slotName, sess: sess, pr: pr, headSHA: gateTransition.HeadSHA})
+					continue
+				}
+				log.Printf("[orch] PR #%d waiting for review gate (%s)", pr.Number, reviewVerdict.Summary())
 				continue // not ready yet
 			}
 			clearReviewPendingTracking(sess)
@@ -6000,9 +6015,11 @@ func (o *Orchestrator) maybeRetriggerStalePendingReview(sess *state.Session, pr 
 	now := time.Now().UTC()
 	if sess.ReviewPendingSince == nil || sess.ReviewPendingHeadSHA != head {
 		// First pending observation on this head — start the clock. A new
-		// head (push or server-side update-branch) restarts it.
+		// head (push or server-side update-branch) restarts it, including the
+		// attempt counter.
 		sess.ReviewPendingHeadSHA = head
 		sess.ReviewPendingSince = &now
+		sess.ReviewRetriggerCount = 0
 		return
 	}
 	pendingFor := now.Sub(*sess.ReviewPendingSince)
@@ -6012,13 +6029,77 @@ func (o *Orchestrator) maybeRetriggerStalePendingReview(sess *state.Session, pr 
 	if sess.ReviewRetriggerAt != nil && now.Sub(*sess.ReviewRetriggerAt) < o.cfg.ReviewRetrigger.EffectiveCooldown() {
 		return
 	}
+	// Stop nagging a reviewer that is not answering. Past the cap the PR still
+	// waits (or clears through the missing-review policy), but it stops
+	// collecting a comment every cooldown window forever.
+	if maxAttempts := o.cfg.ReviewRetrigger.EffectiveMaxAttempts(); sess.ReviewRetriggerCount >= maxAttempts {
+		return
+	}
 	if err := o.commentPR(pr.Number, greptileRetriggerComment); err != nil {
 		log.Printf("[orch] review re-trigger: comment on PR #%d: %v", pr.Number, err)
 		return
 	}
 	sess.ReviewRetriggerAt = &now
-	log.Printf("[orch] review re-trigger: PR #%d greptile=pending for %s on head %s with no review — posted %q (#691)",
-		pr.Number, pendingFor.Round(time.Second), shortHeadSHA(head), greptileRetriggerComment)
+	sess.ReviewRetriggerCount++
+	log.Printf("[orch] review re-trigger: PR #%d greptile=pending for %s on head %s with no review — posted %q (attempt %d/%d, #691)",
+		pr.Number, pendingFor.Round(time.Second), shortHeadSHA(head), greptileRetriggerComment,
+		sess.ReviewRetriggerCount, o.cfg.ReviewRetrigger.EffectiveMaxAttempts())
+}
+
+// notifyMissingReviewGate tells the operator that a merge proceeded without a
+// review, once per PR. Merging past an absent gate is a deliberate, bounded
+// weakening of the safety net — it must never be silent.
+func (o *Orchestrator) notifyMissingReviewGate(prNumber int, silentFor time.Duration) {
+	if o == nil || o.notifier == nil {
+		return
+	}
+	if o.missingReviewNotified == nil {
+		o.missingReviewNotified = make(map[int]bool)
+	}
+	if o.missingReviewNotified[prNumber] {
+		return
+	}
+	o.missingReviewNotified[prNumber] = true
+	project := strings.TrimSpace(o.repo)
+	if project == "" && o.cfg != nil {
+		project = strings.TrimSpace(o.cfg.Repo)
+	}
+	title := "maestro review gate absent"
+	if project != "" {
+		title += ": " + project
+	}
+	if err := o.notifier.Alert(
+		notify.AlertGateFailStreak,
+		fmt.Sprintf("%s:missing_review:%d", project, prNumber),
+		title,
+		fmt.Sprintf("PR #%d merged with NO review signal at all (gate silent for %s). CI was green. Check whether the review service is down or out of credits.",
+			prNumber, silentFor.Round(time.Minute)),
+	); err != nil {
+		log.Printf("[orch] missing-review notification failed for PR #%d: %v", prNumber, err)
+	}
+}
+
+// missingReviewGateElapsed reports whether the review gate has been completely
+// silent — no check run, no comment, nothing — on this head for longer than
+// review_retrigger.missing_after_minutes. A gate that produced ANY signal is
+// never "missing": a reviewer working, or one that reported findings, keeps
+// blocking exactly as before. Opt-in: 0 keeps today's block-forever behavior.
+func (o *Orchestrator) missingReviewGateElapsed(sess *state.Session, verdict github.ReviewGateVerdict, now time.Time) (time.Duration, bool) {
+	if o == nil || o.cfg == nil || sess == nil {
+		return 0, false
+	}
+	grace := o.cfg.ReviewRetrigger.MissingReviewGraceOrZero()
+	if grace <= 0 || verdict.Observed || !verdict.Pending {
+		return 0, false
+	}
+	if sess.ReviewPendingSince == nil {
+		return 0, false
+	}
+	silentFor := now.Sub(*sess.ReviewPendingSince)
+	if silentFor < grace {
+		return 0, false
+	}
+	return silentFor, true
 }
 
 // greptileReviewStreamPending reports whether the greptile stream is the one

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -6038,10 +6038,13 @@ func (o *Orchestrator) maybeRetriggerStalePendingReview(sess *state.Session, pr 
 	if sess.ReviewRetriggerAt != nil && now.Sub(*sess.ReviewRetriggerAt) < o.cfg.ReviewRetrigger.EffectiveCooldown() {
 		return
 	}
-	// Stop nagging a reviewer that is not answering. Past the cap the PR still
-	// waits (or clears through the missing-review policy), but it stops
-	// collecting a comment every cooldown window forever.
-	if maxAttempts := o.cfg.ReviewRetrigger.EffectiveMaxAttempts(); sess.ReviewRetriggerCount >= maxAttempts {
+	// Stop nagging a reviewer that is not answering, when the operator opted
+	// into a cap. Past it the PR still waits (or clears through the
+	// missing-review policy). Unlimited by default: the nudges are the only
+	// automatic recovery for a reviewer that comes back later, so silencing
+	// them without the missing-review escape hatch would wedge the PR for good.
+	maxAttempts := o.cfg.ReviewRetrigger.EffectiveMaxAttempts()
+	if maxAttempts > 0 && sess.ReviewRetriggerCount >= maxAttempts {
 		return
 	}
 	if err := o.commentPR(pr.Number, greptileRetriggerComment); err != nil {
@@ -6050,9 +6053,13 @@ func (o *Orchestrator) maybeRetriggerStalePendingReview(sess *state.Session, pr 
 	}
 	sess.ReviewRetriggerAt = &now
 	sess.ReviewRetriggerCount++
-	log.Printf("[orch] review re-trigger: PR #%d greptile=pending for %s on head %s with no review — posted %q (attempt %d/%d, #691)",
+	cap := "unlimited"
+	if maxAttempts > 0 {
+		cap = strconv.Itoa(maxAttempts)
+	}
+	log.Printf("[orch] review re-trigger: PR #%d greptile=pending for %s on head %s with no review — posted %q (attempt %d/%s, #691)",
 		pr.Number, pendingFor.Round(time.Second), shortHeadSHA(head), greptileRetriggerComment,
-		sess.ReviewRetriggerCount, o.cfg.ReviewRetrigger.EffectiveMaxAttempts())
+		sess.ReviewRetriggerCount, cap)
 }
 
 // reviewClockHead picks the head SHA the review clock applies to: the one the

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -5389,6 +5389,11 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 		sess     *state.Session
 		pr       github.PR
 		headSHA  string
+		// missingReviewFor is non-zero when this candidate bypassed a silent
+		// review gate. The operator alert fires only after the merge actually
+		// succeeds — a candidate can still be deferred by the merge interval,
+		// dropped by conflict filtering, or fail to merge.
+		missingReviewFor time.Duration
 	}
 
 	ready := make([]mergeCandidate, 0)
@@ -5597,17 +5602,18 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			addPRGateReviewVerdict(&gateTransition, reviewVerdict)
 			persistGate()
 			if reviewVerdict.Pending {
+				now := time.Now().UTC()
+				o.trackReviewPendingClock(sess, o.reviewClockHead(pr, gateTransition.HeadSHA), reviewVerdict, now)
 				o.maybeRetriggerStalePendingReview(sess, pr, reviewVerdict)
 				// A gate that never produced any signal is not "reviewing" —
 				// it is absent. Past the configured grace the PR proceeds on
 				// its own merits (CI is already green here) instead of waiting
 				// forever on a reviewer that is not coming.
-				if silentFor, missing := o.missingReviewGateElapsed(sess, reviewVerdict, time.Now().UTC()); missing {
+				if silentFor, missing := o.missingReviewGateElapsed(sess, reviewVerdict, now); missing {
 					log.Printf("[orch] PR #%d: review gate produced no signal for %s — treating the missing review as non-blocking (review_retrigger.missing_after_minutes)",
 						pr.Number, silentFor.Round(time.Minute))
-					o.notifyMissingReviewGate(pr.Number, silentFor)
 					clearReviewPendingTracking(sess)
-					ready = append(ready, mergeCandidate{slotName: slotName, sess: sess, pr: pr, headSHA: gateTransition.HeadSHA})
+					ready = append(ready, mergeCandidate{slotName: slotName, sess: sess, pr: pr, headSHA: gateTransition.HeadSHA, missingReviewFor: silentFor})
 					continue
 				}
 				log.Printf("[orch] PR #%d waiting for review gate (%s)", pr.Number, reviewVerdict.Summary())
@@ -5684,7 +5690,9 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 	strategy := o.mergeStrategy()
 	if strategy == "parallel" {
 		for _, candidate := range ready {
-			o.mergeReadyPRAtExpectedHead(s, candidate.slotName, candidate.sess, candidate.pr, candidate.headSHA)
+			if o.mergeReadyPRAtExpectedHead(s, candidate.slotName, candidate.sess, candidate.pr, candidate.headSHA) && candidate.missingReviewFor > 0 {
+				o.notifyMissingReviewGate(candidate.pr.Number, candidate.missingReviewFor)
+			}
 		}
 		return
 	}
@@ -5720,7 +5728,9 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 	}
 
 	candidate := ready[0]
-	o.mergeReadyPRAtExpectedHead(s, candidate.slotName, candidate.sess, candidate.pr, candidate.headSHA)
+	if o.mergeReadyPRAtExpectedHead(s, candidate.slotName, candidate.sess, candidate.pr, candidate.headSHA) && candidate.missingReviewFor > 0 {
+		o.notifyMissingReviewGate(candidate.pr.Number, candidate.missingReviewFor)
+	}
 	if len(ready) > 1 {
 		log.Printf("[orch] sequential merge mode: deferring %d additional ready PR(s) to next cycle", len(ready)-1)
 	}
@@ -6007,20 +6017,10 @@ func (o *Orchestrator) maybeRetriggerStalePendingReview(sess *state.Session, pr 
 	if !greptileReviewStreamPending(verdict) {
 		return // a non-greptile stream is pending; "@greptile review" won't help
 	}
-	head, err := o.prHeadSHA(pr.Number)
-	if err != nil {
-		log.Printf("[orch] review re-trigger: head SHA for PR #%d: %v", pr.Number, err)
-		return
-	}
+	head := sess.ReviewPendingHeadSHA
 	now := time.Now().UTC()
-	if sess.ReviewPendingSince == nil || sess.ReviewPendingHeadSHA != head {
-		// First pending observation on this head — start the clock. A new
-		// head (push or server-side update-branch) restarts it, including the
-		// attempt counter.
-		sess.ReviewPendingHeadSHA = head
-		sess.ReviewPendingSince = &now
-		sess.ReviewRetriggerCount = 0
-		return
+	if sess.ReviewPendingSince == nil {
+		return // clock not started yet; trackReviewPendingClock owns that
 	}
 	pendingFor := now.Sub(*sess.ReviewPendingSince)
 	if pendingFor < o.cfg.ReviewRetrigger.EffectivePendingFor() {
@@ -6044,6 +6044,51 @@ func (o *Orchestrator) maybeRetriggerStalePendingReview(sess *state.Session, pr 
 	log.Printf("[orch] review re-trigger: PR #%d greptile=pending for %s on head %s with no review — posted %q (attempt %d/%d, #691)",
 		pr.Number, pendingFor.Round(time.Second), shortHeadSHA(head), greptileRetriggerComment,
 		sess.ReviewRetriggerCount, o.cfg.ReviewRetrigger.EffectiveMaxAttempts())
+}
+
+// reviewClockHead picks the head SHA the review clock applies to: the one the
+// gate transition already read, falling back to a direct lookup when the gate
+// is not observable. An empty result skips the clock rather than anchoring it
+// to the wrong head.
+func (o *Orchestrator) reviewClockHead(pr github.PR, gateHead string) string {
+	if strings.TrimSpace(gateHead) != "" {
+		return gateHead
+	}
+	head, err := o.prHeadSHA(pr.Number)
+	if err != nil {
+		log.Printf("[orch] review clock: head SHA for PR #%d: %v", pr.Number, err)
+		return ""
+	}
+	return head
+}
+
+// trackReviewPendingClock maintains the per-head review-gate clock for ANY
+// pending verdict, independent of the Greptile-specific comment re-trigger:
+// a project gating on another stream, or one with re-triggers disabled, still
+// needs the clock for the missing-review policy.
+//
+// ReviewGateObserved is sticky within a head. A reviewer that has spoken once
+// keeps blocking even if a later read comes back unobserved — a transient
+// check-runs API error must not be able to demote a working reviewer to
+// "absent" and let the PR through.
+func (o *Orchestrator) trackReviewPendingClock(sess *state.Session, head string, verdict github.ReviewGateVerdict, now time.Time) {
+	if sess == nil || head == "" {
+		return
+	}
+	if sess.ReviewPendingSince == nil || sess.ReviewPendingHeadSHA != head {
+		// First pending observation on this head — start the clock. A new head
+		// (push or server-side update-branch) restarts it, including the
+		// attempt counter and the observation memory.
+		started := now
+		sess.ReviewPendingHeadSHA = head
+		sess.ReviewPendingSince = &started
+		sess.ReviewRetriggerCount = 0
+		sess.ReviewGateObserved = verdict.Observed
+		return
+	}
+	if verdict.Observed {
+		sess.ReviewGateObserved = true
+	}
 }
 
 // notifyMissingReviewGate tells the operator that a merge proceeded without a
@@ -6090,6 +6135,12 @@ func (o *Orchestrator) missingReviewGateElapsed(sess *state.Session, verdict git
 	}
 	grace := o.cfg.ReviewRetrigger.MissingReviewGraceOrZero()
 	if grace <= 0 || verdict.Observed || !verdict.Pending {
+		return 0, false
+	}
+	// Sticky memory: a reviewer seen on this head keeps blocking even if this
+	// read came back unobserved (e.g. a failed check-runs lookup fell through
+	// to the comment path).
+	if sess.ReviewGateObserved {
 		return 0, false
 	}
 	if sess.ReviewPendingSince == nil {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -5612,7 +5612,13 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 				if silentFor, missing := o.missingReviewGateElapsed(sess, reviewVerdict, now); missing {
 					log.Printf("[orch] PR #%d: review gate produced no signal for %s — treating the missing review as non-blocking (review_retrigger.missing_after_minutes)",
 						pr.Number, silentFor.Round(time.Minute))
-					clearReviewPendingTracking(sess)
+					// Deliberately keep the per-head tracking: sequential mode
+					// may defer this candidate, or the merge may fail, and
+					// clearing here would restart the grace from zero on the
+					// next cycle. Repeated deferrals would then reset the
+					// window forever and the PR would never merge. The state
+					// is irrelevant once the merge succeeds, and a new head
+					// resets it through trackReviewPendingClock.
 					ready = append(ready, mergeCandidate{slotName: slotName, sess: sess, pr: pr, headSHA: gateTransition.HeadSHA, missingReviewFor: silentFor})
 					continue
 				}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -5601,9 +5601,12 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			}
 			addPRGateReviewVerdict(&gateTransition, reviewVerdict)
 			persistGate()
+			// Record what the gate said for this head BEFORE branching: a
+			// settled rejection is evidence the reviewer is alive just as much
+			// as a pending one, and only a head change may erase it.
+			now := time.Now().UTC()
+			o.trackReviewGateHead(sess, o.reviewClockHead(pr, gateTransition.HeadSHA), reviewVerdict, now)
 			if reviewVerdict.Pending {
-				now := time.Now().UTC()
-				o.trackReviewPendingClock(sess, o.reviewClockHead(pr, gateTransition.HeadSHA), reviewVerdict, now)
 				o.maybeRetriggerStalePendingReview(sess, pr, reviewVerdict)
 				// A gate that never produced any signal is not "reviewing" —
 				// it is absent. Past the configured grace the PR proceeds on
@@ -5618,7 +5621,7 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 					// next cycle. Repeated deferrals would then reset the
 					// window forever and the PR would never merge. The state
 					// is irrelevant once the merge succeeds, and a new head
-					// resets it through trackReviewPendingClock.
+					// resets it through trackReviewGateHead.
 					ready = append(ready, mergeCandidate{slotName: slotName, sess: sess, pr: pr, headSHA: gateTransition.HeadSHA, missingReviewFor: silentFor})
 					continue
 				}
@@ -6026,7 +6029,7 @@ func (o *Orchestrator) maybeRetriggerStalePendingReview(sess *state.Session, pr 
 	head := sess.ReviewPendingHeadSHA
 	now := time.Now().UTC()
 	if sess.ReviewPendingSince == nil {
-		return // clock not started yet; trackReviewPendingClock owns that
+		return // clock not started yet; trackReviewGateHead owns that
 	}
 	pendingFor := now.Sub(*sess.ReviewPendingSince)
 	if pendingFor < o.cfg.ReviewRetrigger.EffectivePendingFor() {
@@ -6068,32 +6071,33 @@ func (o *Orchestrator) reviewClockHead(pr github.PR, gateHead string) string {
 	return head
 }
 
-// trackReviewPendingClock maintains the per-head review-gate clock for ANY
-// pending verdict, independent of the Greptile-specific comment re-trigger:
-// a project gating on another stream, or one with re-triggers disabled, still
-// needs the clock for the missing-review policy.
+// trackReviewGateHead maintains the per-head review-gate memory. It runs for
+// EVERY verdict, not just pending ones: a settled rejection is also proof the
+// reviewer is alive, and skipping it would let a later run of failed
+// check-runs reads look like "the reviewer never showed up" and merge a PR the
+// reviewer had already rejected.
 //
-// ReviewGateObserved is sticky within a head. A reviewer that has spoken once
-// keeps blocking even if a later read comes back unobserved — a transient
-// check-runs API error must not be able to demote a working reviewer to
-// "absent" and let the PR through.
-func (o *Orchestrator) trackReviewPendingClock(sess *state.Session, head string, verdict github.ReviewGateVerdict, now time.Time) {
+// ReviewGateObserved is sticky within a head and reset ONLY when the head
+// actually changes — a push or server-side update-branch genuinely restarts
+// the review, everything else must not erase what we already saw. The pending
+// clock starts at the first pending observation on the head; the
+// Greptile-specific comment re-trigger does not own any of this.
+func (o *Orchestrator) trackReviewGateHead(sess *state.Session, head string, verdict github.ReviewGateVerdict, now time.Time) {
 	if sess == nil || head == "" {
 		return
 	}
-	if sess.ReviewPendingSince == nil || sess.ReviewPendingHeadSHA != head {
-		// First pending observation on this head — start the clock. A new head
-		// (push or server-side update-branch) restarts it, including the
-		// attempt counter and the observation memory.
-		started := now
+	if sess.ReviewPendingHeadSHA != head {
 		sess.ReviewPendingHeadSHA = head
-		sess.ReviewPendingSince = &started
+		sess.ReviewPendingSince = nil
 		sess.ReviewRetriggerCount = 0
-		sess.ReviewGateObserved = verdict.Observed
-		return
+		sess.ReviewGateObserved = false
 	}
 	if verdict.Observed {
 		sess.ReviewGateObserved = true
+	}
+	if verdict.Pending && sess.ReviewPendingSince == nil {
+		started := now
+		sess.ReviewPendingSince = &started
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -6147,6 +6147,13 @@ func (o *Orchestrator) missingReviewGateElapsed(sess *state.Session, verdict git
 	if grace <= 0 || verdict.Observed || !verdict.Pending {
 		return 0, false
 	}
+	// A degraded read cannot prove silence. Without this, a GitHub check-runs
+	// outage lasting longer than the grace would look exactly like a reviewer
+	// that never showed up, and PRs would merge unreviewed because of an API
+	// failure.
+	if verdict.LookupFailed {
+		return 0, false
+	}
 	// Sticky memory: a reviewer seen on this head keeps blocking even if this
 	// read came back unobserved (e.g. a failed check-runs lookup fell through
 	// to the comment path).

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -6184,8 +6184,13 @@ func greptileReviewStreamPending(verdict github.ReviewGateVerdict) bool {
 // clearReviewPendingTracking resets the #691 pending clock once the review
 // gate resolves (passed or blocked by findings) so a later pending phase on
 // the same head starts a fresh window.
+// clearReviewPendingTracking stops the pending clock once the gate settles.
+// The head anchor is deliberately KEPT: a check that settles and then goes
+// pending again on the same commit (a re-run, or a check that disappears) must
+// not look like a new head, or the per-head re-trigger cap would reset on every
+// such flap and the PR could collect unlimited "@greptile review" comments.
+// Only trackReviewGateHead clears the anchor, and only for a real head change.
 func clearReviewPendingTracking(sess *state.Session) {
-	sess.ReviewPendingHeadSHA = ""
 	sess.ReviewPendingSince = nil
 }
 

--- a/internal/orchestrator/review_retrigger_test.go
+++ b/internal/orchestrator/review_retrigger_test.go
@@ -238,8 +238,14 @@ func TestReviewRetrigger_GateResolutionClearsTracking(t *testing.T) {
 
 	o.autoMergePRs(s)
 
-	if sess.ReviewPendingHeadSHA != "" || sess.ReviewPendingSince != nil {
-		t.Fatalf("pending tracking = (%q, %v), want cleared once the gate resolves",
-			sess.ReviewPendingHeadSHA, sess.ReviewPendingSince)
+	// The clock stops when the gate resolves, but the head anchor stays: a
+	// check that settles and goes pending again on the same commit must not
+	// look like a new head, or the per-head re-trigger cap would reset on
+	// every such flap.
+	if sess.ReviewPendingSince != nil {
+		t.Fatalf("pending clock = %v, want stopped once the gate resolves", sess.ReviewPendingSince)
+	}
+	if sess.ReviewPendingHeadSHA != "abc123def456789" {
+		t.Fatalf("head anchor = %q, want it retained until the head actually changes", sess.ReviewPendingHeadSHA)
 	}
 }

--- a/internal/orchestrator/review_retrigger_test.go
+++ b/internal/orchestrator/review_retrigger_test.go
@@ -292,3 +292,23 @@ func TestReviewRetrigger_CountsAttemptsPerHead(t *testing.T) {
 		t.Fatalf("count = %d, want 1 after the first re-trigger", sess.ReviewRetriggerCount)
 	}
 }
+
+// Workflow review catch: the cap must be OPT-IN. Capping by default removes the
+// only automatic recovery an untouched install has — the nudges that wake a
+// review service which comes back later — while the escape hatch that would
+// release the PR (missing_after_minutes) is itself off by default.
+func TestReviewRetrigger_UncappedByDefault(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o, comments := newRetriggerTestOrchestrator(retriggerTestConfig(), prs, "abc123def456789")
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(6 * time.Hour)
+	sess.ReviewRetriggerCount = 12 // far beyond any cap an operator might pick
+
+	o.autoMergePRs(s)
+
+	if len(*comments) != 1 {
+		t.Fatalf("comments = %v, want the nudge to still fire — the cap must be opt-in", *comments)
+	}
+}

--- a/internal/orchestrator/review_retrigger_test.go
+++ b/internal/orchestrator/review_retrigger_test.go
@@ -249,3 +249,46 @@ func TestReviewRetrigger_GateResolutionClearsTracking(t *testing.T) {
 		t.Fatalf("head anchor = %q, want it retained until the head actually changes", sess.ReviewPendingHeadSHA)
 	}
 }
+
+// Workflow review catch: the per-head cap must actually suppress comments.
+func TestReviewRetrigger_MaxAttemptsCapSuppressesComment(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := retriggerTestConfig()
+	cfg.ReviewRetrigger.MaxAttempts = 2
+	o, comments := newRetriggerTestOrchestrator(cfg, prs, "abc123def456789")
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(11 * time.Minute)
+	sess.ReviewRetriggerCount = 2 // cap already reached
+
+	o.autoMergePRs(s)
+
+	if len(*comments) != 0 {
+		t.Fatalf("comments = %v, want none once the per-head cap is reached", *comments)
+	}
+	if sess.ReviewRetriggerCount != 2 {
+		t.Fatalf("count = %d, want it to stay at the cap", sess.ReviewRetriggerCount)
+	}
+}
+
+// Below the cap the comment is posted and the counter advances.
+func TestReviewRetrigger_CountsAttemptsPerHead(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := retriggerTestConfig()
+	cfg.ReviewRetrigger.MaxAttempts = 2
+	o, comments := newRetriggerTestOrchestrator(cfg, prs, "abc123def456789")
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(11 * time.Minute)
+
+	o.autoMergePRs(s)
+
+	if len(*comments) != 1 {
+		t.Fatalf("comments = %v, want one below the cap", *comments)
+	}
+	if sess.ReviewRetriggerCount != 1 {
+		t.Fatalf("count = %d, want 1 after the first re-trigger", sess.ReviewRetriggerCount)
+	}
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -2434,11 +2434,11 @@ func (s *FleetServer) handleFleetEmergency(w http.ResponseWriter, r *http.Reques
 		} else {
 			msg = emergencystore.ResumeMessage(emergencystore.State{Level: level}, st)
 		}
-		n.Sendf("%s", msg)
-		// Fan the notify_red-grade alert to ntfy (#1018); dedup keeps a repeated
-		// identical emergency state from re-notifying.
+		// Alert covers both transports: ntfy when configured, otherwise the
+		// base Telegram/OpenClaw send; dedup keeps a repeated identical
+		// emergency state from re-notifying (#1018).
 		if err := n.Alert(notify.AlertEmergency, "emergency", "maestro emergency", msg); err != nil {
-			log.Printf("[fleet] ntfy emergency alert failed: %v", err)
+			log.Printf("[fleet] emergency alert failed: %v", err)
 		}
 	}
 	writeJSON(w, http.StatusOK, emergencyStateToWire(st))

--- a/internal/server/fleet_emergency_test.go
+++ b/internal/server/fleet_emergency_test.go
@@ -33,8 +33,9 @@ func (f *fakeEmergencySwitch) Get(_ context.Context) (emergencystore.State, erro
 }
 
 type fakeEmergencyNotifier struct {
-	msgs   []string
-	alerts []notify.AlertClass
+	msgs        []string
+	alerts      []notify.AlertClass
+	alertBodies []string
 }
 
 func (f *fakeEmergencyNotifier) Sendf(format string, args ...any) {
@@ -46,8 +47,9 @@ func (f *fakeEmergencyNotifier) Sendf(format string, args ...any) {
 	}
 }
 
-func (f *fakeEmergencyNotifier) Alert(class notify.AlertClass, _, _, _ string) error {
+func (f *fakeEmergencyNotifier) Alert(class notify.AlertClass, _, _, body string) error {
 	f.alerts = append(f.alerts, class)
+	f.alertBodies = append(f.alertBodies, body)
 	return nil
 }
 
@@ -115,8 +117,13 @@ func TestHandleFleetEmergency_StopAndResume(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("stop status = %d, want 200 (body: %s)", w.Code, w.Body.String())
 	}
-	if len(notifier.msgs) != 1 || !strings.Contains(notifier.msgs[0], "EMERGENCY STOP activated") {
-		t.Fatalf("notifier messages = %v, want one activation alert", notifier.msgs)
+	// One delivery, through Alert: it covers ntfy when configured and the base
+	// transport otherwise, so a separate Sendf would double-notify.
+	if len(notifier.alertBodies) != 1 || !strings.Contains(notifier.alertBodies[0], "EMERGENCY STOP activated") {
+		t.Fatalf("alert bodies = %v, want one activation alert", notifier.alertBodies)
+	}
+	if len(notifier.msgs) != 0 {
+		t.Fatalf("plain sends = %v, want none — Alert already reaches the base transport", notifier.msgs)
 	}
 	var got fleetEmergency
 	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -373,6 +373,12 @@ type Session struct {
 	ReviewPendingSince   *time.Time `json:"review_pending_since,omitempty"`    // first observation of greptile=pending on that head
 	ReviewRetriggerAt    *time.Time `json:"review_retrigger_at,omitempty"`     // last "@greptile review" re-trigger (cooldown anchor)
 	ReviewRetriggerCount int        `json:"review_retrigger_count,omitempty"`  // re-triggers posted for ReviewPendingHeadSHA; capped by review_retrigger.max_attempts
+	// ReviewGateObserved is sticky for ReviewPendingHeadSHA: once ANY reviewer
+	// signal is seen on that head it stays true until the head changes. A
+	// transient check-runs API error degrades one read to "unobserved", and
+	// without this memory that single blip would look like "the reviewer never
+	// showed up" and expire a gate that is genuinely working.
+	ReviewGateObserved bool `json:"review_gate_observed,omitempty"`
 
 	// #426: distinguish agent execution time from workflow elapsed time.
 	// WorkerEndedAt is stamped the FIRST time the worker process exits

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -372,6 +372,7 @@ type Session struct {
 	ReviewPendingHeadSHA string     `json:"review_pending_head_sha,omitempty"` // head SHA the pending clock applies to
 	ReviewPendingSince   *time.Time `json:"review_pending_since,omitempty"`    // first observation of greptile=pending on that head
 	ReviewRetriggerAt    *time.Time `json:"review_retrigger_at,omitempty"`     // last "@greptile review" re-trigger (cooldown anchor)
+	ReviewRetriggerCount int        `json:"review_retrigger_count,omitempty"`  // re-triggers posted for ReviewPendingHeadSHA; capped by review_retrigger.max_attempts
 
 	// #426: distinguish agent execution time from workflow elapsed time.
 	// WorkerEndedAt is stamped the FIRST time the worker process exits


### PR DESCRIPTION
## Problem

`Pending` conflated two very different states: **the reviewer is working** and **the reviewer never showed up**. On the second, `autoMergePRs` did a bare `continue` — no timeout, no fallback, no alert.

Live 2026-07-25: Greptile paused reviews after exhausting its free OSS credits (period resets Aug 6) and now posts **nothing at all** — no check run, no comment, no status. Traced consequence for every CI-green PR: `pr_open` forever, `monitor_open_pr` re-decided every cycle, `@greptile review` re-posted every 30 minutes with **no attempt cap**, one info-level watchdog line after 20 minutes, and no operator alert. `merge_exhausted_noncritical_review` cannot help — it requires `review_retry_exhausted`, which requires review feedback that never arrives.

## Change

- **`Observed`** on `ReviewStreamVerdict` / `ReviewGateVerdict` — true whenever a reviewer produced any signal for the head (check run in any state incl. queued, comment, or inline finding). False only on the explicit no-signal return.
- **`review_retrigger.missing_after_minutes`** (default `0` = today's block-forever behavior): once an *unobserved* gate has been silent that long on one head, the PR proceeds on its own merits (CI is already green at that point). **A reviewer that answers still hard-blocks at any duration** — the safety property is preserved, only the wait on an absent reviewer is bounded.
- Merging past an absent gate raises a `gate_fail_streak` alert **once per PR**: a deliberately weakened safety net must never be silent.
- **`review_retrigger.max_attempts`** (default 3) caps re-trigger comments per head; a new head resets the counter. Stops the permanent comment spam.

## Tests

Silent-gate-past-grace, within-grace-still-waits, **observed-gate-never-expires**, disabled-by-default, no-clock-yet, settled-gate-ignored, alert-once-per-PR. Full suite green.

Context: `Dev/Areas/maestro/planning/2026-07-25-pre-resume-checklist.md` §2b.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for repeated review re-trigger requests.
  * Added an optional grace period after which a completely silent review gate no longer blocks auto-merge.
  * Review gate status now distinguishes active review signals from no reviewer activity.
  * Review re-trigger attempts reset when the pull request head changes.

* **Bug Fixes**
  * Prevented repeated notifications for the same missing review gate.
  * Preserved blocking behavior for observed or recently started reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-merge behavior when operators enable missing_after_minutes, though observed reviewers still hard-block; sticky session state and deferred-merge clock semantics need careful rollout on production merge paths.
> 
> **Overview**
> **Review gate liveness** — `ReviewStreamVerdict` / `ReviewGateVerdict` gain **`Observed`**, so *pending* no longer means both “reviewer is working” and “reviewer never showed up.” Greptile with no check run and no comment stays pending but **unobserved**, which unlocks new orchestrator policy instead of blocking forever.
> 
> **Opt-in missing-review bypass** — `review_retrigger.missing_after_minutes` (default **0** = unchanged) lets CI-green PRs proceed when the gate has been **fully silent** on one head longer than the grace. Any reviewer that ever produced a signal still blocks; **`ReviewGateObserved`** is sticky per head so a transient API blip cannot expire a working gate. Successful merge after bypass raises a **once-per-PR** classified alert.
> 
> **Greptile re-trigger bounds** — `review_retrigger.max_attempts` (default **3**) stops endless `@greptile review` spam; per-head pending clock and retrigger count reset on head change. Pending tracking is centralized in **`trackReviewPendingClock`** for all pending streams, not only Greptile re-trigger.
> 
> **Alerts without ntfy** — `Notifier.Alert` now **falls back to the base transport** (Telegram/OpenClaw) when ntfy is unset, so classified alerts (e.g. floor breach) are not dropped on installs that only use the primary channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a0af750ad3c2f5a51569cc9cf1c26536bd4b259. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->