### PR TITLE
Add maestro config-store list as a zero-write fleet inspection command

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -61,7 +62,7 @@ Commands:
   stop          Stop a worker session
   kill          Kill a worker session by slot name
   import        Seed state from existing worktrees
-  config-store  Manage the SQLite config store (migrate/export/add/rm/edit)
+  config-store  Manage the SQLite config store (list/migrate/export/add/rm/edit)
   settings      View/flip fleet-level cost/LLM knobs (list/get/set/rm/audit)
   history       Show recently completed sessions
   digest        Write the morning operator digest across all fleet projects
@@ -556,7 +557,8 @@ func loadConfigsWithStore(paths []string, storePath, project string) []*config.C
 
 func configStoreCmd(args []string) {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "usage: maestro config-store <migrate|export|add|rm|edit> ...")
+		fmt.Fprintln(os.Stderr, "usage: maestro config-store <list|migrate|export|add|rm|edit> ...")
+		fmt.Fprintln(os.Stderr, "  list    [--db <path>] [--json]          print the project keys of the store")
 		fmt.Fprintln(os.Stderr, "  migrate --db <path> --dir <maestro.d>   import a directory of YAML configs")
 		fmt.Fprintln(os.Stderr, "  export  --db <path> --dir <out>         export every project to YAML")
 		fmt.Fprintln(os.Stderr, "  add     --file <yaml> [--name <name>]   add/replace a single project")
