### PR TITLE
fix: do not auto-promote Maestro's own gate-fail-streak reports into the queue

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -3699,9 +3699,9 @@ type ReviewStreamVerdict struct {
 	// outage would otherwise look exactly like a reviewer that never showed up.
 	LookupFailed bool            `json:"lookup_failed,omitempty"`
 	Score        int             `json:"score,omitempty"`
-	ScoreMax int             `json:"score_max,omitempty"`
-	Verdict  string          `json:"verdict,omitempty"`
-	Findings []ReviewComment `json:"findings,omitempty"`
+	ScoreMax     int             `json:"score_max,omitempty"`
+	Verdict      string          `json:"verdict,omitempty"`
+	Findings     []ReviewComment `json:"findings,omitempty"`
 }
 
 type ReviewGateVerdict struct {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -84,8 +84,8 @@ type Orchestrator struct {
 	// missingReviewNotified remembers PRs already reported as merged past an
 	// absent review gate, so the alert fires once per PR.
 	missingReviewNotified map[int]bool
-	router                  *router.Router
-	repo                    string
+	router                *router.Router
+	repo                  string
 	binaryVersion         string
 	promptBase            string
 	bugPromptBase         string
@@ -10245,6 +10245,17 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		}
 		if label, ok := matchingIssueLabel(issue, o.operatorGateLabels()); ok {
 			log.Printf("[orch] skipping issue #%d: held by operator gate label %q", issue.Number, label)
+			continue
+		}
+
+		// A gate-fail-streak issue is Maestro's own report that a scheduled gate
+		// failed N times, not a triaged task — see the supervisor's hold. This
+		// loop lists issues itself, so with no issue_labels configured (every
+		// open issue eligible) the supervisor's hold is not in the path and the
+		// report would be dispatched here. There is no label for an operator to
+		// apply in that configuration, so the report is never auto-eligible.
+		if len(o.cfg.IssueLabels) == 0 && supervisor.IsGateFailStreakIssue(issue) && !repairSpawn {
+			log.Printf("[orch] skipping issue #%d: auto-minted gate-fail-streak report awaits operator triage", issue.Number)
 			continue
 		}
 

--- a/internal/state/duplicate_reconcile_budget_test.go
+++ b/internal/state/duplicate_reconcile_budget_test.go
@@ -41,3 +41,52 @@ func TestFailedAttemptsForIssue_StillCountsRealFailures(t *testing.T) {
 		t.Fatalf("FailedAttemptsForIssue = %d, want 2", got)
 	}
 }
