### PR TITLE
Scope a /proc scan failure to the process that caused it

### DIFF
--- a/docs/tmpfs-hygiene-runbook.md
+++ b/docs/tmpfs-hygiene-runbook.md
@@ -84,9 +84,22 @@ symlinks. Deletion uses no-follow, file-descriptor-relative operations rooted
 at the already-open tmpfs directory, so neither a symlink nor a concurrent
 symlink swap can redirect removal outside `/tmp`.
 
-`proc_scan_errors` records process entries that disappeared or could not be
-read during collection. A non-root daemon only removes entries owned by its own
-uid; a root-run installation can inspect and sweep all owners.
+`proc_scan_errors` records `/proc` reads that failed during collection and
+`proc_unresolved_processes` counts the processes behind them — typically
+`systemd --user`, `(sd-pam)` and `ssh-agent`, which run under the daemon's own
+uid with `PR_SET_DUMPABLE` cleared and are therefore present on every tick. A
+failed read protects only the candidates that one process demonstrably
+references (`protect_hits.proc_scan_error`); it is never a verdict on unrelated
+candidates. Charging it to the whole sweep made the sweeper a permanent no-op
+with `protected_entries == matched_entries` and `reclaimable_bytes: 0` (#1125).
+A non-root daemon only removes entries owned by its own uid; a root-run
+installation can inspect and sweep all owners.
+
+A sweep that protects every candidate it matched and reclaims nothing reports
+`sweep_ineffective: true`, attention code `tmpfs_sweep_ineffective` when nothing
+more urgent is pending, and a `SUSPICIOUS` daemon log line. Treat it as a broken
+reaper until proven otherwise: in the metric it is indistinguishable from a
+clean `/tmp`.
 
 ## Scheduling and Fleet pressure
 
@@ -173,6 +186,8 @@ Deployment/runtime verification remains an operator step after the code lands:
 5. Investigate persistent `scan_error`, `mount_boundary`, or high
    `proc_scan_errors` counts before broadening policy. Do not add a catch-all
    pattern or a blanket `/tmp` removal.
+6. Treat any `sweep_ineffective: true` record as a defect report, not as a
+   quiet tick.
 
 Changing tmpfs size, worktree GC, distributed runner cleanup, and producer-side
 ok-player fixes are intentionally outside this runbook.

--- a/internal/daemon/tmpfs_hygiene.go
+++ b/internal/daemon/tmpfs_hygiene.go
@@ -87,6 +87,12 @@ func (d *Daemon) runTmpfsHygieneTick(ctx context.Context) {
 	if err != nil {
 		log.Printf("[tmpfs-hygiene] sweep refused or failed: %v", err)
 	}
+	if summary.SweepIneffective {
+		// Loud on purpose: a reaper that reclaims nothing looks identical to a
+		// clean /tmp in the metric, so it has to announce itself (#1125).
+		log.Printf("[tmpfs-hygiene] SUSPICIOUS: protected every matched entry and reclaimed nothing (matched=%d protected=%d reclaimable_bytes=0 protect_hits=%v proc_scan_errors=%d proc_unresolved_processes=%d) — protection may have stopped discriminating",
+			summary.MatchedEntries, summary.ProtectedEntries, summary.ProtectHits, summary.ProcScanErrors, summary.ProcUnresolvedProcesses)
+	}
 }
 
 func (d *Daemon) sweepTmpfsHygiene(ctx context.Context) (tmpfshygiene.Summary, error) {

--- a/internal/daemon/tmpfs_hygiene_test.go
+++ b/internal/daemon/tmpfs_hygiene_test.go
@@ -70,7 +70,12 @@ func TestTmpfsHygieneLoopAppliesFakeTreeAndPublishesPressure(t *testing.T) {
 	deadline := time.Now().Add(time.Second)
 	for {
 		if summary, ok := d.tmpfsHygieneSummary(); ok {
-			if summary.AttentionCode != "tmpfs_pressure" || summary.DeletedEntries != 1 {
+			// Only the attention code is stable here. tmpfsHygieneSummary
+			// returns the LATEST tick, and by the time this poll runs the
+			// sweep may already be several ticks past the one that deleted
+			// the entry, so DeletedEntries is asserted on the first emitted
+			// metric below instead of on whichever tick happens to be current.
+			if summary.AttentionCode != "tmpfs_pressure" {
 				t.Fatalf("summary = %+v", summary)
 			}
 			break
@@ -93,7 +98,7 @@ func TestTmpfsHygieneLoopAppliesFakeTreeAndPublishesPressure(t *testing.T) {
 	if err := json.NewDecoder(&metrics).Decode(&emitted); err != nil {
 		t.Fatalf("scheduled metric is not JSONL: %v\n%s", err, metrics.String())
 	}
-	if emitted.AttentionCode != "tmpfs_pressure" {
+	if emitted.AttentionCode != "tmpfs_pressure" || emitted.DeletedEntries != 1 {
 		t.Fatalf("emitted summary = %+v", emitted)
 	}
 }

--- a/internal/tmpfshygiene/sweeper.go
+++ b/internal/tmpfshygiene/sweeper.go
@@ -199,19 +199,18 @@ func Sweep(ctx context.Context, opts Options) (Summary, error) {
 	}
 	summary.ProcScanErrors = procScan.errors
 	summary.ProcPermissionSkips = procScan.permissionSkips
+	summary.ProcUnresolvedProcesses = procScan.unresolvedProcesses
+	// A /proc read failure protects only the candidates the failing process is
+	// demonstrably linked to; collectProcessProtects attributes that per candidate
+	// as "proc_scan_error". Vetoing every candidate instead turned the sweeper
+	// into a permanent no-op (#1125): `systemd --user`, `(sd-pam)` and `ssh-agent`
+	// run under the daemon's own uid with PR_SET_DUMPABLE cleared, so a same-uid
+	// EACCES is present on every tick and the veto never lifted — protected ==
+	// matched, reclaimable == 0, while /tmp filled RAM. Deleting a same-uid entry
+	// stays safe even when some holder went unseen: the inode outlives the unlink.
 	for i := range candidates {
 		for reason := range procProtect[candidates[i].name] {
 			candidates[i].protects[reason] = struct{}{}
-		}
-		// Unexpected scan failures blanket-protect the whole sweep, but
-		// permission-denied reads of other users' /proc entries are the normal
-		// state on any multi-user host (the daemon is not root). Treating them
-		// as scan errors made every sweep a permanent no-op (2026-07-23 RCA):
-		// protected==matched, deleted==0, while /tmp filled RAM. A foreign-uid
-		// process can hold a candidate open, but deletion of same-uid entries
-		// is still safe on Linux — the inode outlives the unlink.
-		if procScan.errors > 0 {
-			candidates[i].protects["proc_scan_error"] = struct{}{}
 		}
 	}
 
@@ -306,6 +305,7 @@ func Sweep(ctx context.Context, opts Options) (Summary, error) {
 				freshProtect, freshScan, scanErr := collectProcessProtects(opts.ProcRoot, opts.Root, freshNames, opts.processID())
 				summary.ProcScanErrors += freshScan.errors
 				summary.ProcPermissionSkips += freshScan.permissionSkips
+				summary.ProcUnresolvedProcesses += freshScan.unresolvedProcesses
 				if scanErr != nil {
 					if restoreErr := quarantine.restore(rootFD, item.name); restoreErr != nil {
 						scanErr = fmt.Errorf("%w; also failed to restore isolated candidate: %v", scanErr, restoreErr)
@@ -317,9 +317,6 @@ func Sweep(ctx context.Context, opts Options) (Summary, error) {
 					for reason := range freshProtect[name] {
 						item.protects[reason] = struct{}{}
 					}
-				}
-				if freshScan.errors > 0 {
-					item.protects["proc_scan_error"] = struct{}{}
 				}
 				if len(item.protects) > 0 {
 					if restoreErr := quarantine.restore(rootFD, item.name); restoreErr != nil {
@@ -375,6 +372,17 @@ func Sweep(ctx context.Context, opts Options) (Summary, error) {
 	summary.Pressure = BelowFloor(finalUsage.AvailableBytes, finalUsage.TotalBytes, opts.PressureFloorBytes)
 	if summary.Pressure {
 		summary.AttentionCode = "tmpfs_pressure"
+	}
+	// Protecting every match while reclaiming nothing is the signature of a
+	// sweeper that has stopped discriminating. It reads as "there was nothing to
+	// clean", which is exactly why the blanket /proc veto stayed invisible until
+	// an operator had to prune 8.4GB of /tmp by hand (#1125), so report it instead
+	// of letting it pass for a quiet tick.
+	if summary.MatchedEntries > 0 && summary.ProtectedEntries == summary.MatchedEntries && summary.ReclaimableBytes == 0 {
+		summary.SweepIneffective = true
+		if summary.AttentionCode == "" {
+			summary.AttentionCode = "tmpfs_sweep_ineffective"
+		}
 	}
 	return summary, nil
 }
@@ -626,13 +634,17 @@ func pathWithin(path, base string) bool {
 	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)))
 }
 
-// procScanResult splits /proc scan outcomes: errors are unexpected failures
-// that blanket-protect the sweep; permissionSkips are EACCES reads of other
-// users' processes, which are routine for a non-root sweeper and must not
-// disable deletion (2026-07-23 RCA: they froze every apply sweep into a no-op).
+// procScanResult splits /proc scan outcomes: errors are failures that hid part
+// of one process's held paths; permissionSkips are EACCES reads of other users'
+// processes, which are routine for a non-root sweeper and must not disable
+// deletion (2026-07-23 RCA: they froze every apply sweep into a no-op).
+// unresolvedProcesses counts the processes behind those errors. None of the
+// three is a global verdict: a process the scan could not read in full still
+// protects only the candidates it is demonstrably linked to (#1125).
 type procScanResult struct {
-	errors          int
-	permissionSkips int
+	errors              int
+	permissionSkips     int
+	unresolvedProcesses int
 }
 
 func collectProcessProtects(procRoot, tmpRoot string, candidates map[string]struct{}, ignoredPID int) (map[string]map[string]struct{}, procScanResult, error) {
@@ -641,17 +653,6 @@ func collectProcessProtects(procRoot, tmpRoot string, candidates map[string]stru
 	entries, err := os.ReadDir(procRoot)
 	if err != nil {
 		return nil, scan, err
-	}
-	add := func(value, reason string) {
-		for _, name := range candidateNamesFromValue(value, tmpRoot) {
-			if _, ok := candidates[name]; !ok {
-				continue
-			}
-			if protected[name] == nil {
-				protected[name] = make(map[string]struct{})
-			}
-			protected[name][reason] = struct{}{}
-		}
 	}
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -665,66 +666,75 @@ func collectProcessProtects(procRoot, tmpRoot string, candidates map[string]stru
 			continue
 		}
 		processDir := filepath.Join(procRoot, entry.Name())
-		if cwd, err := os.Readlink(filepath.Join(processDir, "cwd")); err == nil {
-			add(trimDeletedSuffix(cwd), "process_cwd")
-		} else if errors.Is(err, fs.ErrPermission) {
-			// Another user's process: /proc/<pid>/cwd is unreadable for a
-			// non-root sweeper. Routine on every multi-user host — count it
-			// separately so it never blanket-protects the sweep. cmdline
-			// below is still world-readable, so foreign processes that name
-			// a candidate path on their command line stay protected.
-			if procOwnerIsSelf(processDir) {
-				scan.errors++
-			} else {
-				scan.permissionSkips++
+		// linked records the candidates this one process is demonstrably using,
+		// so an unreadable /proc entry can be charged to the candidates that
+		// process actually touches instead of to every candidate (#1125).
+		linked := make(map[string]struct{})
+		unresolved := false
+		add := func(value, reason string) {
+			for _, name := range candidateNamesFromValue(value, tmpRoot) {
+				if _, ok := candidates[name]; !ok {
+					continue
+				}
+				if protected[name] == nil {
+					protected[name] = make(map[string]struct{})
+				}
+				protected[name][reason] = struct{}{}
+				linked[name] = struct{}{}
 			}
-		} else if !errors.Is(err, fs.ErrNotExist) {
+		}
+		// note classifies one failed read of this process. A foreign-uid EACCES
+		// is the normal state on any multi-user host and hides nothing the sweep
+		// needs: cmdline stays world-readable and same-uid entries are what gets
+		// deleted. Anything else leaves this process's held paths partly unknown.
+		note := func(err error) {
+			if errors.Is(err, fs.ErrNotExist) {
+				// The process exited mid-scan, so it holds nothing.
+				return
+			}
+			if errors.Is(err, fs.ErrPermission) && !procOwnerIsSelf(processDir) {
+				scan.permissionSkips++
+				return
+			}
 			scan.errors++
+			unresolved = true
 		}
 
-		fdEntries, err := os.ReadDir(filepath.Join(processDir, "fd"))
-		if err != nil {
-			if errors.Is(err, fs.ErrPermission) {
-				if procOwnerIsSelf(processDir) {
-					scan.errors++
-				} else {
-					scan.permissionSkips++
-				}
-			} else if !errors.Is(err, fs.ErrNotExist) {
-				scan.errors++
-			}
+		if cwd, err := os.Readlink(filepath.Join(processDir, "cwd")); err == nil {
+			add(trimDeletedSuffix(cwd), "process_cwd")
+		} else {
+			note(err)
+		}
+
+		if fdEntries, err := os.ReadDir(filepath.Join(processDir, "fd")); err != nil {
+			note(err)
 		} else {
 			for _, fd := range fdEntries {
 				target, err := os.Readlink(filepath.Join(processDir, "fd", fd.Name()))
-				if err == nil {
-					add(trimDeletedSuffix(target), "process_fd")
-				} else if errors.Is(err, fs.ErrPermission) {
-					if procOwnerIsSelf(processDir) {
-						scan.errors++
-					} else {
-						scan.permissionSkips++
-					}
-				} else if !errors.Is(err, fs.ErrNotExist) {
-					scan.errors++
+				if err != nil {
+					note(err)
+					continue
 				}
+				add(trimDeletedSuffix(target), "process_fd")
 			}
 		}
 
-		cmdline, err := os.ReadFile(filepath.Join(processDir, "cmdline"))
-		if err != nil {
-			if errors.Is(err, fs.ErrPermission) {
-				if procOwnerIsSelf(processDir) {
-					scan.errors++
-				} else {
-					scan.permissionSkips++
-				}
-			} else if !errors.Is(err, fs.ErrNotExist) {
-				scan.errors++
+		if cmdline, err := os.ReadFile(filepath.Join(processDir, "cmdline")); err != nil {
+			note(err)
+		} else {
+			for _, arg := range strings.Split(string(cmdline), "\x00") {
+				add(arg, "process_cmdline")
 			}
-			continue
 		}
-		for _, arg := range strings.Split(string(cmdline), "\x00") {
-			add(arg, "process_cmdline")
+
+		if unresolved {
+			scan.unresolvedProcesses++
+			// Only part of what this process holds was readable, so every
+			// candidate it did reference is individually unresolvable and stays
+			// protected. Candidates it never referenced keep their own verdict.
+			for name := range linked {
+				protected[name]["proc_scan_error"] = struct{}{}
+			}
 		}
 	}
 	return protected, scan, nil

--- a/internal/tmpfshygiene/sweeper_test.go
+++ b/internal/tmpfshygiene/sweeper_test.go
@@ -673,15 +673,17 @@ func TestSweepLeavesNonGeneratedNativeLibLookalikes(t *testing.T) {
 	assertMissing(t, leaked)
 }
 
-// Codex review catch (P1): EACCES does not prove the process belongs to
-// another user — Linux denies the same read for a same-UID process that
-// cleared PR_SET_DUMPABLE. Downgrading that to a routine skip let the sweep
-// delete a tree such a process was sitting in.
-func TestSweepFailsClosedOnSameUIDPermissionDenial(t *testing.T) {
+// EACCES does not prove the process belongs to another user — Linux denies the
+// same read for a same-UID process that cleared PR_SET_DUMPABLE. Such a process
+// still protects what it demonstrably references, but only that: charging its
+// denial to every candidate is what made the sweeper a permanent no-op on the
+// fleet host (#1125).
+func TestSweepScopesSameUIDDenialToTheProcessThatDenied(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("permission denials cannot be simulated as root")
 	}
 	root, proc, now := fakeRoots(t)
+	held := oldDir(t, root, "tmp.held", now, 3*time.Hour, "held")
 	stale := oldDir(t, root, "tmp.stale", now, 3*time.Hour, "stale")
 
 	processDir := filepath.Join(proc, "655")
@@ -693,7 +695,10 @@ func TestSweepFailsClosedOnSameUIDPermissionDenial(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { os.Chmod(fdDir, 0o755) })
-	if err := os.WriteFile(filepath.Join(processDir, "cmdline"), []byte("dumpable-off\x00"), 0o644); err != nil {
+	// Its fd table is unreadable, but its world-readable command line still ties
+	// it to one candidate.
+	cmdline := []byte("dumpable-off\x00--state=" + filepath.Join(held, "state.json") + "\x00")
+	if err := os.WriteFile(filepath.Join(processDir, "cmdline"), cmdline, 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -701,13 +706,103 @@ func TestSweepFailsClosedOnSameUIDPermissionDenial(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if summary.ProcScanErrors == 0 {
-		t.Fatalf("summary = %+v, want a scan error for a same-UID denial", summary)
+	if summary.ProcScanErrors == 0 || summary.ProcUnresolvedProcesses == 0 {
+		t.Fatalf("summary = %+v, want the same-UID denial reported", summary)
 	}
-	if summary.DeletedEntries != 0 {
-		t.Fatalf("summary = %+v, want no deletion while the scan is incomplete", summary)
+	if summary.ProtectHits["proc_scan_error"] != 1 {
+		t.Fatalf("protect hits = %#v, want only the referenced candidate unresolvable", summary.ProtectHits)
 	}
-	assertExists(t, stale)
+	if summary.DeletedEntries != 1 {
+		t.Fatalf("summary = %+v, want the unreferenced candidate swept", summary)
+	}
+	assertExists(t, held)
+	assertMissing(t, stale)
+}
+
+// Regression for #1125: with a /proc scan that fails for a subset of pids, the
+// failing pids must not change the verdict for candidates they never touched,
+// and a candidate a live worker really holds must still be protected.
+func TestSweepKeepsPerCandidateVerdictsWhenSomeProcessesFailToScan(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission denials cannot be simulated as root")
+	}
+	root, proc, now := fakeRoots(t)
+	live := oldDir(t, root, "tmp.live", now, 3*time.Hour, "live")
+	garbage := oldDir(t, root, "tmp.garbage", now, 3*time.Hour, "garbage")
+
+	// A healthy worker sitting in tmp.live: fully resolvable, so tmp.live is
+	// protected on the evidence itself.
+	worker := filepath.Join(proc, "700")
+	if err := os.MkdirAll(filepath.Join(worker, "fd"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(live, filepath.Join(worker, "cwd")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worker, "cmdline"), []byte("claude\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Two same-UID session daemons that deny every read, like `systemd --user`
+	// and `(sd-pam)` on the fleet host. They reference no candidate.
+	for _, pid := range []string{"701", "702"} {
+		processDir := filepath.Join(proc, pid)
+		if err := os.MkdirAll(processDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		fdDir := filepath.Join(processDir, "fd")
+		if err := os.MkdirAll(fdDir, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { os.Chmod(fdDir, 0o755) })
+		if err := os.WriteFile(filepath.Join(processDir, "cmdline"), []byte("session-daemon\x00"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	summary, err := Sweep(context.Background(), fakeOptions(root, proc, now, ModeDryRun, 1, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.ProcUnresolvedProcesses != 2 || summary.ProcScanErrors == 0 {
+		t.Fatalf("summary = %+v, want both denying processes counted", summary)
+	}
+	if summary.ProtectHits["proc_scan_error"] != 0 {
+		t.Fatalf("protect hits = %#v, want no candidate charged with an unrelated denial", summary.ProtectHits)
+	}
+	if summary.ProtectHits["process_cwd"] != 1 || summary.ProtectedEntries != 1 {
+		t.Fatalf("summary = %+v, want only the worker-held candidate protected", summary)
+	}
+	if summary.ReclaimableBytes != int64(len("garbage")) || summary.SweepIneffective {
+		t.Fatalf("summary = %+v, want the abandoned candidate reported as reclaimable", summary)
+	}
+	assertExists(t, live)
+	assertExists(t, garbage)
+}
+
+// #1125: a sweep that protects everything it matched and reclaims nothing is
+// the shape of a broken reaper, not of a clean /tmp, so it must not read as a
+// quiet successful tick.
+func TestSweepFlagsFullyProtectedZeroReclaimSweep(t *testing.T) {
+	root, proc, now := fakeRoots(t)
+	young := oldDir(t, root, "tmp.young", now, 10*time.Minute, "new")
+
+	summary, err := Sweep(context.Background(), fakeOptions(root, proc, now, ModeDryRun, 40, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !summary.SweepIneffective || summary.AttentionCode != "tmpfs_sweep_ineffective" {
+		t.Fatalf("summary = %+v, want the no-op sweep flagged", summary)
+	}
+
+	setTreeAge(t, young, now.Add(-3*time.Hour))
+	summary, err = Sweep(context.Background(), fakeOptions(root, proc, now, ModeDryRun, 40, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.SweepIneffective || summary.AttentionCode != "" {
+		t.Fatalf("summary = %+v, want a productive sweep left unflagged", summary)
+	}
 }
 
 // The 2026-07-25 event: 8.5GB used of a ~15GiB RAM-backed /tmp. That is only

--- a/internal/tmpfshygiene/types.go
+++ b/internal/tmpfshygiene/types.go
@@ -76,12 +76,23 @@ type Summary struct {
 	Categories         map[string]CategoryStats `json:"categories"`
 	ProtectHits        map[string]int           `json:"protect_hits"`
 	ProcScanErrors     int                      `json:"proc_scan_errors,omitempty"`
+	// ProcUnresolvedProcesses counts processes whose held paths the scan could
+	// only read in part — typically a same-uid EACCES from a process that
+	// cleared PR_SET_DUMPABLE, such as `systemd --user` or `ssh-agent`. Each one
+	// protects the candidates it demonstrably references and nothing else, so
+	// this stays a diagnostic instead of a fleet-wide veto (#1125).
+	ProcUnresolvedProcesses int `json:"proc_unresolved_processes,omitempty"`
 	// ProcPermissionSkips counts /proc entries the sweeper could not inspect
 	// because they belong to other users (EACCES). These are expected on any
 	// multi-user host and never blanket-protect candidates; they are surfaced
 	// for observability only.
-	ProcPermissionSkips int    `json:"proc_permission_skips,omitempty"`
-	Error               string `json:"error,omitempty"`
+	ProcPermissionSkips int `json:"proc_permission_skips,omitempty"`
+	// SweepIneffective marks a sweep that protected every candidate it matched
+	// and found nothing reclaimable. That reads as "there was nothing to clean"
+	// while it usually means protection stopped discriminating, which is how the
+	// blanket /proc veto stayed invisible until /tmp filled RAM (#1125).
+	SweepIneffective bool   `json:"sweep_ineffective,omitempty"`
+	Error            string `json:"error,omitempty"`
 }
 
 // PressureSnapshot is one capacity reading of the tmpfs root, taken


### PR DESCRIPTION
## Problem

`internal/tmpfshygiene` reclaimed nothing on the fleet host. Any same-uid `/proc`
read failure set `proc_scan_error` on **every** matched candidate:

```go
if procScan.errors > 0 {
        candidates[i].protects["proc_scan_error"] = struct{}{}
}
```

The fleet host always has such failures. `systemd --user` (pid 507), `(sd-pam)`,
`ssh-agent` and `sshd-session` run under the daemon's own uid with
`PR_SET_DUMPABLE` cleared, so `cwd` / `fd` reads return EACCES on every tick —
73 of them, 64 from `systemd --user`'s fd table alone. The veto therefore never
lifted, and the sweeper was a permanent no-op on a RAM-backed 16GB `/tmp` on a
24GB host with 0B swap.

Live before, `v1.4.2+ge8515796`:

```json
{"mode":"dry-run","matched_entries":109,"protected_entries":109,
 "reclaimable_bytes":0,"protect_hits":{"proc_scan_error":109},
 "proc_scan_errors":73,"proc_permission_skips":52}
```

## Fix

`collectProcessProtects` now resolves in-use state **per process**:

- Each process accumulates the candidates it demonstrably references through
  `cwd`, open fds and `cmdline`.
- If any of that process's reads failed, only those candidates gain
  `proc_scan_error`, and the process is counted in the new
  `proc_unresolved_processes` diagnostic. A process the scan could not read in
  full no longer says anything about candidates it never referenced.
- `protect_hits.proc_scan_error` therefore means "this many candidates were
  individually unresolvable" instead of being a constant equal to
  `matched_entries`.
- The per-source EACCES / ENOENT classification is unchanged and now lives in
  one `note` helper instead of four copies.

Deleting a same-uid entry stays safe even if a holder went unseen — the inode
outlives the unlink — and the apply path still re-scans `/proc` after the
candidate has been quarantined, so a process that appears mid-sweep still wins.

A sweep that protects everything it matched while reclaiming nothing now sets
`sweep_ineffective`, takes attention code `tmpfs_sweep_ineffective` when nothing
more urgent is pending, and makes the daemon emit a `SUSPICIOUS` log line. That
state is indistinguishable from a clean `/tmp` in the metric, which is why this
bug survived until an operator reclaimed 8.4GB by hand on 2026-07-25.

## Evidence

Live after, same host, same `/tmp`, built from this branch (dry-run only, the
fleet stayed stopped):

```json
{"mode":"dry-run","matched_entries":109,"protected_entries":0,
 "reclaimable_bytes":142679107,"protect_hits":{},
 "proc_scan_errors":73,"proc_unresolved_processes":5,"proc_permission_skips":50}
```

`proc_scan_errors` is unchanged at 73 — the same 5 processes still deny reads —
but they no longer veto 109 unrelated candidates. (`native_lib_leak` contributes
0 bytes because all 48 remaining candidates are the zero-byte `.hm` markers; the
`.so` copies were the ones removed by hand yesterday.)

## Tests

Three new tests in `internal/tmpfshygiene/sweeper_test.go`, all failing on the
unfixed sweeper (verified by stashing `sweeper.go` alone and re-running):

- `TestSweepScopesSameUIDDenialToTheProcessThatDenied` — a same-uid process with
  an unreadable fd table whose cmdline names one candidate: that candidate is
  protected with `proc_scan_error`, the unrelated one is swept. Failed before
  with `protect_hits: {proc_scan_error: 2}` and `deleted_entries: 0`.
- `TestSweepKeepsPerCandidateVerdictsWhenSomeProcessesFailToScan` — the
  stubbed-scanner regression: one healthy worker sitting in a candidate plus two
  denying pids that reference nothing. The worker's candidate stays protected via
  `process_cwd`, the abandoned one is reported reclaimable, and
  `protect_hits.proc_scan_error` is 0.
- `TestSweepFlagsFullyProtectedZeroReclaimSweep` — the all-protected/zero-reclaim
  sweep is flagged, and a productive sweep is not.

`TestSweepFailsClosedOnSameUIDPermissionDenial` is replaced by the first of
these: its old assertion (a same-uid denial blocks every deletion) is exactly the
defect.

Full suite: `umask 022 && go build ./... && go test ./... -count=1` — exit 0, 36
packages ok. `gofmt -l` clean for the touched files.

Refs #1125