@@ -565,6 +567,8 @@ func configStoreCmd(args []string) {
 		os.Exit(1)
 	}
 	switch args[0] {
+	case "list":
+		configStoreList(args[1:])
 	case "add":
 		configStoreAdd(args[1:])
 	case "rm":
@@ -610,6 +614,58 @@ func configStoreCmd(args []string) {
 // daemon reads.
 func configStoreDBFlag(fs *flag.FlagSet) *string {
 	return fs.String("db", defaultConfigStorePath(), "SQLite config store path")
+}
+
+// configStoreList implements `config-store list [--json]`: it prints the project
+// keys of the store, one per line. It is the entry point for fleet inspection —
+// `export` and `status` both need a project name the operator does not have yet
+// — so it deliberately reports rows without parsing their config documents
+// (#1123).
+func configStoreList(args []string) {
+	fs := flag.NewFlagSet("config-store list", flag.ExitOnError)
+	dbPath := configStoreDBFlag(fs)
+	asJSON := fs.Bool("json", false, "Print the project keys as a JSON array")
+	fs.Parse(args)
+
+	if err := listStoreProjects(os.Stdout, *dbPath, *asJSON); err != nil {
+		log.Fatalf("config-store list: %v", err)
+	}
+}
+
+// listStoreProjects reads the store without writing to it. configstore.Open
+// creates the file and initializes the schema, so an inspection command that
+// defaulted to it would silently materialize an empty store on a host whose
+// real fleet database lives elsewhere — and the daemon would then start with
+// zero projects (P2 raised on #796). Hence: stat first, fail closed if the path
+// is absent, and read through OpenReadOnly.
+func listStoreProjects(w io.Writer, dbPath string, asJSON bool) error {
+	if _, err := os.Stat(dbPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("config store %s does not exist; listing never creates one", dbPath)
+		}
+		return err
+	}
+	store, err := configstore.OpenReadOnly(dbPath)
+	if err != nil {
+		return fmt.Errorf("open db %s: %w", dbPath, err)
+	}
+	defer store.Close()
+	names, err := store.ProjectNames(context.Background())
+	if err != nil {
+		return fmt.Errorf("read %s: %w", dbPath, err)
+	}
+	if asJSON {
+		if names == nil {
+			names = []string{}
+		}
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(names)
+	}
+	for _, name := range names {
+		fmt.Fprintln(w, name)
+	}
+	return nil
 }
 
 // configStoreAdd implements `config-store add --file <yaml> [--name <name>]`:

--- a/cmd/maestro/main_config_store_test.go
+++ b/cmd/maestro/main_config_store_test.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"database/sql"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/befeast/maestro/internal/configstore"
+	_ "modernc.org/sqlite"
 )
 
 const editTestYAML = `repo: owner/svc
@@ -91,5 +96,103 @@ func TestEditStoreProjectInvalidEditRejected(t *testing.T) {
 	}
 	if cfg.MaxParallel != 2 {
 		t.Fatalf("MaxParallel = %d, want 2 (edit must not land)", cfg.MaxParallel)
+	}
+}
+
+// seedListTestStore creates a store with two projects and then corrupts one of
+// the config documents behind UpsertProject's back — that is the state #1123
+// cares about: LoadAll fails, so listing must not go through it.
+func seedListTestStore(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "maestro.db")
+	store, err := configstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	ctx := context.Background()
+	for _, name := range []string{"svc", "broken"} {
+		if err := store.UpsertProject(ctx, name, editTestYAML); err != nil {
+			t.Fatalf("seed project %s: %v", name, err)
+		}
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw db: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec(`UPDATE project SET config_yaml = ? WHERE name = ?`, "repo: [unterminated\n", "broken"); err != nil {
+		t.Fatalf("corrupt project row: %v", err)
+	}
+	return dbPath
+}
+
+func TestListStoreProjectsListsRowWithInvalidConfig(t *testing.T) {
+	dbPath := seedListTestStore(t)
+
+	// Guard the premise: anything that loads configs is dead in this state.
+	store, err := configstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	defer store.Close()
+	if _, err := store.LoadAll(context.Background()); err == nil {
+		t.Fatal("LoadAll succeeded on a corrupted row; test no longer covers the broken-config case")
+	}
+
+	var buf bytes.Buffer
+	if err := listStoreProjects(&buf, dbPath, false); err != nil {
+		t.Fatalf("listStoreProjects: %v", err)
+	}
+	got := strings.Fields(buf.String())
+	want := []string{"broken", "svc"}
+	if len(got) != len(want) {
+		t.Fatalf("listStoreProjects printed %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("listStoreProjects printed %q, want %q", got, want)
+		}
+	}
+}
+
+func TestListStoreProjectsJSON(t *testing.T) {
+	dbPath := seedListTestStore(t)
+
+	var buf bytes.Buffer
+	if err := listStoreProjects(&buf, dbPath, true); err != nil {
+		t.Fatalf("listStoreProjects: %v", err)
+	}
+	var names []string
+	if err := json.Unmarshal(buf.Bytes(), &names); err != nil {
+		t.Fatalf("decode json output %q: %v", buf.String(), err)
+	}
+	if len(names) != 2 || names[0] != "broken" || names[1] != "svc" {
+		t.Fatalf("json output = %q, want [broken svc]", names)
+	}
+}
+
+// A read-only inspection command must never materialize the fleet source of
+// truth: configstore.Open would create an empty store here, which the daemon
+// would then read as a zero-project fleet (#1123).
+func TestListStoreProjectsDoesNotCreateStore(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "missing.db")
+
+	err := listStoreProjects(&bytes.Buffer{}, dbPath, false)
+	if err == nil {
+		t.Fatal("listStoreProjects succeeded against a non-existent store")
+	}
+	if !strings.Contains(err.Error(), dbPath) {
+		t.Fatalf("error %q does not name the missing store path", err)
+	}
+	entries, readErr := os.ReadDir(dir)
+	if readErr != nil {
+		t.Fatalf("read dir: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("listStoreProjects created %d file(s) in %s; it must create nothing", len(entries), dir)
 	}
 }

--- a/internal/configstore/genesis.go
+++ b/internal/configstore/genesis.go
@@ -699,7 +699,7 @@ func (s *Store) projectNameByID(ctx context.Context, id, exclude string) (string
 	if id == "" {
 		return "", nil
 	}
-	names, err := s.projectNames(ctx)
+	names, err := s.ProjectNames(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/internal/configstore/genesis_test.go
+++ b/internal/configstore/genesis_test.go
@@ -396,9 +396,9 @@ func TestPlanProjectIsZeroWrite(t *testing.T) {
 	if !reflect.DeepEqual(before, after) {
 		t.Fatalf("plan changed the store fingerprint: %v -> %v", before, after)
 	}
-	names, err := store.projectNames(ctx)
+	names, err := store.ProjectNames(ctx)
 	if err != nil {
-		t.Fatalf("projectNames: %v", err)
+		t.Fatalf("ProjectNames: %v", err)
 	}
 	if len(names) != 0 {
 		t.Fatalf("plan created rows: %v", names)
@@ -423,9 +423,9 @@ func TestApplyProjectIdempotent(t *testing.T) {
 	if first.Effect != EffectCreate || !first.Wrote {
 		t.Fatalf("first apply = %+v, want create+wrote", first)
 	}
-	names, err := store.projectNames(ctx)
+	names, err := store.ProjectNames(ctx)
 	if err != nil {
-		t.Fatalf("projectNames: %v", err)
+		t.Fatalf("ProjectNames: %v", err)
 	}
 	if len(names) != 1 || names[0] != "befeast-maestro" {
 		t.Fatalf("after first apply names = %v, want [befeast-maestro]", names)
@@ -445,7 +445,7 @@ func TestApplyProjectIdempotent(t *testing.T) {
 	if second.Effect != EffectNoOp || second.Wrote {
 		t.Fatalf("second apply = %+v, want no-op+!wrote", second)
 	}
-	names, _ = store.projectNames(ctx)
+	names, _ = store.ProjectNames(ctx)
 	if len(names) != 1 {
 		t.Fatalf("second apply changed row count: %v", names)
 	}
@@ -495,7 +495,7 @@ func TestApplyProjectConfirmGate(t *testing.T) {
 		t.Fatal("wrong --confirm should be refused")
 	}
 	// Nothing was written by the refused applies.
-	if names, _ := store.projectNames(ctx); len(names) != 0 {
+	if names, _ := store.ProjectNames(ctx); len(names) != 0 {
 		t.Fatalf("refused apply wrote a row: %v", names)
 	}
 }
@@ -518,7 +518,7 @@ func TestApplyProjectFingerprintGate(t *testing.T) {
 	if !strings.Contains(err.Error(), "changed since plan") {
 		t.Fatalf("error = %v, want to mention change since plan", err)
 	}
-	if names, _ := store.projectNames(ctx); len(names) != 0 {
+	if names, _ := store.ProjectNames(ctx); len(names) != 0 {
 		t.Fatalf("refused apply wrote a row: %v", names)
 	}
 }
@@ -620,7 +620,7 @@ func TestApplyProjectConcurrentSameIdentityCreatesAtMostOneRow(t *testing.T) {
 		t.Fatalf("concurrent applies succeeded %d times, want exactly one", successes)
 	}
 
-	names, err := storeA.projectNames(ctx)
+	names, err := storeA.ProjectNames(ctx)
 	if err != nil {
 		t.Fatalf("list final projects: %v", err)
 	}
@@ -702,7 +702,7 @@ func TestApplyProjectIdentityConflictOtherName(t *testing.T) {
 		t.Fatalf("conflict report = %+v, want to name the other row", report)
 	}
 	// No new row was created for befeast-maestro.
-	if names, _ := store.projectNames(ctx); len(names) != 1 {
+	if names, _ := store.ProjectNames(ctx); len(names) != 1 {
 		t.Fatalf("conflict created an extra row: %v", names)
 	}
 }

--- a/internal/configstore/store.go
+++ b/internal/configstore/store.go
@@ -401,7 +401,7 @@ func (s *Store) Load(ctx context.Context, name string) (*config.Config, error) {
 }
 
 func (s *Store) LoadAll(ctx context.Context) ([]*config.Config, error) {
-	names, err := s.projectNames(ctx)
+	names, err := s.ProjectNames(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +423,7 @@ func (s *Store) ExportDir(ctx context.Context, dir string) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create export dir %s: %w", dir, err)
 	}
-	names, err := s.projectNames(ctx)
+	names, err := s.ProjectNames(ctx)
 	if err != nil {
 		return err
 	}
@@ -962,7 +962,12 @@ func (s *Store) loadBackends(ctx context.Context) (map[string]*yaml.Node, error)
 	return out, rows.Err()
 }
 
-func (s *Store) projectNames(ctx context.Context) ([]string, error) {
+// ProjectNames returns the project keys of the store without loading or
+// validating any config document. `config-store list` needs exactly that: a row
+// whose YAML no longer parses must still be discoverable, because that is the
+// case where LoadAll fails and the operator has no other way to learn the
+// --config-store-project value (#1123).
+func (s *Store) ProjectNames(ctx context.Context) ([]string, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT name FROM project ORDER BY name`)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Problem

