### PR TITLE
Make the outcome healthcheck budget configurable and kill its process group

### DIFF
--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -227,6 +227,10 @@ outcome:
   runtime_target: https://app.example.com
   deployment_status_command: /path/to/repo/scripts/status.sh
   healthcheck_url: https://app.example.com/healthz
+  # Budget for one health check (URL or command). Defaults to 15s; raise it for
+  # a deploy verification or smoke test that legitimately runs longer. A
+  # timed-out check kills the whole command process group.
+  healthcheck_timeout_seconds: 15
   source_repo_path: /path/to/local/clone
   runtime_host: production host or platform
   # Opt-in bounded hands-off recovery for a failing health signal. The

--- a/internal/outcome/checker.go
+++ b/internal/outcome/checker.go
@@ -34,10 +34,9 @@ var errCheckOutputTooLarge = errors.New("outcome check output exceeded safe limi
 // Checker executes configured read-only outcome signals and returns a compact
 // result that can be persisted in Maestro state.
 type Checker struct {
-	HTTPClient     *http.Client
-	CommandTimeout time.Duration
-	Now            func() time.Time
-	RunCommand     func(ctx context.Context, command, dir string) ([]byte, int, error)
+	HTTPClient *http.Client
+	Now        func() time.Time
+	RunCommand func(ctx context.Context, command, dir string) ([]byte, int, error)
 }
 
 func (c Checker) Check(ctx context.Context, brief Brief) HealthCheckResult {
@@ -57,12 +56,16 @@ func (c Checker) Check(ctx context.Context, brief Brief) HealthCheckResult {
 		result.Summary = "No outcome health signal is configured."
 		return result
 	}
+	// The budget comes from the brief itself: every production call site builds
+	// a zero-value Checker, so a field on the struct could never be configured
+	// per project (#1122).
+	timeout := brief.EffectiveHealthcheckTimeout()
 	if strings.TrimSpace(brief.HealthcheckURL) != "" {
-		result = c.checkURL(ctx, brief.HealthcheckURL)
+		result = c.checkURL(ctx, brief.HealthcheckURL, timeout)
 	} else if strings.TrimSpace(brief.HealthcheckCommand) != "" {
-		result = c.checkCommand(ctx, brief.HealthcheckCommand, brief.SourceRepoPath, "healthcheck_command")
+		result = c.checkCommand(ctx, brief.HealthcheckCommand, brief.SourceRepoPath, "healthcheck_command", timeout)
 	} else {
-		result = c.checkCommand(ctx, brief.DeploymentStatusCommand, brief.SourceRepoPath, "deployment_status_command")
+		result = c.checkCommand(ctx, brief.DeploymentStatusCommand, brief.SourceRepoPath, "deployment_status_command", timeout)
 	}
 	if result.CheckedAt.IsZero() {
 		result.CheckedAt = start
@@ -74,9 +77,9 @@ func (c Checker) Check(ctx context.Context, brief Brief) HealthCheckResult {
 	return result
 }
 
-func (c Checker) checkURL(ctx context.Context, rawURL string) HealthCheckResult {
+func (c Checker) checkURL(ctx context.Context, rawURL string, timeout time.Duration) HealthCheckResult {
 	start := c.now()
-	ctx, cancel := context.WithTimeout(ctx, c.timeout())
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
@@ -108,9 +111,9 @@ func (c Checker) checkURL(ctx context.Context, rawURL string) HealthCheckResult 
 	return c.result(start, "healthcheck_url", state, fmt.Sprintf("GET %s returned %s", rawURL, resp.Status), detail, 0)
 }
 
-func (c Checker) checkCommand(ctx context.Context, command, dir, signal string) HealthCheckResult {
+func (c Checker) checkCommand(ctx context.Context, command, dir, signal string, timeout time.Duration) HealthCheckResult {
 	start := c.now()
-	ctx, cancel := context.WithTimeout(ctx, c.timeout())
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	output, exitCode, err := c.runCommand(ctx, command, dir)
@@ -132,7 +135,7 @@ func (c Checker) checkCommand(ctx context.Context, command, dir, signal string) 
 		if errors.Is(err, errCheckOutputTooLarge) {
 			summary = fmt.Sprintf("%s output exceeded the %d-byte safety limit", signal, maxCheckOutputBytes)
 		} else if ctx.Err() == context.DeadlineExceeded {
-			summary = fmt.Sprintf("%s timed out after %s", signal, c.timeout().String())
+			summary = fmt.Sprintf("%s timed out after %s", signal, timeout.String())
 		} else if exitCode >= 0 {
 			summary = fmt.Sprintf("%s failed with exit code %d", signal, exitCode)
 		}
@@ -165,6 +168,22 @@ func (c Checker) runCommand(ctx context.Context, command, dir string) ([]byte, i
 	if strings.TrimSpace(dir) != "" {
 		cmd.Dir = dir
 	}
+	// A read-only probe must not outlive its budget. Give the shell and every
+	// descendant one process group, then make the deadline kill that whole
+	// group instead of only signalling `sh` and leaving a backgrounded child
+	// running until the next check (#1122).
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	cmd.WaitDelay = 2 * time.Second
 	capture := &boundedOutputBuffer{limit: maxCheckOutputBytes}
 	cmd.Stdout = capture
 	cmd.Stderr = capture
@@ -190,13 +209,6 @@ func (c Checker) result(start time.Time, signal, state, summary, detail string, 
 		ExitCode:       exitCode,
 		DurationMillis: int64(c.now().Sub(start) / time.Millisecond),
 	}
-}
-
-func (c Checker) timeout() time.Duration {
-	if c.CommandTimeout > 0 {
-		return c.CommandTimeout
-	}
-	return defaultCheckTimeout
 }
 
 func (c Checker) now() time.Time {

--- a/internal/outcome/outcome.go
+++ b/internal/outcome/outcome.go
@@ -47,21 +47,27 @@ const (
 // Brief is the project operating brief Maestro uses to judge progress by the
 // runtime outcome instead of by raw issue throughput.
 type Brief struct {
-	DesiredOutcome          string   `yaml:"desired_outcome" json:"desired_outcome,omitempty"`
-	RuntimeTarget           string   `yaml:"runtime_target" json:"runtime_target,omitempty"`
-	RuntimeURL              string   `yaml:"runtime_url" json:"runtime_url,omitempty"`
-	DeploymentStatusCommand string   `yaml:"deployment_status_command" json:"deployment_status_command,omitempty"`
-	DeployStatusCommand     string   `yaml:"deploy_status_command" json:"-"`
-	HealthcheckCommand      string   `yaml:"healthcheck_command" json:"healthcheck_command,omitempty"`
-	VerifierCommand         string   `yaml:"verifier_command" json:"verifier_command,omitempty"`
-	HealthcheckURL          string   `yaml:"healthcheck_url" json:"healthcheck_url,omitempty"`
-	SourceRepoPath          string   `yaml:"source_repo_path" json:"source_repo_path,omitempty"`
-	RuntimeHost             string   `yaml:"runtime_host" json:"runtime_host,omitempty"`
-	RequiredRoutes          []string `yaml:"required_routes" json:"required_routes,omitempty"`
-	RequiresDeploy          bool     `yaml:"requires_deploy" json:"requires_deploy,omitempty"`
-	PassRequiredForDone     *bool    `yaml:"pass_required_for_done" json:"-"`
-	FailRequiresVisibleWork *bool    `yaml:"fail_requires_visible_work" json:"-"`
-	NonGoals                []string `yaml:"non_goals" json:"non_goals,omitempty"`
+	DesiredOutcome          string `yaml:"desired_outcome" json:"desired_outcome,omitempty"`
+	RuntimeTarget           string `yaml:"runtime_target" json:"runtime_target,omitempty"`
+	RuntimeURL              string `yaml:"runtime_url" json:"runtime_url,omitempty"`
+	DeploymentStatusCommand string `yaml:"deployment_status_command" json:"deployment_status_command,omitempty"`
+	DeployStatusCommand     string `yaml:"deploy_status_command" json:"-"`
+	HealthcheckCommand      string `yaml:"healthcheck_command" json:"healthcheck_command,omitempty"`
+	VerifierCommand         string `yaml:"verifier_command" json:"verifier_command,omitempty"`
+	HealthcheckURL          string `yaml:"healthcheck_url" json:"healthcheck_url,omitempty"`
+	// HealthcheckTimeoutSeconds bounds a single outcome health check, whether
+	// it runs healthcheck_url, healthcheck_command, or
+	// deployment_status_command. Zero uses the default (15s). A deploy
+	// verification or smoke test that legitimately runs longer needs this
+	// instead of reporting a permanent timeout (#1122).
+	HealthcheckTimeoutSeconds int      `yaml:"healthcheck_timeout_seconds" json:"healthcheck_timeout_seconds,omitempty"`
+	SourceRepoPath            string   `yaml:"source_repo_path" json:"source_repo_path,omitempty"`
+	RuntimeHost               string   `yaml:"runtime_host" json:"runtime_host,omitempty"`
+	RequiredRoutes            []string `yaml:"required_routes" json:"required_routes,omitempty"`
+	RequiresDeploy            bool     `yaml:"requires_deploy" json:"requires_deploy,omitempty"`
+	PassRequiredForDone       *bool    `yaml:"pass_required_for_done" json:"-"`
+	FailRequiresVisibleWork   *bool    `yaml:"fail_requires_visible_work" json:"-"`
+	NonGoals                  []string `yaml:"non_goals" json:"non_goals,omitempty"`
 	// RecoveryCommand is omitted from API JSON: Fleet exposes only its bounded
 	// execution receipt, never command text or output.
 	RecoveryCommand         string `yaml:"recovery_command" json:"-"`
@@ -213,6 +219,9 @@ func (b Brief) Validate() error {
 	if b.RecoveryMaxFutileAttempts < 0 {
 		return fmt.Errorf("outcome recovery_max_futile_attempts must be >= 0")
 	}
+	if b.HealthcheckTimeoutSeconds < 0 {
+		return fmt.Errorf("outcome healthcheck_timeout_seconds must be >= 0")
+	}
 	switch b.RecoveryMode {
 	case RecoveryModeDisabled:
 		return nil
@@ -256,6 +265,16 @@ func (b Brief) EffectiveRecoveryTimeout() time.Duration {
 		return time.Duration(b.RecoveryTimeoutSeconds) * time.Second
 	}
 	return defaultRecoveryTimeout
+}
+
+// EffectiveHealthcheckTimeout bounds one outcome health check. Zero config
+// keeps the historical 15s budget, so a project that configures nothing is
+// unaffected (#1122).
+func (b Brief) EffectiveHealthcheckTimeout() time.Duration {
+	if b.HealthcheckTimeoutSeconds > 0 {
+		return time.Duration(b.HealthcheckTimeoutSeconds) * time.Second
+	}
+	return defaultCheckTimeout
 }
 
 // EffectiveRecoveryMaxFutileAttempts returns the consecutive post-attempt

--- a/internal/outcome/outcome_test.go
+++ b/internal/outcome/outcome_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -302,6 +304,75 @@ func TestCheckerStructuredHealthRejectsFreeFormFields(t *testing.T) {
 	persisted := result.Summary + result.Detail
 	if strings.Contains(persisted, "top-secret") || strings.Contains(persisted, "token=secret") || strings.Contains(persisted, "secret-status") {
 		t.Fatalf("free-form structured output entered durable result: %q", persisted)
+	}
+}
+
+func TestBriefEffectiveHealthcheckTimeout(t *testing.T) {
+	if got := (Brief{}).EffectiveHealthcheckTimeout(); got != defaultCheckTimeout {
+		t.Fatalf("default healthcheck timeout = %s, want %s", got, defaultCheckTimeout)
+	}
+	if got := (Brief{HealthcheckTimeoutSeconds: 60}).EffectiveHealthcheckTimeout(); got != 60*time.Second {
+		t.Fatalf("configured healthcheck timeout = %s, want 1m0s", got)
+	}
+	if err := (Brief{HealthcheckTimeoutSeconds: -1}).Validate(); err == nil || !strings.Contains(err.Error(), "healthcheck_timeout_seconds") {
+		t.Fatalf("negative healthcheck_timeout_seconds error = %v", err)
+	}
+}
+
+func TestCheckerAppliesConfiguredHealthcheckTimeoutBudget(t *testing.T) {
+	cases := []struct {
+		name    string
+		seconds int
+		want    time.Duration
+	}{
+		{name: "default", seconds: 0, want: defaultCheckTimeout},
+		{name: "configured", seconds: 60, want: 60 * time.Second},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var budget time.Duration
+			result := Checker{
+				RunCommand: func(ctx context.Context, command, dir string) ([]byte, int, error) {
+					deadline, ok := ctx.Deadline()
+					if !ok {
+						t.Fatal("healthcheck command ran without a deadline")
+					}
+					budget = time.Until(deadline)
+					return nil, 0, nil
+				},
+			}.Check(context.Background(), Brief{
+				DesiredOutcome:            "App is live",
+				HealthcheckCommand:        "status.sh",
+				HealthcheckTimeoutSeconds: tc.seconds,
+			})
+			if result.State != HealthHealthy {
+				t.Fatalf("State = %q, want %q", result.State, HealthHealthy)
+			}
+			// The deadline is set just before the command runs, so the observed
+			// budget is the configured one minus scheduling slack.
+			if budget > tc.want || budget < tc.want-2*time.Second {
+				t.Fatalf("healthcheck budget = %s, want ~%s", budget, tc.want)
+			}
+		})
+	}
+}
+
+func TestCheckerHealthcheckTimeoutKillsDescendantProcessGroup(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "descendant-survived")
+	result := Checker{}.Check(context.Background(), Brief{
+		DesiredOutcome:            "App is live",
+		HealthcheckCommand:        fmt.Sprintf("(sleep 2; touch %q) & wait", marker),
+		HealthcheckTimeoutSeconds: 1,
+	})
+	if result.State != HealthFailing || !strings.Contains(result.Summary, "timed out after 1s") {
+		t.Fatalf("result = %+v, want a 1s timeout failure", result)
+	}
+
+	time.Sleep(2200 * time.Millisecond)
+	if _, err := os.Stat(marker); err == nil {
+		t.Fatal("healthcheck descendant survived the timeout and produced its marker")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat marker: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

`Checker.CommandTimeout` was dead in production. All three call sites build a zero-value checker:

- `internal/supervisor/supervisor.go:579`
- `internal/supervisor/outcome_recovery.go:18`
- `internal/orchestrator/orchestrator.go:1043`

so `Checker.timeout()` always returned the hardcoded `defaultCheckTimeout = 15s`. A project whose `healthcheck_command` legitimately runs longer — a deploy verification waiting on a service to come up, a smoke test, anything touching a remote host — could never report healthy. It reported `healthcheck_command timed out after 15s` forever, which reads as a failing outcome rather than a misconfigured budget.

Secondary: `runCommand` used `exec.CommandContext(ctx, "sh", "-lc", command)` with the default cancel, which signals `sh` only. A healthcheck that backgrounds work left the child alive past the deadline and into the next check. `RecoveryRunner` already solved this for the recovery command; the checker had not.

## Fix

The budget now comes from the brief, not from a struct field no caller populates.

- `outcome.Brief` gains `healthcheck_timeout_seconds` plus `EffectiveHealthcheckTimeout()`, which falls back to the existing 15s. `Validate()` rejects a negative value alongside the recovery budgets.
- `Checker.CommandTimeout` and `Checker.timeout()` are removed; `Check` resolves the budget once from the brief and passes it to `checkURL` / `checkCommand`. The timeout summary reports the real budget (`timed out after 1m0s`), not a stale constant.
- `runCommand` sets `Setpgid`, kills the whole process group with SIGKILL from `cmd.Cancel`, and sets `WaitDelay`, mirroring `RecoveryRunner.runCommand`.
- The runbook's outcome block documents the new key.

The budget applies to `healthcheck_url` as well, since a single check is a single check whichever signal is configured.

## Evidence

New tests in `internal/outcome/outcome_test.go`:

- `TestBriefEffectiveHealthcheckTimeout` — default 15s, configured 60 → 60s, negative rejected by `Validate`.
- `TestCheckerAppliesConfiguredHealthcheckTimeoutBudget` — inspects the deadline the command actually runs under, for both the default and the configured budget.
- `TestCheckerHealthcheckTimeoutKillsDescendantProcessGroup` — a 1s budget against `(sleep 2; touch marker) & wait`; the check must fail with `timed out after 1s` and the marker must never appear.

Confirmed the tests fail on unfixed behaviour by reintroducing each defect in turn:

- forcing `EffectiveHealthcheckTimeout` back to the constant → `configured healthcheck timeout = 15s, want 1m0s`, `healthcheck budget = 14.99999722s, want ~1m0s`, and the process-group test reports `State:healthy` after 2s because the 15s budget never fired.
- removing only the `Setpgid` / `Cancel` / `WaitDelay` block → `healthcheck descendant survived the timeout and produced its marker`.

Full suite on the branch: `umask 022 && go build ./... && go test ./... -count=1` — 36 packages, all `ok`. `gofmt -l` clean on every changed file.

Refs #1122
