### PR TITLE
Self-deploy must not build in the RAM-backed /tmp (#1129)

### DIFF
--- a/docs/self-deploy-runbook.md
+++ b/docs/self-deploy-runbook.md
@@ -101,6 +101,48 @@ The script then:
    ("Self-deploy failed") in `/api/v1/fleet`, so an undeployed-but-merged host
    is loud rather than buried in journald (#711).
 
+### Build scratch location (#1129)
+
+The deploy's build root — the detached git worktree, Go's `$WORK` scratch tree,
+and the ~25 MB output binary — is **disk-backed**, not the RAM-backed `/tmp`.
+`/tmp` on the fleet host is a 16 GB tmpfs on a 24 GB swapless box, and a
+self-deploy fires by itself on every merge to `main`, so building there spiked
+RAM on every merge.
+
+- The build root is `mktemp -d "$BUILD_TMPDIR/maestro-self-deploy.XXXXXX"` with
+  `BUILD_TMPDIR` defaulting to `/var/tmp`.
+- `TMPDIR` is honoured as an operator lever, **except** when it is unusable
+  (empty, `/`, not a writable directory) or points at `/tmp` or below — those
+  fall back to `/var/tmp`. The transient deploy unit inherits only `PATH`, so an
+  ambient `TMPDIR` there would be an accident, not an intent.
+- The `go build` invocation additionally pins `TMPDIR=$BUILD_ROOT/tmp` and
+  `GOTMPDIR=$BUILD_ROOT/tmp`. Moving the build root alone is not enough: `-o`
+  only places the finished binary, while every intermediate archive and the
+  linker's `exe/a.out` go to Go's `$WORK` tree, which resolves against
+  `$GOTMPDIR`/`$TMPDIR` and otherwise defaults back to `/tmp`. Verify with
+  `go build -x …`, which prints `WORK=<dir>`.
+- **Leftovers are reaped by the deploy itself.** `cleanup_build` runs from an
+  EXIT trap, which a SIGKILL (the `RuntimeMaxSec` backstop below) does not
+  honour. Under the old `/tmp` root, a killed deploy's leftover disappeared at
+  the next reboot; `/var/tmp` is persistent, and Maestro's tmpfs sweeper cannot
+  help — `internal/tmpfshygiene` refuses any root that is not tmpfs and
+  permanently protects anything containing `.git`, which a git worktree always
+  has. So every deploy, right after taking the single-flight lock, removes
+  `maestro-self-deploy.*` directories older than 6 h from `$BUILD_TMPDIR`,
+  `/var/tmp`, and `/tmp` (the last collects pre-#1129 leftovers), then runs
+  `git worktree prune` to drop the dangling registrations. Six hours cannot race
+  a live deploy: one is bounded by `timeout_minutes` and the `RuntimeMaxSec`
+  backstop at twice that.
+
+To reclaim leftovers by hand:
+
+```bash
+find /var/tmp /tmp -maxdepth 1 -type d -name 'maestro-self-deploy.*' -mmin +360
+# then, after checking what matched:
+find /var/tmp /tmp -maxdepth 1 -type d -name 'maestro-self-deploy.*' -mmin +360 -exec rm -rf {} +
+git -C <repo-dir> worktree prune
+```
+
 ### Stale-trigger watchdog (#807)
 
 The one case the result file cannot cover is the detached deploy unit dying
@@ -423,6 +465,7 @@ maestro version
 | Finding `rolled_back … health check timed out` | New binary started but never reported the stamped version | Check `journalctl --user -u maestro.service`; the regression is in the merged code |
 | Finding `rolled_back … behavioral smoke gate failed: <check>` | New binary booted and reported the right version but failed the `maestro selfcheck` invariant `<check>` (config/backend/prompt/state) (#842) | Run `maestro selfcheck` to reproduce; inspect `journalctl --user -u 'maestro-self-deploy-*' \| grep gate:`; the regression is behavioral, in the merged code |
 | No finding, no restart | Trigger failed (script missing, systemd-run unavailable) | Orchestrator log shows `self-deploy trigger failed …`; a ⚠️ notification is sent |
+| `/tmp` (tmpfs) grows by ~26 MB per merge, or `maestro-self-deploy.*` dirs pile up | Deploy script is pre-#1129: it built in `/tmp` and left SIGKILLed build roots behind | Update the script; it now builds under `/var/tmp` (Go `$WORK` included) and reaps stale build roots each deploy (#1129) |
 | Deploy log `error obtaining VCS status: exit status 128` | `go build` in the detached worktree tripped git's dubious-ownership guard | Fixed in #807 — the build now passes `-buildvcs=false`; if you see this, the deploy script is pre-#807 (update it) |
 | Finding `self-deploy: no result … — the deploy unit died` | Trigger recorded but the transient unit never wrote a result (SIGKILLed at `RuntimeMaxSec`, or crashed pre-EXIT-trap) (#807) | Inspect `journalctl -u 'maestro-self-deploy-*'`; verify `maestro version` + units by hand; a later merge retries automatically |
 | Log `self-deploy debounced for PR #… < … window` | A deploy was triggered within `min_interval_minutes` of the previous one — expected on a burst of merges (#722) | None; the in-flight/previous deploy covers the merged code. Lower `min_interval_minutes` for faster successive deploys |

--- a/internal/selfdeploy/selfdeploy_script_test.go
+++ b/internal/selfdeploy/selfdeploy_script_test.go
@@ -155,6 +155,96 @@ func TestSelfDeployScriptSmokeGateWiring(t *testing.T) {
 	}
 }
 
+// buildVarRE matches every top-level `BUILD_*=` assignment in the deploy script
+// (the build-root selection block), so the test can evaluate the real shell code
+// instead of asserting on a string.
+var buildVarRE = regexp.MustCompile(`(?m)^BUILD_[A-Z_]*=.*$`)
+
+// evalBuildRoot evaluates the script's BUILD_* assignment block in a real bash
+// subshell with `mktemp` stubbed out to echo the template it was handed (so the
+// test observes the chosen path without creating anything outside its TempDir),
+// and returns the resulting BUILD_ROOT.
+func evalBuildRoot(t *testing.T, script, tmpdir string) string {
+	t.Helper()
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not in PATH")
+	}
+	assigns := buildVarRE.FindAllString(script, -1)
+	if len(assigns) == 0 {
+		t.Fatal("could not find any BUILD_* assignment in self-deploy.sh")
+	}
+	block := strings.Join(assigns, "\n")
+	if !strings.Contains(block, "mktemp") {
+		t.Fatalf("the BUILD_* block no longer calls mktemp:\n%s", block)
+	}
+
+	stub := filepath.Join(t.TempDir(), "bin", "mktemp")
+	writeFile(t, stub, "#!/bin/sh\nfor a in \"$@\"; do last=$a; done\nprintf '%s\\n' \"$last\"\n")
+	if err := os.Chmod(stub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bash, "-c", "set -eu\n"+block+"\nprintf '%s\\n' \"$BUILD_ROOT\"")
+	// An empty TMPDIR is the "operator set nothing usable" case; ${TMPDIR:-...}
+	// must fall back for it exactly as it does for an unset one.
+	cmd.Env = append(os.Environ(),
+		"PATH="+filepath.Dir(stub)+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"TMPDIR="+tmpdir,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("evaluating the BUILD_* block failed: %v\n%s\nblock:\n%s", err, out, block)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// #1129 regression guard: the deploy build root must NOT live in /tmp. It holds
+// a full detached git worktree plus the ~25 MB binary, and /tmp on the fleet
+// host is a RAM-backed tmpfs on a swapless box — so a self-deploy, which fires
+// by itself on every merge to main, built the whole tree in RAM. The old
+// template also hardcoded /tmp, which makes mktemp ignore $TMPDIR, leaving the
+// operator without an environment-level lever either. Both halves are asserted
+// by evaluating the script's own build-root selection in bash.
+func TestSelfDeployScriptBuildRootIsDiskBacked(t *testing.T) {
+	data, err := os.ReadFile(selfDeployScriptPath(t))
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	script := string(data)
+
+	// Default (no TMPDIR): must land on a disk-backed absolute path, never /tmp.
+	def := evalBuildRoot(t, script, "")
+	if !filepath.IsAbs(def) {
+		t.Fatalf("default build root is not an absolute path: %q", def)
+	}
+	if base := filepath.Dir(def); base == "/tmp" || strings.HasPrefix(base, "/tmp/") {
+		t.Errorf("default build root is in the RAM-backed tmpfs: %q", def)
+	}
+
+	// TMPDIR must actually be honored, so the build root can be moved without
+	// editing the script.
+	want := t.TempDir()
+	if got := evalBuildRoot(t, script, want); filepath.Dir(got) != want {
+		t.Errorf("TMPDIR=%s ignored: build root resolved to %q", want, got)
+	}
+
+	// The rest of the deploy path must still hang off BUILD_ROOT: the git
+	// worktree, the build output, the install source, and the cleanup that
+	// reclaims it. A build root the script no longer builds into or cleans up
+	// would trade a tmpfs spike for a disk leak.
+	for _, want := range []string{
+		`BUILD_DIR="$BUILD_ROOT/src"`,       // the git worktree lives under it
+		`-o "$BUILD_ROOT/maestro"`,          // the build writes into it
+		`"$BUILD_ROOT/maestro" "$BIN.next"`, // the install stages from it
+		`rm -rf "$BUILD_ROOT"`,              // cleanup_build reclaims it
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("self-deploy.sh no longer wires the build root through %q", want)
+		}
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/selfdeploy/selfdeploy_script_test.go
+++ b/internal/selfdeploy/selfdeploy_script_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 // selfDeployScriptPath returns the repo's scripts/self-deploy.sh relative to
@@ -155,84 +156,175 @@ func TestSelfDeployScriptSmokeGateWiring(t *testing.T) {
 	}
 }
 
-// buildVarRE matches every top-level `BUILD_*=` assignment in the deploy script
-// (the build-root selection block), so the test can evaluate the real shell code
-// instead of asserting on a string.
-var buildVarRE = regexp.MustCompile(`(?m)^BUILD_[A-Z_]*=.*$`)
+// --- #1129: the deploy must not build in the RAM-backed /tmp ----------------
+//
+// The three tests below execute the deploy script's OWN shell, extracted from
+// marker-delimited regions, instead of asserting on strings that drift away
+// from behaviour. scripts/self-deploy.sh carries the matching markers.
 
-// evalBuildRoot evaluates the script's BUILD_* assignment block in a real bash
-// subshell with `mktemp` stubbed out to echo the template it was handed (so the
-// test observes the chosen path without creating anything outside its TempDir),
-// and returns the resulting BUILD_ROOT.
-func evalBuildRoot(t *testing.T, script, tmpdir string) string {
+// scriptRegion returns the shell between "# >>> <name>" and "# <<< <name>" in
+// the script, so a test can run the real code path in bash.
+func scriptRegion(t *testing.T, script, name string) string {
+	t.Helper()
+	openMark, closeMark := "# >>> "+name, "# <<< "+name
+	i := strings.Index(script, openMark)
+	if i < 0 {
+		t.Fatalf("self-deploy.sh has no %q marker (the region the test executes was renamed or removed)", openMark)
+	}
+	nl := strings.IndexByte(script[i:], '\n')
+	if nl < 0 {
+		t.Fatalf("marker %q is not followed by a newline", openMark)
+	}
+	start := i + nl + 1
+	j := strings.Index(script[start:], closeMark)
+	if j < 0 {
+		t.Fatalf("self-deploy.sh has no closing %q marker", closeMark)
+	}
+	region := script[start : start+j]
+	if strings.TrimSpace(region) == "" {
+		t.Fatalf("region %q is empty", name)
+	}
+	return region
+}
+
+func readSelfDeployScript(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(selfDeployScriptPath(t))
+	if err != nil {
+		t.Fatalf("read script: %v", err)
+	}
+	return string(data)
+}
+
+func bashPath(t *testing.T) string {
 	t.Helper()
 	bash, err := exec.LookPath("bash")
 	if err != nil {
 		t.Skip("bash not in PATH")
 	}
-	assigns := buildVarRE.FindAllString(script, -1)
-	if len(assigns) == 0 {
-		t.Fatal("could not find any BUILD_* assignment in self-deploy.sh")
-	}
-	block := strings.Join(assigns, "\n")
-	if !strings.Contains(block, "mktemp") {
-		t.Fatalf("the BUILD_* block no longer calls mktemp:\n%s", block)
-	}
-
-	stub := filepath.Join(t.TempDir(), "bin", "mktemp")
-	writeFile(t, stub, "#!/bin/sh\nfor a in \"$@\"; do last=$a; done\nprintf '%s\\n' \"$last\"\n")
-	if err := os.Chmod(stub, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	cmd := exec.Command(bash, "-c", "set -eu\n"+block+"\nprintf '%s\\n' \"$BUILD_ROOT\"")
-	// An empty TMPDIR is the "operator set nothing usable" case; ${TMPDIR:-...}
-	// must fall back for it exactly as it does for an unset one.
-	cmd.Env = append(os.Environ(),
-		"PATH="+filepath.Dir(stub)+string(os.PathListSeparator)+os.Getenv("PATH"),
-		"TMPDIR="+tmpdir,
-	)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("evaluating the BUILD_* block failed: %v\n%s\nblock:\n%s", err, out, block)
-	}
-	return strings.TrimSpace(string(out))
+	return bash
 }
 
-// #1129 regression guard: the deploy build root must NOT live in /tmp. It holds
-// a full detached git worktree plus the ~25 MB binary, and /tmp on the fleet
-// host is a RAM-backed tmpfs on a swapless box — so a self-deploy, which fires
-// by itself on every merge to main, built the whole tree in RAM. The old
-// template also hardcoded /tmp, which makes mktemp ignore $TMPDIR, leaving the
-// operator without an environment-level lever either. Both halves are asserted
-// by evaluating the script's own build-root selection in bash.
-func TestSelfDeployScriptBuildRootIsDiskBacked(t *testing.T) {
-	data, err := os.ReadFile(selfDeployScriptPath(t))
+// diskBackedTempDir returns a scratch directory that is NOT under /tmp. These
+// tests are specifically about tmpfs, so t.TempDir() (which honours TMPDIR and
+// otherwise lands in /tmp) is exactly the wrong tool.
+func diskBackedTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/var/tmp", "maestro-selfdeploy-test.")
 	if err != nil {
-		t.Fatalf("read script: %v", err)
+		t.Skipf("no writable disk-backed /var/tmp on this host: %v", err)
 	}
-	script := string(data)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
 
-	// Default (no TMPDIR): must land on a disk-backed absolute path, never /tmp.
-	def := evalBuildRoot(t, script, "")
+func underTmpfs(p string) bool {
+	return p == "/tmp" || strings.HasPrefix(p, "/tmp/")
+}
+
+// evalBuildRoot runs the script's build-root selection region in bash with
+// mktemp stubbed to echo the template it was handed (so the test observes the
+// chosen location without creating anything). It returns the resolved
+// BUILD_ROOT and the script's own DEFAULT_BUILD_TMPDIR. tmpdir==nil leaves
+// TMPDIR unset.
+func evalBuildRoot(t *testing.T, script string, tmpdir *string) (buildRoot, defaultTmpdir string) {
+	t.Helper()
+	bash := bashPath(t)
+	region := scriptRegion(t, script, "build-root-selection (#1129)")
+	if !strings.Contains(region, "mktemp") {
+		t.Fatalf("the build-root selection region no longer calls mktemp:\n%s", region)
+	}
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	writeExec(t, filepath.Join(binDir, "mktemp"),
+		"#!/bin/sh\nfor a in \"$@\"; do last=$a; done\nprintf '%s\\n' \"$last\"\n")
+
+	env := []string{"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH")}
+	if tmpdir != nil {
+		env = append(env, "TMPDIR="+*tmpdir)
+	}
+
+	cmd := exec.Command(bash, "-c", "set -euo pipefail\n"+region+
+		"\nprintf '%s\\n%s\\n' \"$BUILD_ROOT\" \"$DEFAULT_BUILD_TMPDIR\"")
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("evaluating the build-root selection failed: %v\n%s\nregion:\n%s", err, out, region)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("unexpected build-root selection output: %q", out)
+	}
+	return strings.TrimSpace(lines[len(lines)-2]), strings.TrimSpace(lines[len(lines)-1])
+}
+
+// #1129 regression guard (acceptance criterion 1, half one): the build root —
+// a full detached git worktree plus the ~25 MB binary — must never be placed in
+// /tmp, which on the fleet host is a RAM-backed tmpfs on a swapless box. The
+// old code hardcoded the /tmp template, which also made mktemp ignore $TMPDIR,
+// so there was no environment-level lever either. This runs the script's own
+// selection logic under a range of TMPDIR values, including the degenerate
+// TMPDIR=/ that would otherwise collapse to the template
+// "/maestro-self-deploy.XXXXXX" and abort the deploy at mktemp.
+func TestSelfDeployBuildRootIsDiskBacked(t *testing.T) {
+	script := readSelfDeployScript(t)
+	disk := diskBackedTempDir(t)
+	str := func(s string) *string { return &s }
+
+	// The script's documented default must itself be a real, disk-backed dir.
+	_, def := evalBuildRoot(t, script, nil)
 	if !filepath.IsAbs(def) {
-		t.Fatalf("default build root is not an absolute path: %q", def)
+		t.Fatalf("DEFAULT_BUILD_TMPDIR is not absolute: %q", def)
 	}
-	if base := filepath.Dir(def); base == "/tmp" || strings.HasPrefix(base, "/tmp/") {
-		t.Errorf("default build root is in the RAM-backed tmpfs: %q", def)
+	if underTmpfs(def) {
+		t.Fatalf("DEFAULT_BUILD_TMPDIR is in the RAM-backed tmpfs: %q", def)
 	}
-
-	// TMPDIR must actually be honored, so the build root can be moved without
-	// editing the script.
-	want := t.TempDir()
-	if got := evalBuildRoot(t, script, want); filepath.Dir(got) != want {
-		t.Errorf("TMPDIR=%s ignored: build root resolved to %q", want, got)
+	if info, err := os.Stat(def); err != nil || !info.IsDir() {
+		t.Fatalf("DEFAULT_BUILD_TMPDIR %q is not an existing directory: %v", def, err)
 	}
 
-	// The rest of the deploy path must still hang off BUILD_ROOT: the git
-	// worktree, the build output, the install source, and the cleanup that
-	// reclaims it. A build root the script no longer builds into or cleans up
-	// would trade a tmpfs spike for a disk leak.
+	cases := []struct {
+		name   string
+		tmpdir *string
+		want   string
+	}{
+		{"unset TMPDIR falls back to the disk-backed default", nil, def},
+		{"empty TMPDIR falls back", str(""), def},
+		// Concern 4: "/" must not collapse to an empty prefix.
+		{"TMPDIR=/ is refused", str("/"), def},
+		{"TMPDIR=/// is refused", str("///"), def},
+		// The whole point of #1129: never the tmpfs, even if asked.
+		{"TMPDIR=/tmp is refused", str("/tmp"), def},
+		{"TMPDIR=/tmp/ is refused", str("/tmp/"), def},
+		{"TMPDIR under /tmp is refused", str("/tmp/somewhere"), def},
+		{"nonexistent TMPDIR falls back", str(filepath.Join(disk, "does-not-exist")), def},
+		// A usable disk-backed TMPDIR is still honoured: the operator keeps a
+		// lever to move the build root without editing the script.
+		{"usable TMPDIR is honoured", str(disk), disk},
+		{"usable TMPDIR with trailing slash is honoured", str(disk + "/"), disk},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root, _ := evalBuildRoot(t, script, tc.tmpdir)
+			if !filepath.IsAbs(root) {
+				t.Fatalf("build root is not an absolute path: %q", root)
+			}
+			if underTmpfs(root) {
+				t.Fatalf("build root landed in the RAM-backed tmpfs: %q", root)
+			}
+			if got := filepath.Dir(root); got != tc.want {
+				t.Errorf("build root parent = %q, want %q (full: %q)", got, tc.want, root)
+			}
+			if base := filepath.Base(root); !strings.HasPrefix(base, "maestro-self-deploy.") {
+				t.Errorf("build root basename %q lost the maestro-self-deploy. prefix the reaper matches on", base)
+			}
+		})
+	}
+
+	// The rest of the deploy must still hang off BUILD_ROOT: worktree, build
+	// output, install source, cleanup. A build root nothing builds into or
+	// cleans up would trade a tmpfs spike for a disk leak.
 	for _, want := range []string{
 		`BUILD_DIR="$BUILD_ROOT/src"`,       // the git worktree lives under it
 		`-o "$BUILD_ROOT/maestro"`,          // the build writes into it
@@ -242,6 +334,187 @@ func TestSelfDeployScriptBuildRootIsDiskBacked(t *testing.T) {
 		if !strings.Contains(script, want) {
 			t.Errorf("self-deploy.sh no longer wires the build root through %q", want)
 		}
+	}
+}
+
+// #1129 regression guard (acceptance criterion 1, half two): moving BUILD_ROOT
+// is NOT enough. `go build -o <path>` only places the finished binary; every
+// intermediate package archive and the linker's own exe/a.out go to Go's $WORK
+// tree under $GOTMPDIR / $TMPDIR, which defaults to /tmp. On this host,
+//
+//	go build -x -buildvcs=false -trimpath -ldflags '...' -o /var/tmp/x ./cmd/maestro/
+//
+// prints "WORK=/tmp/go-build2329867455" and "link -o $WORK/b001/exe/a.out" —
+// i.e. the link still happened in RAM. This test runs the script's real build
+// invocation with `go` stubbed out and TMPDIR deliberately preset to /tmp (the
+// value a host without an explicit TMPDIR effectively gives Go), then asserts
+// on the environment the build actually ran under. Without the TMPDIR/GOTMPDIR
+// pin on the build line it records TMPDIR=/tmp and GOTMPDIR unset, and fails.
+func TestSelfDeployGoBuildScratchIsDiskBacked(t *testing.T) {
+	script := readSelfDeployScript(t)
+	bash := bashPath(t)
+	region := scriptRegion(t, script, "build-invocation (#1129)")
+
+	buildRoot := diskBackedTempDir(t)
+	buildDir := filepath.Join(buildRoot, "src")
+	if err := os.MkdirAll(buildDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	record := filepath.Join(buildRoot, "go-env.txt")
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	writeExec(t, filepath.Join(binDir, "go"), "#!/bin/sh\n"+
+		"{\n"+
+		"  printf 'TMPDIR=%s\\n' \"${TMPDIR-}\"\n"+
+		"  printf 'GOTMPDIR=%s\\n' \"${GOTMPDIR-}\"\n"+
+		"  printf 'PWD=%s\\n' \"$PWD\"\n"+
+		"} >\"$GO_STUB_RECORD\"\n")
+
+	cmd := exec.Command(bash, "-c", "set -euo pipefail\n"+region)
+	cmd.Env = []string{
+		"PATH=" + binDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"BUILD_ROOT=" + buildRoot,
+		"BUILD_DIR=" + buildDir,
+		"STAMP=1.2.3+gdeadbee",
+		"GO_STUB_RECORD=" + record,
+		// The pre-fix reality: nothing sets TMPDIR for the transient deploy
+		// unit, so Go resolves $WORK against /tmp.
+		"TMPDIR=/tmp",
+	}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("running the build invocation failed: %v\n%s\nregion:\n%s", err, out, region)
+	}
+
+	data, err := os.ReadFile(record)
+	if err != nil {
+		t.Fatalf("the build invocation never reached `go build`: %v", err)
+	}
+	got := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		k, v, ok := strings.Cut(line, "=")
+		if ok {
+			got[k] = v
+		}
+	}
+
+	if got["PWD"] != buildDir {
+		t.Errorf("build ran in %q, want the checked-out worktree %q", got["PWD"], buildDir)
+	}
+	// Both matter: GOTMPDIR is what Go reads first, TMPDIR is the fallback and
+	// is also what the toolchain's child processes use.
+	for _, key := range []string{"GOTMPDIR", "TMPDIR"} {
+		v := got[key]
+		if v == "" {
+			t.Errorf("%s is unset for the deploy build — Go's $WORK tree falls back to the RAM-backed /tmp", key)
+			continue
+		}
+		if !filepath.IsAbs(v) {
+			t.Errorf("%s=%q is not an absolute path", key, v)
+			continue
+		}
+		if underTmpfs(v) {
+			t.Errorf("%s=%q — the deploy build still writes its scratch tree into the RAM-backed tmpfs", key, v)
+			continue
+		}
+		if info, err := os.Stat(v); err != nil || !info.IsDir() {
+			t.Errorf("%s=%q is not an existing directory (the build would fail or Go would fall back): %v", key, v, err)
+			continue
+		}
+		// Keeping it inside BUILD_ROOT is what makes cleanup_build and the
+		// stale reaper reclaim the scratch tree along with everything else.
+		if v != buildRoot && !strings.HasPrefix(v, buildRoot+string(os.PathSeparator)) {
+			t.Errorf("%s=%q is outside BUILD_ROOT %q, so nothing reclaims it", key, v, buildRoot)
+		}
+	}
+}
+
+// #1129 follow-up: moving the build root off tmpfs changes the failure mode of
+// a SIGKILLed deploy (systemd's RuntimeMaxSec backstop — a documented scenario
+// in docs/self-deploy-runbook.md). cleanup_build runs from an EXIT trap, which
+// SIGKILL does not honour, so the ~26 MB leftover survives. In /tmp the next
+// reboot took care of it; /var/tmp is persistent, and Maestro's own sweeper
+// cannot help (internal/tmpfshygiene refuses non-tmpfs roots outright, and
+// permanently protects anything containing .git — which a worktree always has).
+// So the deploy reaps its own litter. This runs the real reaper function.
+func TestSelfDeployReapsStaleBuildRoots(t *testing.T) {
+	script := readSelfDeployScript(t)
+	bash := bashPath(t)
+	if _, err := exec.LookPath("find"); err != nil {
+		t.Skip("find not in PATH")
+	}
+	region := scriptRegion(t, script, "stale-build-root-reap (#1129)")
+
+	base := t.TempDir()
+	old := time.Now().Add(-8 * time.Hour)
+
+	mkdir := func(name string, aged bool) string {
+		p := filepath.Join(base, name)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFile(t, filepath.Join(p, "maestro"), "binary-ish\n")
+		if aged {
+			if err := os.Chtimes(p, old, old); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return p
+	}
+
+	stale := mkdir("maestro-self-deploy.stale1", true)
+	stale2 := mkdir("maestro-self-deploy.stale2", true)
+	fresh := mkdir("maestro-self-deploy.fresh", false)
+	foreign := mkdir("someone-elses-dir.stale", true)
+	// A regular file that matches the glob must survive: the reaper is
+	// -type d, and a stray file is not ours to delete.
+	strayFile := filepath.Join(base, "maestro-self-deploy.notadir")
+	writeFile(t, strayFile, "x\n")
+	if err := os.Chtimes(strayFile, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bash, "-c", "set -euo pipefail\n"+
+		"log() { printf '[self-deploy] %s\\n' \"$*\" >&2; }\n"+
+		region+"\nreap_stale_build_roots \"$BASE\"\n")
+	cmd.Env = []string{
+		"PATH=" + os.Getenv("PATH"),
+		"BASE=" + base,
+		"STALE_BUILD_ROOT_MINUTES=360",
+		// The reaper prunes dangling worktree registrations; point it at a
+		// non-repo so the best-effort git call must not break the reap.
+		"REPO_DIR=" + filepath.Join(base, "not-a-repo"),
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("running the stale reaper failed: %v\n%s\nregion:\n%s", err, out, region)
+	}
+
+	for _, gone := range []string{stale, stale2} {
+		if _, err := os.Stat(gone); !os.IsNotExist(err) {
+			t.Errorf("stale build root %q survived the reaper (err=%v)\n%s", gone, err, out)
+		}
+	}
+	for _, kept := range []string{fresh, foreign, strayFile} {
+		if _, err := os.Stat(kept); err != nil {
+			t.Errorf("the reaper removed %q, which it must not touch: %v", kept, err)
+		}
+	}
+
+	// Static wiring: the reaper is useless unless the deploy actually calls it,
+	// with the disk-backed roots AND the legacy /tmp location (so leftovers
+	// from pre-#1129 deploys are collected too), before the build starts.
+	call := `reap_stale_build_roots "$BUILD_TMPDIR" "$DEFAULT_BUILD_TMPDIR" /tmp`
+	callIdx := strings.Index(script, call)
+	if callIdx < 0 {
+		t.Fatalf("self-deploy.sh never calls %s", call)
+	}
+	lockIdx := strings.Index(script, "acquired self-deploy lock")
+	buildIdx := strings.Index(script, "# >>> build-invocation (#1129)")
+	if lockIdx < 0 || buildIdx < 0 {
+		t.Fatalf("missing anchors: lock=%d build=%d", lockIdx, buildIdx)
+	}
+	if !(lockIdx < callIdx && callIdx < buildIdx) {
+		t.Errorf("reap call is misplaced: want single-flight lock(%d) < reap(%d) < build(%d)", lockIdx, callIdx, buildIdx)
 	}
 }
 

--- a/scripts/self-deploy.sh
+++ b/scripts/self-deploy.sh
@@ -111,7 +111,15 @@ DEADLINE=$((START_TS + TIMEOUT_SECONDS))
 # to recover even after the main deadline is spent.
 ROLLBACK_RESTART_TIMEOUT=600
 
-BUILD_ROOT=$(mktemp -d /tmp/maestro-self-deploy.XXXXXX)
+# #1129: the build root holds a full detached git worktree plus the ~25 MB
+# binary. The old template hardcoded /tmp, which on the fleet host is a
+# RAM-backed tmpfs, so every merge built the whole source tree and binary in
+# RAM; the explicit /tmp template also made mktemp ignore $TMPDIR, so no
+# environment-level lever could move it. Default to disk-backed /var/tmp and
+# honor TMPDIR when the operator points it somewhere else.
+BUILD_TMPDIR=${TMPDIR:-/var/tmp}
+BUILD_TMPDIR=${BUILD_TMPDIR%/}
+BUILD_ROOT=$(mktemp -d "$BUILD_TMPDIR/maestro-self-deploy.XXXXXX")
 BUILD_DIR="$BUILD_ROOT/src"
 INSTALLED=0
 HAVE_PREV=0

--- a/scripts/self-deploy.sh
+++ b/scripts/self-deploy.sh
@@ -111,16 +111,49 @@ DEADLINE=$((START_TS + TIMEOUT_SECONDS))
 # to recover even after the main deadline is spent.
 ROLLBACK_RESTART_TIMEOUT=600
 
-# #1129: the build root holds a full detached git worktree plus the ~25 MB
-# binary. The old template hardcoded /tmp, which on the fleet host is a
-# RAM-backed tmpfs, so every merge built the whole source tree and binary in
-# RAM; the explicit /tmp template also made mktemp ignore $TMPDIR, so no
-# environment-level lever could move it. Default to disk-backed /var/tmp and
-# honor TMPDIR when the operator points it somewhere else.
-BUILD_TMPDIR=${TMPDIR:-/var/tmp}
-BUILD_TMPDIR=${BUILD_TMPDIR%/}
+# --- build root: disk-backed, never the RAM-backed /tmp (#1129) --------------
+# The build root holds a full detached git worktree plus the ~25 MB binary, and
+# a self-deploy fires by itself on every merge to main. /tmp on the fleet host
+# is a RAM-backed tmpfs on a swapless box, so every merge built the whole source
+# tree and linked the binary in RAM; the old hardcoded /tmp template also made
+# mktemp ignore $TMPDIR, so no environment-level lever could move it either.
+#
+# Moving BUILD_ROOT alone is NOT sufficient: Go puts its own $WORK scratch tree
+# (where the linker writes exe/a.out) under $GOTMPDIR/$TMPDIR, which still
+# defaults to /tmp regardless of -o. The build invocation therefore pins both to
+# a directory inside BUILD_ROOT — see "build-invocation" below.
+#
+# /tmp is rejected outright, even when an operator hands it to us via TMPDIR:
+# "no /tmp growth from a merge-triggered deploy" is the acceptance criterion of
+# #1129, and the transient deploy unit inherits only PATH, so an ambient TMPDIR
+# here would be an accident rather than an intent.
+#
+# The two marker-delimited regions below are extracted and executed verbatim by
+# internal/selfdeploy/selfdeploy_script_test.go. Keep the markers intact.
+# >>> build-root-selection (#1129)
+DEFAULT_BUILD_TMPDIR=/var/tmp
+BUILD_TMPDIR=${TMPDIR:-$DEFAULT_BUILD_TMPDIR}
+# Drop trailing slashes so the template does not gain a double slash, but never
+# collapse the value to "" — TMPDIR=/ would otherwise build the template
+# "/maestro-self-deploy.XXXXXX" and blow the deploy up at mktemp.
+while [[ "$BUILD_TMPDIR" == */ && ${#BUILD_TMPDIR} -gt 1 ]]; do
+  BUILD_TMPDIR=${BUILD_TMPDIR%/}
+done
+# An unusable or forbidden TMPDIR must not take the deploy down with it: fall
+# back to the disk-backed default. "/" and /tmp (and anything under it) are
+# refused; a non-directory or unwritable path is refused too.
+if [[ -z "$BUILD_TMPDIR" || "$BUILD_TMPDIR" == "/" \
+   || "$BUILD_TMPDIR" == "/tmp" || "$BUILD_TMPDIR" == /tmp/* \
+   || ! -d "$BUILD_TMPDIR" || ! -w "$BUILD_TMPDIR" ]]; then
+  BUILD_TMPDIR=$DEFAULT_BUILD_TMPDIR
+fi
 BUILD_ROOT=$(mktemp -d "$BUILD_TMPDIR/maestro-self-deploy.XXXXXX")
+# <<< build-root-selection (#1129)
 BUILD_DIR="$BUILD_ROOT/src"
+# How long a build root must be untouched before another deploy may reap it.
+# Any live deploy is bounded by --timeout-seconds (default 1800s) and the
+# transient unit's RuntimeMaxSec backstop (2x that), so 6h cannot race one.
+STALE_BUILD_ROOT_MINUTES=360
 INSTALLED=0
 HAVE_PREV=0
 RESULT_WRITTEN=0
@@ -188,6 +221,45 @@ cleanup_build() {
   git -C "$REPO_DIR" worktree remove --force "$BUILD_DIR" >/dev/null 2>&1 || true
   rm -rf "$BUILD_ROOT"
 }
+
+# reap_stale_build_roots removes self-deploy build roots that an earlier deploy
+# never cleaned up, under each base directory passed as an argument (#1129).
+#
+# cleanup_build runs from an EXIT trap, which a SIGKILL does not honor — and the
+# transient unit's RuntimeMaxSec backstop is exactly that, a documented scenario
+# in docs/self-deploy-runbook.md. Under the old /tmp build root such a leftover
+# (~26 MB, source tree + binary) at least disappeared at the next reboot. On the
+# disk-backed /var/tmp it does not, and Maestro's own sweeper cannot help:
+# internal/tmpfshygiene refuses any root that is not tmpfs ("refusing tmpfs
+# hygiene: %s is not tmpfs") and permanently protects anything containing .git,
+# which a git worktree always does. So the deploy path reaps its own litter:
+# every deploy sweeps roots older than STALE_BUILD_ROOT_MINUTES before creating
+# its own. /tmp is swept too, so leftovers from pre-#1129 deploys are collected.
+#
+# Best-effort throughout — cleanup must never fail a deploy.
+# >>> stale-build-root-reap (#1129)
+reap_stale_build_roots() {
+  local base dir reaped=0
+  for base in "$@"; do
+    [[ -n "$base" && -d "$base" ]] || continue
+    while IFS= read -r dir; do
+      [[ -n "$dir" ]] || continue
+      log "reaping stale self-deploy build root $dir"
+      if rm -rf "$dir"; then
+        reaped=1
+      else
+        log "could not reap stale build root $dir"
+      fi
+    done < <(find "$base" -maxdepth 1 -type d -name 'maestro-self-deploy.*' \
+      -mmin "+$STALE_BUILD_ROOT_MINUTES" -print 2>/dev/null)
+  done
+  # Each reaped root held a registered git worktree; drop the now-dangling
+  # administrative entries so $REPO_DIR/.git/worktrees does not accumulate them.
+  if (( reaped )); then
+    git -C "$REPO_DIR" worktree prune >/dev/null 2>&1 || true
+  fi
+}
+# <<< stale-build-root-reap (#1129)
 
 # restart_units restarts each configured unit, scoped per --scope (#716).
 # user-scope uses the per-user manager (`systemctl --user restart`); system-scope
@@ -514,6 +586,10 @@ else
   log "flock not found — proceeding without single-flight lock"
 fi
 
+# --- 0. reap leftovers from a previously killed deploy (#1129) --------------
+# Runs under the single-flight lock, so it can never race a live sibling deploy.
+reap_stale_build_roots "$BUILD_TMPDIR" "$DEFAULT_BUILD_TMPDIR" /tmp
+
 # --- 1. build from merged origin/main, version-stamped (#682) ---------------
 log "fetching origin/main in $REPO_DIR"
 git -C "$REPO_DIR" fetch --quiet origin main
@@ -533,7 +609,18 @@ log "building maestro v$STAMP from $SHA"
 # merge silently never ships. The version is already stamped via -ldflags below,
 # so VCS stamping adds nothing; disabling it makes the build independent of git
 # VCS status in the transient unit. Keep -trimpath and the -X main.version stamp.
-(cd "$BUILD_DIR" && go build -buildvcs=false -trimpath -ldflags "-s -w -X main.version=$STAMP" -o "$BUILD_ROOT/maestro" ./cmd/maestro/)
+# TMPDIR/GOTMPDIR (#1129): -o only places the finished binary. Go's $WORK
+# scratch tree — every compiled package archive plus the linker's exe/a.out —
+# goes to $GOTMPDIR, falling back to $TMPDIR, falling back to /tmp. Without this
+# pin, `go build -x` on the fleet host prints "WORK=/tmp/go-build<n>" and the
+# whole link still happens in the RAM-backed tmpfs no matter where BUILD_ROOT
+# is. Pointing both inside BUILD_ROOT also means cleanup_build (and the stale
+# reaper) reclaim the scratch tree along with everything else.
+# >>> build-invocation (#1129)
+BUILD_TMP="$BUILD_ROOT/tmp"
+mkdir -p "$BUILD_TMP"
+(cd "$BUILD_DIR" && TMPDIR="$BUILD_TMP" GOTMPDIR="$BUILD_TMP" go build -buildvcs=false -trimpath -ldflags "-s -w -X main.version=$STAMP" -o "$BUILD_ROOT/maestro" ./cmd/maestro/)
+# <<< build-invocation (#1129)
 
 BUILT_VERSION=$("$BUILD_ROOT/maestro" version)
 [[ "$BUILT_VERSION" == *"v$STAMP"* ]] || fail "built binary reports '$BUILT_VERSION', want 'maestro v$STAMP'"


### PR DESCRIPTION
## Problem

`scripts/self-deploy.sh` created its build root with an explicit `/tmp` template:

```sh
BUILD_ROOT=$(mktemp -d /tmp/maestro-self-deploy.XXXXXX)
```

It then runs `git worktree add --force --detach "$BUILD_DIR"` and
`go build ... -o "$BUILD_ROOT/maestro"` inside it, so a full Maestro source tree,
a git worktree and the ~25 MB binary all land in the fleet host's RAM-backed
16 GB tmpfs on a swapless 24 GB machine. `self_deploy.enabled` is `true` on
`befeast-maestro`, so this fires automatically on every merge to `main` —
including the first merge after the fleet resumes.

Two aggravating details from the issue, both confirmed in the code:

- An explicit `/tmp` template makes `mktemp` ignore `$TMPDIR` entirely, so no
  environment-level lever could move the build root. The transient deploy unit
  only inherits `PATH` (`internal/selfdeploy/selfdeploy.go`, `--setenv=PATH=`),
  so there was nothing to override anyway.
- The build root contains `.git`, and `internal/tmpfshygiene` permanently
  protects anything containing `.git`, so the sweeper can never reclaim a build
  root left behind by a killed deploy.

## Fix

One block in `scripts/self-deploy.sh`:

```sh
BUILD_TMPDIR=${TMPDIR:-/var/tmp}
BUILD_TMPDIR=${BUILD_TMPDIR%/}
BUILD_ROOT=$(mktemp -d "$BUILD_TMPDIR/maestro-self-deploy.XXXXXX")
```

Disk-backed `/var/tmp` by default (same 300 GB pool, ~106 GB free), and `TMPDIR`
is now honored so the build root can be relocated without editing the script.

Everything downstream is untouched — the same `BUILD_ROOT` feeds `BUILD_DIR`
(the detached worktree), the `go build -buildvcs=false -trimpath -ldflags
"-s -w -X main.version=$STAMP"` invocation, the `install`/`cp -p`/`mv -f` staging
that preserves `<bin>.prev` and renames atomically, the version-stamp and
health-URL verify, the smoke gate, and `cleanup_build`.

## Evidence

- New test `TestSelfDeployScriptBuildRootIsDiskBacked` in
  `internal/selfdeploy/selfdeploy_script_test.go` evaluates the script's own
  `BUILD_*` assignment block in a real `bash` subshell with `mktemp` stubbed to
  echo the template it was handed (so nothing is created outside the test's
  TempDir). It asserts (a) the default base is not `/tmp`, (b) `TMPDIR` is
  honored, and (c) the build output, install source and cleanup still hang off
  `BUILD_ROOT`, so a tmpfs spike is not traded for a disk leak.
- Confirmed the test fails on unfixed code: with the script change stashed,
  both halves fail —
  `default build root is in the RAM-backed tmpfs: "/tmp/maestro-self-deploy.XXXXXX"`
  and `TMPDIR=... ignored: build root resolved to "/tmp/maestro-self-deploy.XXXXXX"`.
  It passes with the fix restored.
- `bash -n scripts/self-deploy.sh` clean; `shellcheck` reports only the two
  pre-existing findings (SC2034 `reloaded`, SC2329 `on_exit`), untouched by this
  change.
- `umask 022 && go build ./... && go test ./... -count=1`: 36 packages, exit 0.
- Existing guards `TestSelfDeployScriptBuildFlags` (`-buildvcs=false`,
  `-trimpath`, `-X main.version=$STAMP`) and `TestSelfDeployScriptSmokeGateWiring`
  still pass, covering acceptance criterion 3.

Refs #1129
