### PR TITLE
Release the token-budget mill-hold when the budget that caused it is raised

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1523,13 +1523,21 @@ func (o *Orchestrator) notifyTokenBudgetMill(issueNumber, kills int) {
 	if project != "" {
 		title += ": " + project
 	}
-	body := fmt.Sprintf(
-		"issue #%d stopped at the token budget %d times in a row with no PR; worker_max_tokens=%d is likely below the floor this issue needs. Dispatch is held until the budget is raised.",
-		issueNumber, kills, o.cfg.WorkerMaxTokens,
-	)
+	body := tokenBudgetMillAlertBody(issueNumber, kills, o.cfg.WorkerMaxTokens)
 	if err := o.notifier.Alert(notify.AlertFutileRecovery, fmt.Sprintf("%s:token_budget_wall:%d", project, issueNumber), title, body); err != nil {
 		log.Printf("[orch] token-budget-wall notification failed for issue #%d: %v", issueNumber, err)
 	}
+}
+
+// tokenBudgetMillAlertBody names the one action that actually releases the hold.
+// The pre-#1124 text asked the operator to raise the budget while the streak
+// ignored the budget entirely, so the stated remedy was silently ineffective;
+// the escape route has to be both true and specific.
+func tokenBudgetMillAlertBody(issueNumber, kills, maxTokens int) string {
+	return fmt.Sprintf(
+		"issue #%d stopped at the token budget %d times in a row with no PR; worker_max_tokens=%d is likely below the floor this issue needs. Dispatch stays held until worker_max_tokens is raised above %d — the hold then clears itself on the next dispatch cycle, because stops recorded under a lower ceiling stop counting (#1124). Re-adding a ready label does not release it.",
+		issueNumber, kills, maxTokens, maxTokens,
+	)
 }
 
 func tokenBudgetObservation(sess *state.Session) (int, string) {
@@ -1552,6 +1560,11 @@ func (o *Orchestrator) markTokenBudgetExceeded(slotName string, sess *state.Sess
 	}
 	o.updateTokensUsedFromWorkerLog(slotName, sess)
 	applyTokenBudgetObservation(sess, marker)
+	// Stamp the ceiling this stop actually hit so a later budget raise can
+	// retire the kill streak instead of holding the issue forever (#1124).
+	if marker.MaxTokens > 0 {
+		sess.TokenBudgetMaxTokens = marker.MaxTokens
+	}
 	budgetObserved, budgetMeasure := tokenBudgetObservation(sess)
 	sess.WorkerOutcome = worker.TokenBudgetExceededOutcome
 	sess.LastNotifiedStatus = worker.TokenBudgetExceededOutcome
@@ -10268,7 +10281,7 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 		// the operator raises worker_max_tokens (or fixes the measure) instead
 		// of watching the fleet re-spawn into the same wall.
 		if !repairSpawn {
-			kills := s.ConsecutiveTokenBudgetKillsForIssue(issue.Number)
+			kills := s.ConsecutiveTokenBudgetKillsForIssue(issue.Number, o.cfg.WorkerMaxTokens)
 			if o.tokenBudgetMillHold(issue.Number, kills) {
 				log.Printf("[orch] skipping issue #%d: %d consecutive token-budget stops — worker_max_tokens=%d is likely below the viable floor for this issue",
 					issue.Number, kills, o.cfg.WorkerMaxTokens)

--- a/internal/orchestrator/token_budget_mill_test.go
+++ b/internal/orchestrator/token_budget_mill_test.go
@@ -1,10 +1,14 @@
 package orchestrator
 
 import (
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/worker"
 )
 
 func millTestOrchestrator() *Orchestrator {
@@ -75,5 +79,91 @@ func TestTokenBudgetMillHold_PerIssue(t *testing.T) {
 	}
 	if got := o.tokenBudgetMillNotified[628]; got != 2 {
 		t.Fatalf("issue 628 memory = %d, want 2 (unaffected by 629)", got)
+	}
+}
+
+// recordBudgetKill appends a PR-less budget stop for the issue, as the live
+// dispatch path records one.
+func recordBudgetKill(s *state.State, slot string, issue int, finished time.Time, ceiling, observed int) {
+	at := finished
+	s.Sessions[slot] = &state.Session{
+		IssueNumber:              issue,
+		Status:                   state.StatusFailed,
+		WorkerOutcome:            worker.TokenBudgetExceededOutcome,
+		TokenBudgetMaxTokens:     ceiling,
+		TokenBudgetTokensAttempt: observed,
+		StartedAt:                finished.Add(-2 * time.Minute),
+		FinishedAt:               &at,
+	}
+}
+
+// #1124 end to end: two stops at budget X hold the issue, raising the budget to
+// Y > X makes it dispatchable again with no state.json edit, and two fresh stops
+// at Y hold it again.
+func TestTokenBudgetMill_RaisedBudgetReleasesThenReHolds(t *testing.T) {
+	o := millTestOrchestrator() // worker_max_tokens = 120000
+	s := state.NewState()
+	now := time.Now().UTC()
+
+	recordBudgetKill(s, "sup-1", 628, now.Add(-40*time.Minute), 120000, 157000)
+	recordBudgetKill(s, "sup-2", 628, now.Add(-30*time.Minute), 120000, 158000)
+	kills := s.ConsecutiveTokenBudgetKillsForIssue(628, o.cfg.WorkerMaxTokens)
+	if !o.tokenBudgetMillHold(628, kills) {
+		t.Fatalf("two stops at the configured budget did not hold (kills=%d)", kills)
+	}
+
+	// The operator applies the remedy the alert names, and nothing else.
+	o.cfg.WorkerMaxTokens = 400000
+	kills = s.ConsecutiveTokenBudgetKillsForIssue(628, o.cfg.WorkerMaxTokens)
+	if kills != 0 {
+		t.Fatalf("streak after the raise = %d, want 0", kills)
+	}
+	if o.tokenBudgetMillHold(628, kills) {
+		t.Fatal("raising worker_max_tokens did not release the hold")
+	}
+	if _, remembered := o.tokenBudgetMillNotified[628]; remembered {
+		t.Fatal("alert memory survived the release — the returning wall would hold silently")
+	}
+
+	// The issue walls into the new ceiling too: one stop is not enough, two are.
+	recordBudgetKill(s, "sup-3", 628, now.Add(-10*time.Minute), 400000, 430000)
+	kills = s.ConsecutiveTokenBudgetKillsForIssue(628, o.cfg.WorkerMaxTokens)
+	if kills != 1 || o.tokenBudgetMillHold(628, kills) {
+		t.Fatalf("held after a single stop at the new ceiling (kills=%d)", kills)
+	}
+	recordBudgetKill(s, "sup-4", 628, now.Add(-5*time.Minute), 400000, 440000)
+	kills = s.ConsecutiveTokenBudgetKillsForIssue(628, o.cfg.WorkerMaxTokens)
+	if kills != 2 {
+		t.Fatalf("streak at the new ceiling = %d, want 2", kills)
+	}
+	if !o.tokenBudgetMillHold(628, kills) {
+		t.Fatal("did not hold again after two stops at the raised budget")
+	}
+}
+
+// A budget stop must record the ceiling it hit, otherwise a later raise has
+// nothing to compare against.
+func TestMarkTokenBudgetExceeded_RecordsCeiling(t *testing.T) {
+	o := millTestOrchestrator()
+	sess := &state.Session{IssueNumber: 628, Status: state.StatusRunning, StartedAt: time.Now().UTC()}
+	o.markTokenBudgetExceeded("sup-1", sess, worker.TokenBudgetMarker{
+		Outcome:        worker.TokenBudgetExceededOutcome,
+		TokensObserved: 157000,
+		MaxTokens:      120000,
+		Measure:        worker.TokenBudgetMeasureUncached,
+	}, time.Now().UTC())
+
+	if sess.TokenBudgetMaxTokens != 120000 {
+		t.Fatalf("recorded ceiling = %d, want 120000", sess.TokenBudgetMaxTokens)
+	}
+}
+
+// The alert must name the escape route that actually works.
+func TestTokenBudgetMillAlertBody_NamesTheEscapeRoute(t *testing.T) {
+	body := tokenBudgetMillAlertBody(628, 2, 120000)
+	for _, want := range []string{"worker_max_tokens is raised above 120000", "clears itself"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("alert body %q does not mention %q", body, want)
+		}
 	}
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -299,6 +299,7 @@ type Session struct {
 	TokenBudgetTokensAttempt   int        `json:"token_budget_tokens_attempt,omitempty"`   // current-attempt usage under TokenBudgetMeasure; kept separate from inclusive cost telemetry
 	TokenBudgetTokensWatermark int        `json:"token_budget_tokens_watermark,omitempty"` // high-water mark for the current attempt's cumulative budget measure
 	TokenBudgetMeasure         string     `json:"token_budget_measure,omitempty"`          // explicit live-ceiling measure, e.g. uncached_tokens
+	TokenBudgetMaxTokens       int        `json:"token_budget_max_tokens,omitempty"`       // worker_max_tokens ceiling in effect when the budget stop was recorded (#1124); lets a raised budget retire a stale kill streak
 	WorkerOutcome              string     `json:"worker_outcome,omitempty"`                // deterministic terminal worker outcome, e.g. token_budget_exceeded
 	// #739: cache-aware split token counters stamped from a backend usage
 	// stream (claude stream-json / Pi --mode json). Cumulative run totals so
@@ -5104,14 +5105,22 @@ func (s *State) FailedAttemptsForIssue(issueNum int) int {
 // nothing ever stops re-dispatching. Live 2026-07-24: ok-player #628 spawned 9
 // times in 4.5h, each killed after ~2 minutes at observed≈157k vs max=120k.
 // Callers use this streak to break the mill and surface the misconfiguration.
-func (s *State) ConsecutiveTokenBudgetKillsForIssue(issueNum int) int {
+//
+// currentMaxTokens is the worker_max_tokens ceiling configured right now (0 when
+// none is configured, which counts every stop as before). Stops recorded under a
+// LOWER ceiling are stale evidence — the wall they hit no longer exists — so the
+// walk stops there and the streak clears. Without that the hold had no
+// self-clearing path: the only thing that reset the streak was a new non-budget
+// session, and creating one required the dispatch the hold itself blocked, so
+// raising the budget — the remedy the alert asks for — changed nothing (#1124).
+func (s *State) ConsecutiveTokenBudgetKillsForIssue(issueNum, currentMaxTokens int) int {
 	if s == nil {
 		return 0
 	}
 	type ended struct {
 		at      time.Time
 		budget  bool
-		counted bool
+		ceiling int
 	}
 	var history []ended
 	for _, sess := range s.Sessions {
@@ -5128,7 +5137,7 @@ func (s *State) ConsecutiveTokenBudgetKillsForIssue(issueNum int) int {
 		history = append(history, ended{
 			at:      at,
 			budget:  sess.WorkerOutcome == string(DisplayTokenBudgetExceeded),
-			counted: true,
+			ceiling: tokenBudgetKillCeiling(sess),
 		})
 	}
 	sort.Slice(history, func(i, j int) bool { return history[i].at.After(history[j].at) })
@@ -5137,9 +5146,34 @@ func (s *State) ConsecutiveTokenBudgetKillsForIssue(issueNum int) int {
 		if !entry.budget {
 			break
 		}
+		if currentMaxTokens > 0 && entry.ceiling > 0 && entry.ceiling < currentMaxTokens {
+			break
+		}
 		streak++
 	}
 	return streak
+}
+
+// tokenBudgetKillCeiling reports the worker_max_tokens ceiling a budget stop was
+// recorded under, or 0 when it cannot be established at all.
+//
+// Sessions stopped before #1124 carry no explicit ceiling, so their observed
+// budget usage stands in for it: the stop only fires once usage has reached the
+// ceiling, so observed >= ceiling, and an observation below the current budget
+// still proves the stop happened under a lower one. That fallback is what
+// releases the issues frozen when #1124 was filed (ok-folio #280, ok-player
+// #628) — their whole history predates the field.
+func tokenBudgetKillCeiling(sess *Session) int {
+	if sess == nil {
+		return 0
+	}
+	if sess.TokenBudgetMaxTokens > 0 {
+		return sess.TokenBudgetMaxTokens
+	}
+	if sess.TokenBudgetTokensAttempt > 0 {
+		return sess.TokenBudgetTokensAttempt
+	}
+	return sess.TokensUsedAttempt
 }
 
 // IssueRetryExhausted returns true if any session for the given issue

--- a/internal/state/token_budget_streak_test.go
+++ b/internal/state/token_budget_streak_test.go
@@ -26,10 +26,10 @@ func TestConsecutiveTokenBudgetKillsForIssue_CountsRecentRun(t *testing.T) {
 	s.Sessions["b"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-20*time.Minute), 0)
 	s.Sessions["c"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-10*time.Minute), 0)
 
-	if got := s.ConsecutiveTokenBudgetKillsForIssue(628); got != 3 {
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(628, 0); got != 3 {
 		t.Fatalf("streak = %d, want 3", got)
 	}
-	if got := s.ConsecutiveTokenBudgetKillsForIssue(999); got != 0 {
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(999, 0); got != 0 {
 		t.Fatalf("streak for unrelated issue = %d, want 0", got)
 	}
 }
@@ -43,7 +43,7 @@ func TestConsecutiveTokenBudgetKillsForIssue_NonBudgetEndingBreaksStreak(t *test
 	s.Sessions["b"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-20*time.Minute), 0)
 	s.Sessions["c"] = budgetSession(628, "", StatusDead, now.Add(-5*time.Minute), 0)
 
-	if got := s.ConsecutiveTokenBudgetKillsForIssue(628); got != 0 {
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(628, 0); got != 0 {
 		t.Fatalf("streak = %d, want 0 — the most recent ending was not a budget stop", got)
 	}
 }
@@ -55,7 +55,7 @@ func TestConsecutiveTokenBudgetKillsForIssue_IgnoresSessionsWithPR(t *testing.T)
 	s.Sessions["a"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-30*time.Minute), 0)
 	s.Sessions["b"] = budgetSession(628, string(DisplayTokenBudgetExceeded), StatusFailed, now.Add(-10*time.Minute), 4242)
 
-	if got := s.ConsecutiveTokenBudgetKillsForIssue(628); got != 1 {
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(628, 0); got != 1 {
 		t.Fatalf("streak = %d, want 1 (the PR-bearing session is excluded)", got)
 	}
 }
@@ -69,7 +69,7 @@ func TestConsecutiveTokenBudgetKillsForIssue_IgnoresRunning(t *testing.T) {
 	live.FinishedAt = nil
 	s.Sessions["b"] = live
 
-	if got := s.ConsecutiveTokenBudgetKillsForIssue(628); got != 1 {
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(628, 0); got != 1 {
 		t.Fatalf("streak = %d, want 1", got)
 	}
 }
@@ -83,5 +83,59 @@ func TestFailedAttemptsForIssue_StillExcludesBudgetStops(t *testing.T) {
 
 	if got := s.FailedAttemptsForIssue(628); got != 0 {
 		t.Fatalf("FailedAttemptsForIssue = %d, want 0 — budget stops are a governor, not work failures", got)
+	}
+}
+
+// budgetKill builds a PR-less budget stop that records the ceiling it hit.
+func budgetKill(issue int, finished time.Time, ceiling, observed int) *Session {
+	sess := budgetSession(issue, string(DisplayTokenBudgetExceeded), StatusFailed, finished, 0)
+	sess.TokenBudgetMaxTokens = ceiling
+	sess.TokenBudgetTokensAttempt = observed
+	return sess
+}
+
+// #1124: raising worker_max_tokens above the ceiling that produced the stops
+// retires them. Without this the hold could never clear, because the only thing
+// that reset the streak was a dispatch the hold itself blocked.
+func TestConsecutiveTokenBudgetKillsForIssue_RaisedBudgetRetiresStaleKills(t *testing.T) {
+	now := time.Now().UTC()
+	s := NewState()
+	s.Sessions["a"] = budgetKill(628, now.Add(-30*time.Minute), 120000, 157000)
+	s.Sessions["b"] = budgetKill(628, now.Add(-20*time.Minute), 120000, 158000)
+
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(628, 120000); got != 2 {
+		t.Fatalf("streak at the unchanged budget = %d, want 2", got)
+	}
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(628, 400000); got != 0 {
+		t.Fatalf("streak after the budget raise = %d, want 0 — the wall those stops hit no longer exists", got)
+	}
+}
+
+// Stops recorded at the current ceiling are live evidence and still hold.
+func TestConsecutiveTokenBudgetKillsForIssue_StopsAtCurrentCeilingStillCount(t *testing.T) {
+	now := time.Now().UTC()
+	s := NewState()
+	s.Sessions["a"] = budgetKill(628, now.Add(-30*time.Minute), 400000, 430000)
+	s.Sessions["b"] = budgetKill(628, now.Add(-20*time.Minute), 400000, 440000)
+
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(628, 400000); got != 2 {
+		t.Fatalf("streak = %d, want 2 — these stops hit the budget that is configured now", got)
+	}
+}
+
+// Sessions recorded before #1124 have no ceiling field; their observed usage is
+// the lower bound that proves which side of the current budget they fall on.
+// This is the shape of the live frozen issues (ok-folio #280, ok-player #628).
+func TestConsecutiveTokenBudgetKillsForIssue_LegacyKillsUseObservedUsage(t *testing.T) {
+	now := time.Now().UTC()
+	s := NewState()
+	s.Sessions["a"] = budgetKill(628, now.Add(-30*time.Minute), 0, 157000)
+	s.Sessions["b"] = budgetKill(628, now.Add(-20*time.Minute), 0, 158000)
+
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(628, 120000); got != 2 {
+		t.Fatalf("legacy streak at the old budget = %d, want 2", got)
+	}
+	if got := s.ConsecutiveTokenBudgetKillsForIssue(628, 400000); got != 0 {
+		t.Fatalf("legacy streak after the raise = %d, want 0", got)
 	}
 }


### PR DESCRIPTION
## Problem

The token-budget mill-hold had no self-clearing path, and the obvious operator remedy was silently ineffective.

- `tokenBudgetMillHold` holds an issue as soon as its budget-kill streak reaches 2.
- `ConsecutiveTokenBudgetKillsForIssue` computed that streak by walking PR-less dead/failed/retry_exhausted sessions newest-first, stopping at the first non-budget ending — **never consulting `worker_max_tokens`**.
- So the streak reset only when a *new non-budget session ended*, and producing one required a dispatch, which is exactly what the hold blocked.

Raising `worker_max_tokens` — the remedy the `futile_recovery` alert asked for — changed nothing. Live on the stopped fleet: `BeFeast/ok-folio` #280 (streak 5) and `BeFeast/ok-player` #628 (streak 11) stayed frozen after the ceiling went 120000 → 400000. #280 was ok-folio's only ready issue with `max_parallel: 1`, so the project contributed zero workers to the live band indefinitely.

## Fix

Design 1 from the issue (invalidate the streak when the budget changes) — it is the only one of the three that makes the action the operator already takes work, with no new command, no new dispatch, and no timer.

- `state.Session.TokenBudgetMaxTokens` records the ceiling a budget stop actually hit; `markTokenBudgetExceeded` stamps it from the marker.
- `ConsecutiveTokenBudgetKillsForIssue(issueNum, currentMaxTokens)` stops the walk at a kill recorded under a ceiling **lower** than the one configured now: that stop is evidence about a wall that no longer exists. `currentMaxTokens == 0` (no budget configured) keeps the previous behaviour.
- Sessions written before this change carry no ceiling, so their observed budget usage stands in for it. A budget stop only fires once usage has reached the ceiling, so an observation below the current budget still proves the stop happened under a lower one. That fallback is what releases the two live issues, whose entire history predates the field.
- The alert body moves into `tokenBudgetMillAlertBody` and now names the escape route that works: raise `worker_max_tokens` above the current value, the hold clears itself on the next dispatch cycle, and re-adding a ready label does not release it.

Behaviour: a raise clears the hold on the next cycle with no `state.json` edit; one fresh stop at the new ceiling is not enough; two hold the issue again. `spawn_repair_worker` still bypasses the hold as before.

## Evidence

New tests, all five of which fail on unfixed code (verified by neutralising the three behavioural hunks — the stale-ceiling break, the ceiling stamp, and the alert text — while keeping the new signature so the package still compiles):

- `TestConsecutiveTokenBudgetKillsForIssue_RaisedBudgetRetiresStaleKills` — 2 stops at 120000 → streak 2 at budget 120000, streak 0 at budget 400000.
- `TestConsecutiveTokenBudgetKillsForIssue_StopsAtCurrentCeilingStillCount` — stops at the configured ceiling still count.
- `TestConsecutiveTokenBudgetKillsForIssue_LegacyKillsUseObservedUsage` — the shape of the live frozen issues (no recorded ceiling, observed ≈157k).
- `TestTokenBudgetMill_RaisedBudgetReleasesThenReHolds` — the full acceptance sequence: held at X → raised to Y > X → dispatchable (and the alert memory re-arms) → one stop at Y still dispatchable → two stops at Y held again.
- `TestMarkTokenBudgetExceeded_RecordsCeiling`, `TestTokenBudgetMillAlertBody_NamesTheEscapeRoute`.

Existing streak/hold tests are updated for the new signature and still pass unchanged in meaning, including `TestFailedAttemptsForIssue_StillExcludesBudgetStops` (a budget stop must not burn the retry budget).

`umask 022 && go build ./... && go test ./... -count=1` on the worktree: exit 0, 36 packages ok. `gofmt -l` clean for the touched files (the pre-existing `internal/worker/opencode_usage.go` report is untouched).

Refs #1124
