### PR TITLE
Give supervisor backend children an explicit disk-backed TMPDIR

### DIFF
--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -282,6 +282,7 @@ telegram:
 | `model.backends.<name>.subagent_hint` | Optional sub-agent model policy injected into the worker prompt for that backend; omitted means the prompt is unchanged |
 | `max_parallel` | Maximum concurrent worker sessions |
 | `worker_runtime` | Opt-in durable worker lease runtime. `isolated` gives every attempt a private disk-backed `/tmp`, Go temp directory, Cargo target directory, and exact systemd cleanup boundary; `legacy` is the temporary rollback path. See [isolated worker runtime rollout](worker-runtime-runbook.md) |
+| `supervisor.temp_dir` | Disk-backed `TMPDIR`/`TMP`/`TEMP` for the supervisor's model backend probes, which run outside any worker lease. Defaults to `/var/tmp/maestro-supervisor-<uid>`. See [isolated worker runtime rollout](worker-runtime-runbook.md) |
 | `delivery` | Post-merge delivery block (#872): `mode` (disabled/approval_required/automatic), exact-SHA repo-relative `command` and `verify_command`, timeouts, config-only `target`/`rollback`, and mandatory persistence-safe target/verification/rollback labels. Default-safe: a merge mints an expiring approval and runs nothing until approved |
 | `deploy_cmd` | Deprecated (#872): legacy shell command run automatically after merge; folds into `delivery.mode: automatic` with a deprecation warning |
 | `session_prefix` | Prefix for tmux session names |

--- a/docs/worker-runtime-runbook.md
+++ b/docs/worker-runtime-runbook.md
@@ -38,6 +38,30 @@ The system scope requires passwordless access to the exact `systemd-run` and
 Validate that boundary before enabling a canary; a failure is spawn-fatal and
 does not fall back silently to an unowned worker.
 
+## Supervisor backend children
+
+`worker_runtime` only reaches processes that hold a worker lease. The supervisor's
+model backend probes are started directly by the daemon and never enter a lease,
+so they need their own containment. `BuildSupervisorCmd` therefore assigns an
+explicit child environment whose `TMPDIR`, `TMP`, and `TEMP` all point at a
+disk-backed directory:
+
+```yaml
+supervisor:
+  temp_dir: /var/tmp/maestro-supervisor
+```
+
+- The key is optional. When unset, Maestro uses `/var/tmp/maestro-supervisor-<uid>`
+  and creates it `0700` on first use.
+- Like `worker_runtime.scratch_root`, a configured path must be absolute and must
+  not live under global `/tmp`; production `/tmp` is the RAM-backed filesystem this
+  setting exists to keep backend children out of.
+- This replaces the host-local `maestro.service` `Environment=TMPDIR=` drop-in.
+  The drop-in worked only because the probes are direct children of the daemon,
+  it was invisible to anyone reading the repo, and it was lost on a host rebuild.
+- `PrivateTmp=` is not an alternative: `/tmp/tmux-<uid>` carries the worker tmux
+  server, whose survival across a daemon restart is a hard contract.
+
 ## Canary and rollback
 
 1. Enable `isolated` for one low-risk project and leave the rest on `legacy`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -962,6 +962,13 @@ type SupervisorConfig struct {
 	// force a full-context second opinion on every cycle regardless of token cost.
 	AlwaysConsultLLM bool `yaml:"always_consult_llm" json:"always_consult_llm,omitempty"`
 
+	// TempDir repoints TMPDIR/TMP/TEMP for the supervisor's backend children
+	// (#1127). These probes are started directly by the daemon and never enter a
+	// worker lease, so worker_runtime isolation cannot reach them; without an
+	// explicit environment they inherit the daemon's, which on the fleet host
+	// means the RAM-backed /tmp. Empty selects DefaultSupervisorTempDir().
+	TempDir string `yaml:"temp_dir" json:"temp_dir,omitempty"`
+
 	// AllowMeteredBackend opts this project's supervisor LLM loop into running on
 	// a metered (per-token) backend (#838). Default false: when supervisor.backend
 	// (or the model.default fallback the supervisor uses) resolves to a backend
@@ -2571,6 +2578,9 @@ func parse(data []byte) (*Config, error) {
 	if err := validateWorkerRuntime(cfg.WorkerRuntime); err != nil {
 		return nil, err
 	}
+	if err := validateSupervisorTempDir(cfg.Supervisor); err != nil {
+		return nil, err
+	}
 	if err := validateRemoteRunner(cfg); err != nil {
 		return nil, err
 	}
@@ -2651,6 +2661,7 @@ func parse(data []byte) (*Config, error) {
 	cfg.LocalPath = expandHome(cfg.LocalPath)
 	cfg.WorktreeBase = expandHome(cfg.WorktreeBase)
 	cfg.WorkerRuntime.ScratchRoot = expandHome(cfg.WorkerRuntime.ScratchRoot)
+	cfg.Supervisor.TempDir = expandHome(cfg.Supervisor.TempDir)
 	cfg.Outcome = cfg.Outcome.Normalized()
 	if cfg.Outcome.Configured() {
 		cfg.Outcome.SourceRepoPath = expandHome(cfg.Outcome.SourceRepoPath)

--- a/internal/config/supervisor_temp.go
+++ b/internal/config/supervisor_temp.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DefaultSupervisorTempDir returns the disk-backed directory supervisor backend
+// children use for temporary files when supervisor.temp_dir is unset. /var/tmp
+// is used deliberately instead of os.TempDir(): production /tmp is RAM-backed,
+// and the Bun-built CLIs the supervisor probes extract a multi-megabyte native
+// library into $TMPDIR on every invocation without ever deleting it (#1127).
+// The uid suffix keeps two users on one host out of each other's directory.
+func DefaultSupervisorTempDir() string {
+	return filepath.Join("/var/tmp", fmt.Sprintf("maestro-supervisor-%d", os.Getuid()))
+}
+
+// EffectiveTempDir resolves the TMPDIR handed to supervisor backend children.
+func (c SupervisorConfig) EffectiveTempDir() string {
+	if dir := strings.TrimSpace(c.TempDir); dir != "" {
+		return filepath.Clean(dir)
+	}
+	return DefaultSupervisorTempDir()
+}
+
+// validateSupervisorTempDir applies the same containment rule as
+// worker_runtime.scratch_root: an operator-supplied path must be absolute and
+// must not live under global /tmp, which is the RAM-backed filesystem this
+// setting exists to keep backend children out of.
+func validateSupervisorTempDir(c SupervisorConfig) error {
+	if strings.TrimSpace(c.TempDir) == "" {
+		return nil
+	}
+	dir := expandHome(c.EffectiveTempDir())
+	if !filepath.IsAbs(dir) {
+		return fmt.Errorf("config: supervisor.temp_dir must be absolute")
+	}
+	clean := filepath.Clean(dir)
+	if clean == string(filepath.Separator) {
+		return fmt.Errorf("config: supervisor.temp_dir must not be the filesystem root")
+	}
+	globalTmp := filepath.Clean("/tmp")
+	if clean == globalTmp || strings.HasPrefix(clean, globalTmp+string(filepath.Separator)) {
+		return fmt.Errorf("config: supervisor.temp_dir must be disk-backed and must not live under global %s", globalTmp)
+	}
+	return nil
+}

--- a/internal/config/supervisor_temp_test.go
+++ b/internal/config/supervisor_temp_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSupervisorTempDirDefaultsToDiskBackedPath(t *testing.T) {
+	var supervisor SupervisorConfig
+	got := supervisor.EffectiveTempDir()
+	if !strings.HasPrefix(got, "/var/tmp/maestro-supervisor-") {
+		t.Fatalf("temp dir = %q, want disk-backed /var/tmp default", got)
+	}
+}
+
+func TestParseSupervisorTempDir(t *testing.T) {
+	home := filepath.Join("/var/tmp", "maestro-supervisor-temp-test-home")
+	t.Setenv("HOME", home)
+	cfg, err := Parse([]byte(`
+repo: owner/repo
+local_path: /srv/repo
+worktree_base: /srv/worktrees
+supervisor:
+  temp_dir: ~/supervisor-temp
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := cfg.Supervisor.EffectiveTempDir(), filepath.Join(home, "supervisor-temp"); got != want {
+		t.Fatalf("temp dir = %q, want %q", got, want)
+	}
+}
+
+func TestParseSupervisorTempDirRejectsGlobalTmp(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{name: "relative", value: "relative", wantErr: "must be absolute"},
+		{name: "global tmp", value: "/tmp/maestro-supervisor", wantErr: "must be disk-backed"},
+		{name: "global tmp itself", value: "/tmp", wantErr: "must be disk-backed"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte("repo: owner/repo\nlocal_path: /srv/repo\nworktree_base: /srv/worktrees\nsupervisor:\n  temp_dir: " + tc.value + "\n"))
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/supervisor/llm.go
+++ b/internal/supervisor/llm.go
@@ -294,6 +294,8 @@ func completeSupervisorBackend(name string, def config.BackendDef, cfg *config.C
 	backendCfg := worker.BackendConfig{
 		Cmd: def.Cmd, ExtraArgs: def.ExtraArgs, PromptMode: def.PromptMode, Provider: def.Provider,
 		Model: cfg.Supervisor.Model, Effort: cfg.Supervisor.Effort,
+		// #1127: keep this probe's temp files off the RAM-backed host /tmp.
+		TempDir: cfg.Supervisor.EffectiveTempDir(),
 	}
 	cmd, stdinFile, err := worker.BuildSupervisorCmd(name, backendCfg, promptPath, worktree)
 	if err != nil {

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -66,7 +67,11 @@ type BackendConfig struct {
 	// requires an enforceable live-usage mode; BuildWorkerCmd fails closed for
 	// backend/output combinations that only reveal usage after process exit.
 	TokenBudget int
-	MCP         config.MCPConfig
+	// TempDir is the disk-backed directory BuildSupervisorCmd points a supervisor
+	// backend child's TMPDIR/TMP/TEMP at (#1127). Empty selects
+	// config.DefaultSupervisorTempDir().
+	TempDir string
+	MCP     config.MCPConfig
 }
 
 // Backend builds the exec.Cmd for a specific model CLI.
@@ -839,6 +844,59 @@ func validateLiveTokenBudget(backendName string, cfg BackendConfig) error {
 // the backend name, provider field, and cmd binary (#684) so custom-named
 // backends keep stdin prompt delivery.
 func BuildSupervisorCmd(backendName string, cfg BackendConfig, promptFile, worktree string) (cmd *exec.Cmd, stdinFile string, err error) {
+	cmd, stdinFile, err = buildSupervisorCmd(backendName, cfg, promptFile, worktree)
+	if err != nil {
+		return nil, "", err
+	}
+	if err := applySupervisorTempEnv(cmd, cfg); err != nil {
+		return nil, "", err
+	}
+	return cmd, stdinFile, nil
+}
+
+// supervisorTempDir resolves the temp directory for a supervisor backend child.
+// The built-in default applies when the caller did not thread one through, so a
+// missed wiring cannot silently put a probe back on the RAM-backed /tmp.
+func supervisorTempDir(cfg BackendConfig) string {
+	if dir := strings.TrimSpace(cfg.TempDir); dir != "" {
+		return filepath.Clean(dir)
+	}
+	return config.DefaultSupervisorTempDir()
+}
+
+// applySupervisorTempEnv gives a supervisor backend child an explicit
+// environment whose TMPDIR/TMP/TEMP point at a disk-backed directory (#1127).
+// These probes are direct children of the daemon and never enter a worker
+// lease, so worker_runtime isolation cannot reach them by construction: with no
+// Env assigned they inherit maestro.service's environment and write to the host
+// /tmp, which on the fleet host is a RAM-backed tmpfs. The Bun-built opencode
+// CLI alone extracts a ~5.6MB native library there on every invocation and
+// never removes it (see internal/tmpfshygiene). TMP/TEMP travel with TMPDIR for
+// parity with the isolated worker lease, which sets all three.
+func applySupervisorTempEnv(cmd *exec.Cmd, cfg BackendConfig) error {
+	dir := supervisorTempDir(cfg)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("prepare supervisor temp dir %s: %w", dir, err)
+	}
+	inherited := cmd.Env
+	if inherited == nil {
+		inherited = os.Environ()
+	}
+	env := make([]string, 0, len(inherited)+3)
+	for _, kv := range inherited {
+		switch strings.SplitN(kv, "=", 2)[0] {
+		case "TMPDIR", "TMP", "TEMP":
+			continue
+		}
+		env = append(env, kv)
+	}
+	cmd.Env = append(env, "TMPDIR="+dir, "TMP="+dir, "TEMP="+dir)
+	return nil
+}
+
+// buildSupervisorCmd builds the per-kind argv. Callers go through
+// BuildSupervisorCmd, which owns the child environment for every kind.
+func buildSupervisorCmd(backendName string, cfg BackendConfig, promptFile, worktree string) (*exec.Cmd, string, error) {
 	switch resolveBackendKind(backendName, cfg) {
 	case "claude":
 		claudeCmd := cfg.Cmd

--- a/internal/worker/supervisor_env_test.go
+++ b/internal/worker/supervisor_env_test.go
@@ -1,0 +1,121 @@
+package worker
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// envValues returns every value assigned to key in a child environment. More
+// than one entry is a defect: the last assignment wins on Linux, so a leftover
+// inherited TMPDIR next to the injected one is only accidentally harmless.
+func envValues(env []string, key string) []string {
+	var out []string
+	for _, kv := range env {
+		name, value, found := strings.Cut(kv, "=")
+		if found && name == key {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+// TestBuildSupervisorCmd_TempEnvPerBackendKind covers every kind
+// resolveBackendKind can return plus the generic fallback (#1127). Supervisor
+// probes are daemon children outside any worker lease, so this env assignment
+// is the only thing keeping them off the RAM-backed host /tmp.
+func TestBuildSupervisorCmd_TempEnvPerBackendKind(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("decide safely"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	tempDir := filepath.Join(dir, "supervisor-temp")
+	// The daemon's own environment is what the probes used to inherit; point it
+	// at the RAM-backed /tmp so the assertion proves an override, not an append.
+	t.Setenv("TMPDIR", "/tmp")
+	t.Setenv("TMP", "/tmp")
+	t.Setenv("TEMP", "/tmp")
+
+	tests := []struct {
+		name    string
+		backend string
+		cfg     BackendConfig
+	}{
+		{name: "claude", backend: "claude", cfg: BackendConfig{Cmd: "claude"}},
+		{name: "codex", backend: "codex", cfg: BackendConfig{Cmd: "codex"}},
+		{name: "gemini", backend: "gemini", cfg: BackendConfig{Cmd: "gemini"}},
+		{name: "kimi", backend: "kimi", cfg: BackendConfig{Cmd: "kimi"}},
+		{name: "cline", backend: "cline", cfg: BackendConfig{Cmd: "cline"}},
+		{name: "pi", backend: "pi", cfg: BackendConfig{Cmd: "pi"}},
+		{name: "opencode", backend: "opencode", cfg: BackendConfig{Cmd: "opencode"}},
+		{name: "custom name resolves to claude", backend: "fable", cfg: BackendConfig{Cmd: "claude", Provider: "anthropic"}},
+		{name: "generic", backend: "some-cli", cfg: BackendConfig{Cmd: "some-cli", PromptMode: "stdin"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := tc.cfg
+			cfg.TempDir = tempDir
+			cmd, _, err := BuildSupervisorCmd(tc.backend, cfg, promptFile, dir)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cmd.Env == nil {
+				t.Fatal("cmd.Env is nil: the child inherits the daemon environment and its RAM-backed TMPDIR")
+			}
+			for _, key := range []string{"TMPDIR", "TMP", "TEMP"} {
+				values := envValues(cmd.Env, key)
+				if len(values) != 1 {
+					t.Fatalf("%s assigned %d times (%v), want exactly once", key, len(values), values)
+				}
+				if values[0] != tempDir {
+					t.Errorf("%s = %q, want %q", key, values[0], tempDir)
+				}
+			}
+			// The child still needs the rest of the daemon environment (PATH,
+			// provider credentials); only the temp variables are replaced.
+			if got := envValues(cmd.Env, "PATH"); len(got) != 1 || got[0] != os.Getenv("PATH") {
+				t.Errorf("PATH = %v, want the inherited %q", got, os.Getenv("PATH"))
+			}
+		})
+	}
+
+	info, err := os.Stat(tempDir)
+	if err != nil {
+		t.Fatalf("supervisor temp dir was not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("supervisor temp dir %s is not a directory", tempDir)
+	}
+	if perm := info.Mode().Perm(); perm != 0700 {
+		t.Errorf("supervisor temp dir mode = %o, want 700", perm)
+	}
+}
+
+// TestBuildSupervisorCmd_TempEnvDefaultsToDiskBacked pins the fallback used when
+// a caller does not thread supervisor.temp_dir through: it must still be a
+// disk-backed path outside global /tmp.
+func TestBuildSupervisorCmd_TempEnvDefaultsToDiskBacked(t *testing.T) {
+	dir := t.TempDir()
+	promptFile := filepath.Join(dir, "prompt.md")
+	if err := os.WriteFile(promptFile, []byte("decide safely"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMPDIR", "/tmp")
+
+	cmd, _, err := BuildSupervisorCmd("claude", BackendConfig{Cmd: "claude"}, promptFile, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := config.DefaultSupervisorTempDir()
+	values := envValues(cmd.Env, "TMPDIR")
+	if len(values) != 1 || values[0] != want {
+		t.Fatalf("TMPDIR = %v, want [%s]", values, want)
+	}
+	if want == "/tmp" || strings.HasPrefix(want, "/tmp/") {
+		t.Fatalf("default supervisor temp dir %q is under the RAM-backed global /tmp", want)
+	}
+}


### PR DESCRIPTION
## Problem

`BuildSupervisorCmd` (`internal/worker/backend.go`) built every supervisor backend command with `exec.Command(...)` and set only `cmd.Dir`. `cmd.Env` was never assigned in any branch — claude, codex, gemini, kimi, cline, pi, opencode, or the generic fallback.

`internal/supervisor/llm.go` starts those commands inside the daemon process, so each probe inherited `maestro.service`'s environment. The probes never enter a worker lease, so `worker_runtime.mode: isolated` — the fleet's containment layer for workers — cannot reach them by construction. On the fleet host that meant every probe wrote into the RAM-backed 16 GB `/tmp`.

The cost is documented in Maestro's own source: `internal/tmpfshygiene/sweeper.go` attributes a ~10.5 GB class across 1978 copies to exactly these invocations, because the Bun-built opencode CLI extracts a ~5.6 MB embedded native library to `$TMPDIR/.<hex>-00000000.so` on every run and never deletes it.

The premise held: `rg 'cmd\.Env' internal/worker/backend.go` on clean `main` returned nothing.

## Fix

- `BuildSupervisorCmd` is now a thin wrapper: the per-kind argv construction moved to an unexported `buildSupervisorCmd`, and the wrapper assigns the child environment afterwards. Every kind is covered by construction, including the generic `prompt_mode` fallback and any future branch — there is no per-branch assignment to forget.
- `applySupervisorTempEnv` takes the daemon environment, strips any inherited `TMPDIR`/`TMP`/`TEMP` (so the injected value is the only assignment, not a trailing override), and appends all three pointing at the resolved directory. The rest of the environment — `PATH`, provider credentials — is preserved.
- The directory comes from the new `supervisor.temp_dir` config key, threaded through `worker.BackendConfig.TempDir` from `completeSupervisorBackend`. Unset selects `/var/tmp/maestro-supervisor-<uid>`, created `0700` on first use. A caller that forgets to thread the config still gets the disk-backed default instead of silently falling back to `/tmp`.
- `supervisor.temp_dir` is validated exactly like `worker_runtime.scratch_root`: absolute, not the filesystem root, and not under global `/tmp`. `~` is expanded during normalization.
- Documented in `docs/worker-runtime-runbook.md` under a new "Supervisor backend children" section next to the `worker_runtime` settings, plus a row in the `docs/project-setup-runbook.md` config table.

This replaces the host-local `/etc/systemd/system/maestro.service.d/tmpdir.conf` drop-in. That drop-in can be removed once this binary is installed; it is now redundant rather than load-bearing.

## Audit of other daemon-spawned children

The issue asked for the same treatment anywhere else the daemon shells out. Reviewed every non-test `exec.Command`/`exec.CommandContext` site:

- `internal/router/router.go` `callModel` — the only other site that spawns a **configured model CLI** from the daemon with no `Env`, so it is the same leak class (it can be pointed at opencode). Left unchanged here to keep this change scoped to the acceptance criteria: it is reachable only under `routing.mode: auto`, which is retired as an eval bed. Worth a follow-up issue.
- `internal/github/github.go` and `internal/approver/delivery.go` already build a scrubbed env that carries `TMPDIR` through, so they follow the daemon's value rather than defeating it. `gh`/`git` do not leak into `$TMPDIR`.
- The remaining sites are `git`/`tmux`/`docker` invocations or operator-defined shell commands (`preflight_command`, outcome checker, pipeline visual, worker hooks). None of them extract native libraries per invocation; changing their environment would alter operator-visible behaviour and is out of scope for this fix.

## Evidence

New tests:

- `internal/worker/supervisor_env_test.go` — `TestBuildSupervisorCmd_TempEnvPerBackendKind` walks claude, codex, gemini, kimi, cline, pi, opencode, a custom-named `provider: anthropic` backend, and the generic fallback. For each it asserts `cmd.Env` is non-nil, that `TMPDIR`/`TMP`/`TEMP` each appear exactly once with the configured value (the test seeds the parent env with `TMPDIR=/tmp` so this proves an override, not an append), and that inherited `PATH` survives. It then asserts the directory was created `0700`. `TestBuildSupervisorCmd_TempEnvDefaultsToDiskBacked` pins the default to a path outside global `/tmp`.
- `internal/config/supervisor_temp_test.go` — default resolution, `~` expansion through `Parse`, and rejection of relative paths, `/tmp`, and paths under `/tmp`.

Confirmed the tests fail on unfixed code by neutralising only the behaviour change (replacing the `applySupervisorTempEnv` call and the `validateSupervisorTempDir` call with no-ops, keeping the new API so the package still compiles):

```
--- FAIL: TestBuildSupervisorCmd_TempEnvPerBackendKind/claude
    cmd.Env is nil: the child inherits the daemon environment and its RAM-backed TMPDIR
    ... (same for codex, gemini, kimi, cline, pi, opencode, custom name, generic)
--- FAIL: TestBuildSupervisorCmd_TempEnvDefaultsToDiskBacked
    TMPDIR = [], want [/var/tmp/maestro-supervisor-1000]
--- FAIL: TestParseSupervisorTempDirRejectsGlobalTmp/global_tmp
    error = <nil>, want "must be disk-backed"
```

Then restored and verified green:

```
umask 022 && go build ./... && go vet ./internal/worker ./internal/config ./internal/supervisor && go test ./... -count=1
```

36 packages `ok`, exit 0. `gofmt -l` clean for every file touched here (`internal/worker/opencode_usage.go` was already unformatted on `main`).

The fleet was not started and no config-store row was touched.

Refs #1127