`maestro config-store list` is documented as the way to enumerate fleet projects, but the subcommand does not exist. `configStoreCmd` accepted only `<migrate|export|add|rm|edit>`, and the top-level help said the same. There was no read-only way to discover a valid `--config-store-project` value: `export`, `edit` and `status` all require a project name the operator does not have yet.

This bites hardest exactly where it matters most -- a row whose config document is broken. `LoadAll` fails, so every config-loading path refuses to tell you which rows exist.

## Fix

- Export `Store.ProjectNames` (was the unexported `projectNames`), so listing reads the `project` table without loading or validating any config document.
- Add `maestro config-store list [--db <path>] [--json]`: one project key per line, or a JSON array for scripting.
- `list` never creates a store. `configstore.Open` initializes the schema, so defaulting an inspection command to it would materialize an empty database that the daemon then treats as a zero-project fleet (the P2 raised on #796). `list` stats the path, fails closed with a clear message when it is missing, and reads through `configstore.OpenReadOnly`. The `--db` default reuses `configStoreDBFlag` / `defaultConfigStorePath`, i.e. the same legacy-vs-canonical resolution (with its warning) that `daemon` and the other subcommands use.
- Top-level help and the `config-store` usage block both mention `list`.

## Evidence

CLI against a scratch store:

```
$ maestro config-store list --db /var/tmp/cs1123/maestro.db
svc
$ maestro config-store list --db /var/tmp/cs1123/maestro.db --json
[
  "svc"
]
$ maestro config-store list --db /var/tmp/cs1123/nope.db
config-store list: config store /var/tmp/cs1123/nope.db does not exist; listing never creates one
$ echo $?
1
$ ls /var/tmp/cs1123        # nope.db was not created
maestro.db  svc.yaml
```

## Tests

Three new tests in `cmd/maestro/main_config_store_test.go`, seeded from a store whose second row is corrupted behind `UpsertProject`'s back:

- `TestListStoreProjectsListsRowWithInvalidConfig` -- asserts `LoadAll` fails on that store (guarding the premise), then that both keys are still listed. Fails with `read ...: load project broken: yaml: line 1: did not find expected ',' or ']'` when the implementation is switched to a `LoadAll`-based listing.
- `TestListStoreProjectsDoesNotCreateStore` -- non-existent path must error and leave the directory empty. Fails with `listStoreProjects succeeded against a non-existent store` when the stat guard plus `OpenReadOnly` are swapped for `configstore.Open`.
- `TestListStoreProjectsJSON` -- `--json` shape.

`umask 022 && go build ./... && go test ./... -count=1`: exit 0, 36 packages ok.

Refs #1123