+
+// Codex review catch (P1): the queue paths consult IssueRetryExhausted BEFORE
+// FailedAttemptsForIssue, so excluding an outcome from the count alone leaves
+// the issue blocked the moment one such session carries retry_exhausted status.
+// Live ok-player #627: two duplicate-dispatch siblings held exactly that status.
+func TestIssueRetryExhausted_IgnoresDuplicateDispatchReconcile(t *testing.T) {
+	s := NewState()
+	s.Sessions["a"] = retiredSibling(627, WorkerOutcomeDuplicateDispatchReconciled)
+	s.Sessions["b"] = retiredSibling(627, WorkerOutcomeDuplicateDispatchReconciled)
+
+	if s.IssueRetryExhausted(627) {
+		t.Fatal("retired duplicate siblings must not mark the issue retry-exhausted")
+	}
+	if got := s.FailedAttemptsForIssue(627); got != 0 {
+		t.Fatalf("FailedAttemptsForIssue = %d, want 0", got)
+	}
+}
+
+// A governor stop is not exhaustion either: raising the budget must un-block it.
+func TestIssueRetryExhausted_IgnoresTokenBudgetStops(t *testing.T) {
+	s := NewState()
+	s.Sessions["a"] = retiredSibling(628, string(DisplayTokenBudgetExceeded))
+
+	if s.IssueRetryExhausted(628) {
+		t.Fatal("a token-budget stop marked retry_exhausted must not block the issue forever")
+	}
+}
+
+// Genuine exhaustion still blocks.
+func TestIssueRetryExhausted_RealExhaustionStillBlocks(t *testing.T) {
+	s := NewState()
+	s.Sessions["a"] = retiredSibling(700, "")
+
+	if !s.IssueRetryExhausted(700) {
+		t.Fatal("a genuinely exhausted issue must still be blocked")
+	}
+}
+
+// A transient backend block is not exhaustion.
+func TestIssueRetryExhausted_IgnoresRateLimitedSessions(t *testing.T) {
+	s := NewState()
+	sess := retiredSibling(701, "")
+	sess.RateLimitHit = true
+	s.Sessions["a"] = sess
+
+	if s.IssueRetryExhausted(701) {
+		t.Fatal("a rate-limited session must not mark the issue retry-exhausted")
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -5086,9 +5086,7 @@ func (s *State) FailedAttemptsForIssue(issueNum int) int {
 	for _, sess := range s.Sessions {
 		if sess.IssueNumber == issueNum && sess.PRNumber == 0 &&
 			(sess.Status == StatusDead || sess.Status == StatusFailed || sess.Status == StatusRetryExhausted) &&
-			!sess.RateLimitHit &&
-			sess.WorkerOutcome != string(DisplayTokenBudgetExceeded) &&
-			sess.WorkerOutcome != WorkerOutcomeDuplicateDispatchReconciled {
+			sessionProvesFailedAttempt(sess) {
 			count++
 		}
 	}
@@ -5148,11 +5146,33 @@ func (s *State) ConsecutiveTokenBudgetKillsForIssue(issueNum int) int {
 // has been marked as retry_exhausted.
 func (s *State) IssueRetryExhausted(issueNum int) bool {
 	for _, sess := range s.Sessions {
-		if sess.IssueNumber == issueNum && sess.Status == StatusRetryExhausted {
+		if sess.IssueNumber == issueNum && sess.Status == StatusRetryExhausted &&
+			sessionProvesFailedAttempt(sess) {
 			return true
 		}
 	}
 	return false
+}
+
+// sessionProvesFailedAttempt reports whether a terminal session is evidence the
+// implementation itself failed, as opposed to a transient backend block, a
+// deterministic governor stop, or Maestro's own bookkeeping.
+//
+// Both retry gates must agree on this, and both are consulted: the queue paths
+// check IssueRetryExhausted BEFORE FailedAttemptsForIssue, so excluding an
+// outcome from the count alone leaves the issue blocked anyway the moment one
+// such session carries the retry_exhausted status. Live ok-player #627: two
+// duplicate-dispatch siblings were retired with that status, and the issue
+// stayed permanently undispatchable even after the count was corrected.
+func sessionProvesFailedAttempt(sess *Session) bool {
+	if sess == nil || sess.RateLimitHit {
+		return false
+	}
+	switch sess.WorkerOutcome {
+	case string(DisplayTokenBudgetExceeded), WorkerOutcomeDuplicateDispatchReconciled:
+		return false
+	}
+	return true
 }
 
 // MarkIssueRetryExhausted transitions the most recent dead/failed session

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -5164,6 +5164,16 @@ func (s *State) IssueRetryExhausted(issueNum int) bool {
 // such session carries the retry_exhausted status. Live ok-player #627: two
 // duplicate-dispatch siblings were retired with that status, and the issue
 // stayed permanently undispatchable even after the count was corrected.
+// SessionProvesFailedAttempt is the exported form for callers outside this
+// package that act on retry exhaustion — spawning a repair worker, or raising a
+// Blocked stuck-state. They must agree with the two retry gates: a session
+// retired by Maestro's own duplicate-dispatch cleanup, stopped deterministically
+// at the token budget, or blocked by a rate limit carries the retry_exhausted
+// status without being evidence that the implementation failed.
+func SessionProvesFailedAttempt(sess *Session) bool {
+	return sessionProvesFailedAttempt(sess)
+}
+
 func sessionProvesFailedAttempt(sess *Session) bool {
 	if sess == nil || sess.RateLimitHit {
 		return false

--- a/internal/supervisor/gate_streak_promotion.go
+++ b/internal/supervisor/gate_streak_promotion.go
@@ -17,3 +17,21 @@ const gateFailStreakBodyMarker = "<!-- maestro:gate-fail-streak"
 func isGateFailStreakIssue(issue github.Issue) bool {
 	return strings.Contains(issue.Body, gateFailStreakBodyMarker)
 }
+
+// operatorTriagedGateStreak reports whether an operator has explicitly admitted
+// a minted streak report into the queue by labelling it.
+//
+// This deliberately does NOT reuse matchesRequiredLabels: with no issue_labels
+// and no supervisor.ready_label configured — a supported setup where every open
+// issue is eligible — that predicate is vacuously true, so a freshly minted
+// report would count as triaged the moment it appeared and the wave would spawn
+// against it. In that configuration there is no label for an operator to apply,
+// so a streak report is never auto-eligible; the operator closes it, or converts
+// it into a real issue.
+func (e *Engine) operatorTriagedGateStreak(issue github.Issue) bool {
+	required := e.requiredIssueLabels()
+	if len(required) == 0 {
+		return false
+	}
+	return matchesRequiredLabels(issue, required)
+}

--- a/internal/supervisor/gate_streak_promotion.go
+++ b/internal/supervisor/gate_streak_promotion.go
@@ -18,6 +18,14 @@ func isGateFailStreakIssue(issue github.Issue) bool {
 	return strings.Contains(issue.Body, gateFailStreakBodyMarker)
 }
 
+// IsGateFailStreakIssue is the exported form for the orchestrator, whose spawn
+// loop lists issues itself and never passes through the supervisor's
+// eligibility gate. With no issue_labels configured every open issue reaches
+// that loop, minted reports included.
+func IsGateFailStreakIssue(issue github.Issue) bool {
+	return isGateFailStreakIssue(issue)
+}
+
 // operatorTriagedGateStreak reports whether an operator has explicitly admitted
 // a minted streak report into the queue by labelling it.
 //

--- a/internal/supervisor/gate_streak_promotion.go
+++ b/internal/supervisor/gate_streak_promotion.go
@@ -1,0 +1,19 @@
+package supervisor
+
+import (
+	"strings"
+
+	"github.com/befeast/maestro/internal/github"
+)
+
+// gateFailStreakBodyMarker is the hidden marker Maestro writes into every
+// gate-fail-streak issue it mints (see gateFailStreakIssueBody). It is the only
+// reliable way to tell one of Maestro's own reports from a human-written issue:
+// the issues carry no distinguishing label, because they are created unlabelled.
+const gateFailStreakBodyMarker = "<!-- maestro:gate-fail-streak"
+
+// isGateFailStreakIssue reports whether the issue is one Maestro minted from a
+// scheduled-gate failure streak.
+func isGateFailStreakIssue(issue github.Issue) bool {
+	return strings.Contains(issue.Body, gateFailStreakBodyMarker)
+}

--- a/internal/supervisor/gate_streak_promotion_test.go
+++ b/internal/supervisor/gate_streak_promotion_test.go
@@ -3,6 +3,7 @@ package supervisor
 import (
 	"testing"
 
+	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 )
 
@@ -32,5 +33,41 @@ func TestIsGateFailStreakIssue(t *testing.T) {
 	}
 	if isGateFailStreakIssue(prose) {
 		t.Fatal("prose mentioning the phrase must not match — only the hidden marker counts")
+	}
+}
+
+// Codex review catch (P1): with neither issue_labels nor supervisor.ready_label
+// configured — a supported setup where every open issue is eligible —
+// matchesRequiredLabels is vacuously true, so a guard built on it would treat a
+// freshly minted report as operator-triaged and spawn against it anyway.
+func TestOperatorTriagedGateStreak_NoLabelsConfiguredNeverAutoEligible(t *testing.T) {
+	e := &Engine{cfg: &config.Config{}} // no issue_labels, no ready_label
+	minted := github.Issue{Number: 277, Body: gateFailStreakBodyMarker + " abc -->"}
+
+	if e.operatorTriagedGateStreak(minted) {
+		t.Fatal("with no labels configured a minted report must never count as triaged")
+	}
+}
+
+// With a ready label configured, the operator applying it admits the report.
+func TestOperatorTriagedGateStreak_ReadyLabelAdmitsReport(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Supervisor.ReadyLabel = "maestro-ready"
+	e := &Engine{cfg: cfg}
+
+	unlabelled := github.Issue{Number: 277, Body: gateFailStreakBodyMarker + " abc -->"}
+	if e.operatorTriagedGateStreak(unlabelled) {
+		t.Fatal("an unlabelled report must not be treated as triaged")
+	}
+
+	labelled := github.Issue{
+		Number: 277,
+		Body:   gateFailStreakBodyMarker + " abc -->",
+	}
+	labelled.Labels = append(labelled.Labels, struct {
+		Name string `json:"name"`
+	}{Name: "maestro-ready"})
+	if !e.operatorTriagedGateStreak(labelled) {
+		t.Fatal("an operator-labelled report must run normally")
 	}
 }

--- a/internal/supervisor/gate_streak_promotion_test.go
+++ b/internal/supervisor/gate_streak_promotion_test.go
@@ -1,0 +1,36 @@
+package supervisor
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/github"
+)
+
+func TestIsGateFailStreakIssue(t *testing.T) {
+	minted := github.Issue{
+		Number: 277,
+		Title:  "gate failure streak: healthcheck_command failing 2 consecutive scheduled runs",
+		Body:   "<!-- maestro:gate-fail-streak 658f0089bedb2248 -->\n\nScheduled gate `healthcheck_command` failed 2 consecutive runs.",
+	}
+	if !isGateFailStreakIssue(minted) {
+		t.Fatal("a Maestro-minted streak issue was not recognised by its marker")
+	}
+
+	human := github.Issue{
+		Number: 628,
+		Title:  "P0 Linux: screenshot in fullscreen leaves stale oversized native video",
+		Body:   "## Summary\nThe fullscreen screenshot path leaves the native surface at the wrong size.",
+	}
+	if isGateFailStreakIssue(human) {
+		t.Fatal("a human-written issue must not be mistaken for a minted streak report")
+	}
+
+	// An issue that merely mentions the phrase in prose is not a minted report.
+	prose := github.Issue{
+		Number: 900,
+		Body:   "We keep seeing a gate failure streak on Linux; see the maestro docs.",
+	}
+	if isGateFailStreakIssue(prose) {
+		t.Fatal("prose mentioning the phrase must not match — only the hidden marker counts")
+	}
+}

--- a/internal/supervisor/gate_streak_reach_test.go
+++ b/internal/supervisor/gate_streak_reach_test.go
@@ -1,0 +1,87 @@
+package supervisor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func mintedStreakIssue(number int) github.Issue {
+	return github.Issue{
+		Number: number,
+		Title:  "gate failure streak: healthcheck_command failing 2 consecutive scheduled runs",
+		Body:   gateFailStreakBodyMarker + " 658f0089bedb2248 -->\n\nScheduled gate failed.",
+	}
+}
+
+// Codex review catch (P1): the hold lived only inside decideDynamicWave, but
+// gate-streak intake is enabled independently of dynamic-wave policy. With
+// dynamic wave off, the default eligibility path decided the same report was
+// spawnable, so the hold was one branch wide instead of fleet wide.
+func TestIssueSkipReason_HoldsUntriagedGateStreakReport(t *testing.T) {
+	e := &Engine{cfg: &config.Config{}} // no issue_labels, no ready_label
+	st := state.NewState()
+
+	reason, err := e.issueSkipReason(st, mintedStreakIssue(277))
+	if err != nil {
+		t.Fatalf("issueSkipReason: %v", err)
+	}
+	if !strings.Contains(reason, "gate-fail-streak") {
+		t.Fatalf("skip reason = %q, want the untriaged gate-streak hold — the default "+
+			"dispatch path must not depend on dynamic wave being enabled", reason)
+	}
+
+	// A human-written issue is untouched by the hold.
+	human := github.Issue{Number: 628, Body: "## Summary\nreal work"}
+	reason, err = e.issueSkipReason(st, human)
+	if err != nil {
+		t.Fatalf("issueSkipReason: %v", err)
+	}
+	if strings.Contains(reason, "gate-fail-streak") {
+		t.Fatalf("human issue skipped as a streak report: %q", reason)
+	}
+}
+
+// The repair path reaches dispatch through its own skip predicate, so the hold
+// has to be there too or a minted report can still be picked up as repair work.
+func TestIssueRepairSkipReason_HoldsUntriagedGateStreakReport(t *testing.T) {
+	e := &Engine{cfg: &config.Config{}}
+	st := state.NewState()
+
+	reason, err := e.issueRepairSkipReason(st, mintedStreakIssue(277))
+	if err != nil {
+		t.Fatalf("issueRepairSkipReason: %v", err)
+	}
+	if !strings.Contains(reason, "gate-fail-streak") {
+		t.Fatalf("repair skip reason = %q, want the untriaged gate-streak hold", reason)
+	}
+}
+
+// An operator-labelled report runs normally through both predicates.
+func TestSkipReasons_LabelledGateStreakReportRunsNormally(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Supervisor.ReadyLabel = "maestro-ready"
+	e := &Engine{cfg: cfg}
+	st := state.NewState()
+
+	issue := mintedStreakIssue(277)
+	issue.Labels = append(issue.Labels, struct {
+		Name string `json:"name"`
+	}{Name: "maestro-ready"})
+
+	for name, fn := range map[string]func(*state.State, github.Issue) (string, error){
+		"issueSkipReason":       e.issueSkipReason,
+		"issueRepairSkipReason": e.issueRepairSkipReason,
+	} {
+		reason, err := fn(st, issue)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if strings.Contains(reason, "gate-fail-streak") {
+			t.Fatalf("%s held an operator-labelled report: %q", name, reason)
+		}
+	}
+}

--- a/internal/supervisor/retry_exhausted_bookkeeping_test.go
+++ b/internal/supervisor/retry_exhausted_bookkeeping_test.go
@@ -1,0 +1,72 @@
+package supervisor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+)
+
+func bookkeepingRetiredSession(issue int, outcome string) *state.Session {
+	now := time.Now().UTC()
+	return &state.Session{
+		IssueNumber:   issue,
+		Status:        state.StatusRetryExhausted,
+		WorkerOutcome: outcome,
+		StartedAt:     now.Add(-time.Hour),
+		FinishedAt:    &now,
+	}
+}
+
+// Codex review catch (P1): correcting the two retry gates was not enough.
+// retryExhaustedSession, retryExhaustedRepairCandidate and the stuck-state scan
+// each act on the raw retry_exhausted status, so a sibling Maestro retired
+// while reconciling its own duplicate dispatch still drove repair spawns and a
+// Blocked finding — the same class of bug one layer down.
+func TestRetryExhaustedSession_IgnoresBookkeepingRetirements(t *testing.T) {
+	e := &Engine{cfg: &config.Config{}}
+	cache := newResolutionCache(nil)
+
+	for _, tc := range []struct {
+		name    string
+		outcome string
+	}{
+		{"duplicate dispatch reconciled", state.WorkerOutcomeDuplicateDispatchReconciled},
+		{"token budget stop", string(state.DisplayTokenBudgetExceeded)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := state.NewState()
+			st.Sessions["a"] = bookkeepingRetiredSession(627, tc.outcome)
+
+			if slot, _, ok := e.retryExhaustedSession(st, cache); ok {
+				t.Fatalf("slot %q reported as retry-exhausted: %s is control-plane "+
+					"bookkeeping, not evidence the implementation failed", slot, tc.outcome)
+			}
+		})
+	}
+}
+
+// A genuine failure still surfaces — the filter must not silence real exhaustion.
+func TestRetryExhaustedSession_StillReportsGenuineFailure(t *testing.T) {
+	e := &Engine{cfg: &config.Config{}}
+	st := state.NewState()
+	st.Sessions["a"] = bookkeepingRetiredSession(627, "")
+
+	if _, _, ok := e.retryExhaustedSession(st, newResolutionCache(nil)); !ok {
+		t.Fatal("a genuinely exhausted session must still be reported")
+	}
+}
+
+// A rate-limited session is a transient backend block, not a failed attempt.
+func TestRetryExhaustedSession_IgnoresRateLimitedSession(t *testing.T) {
+	e := &Engine{cfg: &config.Config{}}
+	st := state.NewState()
+	sess := bookkeepingRetiredSession(627, "")
+	sess.RateLimitHit = true
+	st.Sessions["a"] = sess
+
+	if _, _, ok := e.retryExhaustedSession(st, newResolutionCache(nil)); ok {
+		t.Fatal("a rate-limited session must not count as retry exhaustion")
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1355,10 +1355,6 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 			continue
 		}
 
-		if analysis != nil {
-			analysis.SelectedCandidate = supervisorIssueCandidate(issue)
-		}
-
 		// A gate-fail-streak issue is Maestro reporting that a scheduled gate
 		// failed N times — it is a notification, not a triaged task. Whether a
 		// worker can fix it depends entirely on what the gate checks: repo code,
@@ -1367,11 +1363,20 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 		// ok-folio's LAN healthcheck flapped under host load and the fleet
 		// ground through 31 failed sessions on the minted issues). The operator
 		// decides; an explicitly labelled streak issue still runs normally.
+		//
+		// This must stay ahead of the SelectedCandidate assignment below: with
+		// owns_ready_label enabled, a skipped-but-selected candidate is handed
+		// to applySupervisorOwnedReadyFilter, which admits it to the dispatch
+		// list even though the decision itself was `none`.
 		if isGateFailStreakIssue(issue) && !e.operatorTriagedGateStreak(issue) {
 			baseReasons = appendReasons(baseReasons,
 				fmt.Sprintf("Issue #%d is an auto-minted gate-fail-streak report — it needs an operator to judge whether the gate failure is repo-fixable before it enters the queue", issue.Number),
 			)
 			continue
+		}
+
+		if analysis != nil {
+			analysis.SelectedCandidate = supervisorIssueCandidate(issue)
 		}
 
 		queueCandidate := e.dynamicQueueActionCandidate(st, issue, issues)
@@ -1925,7 +1930,8 @@ func (e *Engine) detectWorkerStuckStates(st *state.State, now time.Time, cache *
 			}
 		}
 
-		if sess.Status == state.StatusRetryExhausted && sess.PRNumber == 0 && !e.retryExhaustedSessionResolved(st, sess, cache) {
+		if sess.Status == state.StatusRetryExhausted && sess.PRNumber == 0 &&
+			state.SessionProvesFailedAttempt(sess) && !e.retryExhaustedSessionResolved(st, sess, cache) {
 			findings = append(findings, stuckState("retry_exhausted", SeverityBlocked,
 				fmt.Sprintf("Issue #%d exhausted its retry budget.", sess.IssueNumber),
 				"Review the failed attempts, adjust the issue or retry budget, then restart intentionally.", false, target,
@@ -2860,6 +2866,9 @@ func (e *Engine) issueRepairSkipReason(st *state.State, issue github.Issue) (str
 	if e.cfg.Missions.Enabled && mission.IsMissionIssue(issue, e.cfg.Missions.Labels) && !st.IsMissionChild(issue.Number) {
 		return heldMetaSkipReason("mission issue awaits decomposition"), nil
 	}
+	if isGateFailStreakIssue(issue) && !e.operatorTriagedGateStreak(issue) {
+		return heldMetaSkipReason("auto-minted gate-fail-streak report awaits operator triage"), nil
+	}
 	policyExcludedLabels := e.policyExcludedLabels()
 	if label, ok := firstMatchingIssueLabel(issue, heldMetaLabels()); ok && (hasLabelName(e.excludeLabels(), label) || hasLabelName(policyExcludedLabels, label)) {
 		return heldMetaSkipReason(fmt.Sprintf("label %q", label)), nil
@@ -2907,6 +2916,12 @@ func (e *Engine) issueSkipReasonWithExcludeLabels(st *state.State, issue github.
 	}
 	if e.cfg.Missions.Enabled && mission.IsMissionIssue(issue, e.cfg.Missions.Labels) && !st.IsMissionChild(issue.Number) {
 		return heldMetaSkipReason("mission issue awaits decomposition"), nil
+	}
+	// Gate-streak intake is enabled independently of dynamic-wave policy, so the
+	// hold cannot live only in decideDynamicWave: the default eligibility path
+	// and the repair path both reach dispatch through here.
+	if isGateFailStreakIssue(issue) && !e.operatorTriagedGateStreak(issue) {
+		return heldMetaSkipReason("auto-minted gate-fail-streak report awaits operator triage"), nil
 	}
 	policyExcludedLabels := excludeLabelsExcept(e.policyExcludedLabels(), ignoredBlockedLabel)
 	if label, ok := firstMatchingIssueLabel(issue, heldMetaLabels()); ok && (hasLabelName(excludeLabels, label) || hasLabelName(policyExcludedLabels, label)) {
@@ -3535,7 +3550,8 @@ func (e *Engine) hasLiveRunningSessionForIssue(st *state.State, issueNumber int)
 func (e *Engine) retryExhaustedSession(st *state.State, cache *resolutionCache) (string, *state.Session, bool) {
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
-		if sess == nil || sess.Status != state.StatusRetryExhausted {
+		if sess == nil || sess.Status != state.StatusRetryExhausted ||
+			!state.SessionProvesFailedAttempt(sess) {
 			continue
 		}
 		if e.retryExhaustedSessionResolved(st, sess, cache) {
@@ -3556,7 +3572,8 @@ func (e *Engine) retryExhaustedRepairCandidate(st *state.State, issues []github.
 	}
 	for _, slot := range sortedSessionNames(st) {
 		sess := st.Sessions[slot]
-		if sess == nil || sess.Status != state.StatusRetryExhausted || sess.PRNumber > 0 {
+		if sess == nil || sess.Status != state.StatusRetryExhausted || sess.PRNumber > 0 ||
+			!state.SessionProvesFailedAttempt(sess) {
 			continue
 		}
 		if e.retryExhaustedSessionResolved(st, sess, cache) {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1359,6 +1359,21 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 			analysis.SelectedCandidate = supervisorIssueCandidate(issue)
 		}
 
+		// A gate-fail-streak issue is Maestro reporting that a scheduled gate
+		// failed N times — it is a notification, not a triaged task. Whether a
+		// worker can fix it depends entirely on what the gate checks: repo code,
+		// or an external service Maestro has no reach into. Auto-promoting it
+		// spawns workers against outages they cannot fix (live 2026-07-23:
+		// ok-folio's LAN healthcheck flapped under host load and the fleet
+		// ground through 31 failed sessions on the minted issues). The operator
+		// decides; an explicitly labelled streak issue still runs normally.
+		if isGateFailStreakIssue(issue) && !matchesRequiredLabels(issue, e.requiredIssueLabels()) {
+			baseReasons = appendReasons(baseReasons,
+				fmt.Sprintf("Issue #%d is an auto-minted gate-fail-streak report — it needs an operator to judge whether the gate failure is repo-fixable before it enters the queue", issue.Number),
+			)
+			continue
+		}
+
 		queueCandidate := e.dynamicQueueActionCandidate(st, issue, issues)
 		if queueCandidate != nil {
 			mutations := queueCandidate.plannedMutations(e.cfg)

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -1367,7 +1367,7 @@ func (e *Engine) decideDynamicWave(st *state.State, now time.Time, projectState 
 		// ok-folio's LAN healthcheck flapped under host load and the fleet
 		// ground through 31 failed sessions on the minted issues). The operator
 		// decides; an explicitly labelled streak issue still runs normally.
-		if isGateFailStreakIssue(issue) && !matchesRequiredLabels(issue, e.requiredIssueLabels()) {
+		if isGateFailStreakIssue(issue) && !e.operatorTriagedGateStreak(issue) {
 			baseReasons = appendReasons(baseReasons,
 				fmt.Sprintf("Issue #%d is an auto-minted gate-fail-streak report — it needs an operator to judge whether the gate failure is repo-fixable before it enters the queue", issue.Number),
 			)


### PR DESCRIPTION
## Problem

`gateFailStreakIssueBody` mints an issue when a scheduled gate fails N consecutive times, and creates it **unlabelled** (`CreateIssue(title, body, nil)`) — it is a notification, not a triaged task.

The dynamic wave then treated it as ordinary backlog: `dynamicQueueActionCandidate` selected it, the supervisor decided `label_issue_ready` (in `safe_actions`, so it executed directly), and a worker was dispatched.

Whether a worker can fix a gate failure depends entirely on what the gate checks — repo code, or an external service Maestro has no reach into. Maestro cannot tell, so it should not decide.

**Live evidence, 2026-07-23:** ok-folio's healthcheck (LAN PhotoPrism + extractor) flapped while the host was overloaded. The fleet minted streak issues, promoted them, and ground through **31 failed sessions** against a service outage. Two days later 22 such issues were still open and stale across ok-folio / ok-gobot / panoptikon / tx10-clock, and every one of them re-verified green by hand once the host was quiet.

## Change

The dynamic wave skips an **unlabelled** issue whose body carries the hidden `<!-- maestro:gate-fail-streak` marker, recording the reason in the decision. Nothing else changes:

- the streak notification still fires,
- the issue is still created, so the operator sees it,
- an operator who judges the failure repo-fixable labels it ready, and it then runs exactly as before (the skip only applies while it lacks the required labels).

## Tests

Marker recognition: a minted report matches, a human-written issue does not, and prose merely mentioning the phrase does not (only the hidden marker counts). Full suite green.