### PR TITLE
fix: duplicate-dispatch cleanup must not burn the per-issue retry budget

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -5972,7 +5972,7 @@ func (o *Orchestrator) attachPreservedSiblingHandoffs(s *state.State, issue int,
 		// its branch/worktree intact for forensics and recovery. Without this,
 		// the preserved worktree itself blocks the canonical repair forever.
 		sibling.ReleasedForRedispatch = true
-		sibling.WorkerOutcome = "duplicate_dispatch_reconciled"
+		sibling.WorkerOutcome = state.WorkerOutcomeDuplicateDispatchReconciled
 		released = append(released, siblingSlot)
 	}
 	if len(handoffs) > 0 {

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -5121,7 +5121,7 @@ func fleetSupersedingIssueSession(candidate sessionInfo, all []sessionInfo) (ses
 			// started-after-completion / released-for-redispatch guards, so a
 			// genuinely regressed later session surfaces instead of a predecessor.
 			if peer.PRNumber > 0 && !peer.ReleasedForRedispatch &&
-				(candidate.WorkerOutcome == "duplicate_dispatch_reconciled" ||
+				(candidate.WorkerOutcome == state.WorkerOutcomeDuplicateDispatchReconciled ||
 					fleetSessionStartedAfterCanonicalCompletion(candidate, peer) ||
 					fleetSessionPrecededLaterAuthoritative(candidate, peer)) {
 				return peer, true

--- a/internal/state/duplicate_reconcile_budget_test.go
+++ b/internal/state/duplicate_reconcile_budget_test.go
@@ -1,0 +1,43 @@
+package state
+
+import (
+	"testing"
+	"time"
+)
+
+func retiredSibling(issue int, outcome string) *Session {
+	now := time.Now().UTC()
+	return &Session{
+		IssueNumber:   issue,
+		Status:        StatusRetryExhausted,
+		WorkerOutcome: outcome,
+		StartedAt:     now.Add(-time.Hour),
+		FinishedAt:    &now,
+	}
+}
+
+// Live 2026-07-23 (ok-player #627): Maestro's own duplicate-dispatch cleanup
+// retired two sibling sessions, and those retirements counted against the
+// per-issue retry budget. With a single genuine failure the issue still read
+// 3/3 attempts and stopped being dispatched entirely.
+func TestFailedAttemptsForIssue_ExcludesDuplicateDispatchReconcile(t *testing.T) {
+	s := NewState()
+	s.Sessions["a"] = retiredSibling(627, WorkerOutcomeDuplicateDispatchReconciled)
+	s.Sessions["b"] = retiredSibling(627, WorkerOutcomeDuplicateDispatchReconciled)
+	s.Sessions["c"] = retiredSibling(627, "") // one real failed attempt
+
+	if got := s.FailedAttemptsForIssue(627); got != 1 {
+		t.Fatalf("FailedAttemptsForIssue = %d, want 1 — Maestro retiring its own duplicate siblings is bookkeeping, not failed attempts", got)
+	}
+}
+
+// Real failures still count, so the retry budget keeps protecting the fleet.
+func TestFailedAttemptsForIssue_StillCountsRealFailures(t *testing.T) {
+	s := NewState()
+	s.Sessions["a"] = retiredSibling(700, "")
+	s.Sessions["b"] = retiredSibling(700, WorkerOutcomeRepeatedUnexpectedExit)
+
+	if got := s.FailedAttemptsForIssue(700); got != 2 {
+		t.Fatalf("FailedAttemptsForIssue = %d, want 2", got)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -96,6 +96,13 @@ const (
 	// worker that disappeared again after Maestro already gave the same
 	// canonical session one automatic unexpected-exit recovery.
 	WorkerOutcomeRepeatedUnexpectedExit = "repeated_unexpected_exit"
+	// WorkerOutcomeDuplicateDispatchReconciled marks a SIBLING session that
+	// Maestro itself retired while reconciling duplicate dispatches for one
+	// issue: its durable work was proven patch-equivalent or handed off to the
+	// canonical session, and only its dispatcher claim was released. It is
+	// Maestro's own bookkeeping, never evidence that the issue is hard — so it
+	// must not consume the per-issue retry budget.
+	WorkerOutcomeDuplicateDispatchReconciled = "duplicate_dispatch_reconciled"
 )
 
 const (
@@ -5067,12 +5074,21 @@ func (s *State) IssueDone(issueNum int) bool {
 // as failed attempts: neither condition proves the implementation itself failed,
 // and both must remain runnable after their independent hold/release policy.
 // See #432 / #458 / #466 / #693.
+//
+// Sessions Maestro itself retired while reconciling duplicate dispatches are
+// excluded for the same reason: that outcome records the control plane tidying
+// up after spawning two workers for one issue, not an attempt that failed.
+// Live 2026-07-23 (ok-player #627): a respawn-thrash incident produced two such
+// siblings, and with only one genuine failure the issue still reported 3/3
+// attempts and stopped being dispatched at all.
 func (s *State) FailedAttemptsForIssue(issueNum int) int {
 	count := 0
 	for _, sess := range s.Sessions {
 		if sess.IssueNumber == issueNum && sess.PRNumber == 0 &&
 			(sess.Status == StatusDead || sess.Status == StatusFailed || sess.Status == StatusRetryExhausted) &&
-			!sess.RateLimitHit && sess.WorkerOutcome != string(DisplayTokenBudgetExceeded) {
+			!sess.RateLimitHit &&
+			sess.WorkerOutcome != string(DisplayTokenBudgetExceeded) &&
+			sess.WorkerOutcome != WorkerOutcomeDuplicateDispatchReconciled {
 			count++
 		}
 	}


### PR DESCRIPTION
## Problem

When two workers get dispatched for one issue, `terminal/open-PR reconcile` proves the sibling's durable work is patch-equivalent (or hands its commits to the canonical session), retires it with `WorkerOutcome = duplicate_dispatch_reconciled`, and releases only its dispatcher claim. That is Maestro tidying up after **its own** double dispatch.

`FailedAttemptsForIssue` counted those retirements as failed attempts: it excluded rate-limit and token-budget outcomes, but not this one.

**Live evidence — ok-player #627 (2026-07-23 respawn-thrash incident):** 4 sessions, 3 counted against `max_retries_per_issue: 3`, of which **two are `duplicate_dispatch_reconciled`**. One genuine failure, and the issue was permanently undispatchable with `skipping issue #627: retry limit exhausted (3/3 attempts)` — the queue looked exhausted because the orchestrator spawned duplicates and then counted its own cleanup against the work.

## Change

- `state.WorkerOutcomeDuplicateDispatchReconciled` — the string literal is now a named constant, used at both existing call sites (`orchestrator.go` reconcile, `fleet.go` attention filter).
- `FailedAttemptsForIssue` excludes it, for the same reason it already excludes rate limits and budget stops: none of them prove the implementation failed.

Real failures (including `repeated_unexpected_exit`) still count, so the retry budget keeps doing its job.

## Tests

Two siblings + one real failure counts as 1; real failures still count. Full suite green.