### PR TITLE
Kill the checkpoint git process group when shutdown times out

### DIFF
--- a/internal/daemon/checkpoint_cancel_test.go
+++ b/internal/daemon/checkpoint_cancel_test.go
@@ -1,0 +1,119 @@
+package daemon
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/worker"
+)
+
+// #1121: the shutdown budget bounds the daemon's own goroutines, but what keeps
+// maestro.service deactivating is the checkpoint git child, not the goroutine
+// waiting on it. Timing out must cancel the capture — and join it — so the child
+// is gone before shutdown continues.
+func TestSaveCheckpointWithinCancelsAndJoinsTimedOutCapture(t *testing.T) {
+	oldCheckpointFn := checkpointFn
+	defer func() { checkpointFn = oldCheckpointFn }()
+
+	released := make(chan struct{})
+	checkpointFn = func(ctx context.Context, _ *state.Session) (string, error) {
+		<-ctx.Done()
+		close(released)
+		return "", ctx.Err()
+	}
+
+	path, err, timedOut := saveCheckpointWithin(&state.Session{IssueNumber: 1121, Worktree: t.TempDir()}, 20*time.Millisecond)
+	if !timedOut || path != "" || err != nil {
+		t.Fatalf("want timed-out capture with no path and no error, got path=%q err=%v timedOut=%v", path, err, timedOut)
+	}
+	select {
+	case <-released:
+	default:
+		t.Fatal("saveCheckpointWithin returned while the timed-out capture was still running; its git child would outlive the drain deadline")
+	}
+}
+
+// A capture that ignores cancellation must still not hold shutdown open: the
+// post-cancel join is bounded by checkpointCancelGrace.
+func TestSaveCheckpointWithinBoundsThePostCancelJoin(t *testing.T) {
+	oldCheckpointFn, oldCancelGrace := checkpointFn, checkpointCancelGrace
+	checkpointCancelGrace = 20 * time.Millisecond
+	blocked := make(chan struct{})
+	finished := make(chan struct{})
+	checkpointFn = func(context.Context, *state.Session) (string, error) {
+		defer close(finished)
+		<-blocked
+		return "", nil
+	}
+	defer func() {
+		close(blocked)
+		<-finished
+		checkpointFn = oldCheckpointFn
+		checkpointCancelGrace = oldCancelGrace
+	}()
+
+	started := time.Now()
+	if _, _, timedOut := saveCheckpointWithin(&state.Session{IssueNumber: 1121}, 20*time.Millisecond); !timedOut {
+		t.Fatal("want timedOut=true for a capture that never returns")
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("uncancellable capture held shutdown for %v", elapsed)
+	}
+}
+
+// End-to-end over the real capture: a wedged git that has itself forked leaves
+// nothing behind once saveCheckpointWithin reports timedOut=true.
+func TestSaveCheckpointWithinLeavesNoGitChildAfterTimeout(t *testing.T) {
+	oldCheckpointFn := checkpointFn
+	checkpointFn = worker.SaveCheckpointContext
+	defer func() { checkpointFn = oldCheckpointFn }()
+
+	dir := t.TempDir()
+	pidFile := filepath.Join(dir, "grandchild.pid")
+	script := "#!/bin/sh\n" +
+		"sh -c 'echo $$ > \"$MAESTRO_TEST_CHECKPOINT_CHILD_PID\"; exec sleep 300' &\n" +
+		"sleep 300\n"
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("MAESTRO_TEST_CHECKPOINT_CHILD_PID", pidFile)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	sess := &state.Session{IssueNumber: 1121, Worktree: t.TempDir()}
+	if _, _, timedOut := saveCheckpointWithin(sess, 200*time.Millisecond); !timedOut {
+		t.Fatal("want timedOut=true for a wedged git capture")
+	}
+
+	grandchild := 0
+	for deadline := time.Now().Add(10 * time.Second); time.Now().Before(deadline) && grandchild == 0; {
+		if data, err := os.ReadFile(pidFile); err == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(data))); convErr == nil && pid > 0 {
+				grandchild = pid
+				break
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if grandchild == 0 {
+		t.Fatalf("fake git never published its grandchild pid to %s", pidFile)
+	}
+
+	gone := false
+	for deadline := time.Now().Add(10 * time.Second); time.Now().Before(deadline); {
+		if syscall.Kill(grandchild, 0) != nil {
+			gone = true
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !gone {
+		t.Fatalf("git child %d is still in the unit cgroup after saveCheckpointWithin reported timedOut=true", grandchild)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -115,20 +115,32 @@ var shutdownCheckpointBudget = 60 * time.Second
 var restartCheckpointRetries = 5
 
 // checkpointFn writes the best-effort CHECKPOINT.md context blob for one
-// in-flight session and returns its path. It defaults to worker.SaveCheckpoint,
-// which shells out to git; a var so tests can inject a fast or deliberately
-// wedged stub. It is called through saveCheckpointWithin so a git invocation
-// contending with a live worker's index.lock cannot hang the shutdown pass past
-// the drain deadline (#966).
-var checkpointFn = worker.SaveCheckpoint
+// in-flight session and returns its path. It defaults to
+// worker.SaveCheckpointContext, which shells out to git under the caller's
+// context; a var so tests can inject a fast or deliberately wedged stub. It is
+// called through saveCheckpointWithin so a git invocation contending with a live
+// worker's index.lock cannot hang the shutdown pass past the drain deadline
+// (#966) and cannot survive it as a subprocess (#1121).
+var checkpointFn = worker.SaveCheckpointContext
 
-// saveCheckpointWithin runs checkpointFn but abandons it if it does not return
-// within budget. Checkpoint capture shells out to git against worktrees that are
-// still owned by surviving workers, so it must not be allowed to defeat the same
-// global shutdown deadline as a wedged flow callback (#966). The marker is
-// persisted before this helper runs; the abandoned goroutine is harmless and is
-// reaped when the process exits. A non-positive budget skips the optional capture
-// entirely (timedOut=true).
+// checkpointCancelGrace bounds how long saveCheckpointWithin waits, after
+// cancelling a timed-out capture, for that capture to actually release its git
+// process group. The kill is a SIGKILL to the group, so this is normally
+// microseconds; the bound only exists so a capture that ignores cancellation
+// cannot re-introduce the unbounded hold this helper exists to prevent. A var so
+// tests can exercise both outcomes deterministically.
+var checkpointCancelGrace = 2 * time.Second
+
+// saveCheckpointWithin runs checkpointFn under a context it cancels if the
+// capture does not return within budget. Checkpoint capture shells out to git
+// against worktrees that are still owned by surviving workers, so it must not be
+// allowed to defeat the same global shutdown deadline as a wedged flow callback
+// (#966). Cancelling — rather than merely abandoning the waiting goroutine — is
+// what reclaims the git child: maestro.service runs KillMode=mixed, so a git
+// left behind stays in the unit cgroup and holds the unit in deactivating until
+// TimeoutStopSec, which is exactly the failure #966 set out to remove (#1121).
+// The marker is persisted before this helper runs. A non-positive budget skips
+// the optional capture entirely (timedOut=true).
 func saveCheckpointWithin(sess *state.Session, budget time.Duration) (path string, err error, timedOut bool) {
 	if budget <= 0 {
 		return "", nil, true
@@ -137,16 +149,29 @@ func saveCheckpointWithin(sess *state.Session, budget time.Duration) (path strin
 		path string
 		err  error
 	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	ch := make(chan result, 1)
-	go func() { p, e := checkpointFn(sess); ch <- result{p, e} }()
+	go func() { p, e := checkpointFn(ctx, sess); ch <- result{p, e} }()
 	timer := time.NewTimer(budget)
 	defer timer.Stop()
 	select {
 	case r := <-ch:
 		return r.path, r.err, false
 	case <-timer.C:
-		return "", nil, true
 	}
+	// Budget spent: kill the capture's git process group and join it, so the
+	// subprocess is gone before shutdown continues instead of racing the
+	// daemon's own force-exit.
+	cancel()
+	grace := time.NewTimer(checkpointCancelGrace)
+	defer grace.Stop()
+	select {
+	case <-ch:
+	case <-grace.C:
+		log.Printf("[daemon] restart-checkpoint: cancelled checkpoint capture for issue #%d did not release within %s; continuing shutdown", sess.IssueNumber, checkpointCancelGrace)
+	}
+	return "", nil, true
 }
 
 // ConfigLoader yields the set of project configs the daemon supervises. It is

--- a/internal/daemon/daemon_drain_test.go
+++ b/internal/daemon/daemon_drain_test.go
@@ -230,7 +230,7 @@ func TestTwelveFlowShutdownKeepsHealthDuringDrainAndDetachesHungFlow(t *testing.
 	oldPoll, oldFlowTimeout, oldCheckpointFn := drainPollInterval, shutdownFlowTimeout, checkpointFn
 	drainPollInterval = 5 * time.Millisecond
 	shutdownFlowTimeout = 5 * time.Second
-	checkpointFn = func(*state.Session) (string, error) { return "", nil }
+	checkpointFn = func(context.Context, *state.Session) (string, error) { return "", nil }
 	defer func() {
 		drainPollInterval = oldPoll
 		shutdownFlowTimeout = oldFlowTimeout

--- a/internal/daemon/restart_checkpoint_test.go
+++ b/internal/daemon/restart_checkpoint_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -131,10 +132,15 @@ func TestCheckpointInFlightForRestart_PastDeadlineStampsMarkerWithoutCheckpointF
 // tail before later workers receive their correctness-critical restart markers.
 // Markers are persisted for the whole state dir first; CHECKPOINT.md is optional.
 func TestCheckpointInFlightForRestart_WedgedContextStillMarksEveryWorker(t *testing.T) {
-	oldCheckpointFn := checkpointFn
+	oldCheckpointFn, oldCancelGrace := checkpointFn, checkpointCancelGrace
+	// #1121: this stub deliberately ignores cancellation, standing in for a git
+	// child that refuses to die even after its process group is killed. Shorten
+	// the post-cancel join so the assertion below still measures the shutdown
+	// hold and not the grace.
+	checkpointCancelGrace = 20 * time.Millisecond
 	blocked := make(chan struct{})
 	checkpointFinished := make(chan struct{})
-	checkpointFn = func(*state.Session) (string, error) {
+	checkpointFn = func(context.Context, *state.Session) (string, error) {
 		defer close(checkpointFinished)
 		<-blocked
 		return "", nil
@@ -143,6 +149,7 @@ func TestCheckpointInFlightForRestart_WedgedContextStillMarksEveryWorker(t *test
 		close(blocked)
 		<-checkpointFinished
 		checkpointFn = oldCheckpointFn
+		checkpointCancelGrace = oldCancelGrace
 	}()
 
 	stateDir := t.TempDir()

--- a/internal/worker/checkpoint.go
+++ b/internal/worker/checkpoint.go
@@ -1,6 +1,7 @@
 package worker
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -12,6 +13,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
@@ -279,9 +281,43 @@ func rotateWorkerAttemptLog(logFile string) error {
 	return nil
 }
 
+// checkpointGitCommand builds one cancellable git invocation for checkpoint
+// capture. Capture runs against worktrees that surviving workers still own, so
+// blocking on index.lock is normal rather than pathological, and shutdown must
+// be able to terminate the child instead of only abandoning the goroutine that
+// waits on it (#1121). The child leads its own process group and cancellation
+// kills the group, not just the leader, so a git that has itself forked (pager,
+// credential helper, hook) cannot outlive the drain deadline: maestro.service
+// runs with KillMode=mixed, so any survivor keeps the unit deactivating in the
+// unit cgroup until the TimeoutStopSec backstop.
+func checkpointGitCommand(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	cmd.WaitDelay = 2 * time.Second
+	return cmd
+}
+
 // SaveCheckpoint captures the worker's progress and writes a CHECKPOINT.md
-// file to the worktree. Returns the path to the checkpoint file.
+// file to the worktree. Returns the path to the checkpoint file. Callers that
+// are on a deadline (shutdown) must use SaveCheckpointContext instead.
 func SaveCheckpoint(sess *state.Session) (string, error) {
+	return SaveCheckpointContext(context.Background(), sess)
+}
+
+// SaveCheckpointContext is SaveCheckpoint with every git invocation bound to
+// ctx. Cancelling ctx kills each in-flight git process group and makes the
+// capture return, so a bounded shutdown can reclaim it (#1121).
+func SaveCheckpointContext(ctx context.Context, sess *state.Session) (string, error) {
 	if sess.Worktree == "" {
 		return "", fmt.Errorf("session has no worktree")
 	}
@@ -293,7 +329,7 @@ func SaveCheckpoint(sess *state.Session) (string, error) {
 	sections = append(sections, fmt.Sprintf("Tokens used (total): %d", sess.TokensUsedTotal))
 
 	// Capture branch commits (relative to origin/main)
-	if out, err := exec.Command("git", "-C", sess.Worktree,
+	if out, err := checkpointGitCommand(ctx, "-C", sess.Worktree,
 		"log", "--oneline", "origin/main..HEAD").CombinedOutput(); err == nil {
 		commits := strings.TrimSpace(string(out))
 		if commits != "" {
@@ -302,7 +338,7 @@ func SaveCheckpoint(sess *state.Session) (string, error) {
 	}
 
 	// Capture diff stat for uncommitted changes
-	if out, err := exec.Command("git", "-C", sess.Worktree,
+	if out, err := checkpointGitCommand(ctx, "-C", sess.Worktree,
 		"diff", "--stat").CombinedOutput(); err == nil {
 		diff := strings.TrimSpace(string(out))
 		if diff != "" {
@@ -311,7 +347,7 @@ func SaveCheckpoint(sess *state.Session) (string, error) {
 	}
 
 	// Capture staged changes stat
-	if out, err := exec.Command("git", "-C", sess.Worktree,
+	if out, err := checkpointGitCommand(ctx, "-C", sess.Worktree,
 		"diff", "--cached", "--stat").CombinedOutput(); err == nil {
 		staged := strings.TrimSpace(string(out))
 		if staged != "" {
@@ -324,6 +360,14 @@ func SaveCheckpoint(sess *state.Session) (string, error) {
 		if tail, err := readTailLines(sess.LogFile, 30); err == nil && tail != "" {
 			sections = append(sections, "\n## Last worker output\n```\n"+tail+"\n```")
 		}
+	}
+
+	// A cancelled capture has only the header and whatever ran before the
+	// deadline; writing that into a live worker's worktree would leave a
+	// misleading artefact behind for no benefit, since the shutdown caller
+	// discards the result anyway.
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("checkpoint capture cancelled: %w", err)
 	}
 
 	content := strings.Join(sections, "\n")

--- a/internal/worker/checkpoint_cancel_test.go
+++ b/internal/worker/checkpoint_cancel_test.go
@@ -1,0 +1,94 @@
+package worker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// wedgedGitOnPath installs a fake git that forks a grandchild and then blocks
+// forever. The grandchild's pid is published through a pid file so a test can
+// prove cancellation killed the whole process group and not merely the leader.
+func wedgedGitOnPath(t *testing.T) (pidFile string) {
+	t.Helper()
+	dir := t.TempDir()
+	pidFile = filepath.Join(dir, "grandchild.pid")
+	script := "#!/bin/sh\n" +
+		"sh -c 'echo $$ > \"$MAESTRO_TEST_CHECKPOINT_CHILD_PID\"; exec sleep 300' &\n" +
+		"sleep 300\n"
+	if err := os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("MAESTRO_TEST_CHECKPOINT_CHILD_PID", pidFile)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return pidFile
+}
+
+func waitForPublishedPID(t *testing.T, pidFile string) int {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if data, err := os.ReadFile(pidFile); err == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(data))); convErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("fake git never published its grandchild pid to %s", pidFile)
+	return 0
+}
+
+func waitProcessGone(pid int, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if syscall.Kill(pid, 0) != nil {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return syscall.Kill(pid, 0) != nil
+}
+
+// #1121: checkpoint capture shells out to git against worktrees that surviving
+// workers still own, so wedging on index.lock is a normal occurrence. Cancelling
+// the capture must terminate the git process group: maestro.service runs with
+// KillMode=mixed, so a descendant that outlives the daemon stays in the unit
+// cgroup and holds the unit in deactivating until TimeoutStopSec.
+func TestSaveCheckpointContextKillsWedgedGitProcessGroup(t *testing.T) {
+	pidFile := wedgedGitOnPath(t)
+	worktree := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		_, err := SaveCheckpointContext(ctx, &state.Session{IssueNumber: 1121, Worktree: worktree})
+		done <- err
+	}()
+
+	grandchild := waitForPublishedPID(t, pidFile)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("cancelled capture must report the cancellation instead of writing a truncated checkpoint")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("SaveCheckpointContext did not return after its context was cancelled")
+	}
+	if _, err := os.Stat(filepath.Join(worktree, "CHECKPOINT.md")); !os.IsNotExist(err) {
+		t.Fatalf("cancelled capture must not write CHECKPOINT.md into a live worker worktree: %v", err)
+	}
+	if !waitProcessGone(grandchild, 10*time.Second) {
+		t.Fatalf("git grandchild %d survived cancellation; only the process leader was killed", grandchild)
+	}
+}


### PR DESCRIPTION
## Problem

`#966`'s bounded shutdown bounds the daemon's own goroutines, not the subprocesses restart checkpointing spawns.

`saveCheckpointWithin` abandoned the waiting goroutine on timeout and terminated nothing — but the goroutine was never what held a resource, the `git` child was. `worker.SaveCheckpoint` shelled out through bare `exec.Command`, with no context and no process-group handling, so nothing could reclaim it.

Checkpoint capture runs `git` against worktrees that surviving workers still own, so contending on `index.lock` is normal — that contention is exactly why `saveCheckpointWithin` exists. `maestro.service` runs `KillMode=mixed`, so the stop SIGTERM reaches the daemon's main process only and a wedged `git` stays in the unit cgroup, keeping the unit `deactivating` until the `TimeoutStopSec=6min` backstop. Self-deploy's restart budget is shorter than that backstop, so the deploy reports a restart timeout and Fleet stays offline.

## Fix

- `internal/worker/checkpoint.go`: new `checkpointGitCommand` builds every checkpoint `git` invocation with `exec.CommandContext`, `SysProcAttr{Setpgid: true}`, and a `Cancel` that `SIGKILL`s the **process group** (`kill(-pid)`), so a `git` that has itself forked (pager, credential helper, hook) cannot survive either. Same idiom already used in `internal/github`, `internal/approver`, and `internal/outcome`.
- `SaveCheckpointContext(ctx, sess)` carries the caller's context through all three capture commands. `SaveCheckpoint(sess)` stays as the background-context wrapper for the non-shutdown orchestrator path. A cancelled capture returns the cancellation instead of writing a truncated `CHECKPOINT.md` into a live worker's worktree.
- `internal/daemon/daemon.go`: `saveCheckpointWithin` runs `checkpointFn` under a cancellable context and, when the budget expires, **cancels** it and joins the capture (bounded by the new `checkpointCancelGrace`, default 2s) before returning `timedOut=true`. The child is therefore gone before shutdown continues, instead of the kill racing the daemon's own force-exit. A capture that ignores cancellation still cannot hold shutdown open past the grace.

## Evidence

New tests, both driving a fake `git` on `PATH` that forks a grandchild into the same process group and then blocks:

- `internal/worker`: `TestSaveCheckpointContextKillsWedgedGitProcessGroup` — after cancellation the capture returns, no `CHECKPOINT.md` is written, and the **grandchild** is gone (proves group kill, not leader-only kill).
- `internal/daemon`: `TestSaveCheckpointWithinLeavesNoGitChildAfterTimeout` — end-to-end over the real capture, asserts no `git` child remains once `saveCheckpointWithin` reports `timedOut=true`.
- `internal/daemon`: `TestSaveCheckpointWithinCancelsAndJoinsTimedOutCapture` — the capture is cancelled *and* released before the helper returns.
- `internal/daemon`: `TestSaveCheckpointWithinBoundsThePostCancelJoin` — an uncancellable capture is bounded by `checkpointCancelGrace`.

Confirmed the tests fail on unfixed behaviour by mutating the fix in place and re-running:

- Removing `Setpgid` + the group-kill `Cancel` (plain `exec.CommandContext`): `git grandchild 370296 survived cancellation; only the process leader was killed` (worker) and `git child 371343 is still in the unit cgroup after saveCheckpointWithin reported timedOut=true` (daemon).
- Removing the cancel-and-join from `saveCheckpointWithin` (back to abandoning the goroutine): `TestSaveCheckpointWithinCancelsAndJoinsTimedOutCapture` fails 5/5 with `-count=5`.

Full suite green on the branch: `umask 022 && go build ./... && go test ./... -count=1` → 36 packages `ok`, exit 0. `gofmt -l` clean for the touched files (pre-existing `internal/worker/opencode_usage.go` untouched).

Refs #1121
