### PR TITLE
Stop re-counting the previous attempt tokens on every respawn

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1458,6 +1458,29 @@ func updateTokenBudgetUsage(sess *state.Session, cumulative int, measure string)
 	return changed
 }
 
+// resetUsageWatermarksIfStreamRestarted rewinds the read positions into the
+// backend's usage side channel when that stream demonstrably started over.
+// Every parser is cumulative over an append-only file, so the total can only
+// go backwards when the file behind it changed: an in-place respawn rotates
+// slot.log/slot.jsonl, a phase transition switches to a new log path, and a
+// fallover hands the same slot.jsonl to a different backend whose parser sees
+// only its own frames. #1120: this is the only place the watermarks may be
+// cleared — beginSessionAttempt deliberately no longer clears them per
+// attempt, because a plain fallover respawn keeps appending to the same file
+// and a blind reset re-counted the previous attempt's tokens into
+// TokensUsedTotal.
+//
+// A cumulative of zero is never a restart: a terminal frame with missing usage
+// reports zero, and rewinding on it would let the next real frame be added a
+// second time.
+func resetUsageWatermarksIfStreamRestarted(sess *state.Session, cumulative int) {
+	if sess == nil || cumulative <= 0 || cumulative >= sess.UsageTokensWatermark {
+		return
+	}
+	sess.UsageTokensWatermark = 0
+	sess.TokenBudgetTokensWatermark = 0
+}
+
 func applyTokenBudgetObservation(sess *state.Session, marker worker.TokenBudgetMarker) {
 	if sess == nil {
 		return
@@ -1650,6 +1673,7 @@ func (o *Orchestrator) updatePiUsageFromOutput(slotName string, sess *state.Sess
 	if !ok {
 		return false
 	}
+	resetUsageWatermarksIfStreamRestarted(sess, usage.TotalTokens)
 	changed := false
 	// #730: Pi re-parses the full appended slot log on each call, so
 	// usage.TotalTokens is the cumulative run total across every attempt.
@@ -1657,7 +1681,8 @@ func (o *Orchestrator) updatePiUsageFromOutput(slotName string, sess *state.Sess
 	// TokensUsedAttempt resets to 0 — comparing against TokensUsedAttempt
 	// would re-add the prior attempts' tokens. Use a separate monotonic
 	// watermark (UsageTokensWatermark) that persists across respawns so only
-	// the new attempt's tokens are counted.
+	// the new attempt's tokens are counted (#1120: beginSessionAttempt no
+	// longer clears it, which is what makes that claim true).
 	if usage.TotalTokens > sess.UsageTokensWatermark {
 		delta := usage.TotalTokens - sess.UsageTokensWatermark
 		sess.UsageTokensWatermark = usage.TotalTokens
@@ -1708,12 +1733,14 @@ func (o *Orchestrator) workerJSONLFile(slotName string, sess *state.Session) str
 // updateClaudeUsageFromJSONL parses the claude stream-json side-channel
 // (slot.jsonl) and stamps model/tokens/cost_usd onto the session (#737).
 // Like the Pi path it re-parses the full appended jsonl on each call, so
-// ParseClaudeUsage returns the cumulative run total across every attempt;
-// the monotonic UsageTokensWatermark persists across respawns so only the
-// new attempt's tokens are added (no double-count on retry/respawn). Cost
-// prefers the backend-reported total_cost_usd. A successful terminal frame
-// with missing/zero usage marks the active attribution usage-unreliable and
-// logs once; zero never advances token counters or budget progress.
+// ParseClaudeUsage returns the cumulative run total across every attempt.
+// #1120: a fallover respawn keeps appending to that same file, so the
+// UsageTokensWatermark is a read position that survives the new attempt and
+// only the unseen tail is added; resetUsageWatermarksIfStreamRestarted rewinds
+// it when the stream itself started over. Cost prefers the backend-reported
+// total_cost_usd. A successful terminal frame with missing/zero usage marks
+// the active attribution usage-unreliable and logs once; zero never advances
+// token counters or budget progress.
 func (o *Orchestrator) updateClaudeUsageFromJSONL(slotName string, sess *state.Session) bool {
 	jsonlPath := o.workerJSONLFile(slotName, sess)
 	if jsonlPath == "" {
@@ -1726,6 +1753,9 @@ func (o *Orchestrator) updateClaudeUsageFromJSONL(slotName string, sess *state.S
 		return false
 	}
 	usage, ok := worker.ParseClaudeUsage(string(data))
+	if ok {
+		resetUsageWatermarksIfStreamRestarted(sess, usage.TotalTokens)
+	}
 	changed := false
 	if usage.UsageUnreliable && state.MarkActiveAttributionUsageUnreliable(sess, usage.UsageUnreliableReason, usage.UsageUnreliableScope) {
 		log.Printf("[orch] %s claude usage-unreliable: scope=%s reason=%s; preserving observed counters and treating zero tokens as unavailable, not progress",
@@ -1773,11 +1803,13 @@ func (o *Orchestrator) updateClaudeUsageFromJSONL(slotName string, sess *state.S
 // (slot.jsonl) and stamps tokens onto the session (#738). codex emits one
 // terminal turn.completed usage event per `codex exec` invocation; the
 // splitter appends each attempt's frames to the same slot.jsonl, so
-// ParseCodexUsage sums them to the cumulative run total. The monotonic
-// UsageTokensWatermark persists across respawns so a forced retry never
-// double-counts (mirrors the claude/Pi paths). codex reports no USD, so cost
-// stays virtual: CostUSDBackend is left at 0 and sessionCostEstimate supplies
-// the dollar figure from the configured pricing block. codex --json carries no
+// ParseCodexUsage sums them to the cumulative run total. #1120: the
+// UsageTokensWatermark is a read position into that append-only file and
+// survives a respawn, so a forced retry adds only the unseen tail; a stream
+// that started over is rewound by resetUsageWatermarksIfStreamRestarted
+// (mirrors the claude/Pi paths). codex reports no USD, so cost stays virtual:
+// CostUSDBackend is left at 0 and sessionCostEstimate supplies the dollar
+// figure from the configured pricing block. codex --json carries no
 // model name, so sess.Model is left as configured. Returns true when tokens
 // changed; false (tokens stay 0) when the jsonl is absent — the documented
 // degradation when the stream-splitter was unavailable.
@@ -1796,6 +1828,7 @@ func (o *Orchestrator) updateCodexUsageFromJSONL(slotName string, sess *state.Se
 	if !ok {
 		return false
 	}
+	resetUsageWatermarksIfStreamRestarted(sess, usage.TotalTokens)
 	changed := false
 	if usage.TotalTokens > sess.UsageTokensWatermark {
 		delta := usage.TotalTokens - sess.UsageTokensWatermark
@@ -1816,10 +1849,12 @@ func (o *Orchestrator) updateCodexUsageFromJSONL(slotName string, sess *state.Se
 
 // updateKimiUsageFromJSONL parses Kimi's first-class stream-json side channel
 // and stamps split tokens onto the session. ParseKimiUsage returns cumulative
-// usage across the append-only file, so UsageTokensWatermark keeps retries and
-// respawns from double-counting. Native Kimi usage normally has no USD field;
-// when absent, Fleet cost observability applies the backend's configured split
-// pricing to these counters.
+// usage across the append-only file, so the UsageTokensWatermark read position
+// survives a respawn and keeps retries from double-counting (#1120); a stream
+// that started over is rewound by resetUsageWatermarksIfStreamRestarted.
+// Native Kimi usage normally has no USD field; when absent, Fleet cost
+// observability applies the backend's configured split pricing to these
+// counters.
 func (o *Orchestrator) updateKimiUsageFromJSONL(slotName string, sess *state.Session) bool {
 	jsonlPath := o.workerJSONLFile(slotName, sess)
 	if jsonlPath == "" {
@@ -1833,6 +1868,7 @@ func (o *Orchestrator) updateKimiUsageFromJSONL(slotName string, sess *state.Ses
 	if !ok {
 		return false
 	}
+	resetUsageWatermarksIfStreamRestarted(sess, usage.TotalTokens)
 	changed := false
 	if usage.TotalTokens > sess.UsageTokensWatermark {
 		delta := usage.TotalTokens - sess.UsageTokensWatermark
@@ -1865,11 +1901,13 @@ func (o *Orchestrator) updateKimiUsageFromJSONL(slotName string, sess *state.Ses
 // (slot.jsonl) and stamps tokens/cost onto the session. opencode emits one
 // terminal step_finish event per `opencode run` invocation; the stream-splitter
 // appends each attempt's frames to the same slot.jsonl, so
-// ParseOpenCodeUsage sums them to the cumulative run total. The monotonic
-// UsageTokensWatermark persists across respawns so a forced retry never
-// double-counts (mirrors the claude/codex/Pi paths). opencode carries no model
-// name in the event stream, so sess.Model is left as configured. Returns true
-// when anything changed; false (tokens stay 0) when the jsonl is absent — the
+// ParseOpenCodeUsage sums them to the cumulative run total. #1120: the
+// UsageTokensWatermark is a read position into that append-only file and
+// survives a respawn, so a forced retry adds only the unseen tail; a stream
+// that started over is rewound by resetUsageWatermarksIfStreamRestarted
+// (mirrors the claude/codex/Pi paths). opencode carries no model name in the
+// event stream, so sess.Model is left as configured. Returns true when
+// anything changed; false (tokens stay 0) when the jsonl is absent — the
 // documented degradation when the stream-splitter was unavailable.
 func (o *Orchestrator) updateOpenCodeUsageFromJSONL(slotName string, sess *state.Session) bool {
 	jsonlPath := o.workerJSONLFile(slotName, sess)
@@ -1884,6 +1922,7 @@ func (o *Orchestrator) updateOpenCodeUsageFromJSONL(slotName string, sess *state
 	if !ok {
 		return false
 	}
+	resetUsageWatermarksIfStreamRestarted(sess, usage.TotalTokens)
 	changed := false
 	if usage.TotalTokens > sess.UsageTokensWatermark {
 		delta := usage.TotalTokens - sess.UsageTokensWatermark

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1440,7 +1440,20 @@ func (o *Orchestrator) updateTokensUsedFromOutput(slotName string, sess *state.S
 	return true
 }
 
-func updateTokenBudgetUsage(sess *state.Session, cumulative int, measure string) bool {
+// updateTokenBudgetUsage records an absolute budget observation for the
+// current attempt: the generic text parser's total, or the durable marker the
+// per-generation live token monitor wrote. Both figures already cover exactly
+// one attempt, which is why TokenBudgetTokensWatermark is cleared by
+// beginSessionAttempt while the UsageStreamCursors read positions are not
+// (#1120) — mixing a file-cumulative scale into this field is what let a
+// respawn inherit the previous attempt's ceiling.
+//
+// The attempt counter is raised to the observation instead of accumulating on
+// top of it, so an absolute marker cannot be added a second time to the
+// per-attempt deltas a JSONL stream already contributed. With only absolute
+// feeders the watermark and the attempt counter move together, which is the
+// behaviour this function has always had.
+func updateTokenBudgetUsage(sess *state.Session, observed int, measure string) bool {
 	if sess == nil {
 		return false
 	}
@@ -1449,36 +1462,130 @@ func updateTokenBudgetUsage(sess *state.Session, cumulative int, measure string)
 		sess.TokenBudgetMeasure = measure
 		changed = true
 	}
-	if cumulative > sess.TokenBudgetTokensWatermark {
-		delta := cumulative - sess.TokenBudgetTokensWatermark
-		sess.TokenBudgetTokensWatermark = cumulative
+	if observed > sess.TokenBudgetTokensWatermark {
+		sess.TokenBudgetTokensWatermark = observed
+		changed = true
+	}
+	if sess.TokenBudgetTokensWatermark > sess.TokenBudgetTokensAttempt {
+		sess.TokenBudgetTokensAttempt = sess.TokenBudgetTokensWatermark
+		changed = true
+	}
+	return changed
+}
+
+// updateTokenBudgetUsageFromStream folds a file-cumulative budget measure into
+// the attempt counter through that parser's own read position, so a respawn
+// which keeps appending to the same file contributes only the new tail and a
+// fallover partner's frames stay on their own cursor (#1120).
+func updateTokenBudgetUsageFromStream(sess *state.Session, stream string, cumulative int, measure string) bool {
+	if sess == nil {
+		return false
+	}
+	changed := false
+	if measure = strings.TrimSpace(measure); measure != "" && sess.TokenBudgetMeasure != measure {
+		sess.TokenBudgetMeasure = measure
+		changed = true
+	}
+	cursor := usageStreamCursor(sess, stream)
+	if cumulative > cursor.BudgetTokens {
+		delta := cumulative - cursor.BudgetTokens
+		cursor.BudgetTokens = cumulative
+		setUsageStreamCursor(sess, stream, cursor)
 		sess.TokenBudgetTokensAttempt += delta
 		changed = true
 	}
 	return changed
 }
 
-// resetUsageWatermarksIfStreamRestarted rewinds the read positions into the
-// backend's usage side channel when that stream demonstrably started over.
-// Every parser is cumulative over an append-only file, so the total can only
-// go backwards when the file behind it changed: an in-place respawn rotates
-// slot.log/slot.jsonl, a phase transition switches to a new log path, and a
-// fallover hands the same slot.jsonl to a different backend whose parser sees
-// only its own frames. #1120: this is the only place the watermarks may be
-// cleared — beginSessionAttempt deliberately no longer clears them per
-// attempt, because a plain fallover respawn keeps appending to the same file
-// and a blind reset re-counted the previous attempt's tokens into
-// TokensUsedTotal.
+// Usage stream identifiers — one per parser, not one per backend. A fallover
+// respawn hands the same <slot>.jsonl to a different backend and each parser
+// sums only the frames it recognises, so after a codex->claude fallover
+// ParseCodexUsage still returns the codex total while ParseClaudeUsage returns
+// claude's, on two independent scales. A single shared watermark silently
+// undercounts whichever of the two is the smaller number (#1120), so every
+// parser keeps its own read position.
+const (
+	usageStreamPi       = "pi"
+	usageStreamClaude   = "claude"
+	usageStreamCodex    = "codex"
+	usageStreamKimi     = "kimi"
+	usageStreamOpencode = "opencode"
+)
+
+// usageStreamCursor returns this parser's read position into the worker's
+// append-only usage side channel.
 //
-// A cumulative of zero is never a restart: a terminal frame with missing usage
-// reports zero, and rewinding on it would let the next real frame be added a
-// second time.
-func resetUsageWatermarksIfStreamRestarted(sess *state.Session, cumulative int) {
-	if sess == nil || cumulative <= 0 || cumulative >= sess.UsageTokensWatermark {
+// A session that was already running when the cursor map was introduced
+// carries only the flat watermarks. They were produced by whichever parser was
+// polling at the time — in practice the one asking now, because the
+// orchestrator polls the live attempt every tick — so they seed the first
+// lookup instead of restarting from zero and re-counting the whole file. The
+// first stored cursor closes that upgrade window.
+func usageStreamCursor(sess *state.Session, stream string) state.UsageStreamCursor {
+	if sess == nil {
+		return state.UsageStreamCursor{}
+	}
+	if sess.UsageStreamCursors != nil {
+		return sess.UsageStreamCursors[stream]
+	}
+	return state.UsageStreamCursor{
+		TotalTokens:  sess.UsageTokensWatermark,
+		BudgetTokens: sess.TokenBudgetTokensWatermark,
+	}
+}
+
+// setUsageStreamCursor stores a parser's advanced read position. The flat
+// UsageTokensWatermark is kept as a mirror of the stream that last reported so
+// persisted state stays readable and a downgrade still finds a sane position.
+func setUsageStreamCursor(sess *state.Session, stream string, cursor state.UsageStreamCursor) {
+	if sess == nil {
 		return
 	}
+	if sess.UsageStreamCursors == nil {
+		sess.UsageStreamCursors = make(map[string]state.UsageStreamCursor, 2)
+	}
+	sess.UsageStreamCursors[stream] = cursor
+	sess.UsageTokensWatermark = cursor.TotalTokens
+}
+
+// usageStreamRead returns the read position for stream, first rewinding every
+// cursor when cumulative proves the file behind them restarted.
+//
+// Each parser is cumulative over an append-only file, so its own total can
+// only shrink when that file was replaced: an in-place respawn rotates
+// <slot>.log (worker.rotateWorkerAttemptLog), a phase transition points the
+// session at a different log path, and state-dir cleanup can remove either
+// file. Nothing rotates the <slot>.jsonl side channel today —
+// rotateWorkerAttemptLog moves <slot>.log and <slot>.log.jsonl, which is not
+// the path JSONLPathForLog derives — so for the structured parsers this is a
+// guard against an out-of-band replacement rather than a routine event. The
+// rewind clears every stream because the file all of them read is the one that
+// went away.
+//
+// A cumulative of zero is never a restart: a terminal frame with missing usage
+// reports zero, and rewinding on it would let the next real frame be counted
+// twice.
+func usageStreamRead(sess *state.Session, stream string, cumulative int) state.UsageStreamCursor {
+	cursor := usageStreamCursor(sess, stream)
+	if sess == nil || cumulative <= 0 || cumulative >= cursor.TotalTokens {
+		return cursor
+	}
+	sess.UsageStreamCursors = make(map[string]state.UsageStreamCursor, 2)
 	sess.UsageTokensWatermark = 0
-	sess.TokenBudgetTokensWatermark = 0
+	return state.UsageStreamCursor{}
+}
+
+// cloneUsageStreamCursors copies the read-position map so a runtime projection
+// overlay cannot alias the source session's map.
+func cloneUsageStreamCursors(src map[string]state.UsageStreamCursor) map[string]state.UsageStreamCursor {
+	if src == nil {
+		return nil
+	}
+	out := make(map[string]state.UsageStreamCursor, len(src))
+	for stream, cursor := range src {
+		out[stream] = cursor
+	}
+	return out
 }
 
 func applyTokenBudgetObservation(sess *state.Session, marker worker.TokenBudgetMarker) {
@@ -1673,19 +1780,20 @@ func (o *Orchestrator) updatePiUsageFromOutput(slotName string, sess *state.Sess
 	if !ok {
 		return false
 	}
-	resetUsageWatermarksIfStreamRestarted(sess, usage.TotalTokens)
+	cursor := usageStreamRead(sess, usageStreamPi, usage.TotalTokens)
 	changed := false
 	// #730: Pi re-parses the full appended slot log on each call, so
 	// usage.TotalTokens is the cumulative run total across every attempt.
 	// On a respawn, the runner keeps appending to the same slot log while
 	// TokensUsedAttempt resets to 0 — comparing against TokensUsedAttempt
-	// would re-add the prior attempts' tokens. Use a separate monotonic
-	// watermark (UsageTokensWatermark) that persists across respawns so only
-	// the new attempt's tokens are counted (#1120: beginSessionAttempt no
-	// longer clears it, which is what makes that claim true).
-	if usage.TotalTokens > sess.UsageTokensWatermark {
-		delta := usage.TotalTokens - sess.UsageTokensWatermark
-		sess.UsageTokensWatermark = usage.TotalTokens
+	// would re-add the prior attempts' tokens. #1120: the Pi read position in
+	// UsageStreamCursors survives the new attempt instead (beginSessionAttempt
+	// no longer clears it) so only the unseen tail is counted, and an in-place
+	// respawn that really does rotate <slot>.log rewinds it in usageStreamRead.
+	if usage.TotalTokens > cursor.TotalTokens {
+		delta := usage.TotalTokens - cursor.TotalTokens
+		cursor.TotalTokens = usage.TotalTokens
+		setUsageStreamCursor(sess, usageStreamPi, cursor)
 		sess.TokensUsedAttempt += delta
 		sess.TokensUsedTotal += delta
 		// #739: stamp the cache-aware split so the cost panel can price each
@@ -1698,14 +1806,14 @@ func (o *Orchestrator) updatePiUsageFromOutput(slotName string, sess *state.Sess
 		sess.TokensCacheWrite = usage.CacheWrite
 		changed = true
 	}
-	if updateTokenBudgetUsage(sess, usage.BudgetTokens, worker.TokenBudgetMeasureUncached) {
+	if updateTokenBudgetUsageFromStream(sess, usageStreamPi, usage.BudgetTokens, worker.TokenBudgetMeasureUncached) {
 		changed = true
 	}
 	if strings.TrimSpace(usage.Model) != "" && strings.TrimSpace(sess.Model) == "" {
 		sess.Model = usage.Model
 		changed = true
 	}
-	// #730: cost uses the same monotonic watermark as tokens — the full-log
+	// #730: cost uses the same monotonic read position as tokens — the full-log
 	// parse returns the cumulative run cost, so guard with `>` instead of a
 	// first-non-zero freeze (which would never update after the first turn).
 	if usage.CostUSD > sess.CostUSDBackend {
@@ -1733,11 +1841,14 @@ func (o *Orchestrator) workerJSONLFile(slotName string, sess *state.Session) str
 // updateClaudeUsageFromJSONL parses the claude stream-json side-channel
 // (slot.jsonl) and stamps model/tokens/cost_usd onto the session (#737).
 // Like the Pi path it re-parses the full appended jsonl on each call, so
-// ParseClaudeUsage returns the cumulative run total across every attempt.
-// #1120: a fallover respawn keeps appending to that same file, so the
-// UsageTokensWatermark is a read position that survives the new attempt and
-// only the unseen tail is added; resetUsageWatermarksIfStreamRestarted rewinds
-// it when the stream itself started over. Cost prefers the backend-reported
+// ParseClaudeUsage returns the cumulative total of every claude frame in the
+// file. #1120: no respawn rotates that file — the same <slot>.log path is
+// recomputed and the splitter reopens the jsonl with O_APPEND — so claude's
+// read position in UsageStreamCursors survives the new attempt and only the
+// unseen tail is added. The position is claude's alone: after a codex->claude
+// fallover the same file also holds codex frames that ParseClaudeUsage never
+// sees, and a shared watermark would undercount claude's first result frame by
+// whatever codex had already reached. Cost prefers the backend-reported
 // total_cost_usd. A successful terminal frame with missing/zero usage marks
 // the active attribution usage-unreliable and logs once; zero never advances
 // token counters or budget progress.
@@ -1753,8 +1864,9 @@ func (o *Orchestrator) updateClaudeUsageFromJSONL(slotName string, sess *state.S
 		return false
 	}
 	usage, ok := worker.ParseClaudeUsage(string(data))
+	cursor := state.UsageStreamCursor{}
 	if ok {
-		resetUsageWatermarksIfStreamRestarted(sess, usage.TotalTokens)
+		cursor = usageStreamRead(sess, usageStreamClaude, usage.TotalTokens)
 	}
 	changed := false
 	if usage.UsageUnreliable && state.MarkActiveAttributionUsageUnreliable(sess, usage.UsageUnreliableReason, usage.UsageUnreliableScope) {
@@ -1763,22 +1875,23 @@ func (o *Orchestrator) updateClaudeUsageFromJSONL(slotName string, sess *state.S
 		changed = true
 	}
 	telemetryChanged := false
-	if ok && usage.TotalTokens > sess.UsageTokensWatermark {
-		delta := usage.TotalTokens - sess.UsageTokensWatermark
-		sess.UsageTokensWatermark = usage.TotalTokens
+	if ok && usage.TotalTokens > cursor.TotalTokens {
+		delta := usage.TotalTokens - cursor.TotalTokens
+		cursor.TotalTokens = usage.TotalTokens
+		setUsageStreamCursor(sess, usageStreamClaude, cursor)
 		sess.TokensUsedAttempt += delta
 		sess.TokensUsedTotal += delta
 		// #739: stamp the cache-aware split (input/output/cache_read/cache_write)
 		// so the cost panel can price the cache-read discount. The full-jsonl
-		// parse is cumulative, so assigning the run totals is respawn-safe
-		// alongside the watermark guard.
+		// parse is cumulative, so assigning the run totals tracks this parser's
+		// running total alongside the read-position guard.
 		sess.TokensInput = usage.Input
 		sess.TokensOutput = usage.Output
 		sess.TokensCacheRead = usage.CacheRead
 		sess.TokensCacheWrite = usage.CacheWrite
 		telemetryChanged = true
 	}
-	if ok && updateTokenBudgetUsage(sess, usage.BudgetTokens, worker.TokenBudgetMeasureUncached) {
+	if ok && updateTokenBudgetUsageFromStream(sess, usageStreamClaude, usage.BudgetTokens, worker.TokenBudgetMeasureUncached) {
 		telemetryChanged = true
 	}
 	if strings.TrimSpace(usage.Model) != "" && strings.TrimSpace(sess.Model) == "" {
@@ -1803,11 +1916,12 @@ func (o *Orchestrator) updateClaudeUsageFromJSONL(slotName string, sess *state.S
 // (slot.jsonl) and stamps tokens onto the session (#738). codex emits one
 // terminal turn.completed usage event per `codex exec` invocation; the
 // splitter appends each attempt's frames to the same slot.jsonl, so
-// ParseCodexUsage sums them to the cumulative run total. #1120: the
-// UsageTokensWatermark is a read position into that append-only file and
-// survives a respawn, so a forced retry adds only the unseen tail; a stream
-// that started over is rewound by resetUsageWatermarksIfStreamRestarted
-// (mirrors the claude/Pi paths). codex reports no USD, so cost stays virtual:
+// ParseCodexUsage sums them to the cumulative codex total. #1120: nothing
+// rotates that file, so codex's read position in UsageStreamCursors survives a
+// respawn and a forced retry adds only the unseen tail. The position is
+// codex's alone, because after a fallover the same file also holds the other
+// backend's frames that ParseCodexUsage never sees (mirrors the claude/Pi
+// paths). codex reports no USD, so cost stays virtual:
 // CostUSDBackend is left at 0 and sessionCostEstimate supplies the dollar
 // figure from the configured pricing block. codex --json carries no
 // model name, so sess.Model is left as configured. Returns true when tokens
@@ -1828,16 +1942,17 @@ func (o *Orchestrator) updateCodexUsageFromJSONL(slotName string, sess *state.Se
 	if !ok {
 		return false
 	}
-	resetUsageWatermarksIfStreamRestarted(sess, usage.TotalTokens)
+	cursor := usageStreamRead(sess, usageStreamCodex, usage.TotalTokens)
 	changed := false
-	if usage.TotalTokens > sess.UsageTokensWatermark {
-		delta := usage.TotalTokens - sess.UsageTokensWatermark
-		sess.UsageTokensWatermark = usage.TotalTokens
+	if usage.TotalTokens > cursor.TotalTokens {
+		delta := usage.TotalTokens - cursor.TotalTokens
+		cursor.TotalTokens = usage.TotalTokens
+		setUsageStreamCursor(sess, usageStreamCodex, cursor)
 		sess.TokensUsedAttempt += delta
 		sess.TokensUsedTotal += delta
 		changed = true
 	}
-	if updateTokenBudgetUsage(sess, usage.TotalTokens, worker.TokenBudgetMeasureCodexRollout) {
+	if updateTokenBudgetUsageFromStream(sess, usageStreamCodex, usage.TotalTokens, worker.TokenBudgetMeasureCodexRollout) {
 		changed = true
 	}
 	if changed {
@@ -1849,10 +1964,10 @@ func (o *Orchestrator) updateCodexUsageFromJSONL(slotName string, sess *state.Se
 
 // updateKimiUsageFromJSONL parses Kimi's first-class stream-json side channel
 // and stamps split tokens onto the session. ParseKimiUsage returns cumulative
-// usage across the append-only file, so the UsageTokensWatermark read position
-// survives a respawn and keeps retries from double-counting (#1120); a stream
-// that started over is rewound by resetUsageWatermarksIfStreamRestarted.
-// Native Kimi usage normally has no USD field; when absent, Fleet cost
+// Kimi usage across the append-only file, so Kimi's own read position in
+// UsageStreamCursors survives a respawn and keeps retries from double-counting
+// (#1120) without hiding a fallover partner's frames behind a shared
+// watermark. Native Kimi usage normally has no USD field; when absent, Fleet cost
 // observability applies the backend's configured split pricing to these
 // counters.
 func (o *Orchestrator) updateKimiUsageFromJSONL(slotName string, sess *state.Session) bool {
@@ -1868,11 +1983,12 @@ func (o *Orchestrator) updateKimiUsageFromJSONL(slotName string, sess *state.Ses
 	if !ok {
 		return false
 	}
-	resetUsageWatermarksIfStreamRestarted(sess, usage.TotalTokens)
+	cursor := usageStreamRead(sess, usageStreamKimi, usage.TotalTokens)
 	changed := false
-	if usage.TotalTokens > sess.UsageTokensWatermark {
-		delta := usage.TotalTokens - sess.UsageTokensWatermark
-		sess.UsageTokensWatermark = usage.TotalTokens
+	if usage.TotalTokens > cursor.TotalTokens {
+		delta := usage.TotalTokens - cursor.TotalTokens
+		cursor.TotalTokens = usage.TotalTokens
+		setUsageStreamCursor(sess, usageStreamKimi, cursor)
 		sess.TokensUsedAttempt += delta
 		sess.TokensUsedTotal += delta
 		sess.TokensInput = usage.Input
@@ -1901,10 +2017,10 @@ func (o *Orchestrator) updateKimiUsageFromJSONL(slotName string, sess *state.Ses
 // (slot.jsonl) and stamps tokens/cost onto the session. opencode emits one
 // terminal step_finish event per `opencode run` invocation; the stream-splitter
 // appends each attempt's frames to the same slot.jsonl, so
-// ParseOpenCodeUsage sums them to the cumulative run total. #1120: the
-// UsageTokensWatermark is a read position into that append-only file and
-// survives a respawn, so a forced retry adds only the unseen tail; a stream
-// that started over is rewound by resetUsageWatermarksIfStreamRestarted
+// ParseOpenCodeUsage sums them to the cumulative opencode total. #1120:
+// nothing rotates that file, so opencode's own read position in
+// UsageStreamCursors survives a respawn and a forced retry adds only the
+// unseen tail, while a fallover partner's frames stay on their own cursor
 // (mirrors the claude/codex/Pi paths). opencode carries no model name in the
 // event stream, so sess.Model is left as configured. Returns true when
 // anything changed; false (tokens stay 0) when the jsonl is absent — the
@@ -1922,11 +2038,12 @@ func (o *Orchestrator) updateOpenCodeUsageFromJSONL(slotName string, sess *state
 	if !ok {
 		return false
 	}
-	resetUsageWatermarksIfStreamRestarted(sess, usage.TotalTokens)
+	cursor := usageStreamRead(sess, usageStreamOpencode, usage.TotalTokens)
 	changed := false
-	if usage.TotalTokens > sess.UsageTokensWatermark {
-		delta := usage.TotalTokens - sess.UsageTokensWatermark
-		sess.UsageTokensWatermark = usage.TotalTokens
+	if usage.TotalTokens > cursor.TotalTokens {
+		delta := usage.TotalTokens - cursor.TotalTokens
+		cursor.TotalTokens = usage.TotalTokens
+		setUsageStreamCursor(sess, usageStreamOpencode, cursor)
 		sess.TokensUsedAttempt += delta
 		sess.TokensUsedTotal += delta
 		// Reasoning tokens are a separate thinking-tokens bucket in opencode
@@ -1938,7 +2055,7 @@ func (o *Orchestrator) updateOpenCodeUsageFromJSONL(slotName string, sess *state
 		sess.TokensCacheWrite = usage.CacheWrite
 		changed = true
 	}
-	if updateTokenBudgetUsage(sess, usage.TotalTokens, worker.TokenBudgetMeasureInputOutputReasoning) {
+	if updateTokenBudgetUsageFromStream(sess, usageStreamOpencode, usage.TotalTokens, worker.TokenBudgetMeasureInputOutputReasoning) {
 		changed = true
 	}
 	if usage.CostUSD > sess.CostUSDBackend {
@@ -4438,6 +4555,7 @@ func applyLiveRuntimeProjection(current, runtime *state.Session) {
 	current.Model = runtime.Model
 	current.CostUSDBackend = runtime.CostUSDBackend
 	current.UsageTokensWatermark = runtime.UsageTokensWatermark
+	current.UsageStreamCursors = cloneUsageStreamCursors(runtime.UsageStreamCursors)
 	current.TokensUsedAttempt = runtime.TokensUsedAttempt
 	current.TokenBudgetTokensWatermark = runtime.TokenBudgetTokensWatermark
 	current.TokenBudgetTokensAttempt = runtime.TokenBudgetTokensAttempt

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -11588,8 +11588,12 @@ func TestUpdateTokensUsedFromOutput_PiBackendRetryNoDoubleCount(t *testing.T) {
 		t.Fatalf("attempt1: total=%d wm=%d attempt=%d, want 773/773/773",
 			sess.TokensUsedTotal, sess.UsageTokensWatermark, sess.TokensUsedAttempt)
 	}
-	if sess.TokenBudgetTokensAttempt != 773 || sess.TokenBudgetTokensWatermark != 773 || sess.TokenBudgetMeasure != worker.TokenBudgetMeasureUncached {
-		t.Fatalf("attempt1 budget=%d watermark=%d measure=%q, want 773/773/%q", sess.TokenBudgetTokensAttempt, sess.TokenBudgetTokensWatermark, sess.TokenBudgetMeasure, worker.TokenBudgetMeasureUncached)
+	// #1120: a cumulative stream's budget measure is tracked by that parser's
+	// read position, not by TokenBudgetTokensWatermark — that field holds the
+	// absolute per-attempt observations (text total, live-monitor marker) and
+	// resets with the attempt.
+	if sess.TokenBudgetTokensAttempt != 773 || sess.UsageStreamCursors[usageStreamPi].BudgetTokens != 773 || sess.TokenBudgetMeasure != worker.TokenBudgetMeasureUncached {
+		t.Fatalf("attempt1 budget=%d read_position=%d measure=%q, want 773/773/%q", sess.TokenBudgetTokensAttempt, sess.UsageStreamCursors[usageStreamPi].BudgetTokens, sess.TokenBudgetMeasure, worker.TokenBudgetMeasureUncached)
 	}
 
 	// Simulate respawn: per-attempt counter resets to 0 (checkpoint/worker/phase
@@ -11683,8 +11687,10 @@ func TestUpdateTokensUsedFromOutput_ClaudeBackendStampsUsage(t *testing.T) {
 	if sess.UsageTokensWatermark != 20076 {
 		t.Errorf("UsageTokensWatermark = %d, want 20076", sess.UsageTokensWatermark)
 	}
-	if sess.TokenBudgetTokensAttempt != 4415 || sess.TokenBudgetTokensWatermark != 4415 || sess.TokenBudgetMeasure != worker.TokenBudgetMeasureUncached {
-		t.Errorf("budget usage=%d watermark=%d measure=%q, want 4415/4415/%q", sess.TokenBudgetTokensAttempt, sess.TokenBudgetTokensWatermark, sess.TokenBudgetMeasure, worker.TokenBudgetMeasureUncached)
+	// #1120: the budget measure from this cumulative stream is tracked by
+	// claude's own read position, not by TokenBudgetTokensWatermark.
+	if sess.TokenBudgetTokensAttempt != 4415 || sess.UsageStreamCursors[usageStreamClaude].BudgetTokens != 4415 || sess.TokenBudgetMeasure != worker.TokenBudgetMeasureUncached {
+		t.Errorf("budget usage=%d read_position=%d measure=%q, want 4415/4415/%q", sess.TokenBudgetTokensAttempt, sess.UsageStreamCursors[usageStreamClaude].BudgetTokens, sess.TokenBudgetMeasure, worker.TokenBudgetMeasureUncached)
 	}
 	if !approxCostEq(sess.CostUSDBackend, 0.0401785) {
 		t.Errorf("CostUSDBackend = %v, want 0.0401785", sess.CostUSDBackend)
@@ -11948,14 +11954,28 @@ func TestUpdateTokensUsedFromOutput_CodexBackendRetryNoDoubleCount(t *testing.T)
 }
 
 // beginRespawnedAttempt starts a new worker attempt on an existing session
-// through the production reset path. worker.AdoptLiveRuntime is the exported
-// entry point into beginSessionAttempt — the single function every respawn
-// (fallover, in-place, phase transition) calls to open a new attempt — so the
-// usage tests below stay bound to what the worker package really resets
-// instead of a hand-rolled copy of it.
+// through the production reset path, keeping the same backend.
+// worker.AdoptLiveRuntime is the exported entry point into beginSessionAttempt
+// — the single function every respawn (fallover, in-place, phase transition)
+// calls to open a new attempt — so the usage tests below stay bound to what
+// the worker package really resets instead of a hand-rolled copy of it.
 func beginRespawnedAttempt(t *testing.T, sess *state.Session) {
 	t.Helper()
 	worker.AdoptLiveRuntime(nil, sess, 4242, "maestro-test-1120", time.Now().UTC())
+}
+
+// falloverToBackend starts the next attempt on a different backend through the
+// same production reset. worker.Respawn's fallover is
+// beginSessionAttempt(cfg, sess, backendName, "fallover", "fallover", now),
+// and AdoptLiveRuntime calls beginSessionAttempt with sess.Backend — so
+// assigning the fallover target first reproduces exactly the state transition
+// a cross-backend fallover performs (only the attribution reason string
+// differs; the fallover call itself is pinned by
+// internal/worker.TestBeginSessionAttemptFalloverKeepsStreamCursorsAndResetsBudgetCeiling).
+func falloverToBackend(t *testing.T, sess *state.Session, backend string) {
+	t.Helper()
+	sess.Backend = backend
+	beginRespawnedAttempt(t, sess)
 }
 
 // kimiUsageFrame builds one Kimi StatusUpdate frame carrying a token_usage
@@ -12164,18 +12184,20 @@ func TestUpdateOpenCodeUsageFromJSONL_RespawnDoesNotRecountPreviousAttempt(t *te
 	}
 }
 
-// #1120: an in-place respawn rotates slot.log/slot.jsonl and a phase
-// transition switches to a new log path, so the replacement stream really does
-// start from zero. The cumulative parse going backwards is the only honest
-// signal of that, and it must rewind the watermark — otherwise the new
-// attempt's tokens are swallowed until they pass the old attempt's total.
-func TestUpdateClaudeUsageFromJSONL_RotatedStreamCountsNewAttemptInFull(t *testing.T) {
-	o, sess, jsonlPath := claudeTestOrchestrator(t, "sup-1120-rotate")
+// #1120: no respawn rotates <slot>.jsonl — worker.rotateWorkerAttemptLog moves
+// <slot>.log and <slot>.log.jsonl, which is not the path JSONLPathForLog
+// derives — but the side channel can still be replaced out of band (state-dir
+// cleanup, or a phase transition pointing the session at a fresh log path).
+// The cumulative parse going backwards is the only honest signal of that, and
+// it must rewind the read position — otherwise the new stream's tokens are
+// swallowed until they pass the previous total.
+func TestUpdateClaudeUsageFromJSONL_ReplacedStreamCountsNewAttemptInFull(t *testing.T) {
+	o, sess, jsonlPath := claudeTestOrchestrator(t, "sup-1120-replaced")
 
 	if err := os.WriteFile(jsonlPath, []byte(claudeResultFrame(770, 3, 0, 0, 0.001, "a")), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if !o.updateClaudeUsageFromJSONL("sup-1120-rotate", sess) {
+	if !o.updateClaudeUsageFromJSONL("sup-1120-replaced", sess) {
 		t.Fatal("attempt 1: expected the jsonl side channel to stamp usage")
 	}
 	if sess.TokensUsedTotal != 773 || sess.UsageTokensWatermark != 773 {
@@ -12184,34 +12206,34 @@ func TestUpdateClaudeUsageFromJSONL_RotatedStreamCountsNewAttemptInFull(t *testi
 
 	beginRespawnedAttempt(t, sess)
 
-	// rotateWorkerAttemptLog moved the previous attempt aside; the replacement
-	// process writes a fresh, smaller stream to the same path.
+	// The side channel was replaced out of band; the next process writes a
+	// fresh, smaller stream to the same path.
 	if err := os.WriteFile(jsonlPath, []byte(claudeResultFrame(400, 100, 0, 0, 0.0005, "b")), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if !o.updateClaudeUsageFromJSONL("sup-1120-rotate", sess) {
-		t.Fatal("attempt 2: expected the rotated stream to stamp usage")
+	if !o.updateClaudeUsageFromJSONL("sup-1120-replaced", sess) {
+		t.Fatal("attempt 2: expected the replaced stream to stamp usage")
 	}
 	if sess.TokensUsedTotal != 1273 || sess.TokensUsedAttempt != 500 || sess.UsageTokensWatermark != 500 {
-		t.Fatalf("attempt 2: total=%d attempt=%d watermark=%d, want 1273/500/500 (rotated stream counted in full)",
+		t.Fatalf("attempt 2: total=%d attempt=%d watermark=%d, want 1273/500/500 (replaced stream counted in full)",
 			sess.TokensUsedTotal, sess.TokensUsedAttempt, sess.UsageTokensWatermark)
 	}
 }
 
-// #1120: the token-budget watermark indexes the same rotated stream, so it has
-// to rewind with it. A budget watermark left at the previous attempt's total
-// would report the replacement worker as having burned nothing.
-func TestUpdateCodexUsageFromJSONL_RotatedStreamRewindsBudgetWatermark(t *testing.T) {
-	o, sess, jsonlPath := codexTestOrchestrator(t, "sup-1120-rotate-codex")
+// #1120: the budget read position indexes the same side channel, so it rewinds
+// with it. A budget position left at the previous stream's total would report
+// the replacement worker as having burned nothing.
+func TestUpdateCodexUsageFromJSONL_ReplacedStreamRewindsBudgetReadPosition(t *testing.T) {
+	o, sess, jsonlPath := codexTestOrchestrator(t, "sup-1120-replaced-codex")
 
 	if err := os.WriteFile(jsonlPath, []byte(codexTurnFrame(770, 0, 3)), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if !o.updateCodexUsageFromJSONL("sup-1120-rotate-codex", sess) {
+	if !o.updateCodexUsageFromJSONL("sup-1120-replaced-codex", sess) {
 		t.Fatal("attempt 1: expected the jsonl side channel to stamp usage")
 	}
-	if sess.TokenBudgetTokensWatermark != 773 {
-		t.Fatalf("attempt 1: TokenBudgetTokensWatermark = %d, want 773", sess.TokenBudgetTokensWatermark)
+	if sess.TokenBudgetTokensAttempt != 773 {
+		t.Fatalf("attempt 1: TokenBudgetTokensAttempt = %d, want 773", sess.TokenBudgetTokensAttempt)
 	}
 
 	beginRespawnedAttempt(t, sess)
@@ -12219,11 +12241,187 @@ func TestUpdateCodexUsageFromJSONL_RotatedStreamRewindsBudgetWatermark(t *testin
 	if err := os.WriteFile(jsonlPath, []byte(codexTurnFrame(400, 0, 100)), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if !o.updateCodexUsageFromJSONL("sup-1120-rotate-codex", sess) {
-		t.Fatal("attempt 2: expected the rotated stream to stamp usage")
+	if !o.updateCodexUsageFromJSONL("sup-1120-replaced-codex", sess) {
+		t.Fatal("attempt 2: expected the replaced stream to stamp usage")
 	}
-	if sess.TokenBudgetTokensAttempt != 500 || sess.TokenBudgetTokensWatermark != 500 {
-		t.Fatalf("attempt 2: budget attempt=%d watermark=%d, want 500/500 (rotated stream counted in full)",
-			sess.TokenBudgetTokensAttempt, sess.TokenBudgetTokensWatermark)
+	if sess.TokenBudgetTokensAttempt != 500 {
+		t.Fatalf("attempt 2: TokenBudgetTokensAttempt = %d, want 500 (replaced stream counted in full)",
+			sess.TokenBudgetTokensAttempt)
+	}
+	if cursor := sess.UsageStreamCursors[usageStreamCodex]; cursor.BudgetTokens != 500 {
+		t.Fatalf("attempt 2: codex budget read position = %d, want 500 (rewound with the stream)", cursor.BudgetTokens)
+	}
+}
+
+// #1120 (cross-backend fallover): the replacement backend appends to the SAME
+// <slot>.jsonl and every parser sums only the frames it recognises. With one
+// shared watermark a codex attempt reaching 773 followed by a claude attempt
+// emitting a 1000-token result frame produced a 227 delta — 1000 > 773, so no
+// backwards-rewind fired — and TokensUsedTotal landed on 1000 instead of 1773.
+// Per-parser read positions count each backend's own stream in full, in both
+// directions of the fallover chain.
+func TestUpdateTokensUsedFromOutput_CrossBackendFalloverCountsEachParserInFull(t *testing.T) {
+	dir := t.TempDir()
+	o := &Orchestrator{cfg: &config.Config{
+		StateDir: dir,
+		Model: config.ModelConfig{
+			Default: "sol",
+			Backends: map[string]config.BackendDef{
+				"sol":    {Cmd: "codex", UsageStream: true},
+				"claude": {Cmd: "claude", UsageStream: true},
+			},
+		},
+	}}
+	logFile := filepath.Join(dir, "sup-1120-fallover.log")
+	jsonlPath := worker.JSONLPathForLog(logFile)
+	sess := &state.Session{Backend: "sol", LogFile: logFile}
+
+	codexRun := codexTurnFrame(770, 0, 3) // codex cumulative 773
+	if err := os.WriteFile(jsonlPath, []byte(codexRun), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateTokensUsedFromOutput("sup-1120-fallover", sess, "") {
+		t.Fatal("codex attempt: expected the jsonl side channel to stamp usage")
+	}
+	if sess.TokensUsedTotal != 773 {
+		t.Fatalf("codex attempt: TokensUsedTotal = %d, want 773", sess.TokensUsedTotal)
+	}
+
+	falloverToBackend(t, sess, "claude")
+
+	// The splitter reopens the same jsonl with O_APPEND, so claude's frames
+	// land behind codex's and ParseClaudeUsage sees only its own 1000.
+	claudeRun := claudeResultFrame(900, 100, 0, 0, 0.002, "b")
+	if err := os.WriteFile(jsonlPath, []byte(codexRun+claudeRun), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateTokensUsedFromOutput("sup-1120-fallover", sess, "") {
+		t.Fatal("claude attempt: expected the new frames to stamp usage")
+	}
+	if sess.TokensUsedTotal != 1773 || sess.TokensUsedAttempt != 1000 {
+		t.Fatalf("after codex->claude fallover: total=%d attempt=%d, want 1773/1000 — claude's 1000 tokens counted in full, not as a 227 delta over codex's watermark",
+			sess.TokensUsedTotal, sess.TokensUsedAttempt)
+	}
+
+	// Falling back to codex resumes codex's own position instead of restarting
+	// it: a plain reset-on-backend-change would re-add codex's first 773.
+	falloverToBackend(t, sess, "sol")
+	if err := os.WriteFile(jsonlPath, []byte(codexRun+claudeRun+codexTurnFrame(200, 0, 27)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateTokensUsedFromOutput("sup-1120-fallover", sess, "") {
+		t.Fatal("codex second attempt: expected the new frames to stamp usage")
+	}
+	if sess.TokensUsedTotal != 2000 || sess.TokensUsedAttempt != 227 {
+		t.Fatalf("after claude->codex fallover: total=%d attempt=%d, want 2000/227 (only codex's new tail)",
+			sess.TokensUsedTotal, sess.TokensUsedAttempt)
+	}
+}
+
+// #1120: a backend without usage_stream gets no stream splitter, therefore no
+// live token monitor and no durable token-budget marker —
+// terminalizeTokenBudgetIfExceeded reading TokenBudgetTokensAttempt is the
+// only thing enforcing worker_max_tokens. TokenBudgetTokensWatermark is the
+// high-water mark of those absolute per-attempt observations, so it must reset
+// with the attempt: carried across a respawn it raises every replacement
+// worker's effective budget by whatever the previous attempt burned.
+func TestTerminalizeTokenBudgetIfExceeded_RespawnKeepsEnforcingWithoutUsageStream(t *testing.T) {
+	dir := t.TempDir()
+	o := &Orchestrator{cfg: &config.Config{
+		StateDir:        dir,
+		WorkerMaxTokens: 1000,
+		Model: config.ModelConfig{
+			Default:  "claude",
+			Backends: map[string]config.BackendDef{"claude": {Cmd: "claude"}}, // no usage_stream: text parser only
+		},
+	}}
+	logFile := filepath.Join(dir, "sup-1120-budget.log")
+	sess := &state.Session{Backend: "claude", LogFile: logFile, Status: state.StatusRunning}
+
+	if err := os.WriteFile(logFile, []byte("total tokens: 900\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateTokensUsedFromWorkerLog("sup-1120-budget", sess) {
+		t.Fatal("attempt 1: expected the text parser to stamp usage")
+	}
+	if sess.TokenBudgetTokensAttempt != 900 {
+		t.Fatalf("attempt 1: TokenBudgetTokensAttempt = %d, want 900", sess.TokenBudgetTokensAttempt)
+	}
+	if o.terminalizeTokenBudgetIfExceeded("sup-1120-budget", sess, time.Now().UTC()) {
+		t.Fatal("attempt 1: 900 of a 1000 budget must not terminalize")
+	}
+
+	beginRespawnedAttempt(t, sess)
+
+	if err := os.WriteFile(logFile, []byte("total tokens: 1200\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateTokensUsedFromWorkerLog("sup-1120-budget", sess) {
+		t.Fatal("attempt 2: expected the text parser to stamp usage")
+	}
+	if sess.TokenBudgetTokensAttempt != 1200 {
+		t.Fatalf("attempt 2: TokenBudgetTokensAttempt = %d, want 1200 — an inherited ceiling from attempt 1 hides the replacement worker's own burn",
+			sess.TokenBudgetTokensAttempt)
+	}
+	if !o.terminalizeTokenBudgetIfExceeded("sup-1120-budget", sess, time.Now().UTC()) {
+		t.Fatal("attempt 2: 1200 of a 1000 budget must terminalize — this is the only budget enforcement without usage_stream")
+	}
+	if sess.WorkerOutcome != worker.TokenBudgetExceededOutcome {
+		t.Fatalf("WorkerOutcome = %q, want %q", sess.WorkerOutcome, worker.TokenBudgetExceededOutcome)
+	}
+}
+
+// #1120: the two watermarks used to sit on different scales after a respawn —
+// the JSONL one cumulative over the whole file, the budget one an absolute
+// per-generation observation floored to worker_max_tokens — so whichever
+// number happened to be larger silently won. The file-cumulative position now
+// lives in UsageStreamCursors and the absolute observations in
+// TokenBudgetTokensWatermark, which keeps the live monitor's marker
+// authoritative for the attempt it was written for: neither swallowed by a
+// stale file-cumulative watermark nor added on top of the stream deltas.
+func TestMarkTokenBudgetExceeded_MarkerIsAttemptScopedAfterRespawn(t *testing.T) {
+	o, sess, jsonlPath := codexTestOrchestrator(t, "sup-1120-marker")
+	o.cfg.WorkerMaxTokens = 1000
+
+	run1 := codexTurnFrame(770, 0, 3) // cumulative 773
+	if err := os.WriteFile(jsonlPath, []byte(run1), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateCodexUsageFromJSONL("sup-1120-marker", sess) {
+		t.Fatal("attempt 1: expected the jsonl side channel to stamp usage")
+	}
+	if sess.TokenBudgetTokensAttempt != 773 {
+		t.Fatalf("attempt 1: TokenBudgetTokensAttempt = %d, want 773", sess.TokenBudgetTokensAttempt)
+	}
+
+	beginRespawnedAttempt(t, sess)
+
+	run2 := codexTurnFrame(200, 0, 27) // file cumulative 1000, this attempt's tail 227
+	if err := os.WriteFile(jsonlPath, []byte(run1+run2), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateCodexUsageFromJSONL("sup-1120-marker", sess) {
+		t.Fatal("attempt 2: expected the new frames to stamp usage")
+	}
+	if sess.TokenBudgetTokensAttempt != 227 {
+		t.Fatalf("attempt 2: TokenBudgetTokensAttempt = %d, want 227 (only this attempt's tail)", sess.TokenBudgetTokensAttempt)
+	}
+
+	marker := worker.TokenBudgetMarker{
+		Outcome:          worker.TokenBudgetExceededOutcome,
+		Backend:          "codex",
+		TokensObserved:   1000,
+		MaxTokens:        1000,
+		Measure:          worker.TokenBudgetMeasureCodexRollout,
+		WorkerGeneration: sess.WorkerGeneration,
+		MeasuredAt:       time.Now().UTC(),
+	}
+	o.markTokenBudgetExceeded("sup-1120-marker", sess, marker, time.Now().UTC())
+
+	if sess.TokenBudgetTokensAttempt != 1000 {
+		t.Fatalf("TokenBudgetTokensAttempt = %d, want 1000: the live monitor's per-generation observation is authoritative for this attempt", sess.TokenBudgetTokensAttempt)
+	}
+	if sess.WorkerOutcome != worker.TokenBudgetExceededOutcome {
+		t.Fatalf("WorkerOutcome = %q, want %q", sess.WorkerOutcome, worker.TokenBudgetExceededOutcome)
 	}
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -11946,3 +11946,284 @@ func TestUpdateTokensUsedFromOutput_CodexBackendRetryNoDoubleCount(t *testing.T)
 		t.Errorf("UsageTokensWatermark = %d, want 1773", sess.UsageTokensWatermark)
 	}
 }
+
+// beginRespawnedAttempt starts a new worker attempt on an existing session
+// through the production reset path. worker.AdoptLiveRuntime is the exported
+// entry point into beginSessionAttempt — the single function every respawn
+// (fallover, in-place, phase transition) calls to open a new attempt — so the
+// usage tests below stay bound to what the worker package really resets
+// instead of a hand-rolled copy of it.
+func beginRespawnedAttempt(t *testing.T, sess *state.Session) {
+	t.Helper()
+	worker.AdoptLiveRuntime(nil, sess, 4242, "maestro-test-1120", time.Now().UTC())
+}
+
+// kimiUsageFrame builds one Kimi StatusUpdate frame carrying a token_usage
+// block, matching the shape of internal/worker/testdata/kimi_stream.jsonl.
+func kimiUsageFrame(messageID string, in, out int) string {
+	return fmt.Sprintf(`{"timestamp":1,"message":{"type":"StatusUpdate","payload":{"token_usage":{"input_other":%d,"output":%d,"input_cache_read":0,"input_cache_creation":0},"message_id":%q,"model":"kimi-k2.5"}}}`+"\n",
+		in, out, messageID)
+}
+
+// kimiTestOrchestrator wires a session to a Kimi backend whose slot.jsonl lives
+// at <dir>/<slot>.jsonl. Kimi always streams JSON, so no usage_stream opt-in.
+func kimiTestOrchestrator(t *testing.T, slot string) (*Orchestrator, *state.Session, string) {
+	t.Helper()
+	dir := t.TempDir()
+	o := &Orchestrator{
+		cfg: &config.Config{
+			StateDir: dir,
+			Model: config.ModelConfig{
+				Default:  "moonshot-primary",
+				Backends: map[string]config.BackendDef{"moonshot-primary": {Cmd: "kimi", Provider: "moonshot"}},
+			},
+		},
+	}
+	logFile := filepath.Join(dir, slot+".log")
+	sess := &state.Session{Backend: "moonshot-primary", LogFile: logFile}
+	return o, sess, worker.JSONLPathForLog(logFile)
+}
+
+// opencodeStepFinishFrame builds one terminal opencode --format json
+// step_finish event with the given tokens + cost.
+func opencodeStepFinishFrame(in, out int, cost float64) string {
+	return fmt.Sprintf(`{"type":"step_finish","part":{"type":"step-finish","tokens":{"input":%d,"output":%d,"reasoning":0,"cache":{"read":0,"write":0}},"cost":%g}}`+"\n",
+		in, out, cost)
+}
+
+// opencodeTestOrchestrator wires a session to an opencode backend whose
+// slot.jsonl lives at <dir>/<slot>.jsonl.
+func opencodeTestOrchestrator(t *testing.T, slot string) (*Orchestrator, *state.Session, string) {
+	t.Helper()
+	dir := t.TempDir()
+	o := &Orchestrator{
+		cfg: &config.Config{
+			StateDir: dir,
+			Model: config.ModelConfig{
+				Default:  "opencode",
+				Backends: map[string]config.BackendDef{"opencode": {Cmd: "opencode", UsageStream: true}},
+			},
+		},
+	}
+	logFile := filepath.Join(dir, slot+".log")
+	sess := &state.Session{Backend: "opencode", LogFile: logFile}
+	return o, sess, worker.JSONLPathForLog(logFile)
+}
+
+// #1120: a fallover respawn recomputes the same slot.log path and the
+// stream-splitter reopens slot.jsonl with O_APPEND, so the previous attempt's
+// frames are still there when the replacement process starts. Polling usage
+// before that process has emitted anything must leave TokensUsedTotal alone,
+// and its first real frames must then be counted exactly once.
+func TestUpdateClaudeUsageFromJSONL_RespawnDoesNotRecountPreviousAttempt(t *testing.T) {
+	o, sess, jsonlPath := claudeTestOrchestrator(t, "sup-1120-claude")
+
+	run1 := claudeResultFrame(770, 3, 0, 0, 0.001, "a") // total 773
+	if err := os.WriteFile(jsonlPath, []byte(run1), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateClaudeUsageFromJSONL("sup-1120-claude", sess) {
+		t.Fatal("attempt 1: expected the jsonl side channel to stamp usage")
+	}
+	if sess.TokensUsedTotal != 773 {
+		t.Fatalf("attempt 1: TokensUsedTotal = %d, want 773", sess.TokensUsedTotal)
+	}
+
+	beginRespawnedAttempt(t, sess)
+
+	o.updateClaudeUsageFromJSONL("sup-1120-claude", sess)
+	if sess.TokensUsedTotal != 773 {
+		t.Fatalf("respawn recount: TokensUsedTotal = %d, want 773 (no new worker output)", sess.TokensUsedTotal)
+	}
+	if sess.TokensUsedAttempt != 0 {
+		t.Fatalf("respawn recount: TokensUsedAttempt = %d, want 0 (no new worker output)", sess.TokensUsedAttempt)
+	}
+
+	run2 := claudeResultFrame(900, 100, 0, 0, 0.002, "b") // total 1000
+	if err := os.WriteFile(jsonlPath, []byte(run1+run2), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateClaudeUsageFromJSONL("sup-1120-claude", sess) {
+		t.Fatal("attempt 2: expected the new frames to stamp usage")
+	}
+	if sess.TokensUsedTotal != 1773 || sess.TokensUsedAttempt != 1000 {
+		t.Fatalf("attempt 2: total=%d attempt=%d, want 1773/1000 (new usage counted once)",
+			sess.TokensUsedTotal, sess.TokensUsedAttempt)
+	}
+}
+
+// #1120, codex path: same append-only slot.jsonl, same respawn recount.
+func TestUpdateCodexUsageFromJSONL_RespawnDoesNotRecountPreviousAttempt(t *testing.T) {
+	o, sess, jsonlPath := codexTestOrchestrator(t, "sup-1120-codex")
+
+	run1 := codexTurnFrame(770, 0, 3) // total 773
+	if err := os.WriteFile(jsonlPath, []byte(run1), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateCodexUsageFromJSONL("sup-1120-codex", sess) {
+		t.Fatal("attempt 1: expected the jsonl side channel to stamp usage")
+	}
+	if sess.TokensUsedTotal != 773 {
+		t.Fatalf("attempt 1: TokensUsedTotal = %d, want 773", sess.TokensUsedTotal)
+	}
+
+	beginRespawnedAttempt(t, sess)
+
+	o.updateCodexUsageFromJSONL("sup-1120-codex", sess)
+	if sess.TokensUsedTotal != 773 || sess.TokensUsedAttempt != 0 {
+		t.Fatalf("respawn recount: total=%d attempt=%d, want 773/0 (no new worker output)",
+			sess.TokensUsedTotal, sess.TokensUsedAttempt)
+	}
+	if sess.TokenBudgetTokensAttempt != 0 {
+		t.Fatalf("respawn recount: TokenBudgetTokensAttempt = %d, want 0 — a budget attempt that starts full kills the replacement early", sess.TokenBudgetTokensAttempt)
+	}
+
+	run2 := codexTurnFrame(900, 0, 100) // total 1000
+	if err := os.WriteFile(jsonlPath, []byte(run1+run2), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateCodexUsageFromJSONL("sup-1120-codex", sess) {
+		t.Fatal("attempt 2: expected the new frames to stamp usage")
+	}
+	if sess.TokensUsedTotal != 1773 || sess.TokensUsedAttempt != 1000 || sess.TokenBudgetTokensAttempt != 1000 {
+		t.Fatalf("attempt 2: total=%d attempt=%d budget=%d, want 1773/1000/1000",
+			sess.TokensUsedTotal, sess.TokensUsedAttempt, sess.TokenBudgetTokensAttempt)
+	}
+}
+
+// #1120, kimi path: same append-only slot.jsonl, same respawn recount. This is
+// the path PR #1095 flagged; the bug is identical on the other three.
+func TestUpdateKimiUsageFromJSONL_RespawnDoesNotRecountPreviousAttempt(t *testing.T) {
+	o, sess, jsonlPath := kimiTestOrchestrator(t, "sup-1120-kimi")
+
+	run1 := kimiUsageFrame("msg_1", 700, 73) // total 773
+	if err := os.WriteFile(jsonlPath, []byte(run1), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateKimiUsageFromJSONL("sup-1120-kimi", sess) {
+		t.Fatal("attempt 1: expected the jsonl side channel to stamp usage")
+	}
+	if sess.TokensUsedTotal != 773 {
+		t.Fatalf("attempt 1: TokensUsedTotal = %d, want 773", sess.TokensUsedTotal)
+	}
+
+	beginRespawnedAttempt(t, sess)
+
+	o.updateKimiUsageFromJSONL("sup-1120-kimi", sess)
+	if sess.TokensUsedTotal != 773 || sess.TokensUsedAttempt != 0 {
+		t.Fatalf("respawn recount: total=%d attempt=%d, want 773/0 (no new worker output)",
+			sess.TokensUsedTotal, sess.TokensUsedAttempt)
+	}
+
+	run2 := kimiUsageFrame("msg_2", 900, 100) // total 1000
+	if err := os.WriteFile(jsonlPath, []byte(run1+run2), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateKimiUsageFromJSONL("sup-1120-kimi", sess) {
+		t.Fatal("attempt 2: expected the new frames to stamp usage")
+	}
+	if sess.TokensUsedTotal != 1773 || sess.TokensUsedAttempt != 1000 {
+		t.Fatalf("attempt 2: total=%d attempt=%d, want 1773/1000 (new usage counted once)",
+			sess.TokensUsedTotal, sess.TokensUsedAttempt)
+	}
+}
+
+// #1120, opencode path: same append-only slot.jsonl, same respawn recount.
+func TestUpdateOpenCodeUsageFromJSONL_RespawnDoesNotRecountPreviousAttempt(t *testing.T) {
+	o, sess, jsonlPath := opencodeTestOrchestrator(t, "sup-1120-opencode")
+
+	run1 := opencodeStepFinishFrame(770, 3, 0.001) // total 773
+	if err := os.WriteFile(jsonlPath, []byte(run1), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateOpenCodeUsageFromJSONL("sup-1120-opencode", sess) {
+		t.Fatal("attempt 1: expected the jsonl side channel to stamp usage")
+	}
+	if sess.TokensUsedTotal != 773 {
+		t.Fatalf("attempt 1: TokensUsedTotal = %d, want 773", sess.TokensUsedTotal)
+	}
+
+	beginRespawnedAttempt(t, sess)
+
+	o.updateOpenCodeUsageFromJSONL("sup-1120-opencode", sess)
+	if sess.TokensUsedTotal != 773 || sess.TokensUsedAttempt != 0 {
+		t.Fatalf("respawn recount: total=%d attempt=%d, want 773/0 (no new worker output)",
+			sess.TokensUsedTotal, sess.TokensUsedAttempt)
+	}
+
+	run2 := opencodeStepFinishFrame(900, 100, 0.002) // total 1000
+	if err := os.WriteFile(jsonlPath, []byte(run1+run2), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateOpenCodeUsageFromJSONL("sup-1120-opencode", sess) {
+		t.Fatal("attempt 2: expected the new frames to stamp usage")
+	}
+	if sess.TokensUsedTotal != 1773 || sess.TokensUsedAttempt != 1000 {
+		t.Fatalf("attempt 2: total=%d attempt=%d, want 1773/1000 (new usage counted once)",
+			sess.TokensUsedTotal, sess.TokensUsedAttempt)
+	}
+}
+
+// #1120: an in-place respawn rotates slot.log/slot.jsonl and a phase
+// transition switches to a new log path, so the replacement stream really does
+// start from zero. The cumulative parse going backwards is the only honest
+// signal of that, and it must rewind the watermark — otherwise the new
+// attempt's tokens are swallowed until they pass the old attempt's total.
+func TestUpdateClaudeUsageFromJSONL_RotatedStreamCountsNewAttemptInFull(t *testing.T) {
+	o, sess, jsonlPath := claudeTestOrchestrator(t, "sup-1120-rotate")
+
+	if err := os.WriteFile(jsonlPath, []byte(claudeResultFrame(770, 3, 0, 0, 0.001, "a")), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateClaudeUsageFromJSONL("sup-1120-rotate", sess) {
+		t.Fatal("attempt 1: expected the jsonl side channel to stamp usage")
+	}
+	if sess.TokensUsedTotal != 773 || sess.UsageTokensWatermark != 773 {
+		t.Fatalf("attempt 1: total=%d watermark=%d, want 773/773", sess.TokensUsedTotal, sess.UsageTokensWatermark)
+	}
+
+	beginRespawnedAttempt(t, sess)
+
+	// rotateWorkerAttemptLog moved the previous attempt aside; the replacement
+	// process writes a fresh, smaller stream to the same path.
+	if err := os.WriteFile(jsonlPath, []byte(claudeResultFrame(400, 100, 0, 0, 0.0005, "b")), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateClaudeUsageFromJSONL("sup-1120-rotate", sess) {
+		t.Fatal("attempt 2: expected the rotated stream to stamp usage")
+	}
+	if sess.TokensUsedTotal != 1273 || sess.TokensUsedAttempt != 500 || sess.UsageTokensWatermark != 500 {
+		t.Fatalf("attempt 2: total=%d attempt=%d watermark=%d, want 1273/500/500 (rotated stream counted in full)",
+			sess.TokensUsedTotal, sess.TokensUsedAttempt, sess.UsageTokensWatermark)
+	}
+}
+
+// #1120: the token-budget watermark indexes the same rotated stream, so it has
+// to rewind with it. A budget watermark left at the previous attempt's total
+// would report the replacement worker as having burned nothing.
+func TestUpdateCodexUsageFromJSONL_RotatedStreamRewindsBudgetWatermark(t *testing.T) {
+	o, sess, jsonlPath := codexTestOrchestrator(t, "sup-1120-rotate-codex")
+
+	if err := os.WriteFile(jsonlPath, []byte(codexTurnFrame(770, 0, 3)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateCodexUsageFromJSONL("sup-1120-rotate-codex", sess) {
+		t.Fatal("attempt 1: expected the jsonl side channel to stamp usage")
+	}
+	if sess.TokenBudgetTokensWatermark != 773 {
+		t.Fatalf("attempt 1: TokenBudgetTokensWatermark = %d, want 773", sess.TokenBudgetTokensWatermark)
+	}
+
+	beginRespawnedAttempt(t, sess)
+
+	if err := os.WriteFile(jsonlPath, []byte(codexTurnFrame(400, 0, 100)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if !o.updateCodexUsageFromJSONL("sup-1120-rotate-codex", sess) {
+		t.Fatal("attempt 2: expected the rotated stream to stamp usage")
+	}
+	if sess.TokenBudgetTokensAttempt != 500 || sess.TokenBudgetTokensWatermark != 500 {
+		t.Fatalf("attempt 2: budget attempt=%d watermark=%d, want 500/500 (rotated stream counted in full)",
+			sess.TokenBudgetTokensAttempt, sess.TokenBudgetTokensWatermark)
+	}
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -281,7 +281,7 @@ type Session struct {
 	// configured per-backend pricing estimate.
 	Model                      string     `json:"model,omitempty"`                  // model the backend reported for this run (e.g. glm-5.2:cloud, claude-opus-4-8)
 	CostUSDBackend             float64    `json:"cost_usd_backend,omitempty"`       // USD cost the backend self-reported (Pi cost.total / claude total_cost_usd)
-	UsageTokensWatermark       int        `json:"usage_tokens_watermark,omitempty"` // #730/#737: high-water mark of the current attempt's backend usage stream; reset when an attempt log is rotated so a replacement process starts from its own zero while TokensUsedTotal remains cumulative
+	UsageTokensWatermark       int        `json:"usage_tokens_watermark,omitempty"` // #730/#737/#1120: read position in the backend's append-only usage side channel; survives a respawn that keeps appending to the same log/jsonl and is rewound only when the parsed cumulative total goes backwards (rotated or replaced stream), so TokensUsedTotal counts every token exactly once
 	LongRunning                bool       `json:"long_running,omitempty"`
 	RebaseAttempted            bool       `json:"rebase_attempted,omitempty"`
 	NotifiedCIFail             bool       `json:"notified_ci_fail,omitempty"`           // deprecated: use LastNotifiedStatus

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -238,6 +238,15 @@ type AdvisorReview struct {
 	ReviewedAt     time.Time `json:"reviewed_at"`
 }
 
+// UsageStreamCursor is one parser's read position into the worker's
+// append-only usage side channel. Every usage parser re-reads the whole file
+// and returns a cumulative total, so the cursor records how much of that
+// total has already been folded into the session's counters (#1120).
+type UsageStreamCursor struct {
+	TotalTokens  int `json:"total_tokens,omitempty"`  // cumulative provider total already counted into TokensUsedTotal
+	BudgetTokens int `json:"budget_tokens,omitempty"` // cumulative budget measure already counted into TokenBudgetTokensAttempt
+}
+
 type Session struct {
 	IssueNumber int    `json:"issue_number"`
 	IssueTitle  string `json:"issue_title"`
@@ -279,9 +288,20 @@ type Session struct {
 	// usage stream (Pi --mode json event stream). Empty/zero for backends
 	// that do not self-report; the fleet cost panel then falls back to the
 	// configured per-backend pricing estimate.
-	Model                      string     `json:"model,omitempty"`                  // model the backend reported for this run (e.g. glm-5.2:cloud, claude-opus-4-8)
-	CostUSDBackend             float64    `json:"cost_usd_backend,omitempty"`       // USD cost the backend self-reported (Pi cost.total / claude total_cost_usd)
-	UsageTokensWatermark       int        `json:"usage_tokens_watermark,omitempty"` // #730/#737/#1120: read position in the backend's append-only usage side channel; survives a respawn that keeps appending to the same log/jsonl and is rewound only when the parsed cumulative total goes backwards (rotated or replaced stream), so TokensUsedTotal counts every token exactly once
+	Model                string  `json:"model,omitempty"`                  // model the backend reported for this run (e.g. glm-5.2:cloud, claude-opus-4-8)
+	CostUSDBackend       float64 `json:"cost_usd_backend,omitempty"`       // USD cost the backend self-reported (Pi cost.total / claude total_cost_usd)
+	UsageTokensWatermark int     `json:"usage_tokens_watermark,omitempty"` // #730/#737/#1120: mirror of the usage-stream read position that last advanced; UsageStreamCursors is authoritative, this stays readable in state dumps and seeds the cursor of a session upgraded mid-attempt
+
+	// #1120: per-parser read positions into the worker's append-only usage
+	// side channel (<slot>.log for the text/Pi parsers, <slot>.jsonl for the
+	// structured ones). A respawn recomputes those exact paths, so the
+	// positions must survive a new attempt or the next poll re-adds the
+	// previous attempt's whole cumulative total to TokensUsedTotal. They are
+	// keyed per parser because a fallover leaves one file holding two
+	// backends' frames and each parser sums only its own: one shared position
+	// would silently swallow whichever backend's total is the smaller number.
+	UsageStreamCursors map[string]UsageStreamCursor `json:"usage_stream_cursors,omitempty"`
+
 	LongRunning                bool       `json:"long_running,omitempty"`
 	RebaseAttempted            bool       `json:"rebase_attempted,omitempty"`
 	NotifiedCIFail             bool       `json:"notified_ci_fail,omitempty"`           // deprecated: use LastNotifiedStatus
@@ -297,7 +317,7 @@ type Session struct {
 	TokensUsedAttempt          int        `json:"tokens_used_attempt,omitempty"`           // tokens consumed in current attempt (reset on respawn)
 	TokensUsedTotal            int        `json:"tokens_used_total,omitempty"`             // cumulative tokens across the issue lifecycle (sum of the split dimensions below; kept for back-compat)
 	TokenBudgetTokensAttempt   int        `json:"token_budget_tokens_attempt,omitempty"`   // current-attempt usage under TokenBudgetMeasure; kept separate from inclusive cost telemetry
-	TokenBudgetTokensWatermark int        `json:"token_budget_tokens_watermark,omitempty"` // high-water mark for the current attempt's cumulative budget measure
+	TokenBudgetTokensWatermark int        `json:"token_budget_tokens_watermark,omitempty"` // #1120: high-water mark of the absolute, already-attempt-scoped budget observations (generic text total, live-monitor marker); reset per attempt, unlike the UsageStreamCursors read positions
 	TokenBudgetMeasure         string     `json:"token_budget_measure,omitempty"`          // explicit live-ceiling measure, e.g. uncached_tokens
 	WorkerOutcome              string     `json:"worker_outcome,omitempty"`                // deterministic terminal worker outcome, e.g. token_budget_exceeded
 	// #739: cache-aware split token counters stamped from a backend usage

--- a/internal/worker/attribution.go
+++ b/internal/worker/attribution.go
@@ -26,9 +26,16 @@ func beginSessionAttempt(cfg *config.Config, sess *state.Session, backendName, r
 	sess.Backend = backendName
 	sess.Model = ""
 	sess.CostUSDBackend = 0
-	sess.UsageTokensWatermark = 0
+	// #1120: the per-attempt counters restart at zero, but the usage/budget
+	// watermarks must not. They are read positions in the backend's
+	// append-only side channel (slot.log / slot.jsonl), and a fallover respawn
+	// keeps writing to the same files — clearing them here made the next
+	// orchestrator poll re-add the previous attempt's whole cumulative total
+	// to TokensUsedTotal. When the stream really does start over (an in-place
+	// respawn rotates the log, a phase transition switches to a new path, or
+	// the replacement backend's parser sees only its own frames) the parsed
+	// cumulative goes backwards and the orchestrator rewinds them there.
 	sess.TokensUsedAttempt = 0
-	sess.TokenBudgetTokensWatermark = 0
 	sess.TokenBudgetTokensAttempt = 0
 	sess.TokenBudgetMeasure = ""
 	sess.WorkerOutcome = ""

--- a/internal/worker/attribution.go
+++ b/internal/worker/attribution.go
@@ -26,17 +26,28 @@ func beginSessionAttempt(cfg *config.Config, sess *state.Session, backendName, r
 	sess.Backend = backendName
 	sess.Model = ""
 	sess.CostUSDBackend = 0
-	// #1120: the per-attempt counters restart at zero, but the usage/budget
-	// watermarks must not. They are read positions in the backend's
-	// append-only side channel (slot.log / slot.jsonl), and a fallover respawn
-	// keeps writing to the same files — clearing them here made the next
+	// #1120: the per-attempt counters restart at zero, but the usage-stream
+	// read positions (UsageTokensWatermark / UsageStreamCursors) must not.
+	// They index the backend's append-only side channel, and a fallover
+	// respawn recomputes the same <slot>.log path while the stream splitter
+	// reopens <slot>.jsonl with O_APPEND — clearing them here made the next
 	// orchestrator poll re-add the previous attempt's whole cumulative total
-	// to TokensUsedTotal. When the stream really does start over (an in-place
-	// respawn rotates the log, a phase transition switches to a new path, or
-	// the replacement backend's parser sees only its own frames) the parsed
-	// cumulative goes backwards and the orchestrator rewinds them there.
+	// to TokensUsedTotal. The orchestrator rewinds them itself when a parse
+	// proves the file behind them restarted; an in-place respawn does rotate
+	// <slot>.log (rotateWorkerAttemptLog) and a phase transition points the
+	// session at a new log path.
+	//
+	// TokenBudgetTokensWatermark is not a read position: it is the high-water
+	// mark of the absolute, already-attempt-scoped budget observations (the
+	// generic text total and the per-generation live-monitor marker), so it
+	// does reset here. Leaving it set would hand the replacement worker the
+	// previous attempt's ceiling, and for a backend without usage_stream
+	// there is no splitter, no live monitor and no marker —
+	// TokenBudgetTokensAttempt is then the only thing enforcing
+	// worker_max_tokens at all.
 	sess.TokensUsedAttempt = 0
 	sess.TokenBudgetTokensAttempt = 0
+	sess.TokenBudgetTokensWatermark = 0
 	sess.TokenBudgetMeasure = ""
 	sess.WorkerOutcome = ""
 	sess.WorkerLeaseID = ""

--- a/internal/worker/attribution_test.go
+++ b/internal/worker/attribution_test.go
@@ -186,3 +186,35 @@ func TestRecordBackendAttribution_UnknownBackend_NoMetadata(t *testing.T) {
 		t.Fatalf("unknown backend should have empty metadata, got %+v", seg)
 	}
 }
+
+// #1120: a fallover respawn recomputes the same <slot>.log path, the
+// stream-splitter reopens <slot>.jsonl with O_APPEND, and nothing truncates
+// either file. The usage watermarks are therefore read positions into a stream
+// the replacement process keeps extending — clearing them made the next
+// orchestrator poll add the previous attempt's cumulative total to
+// TokensUsedTotal a second time, doubling the session total per retry.
+func TestBeginSessionAttemptKeepsUsageWatermarksAcrossFallover(t *testing.T) {
+	sess := &state.Session{
+		Backend:                    "claude",
+		Status:                     state.StatusDead,
+		UsageTokensWatermark:       26064,
+		TokensUsedAttempt:          26064,
+		TokensUsedTotal:            26064,
+		TokenBudgetTokensWatermark: 9000,
+		TokenBudgetTokensAttempt:   9000,
+	}
+
+	beginSessionAttempt(attribCfgWithBackends(), sess, "sol", "fallover", "fallover", time.Now().UTC())
+
+	if sess.UsageTokensWatermark != 26064 || sess.TokenBudgetTokensWatermark != 9000 {
+		t.Fatalf("watermarks = %d/%d, want 26064/9000 preserved (the jsonl was not rotated)",
+			sess.UsageTokensWatermark, sess.TokenBudgetTokensWatermark)
+	}
+	if sess.TokensUsedAttempt != 0 || sess.TokenBudgetTokensAttempt != 0 {
+		t.Fatalf("attempt counters = %d/%d, want 0/0 for the new attempt",
+			sess.TokensUsedAttempt, sess.TokenBudgetTokensAttempt)
+	}
+	if sess.TokensUsedTotal != 26064 {
+		t.Fatalf("TokensUsedTotal = %d, want 26064 unchanged by starting an attempt", sess.TokensUsedTotal)
+	}
+}

--- a/internal/worker/attribution_test.go
+++ b/internal/worker/attribution_test.go
@@ -189,15 +189,27 @@ func TestRecordBackendAttribution_UnknownBackend_NoMetadata(t *testing.T) {
 
 // #1120: a fallover respawn recomputes the same <slot>.log path, the
 // stream-splitter reopens <slot>.jsonl with O_APPEND, and nothing truncates
-// either file. The usage watermarks are therefore read positions into a stream
+// either file. The usage cursors are therefore read positions into a stream
 // the replacement process keeps extending — clearing them made the next
 // orchestrator poll add the previous attempt's cumulative total to
 // TokensUsedTotal a second time, doubling the session total per retry.
-func TestBeginSessionAttemptKeepsUsageWatermarksAcrossFallover(t *testing.T) {
+//
+// TokenBudgetTokensWatermark is the opposite case and must still reset: it is
+// the high-water mark of absolute, already-attempt-scoped budget observations,
+// and a backend without usage_stream has no stream splitter, no live token
+// monitor and no durable marker — TokenBudgetTokensAttempt is then the only
+// thing enforcing worker_max_tokens, so an inherited ceiling silently raises
+// the budget for every replacement worker.
+//
+// This exercises the real cross-backend fallover call: internal/worker's
+// Respawn runs beginSessionAttempt(cfg, sess, backendName, "fallover",
+// "fallover", now) with the next backend in the chain.
+func TestBeginSessionAttemptFalloverKeepsStreamCursorsAndResetsBudgetCeiling(t *testing.T) {
 	sess := &state.Session{
 		Backend:                    "claude",
 		Status:                     state.StatusDead,
 		UsageTokensWatermark:       26064,
+		UsageStreamCursors:         map[string]state.UsageStreamCursor{"claude": {TotalTokens: 26064, BudgetTokens: 21000}},
 		TokensUsedAttempt:          26064,
 		TokensUsedTotal:            26064,
 		TokenBudgetTokensWatermark: 9000,
@@ -206,9 +218,18 @@ func TestBeginSessionAttemptKeepsUsageWatermarksAcrossFallover(t *testing.T) {
 
 	beginSessionAttempt(attribCfgWithBackends(), sess, "sol", "fallover", "fallover", time.Now().UTC())
 
-	if sess.UsageTokensWatermark != 26064 || sess.TokenBudgetTokensWatermark != 9000 {
-		t.Fatalf("watermarks = %d/%d, want 26064/9000 preserved (the jsonl was not rotated)",
-			sess.UsageTokensWatermark, sess.TokenBudgetTokensWatermark)
+	if sess.Backend != "sol" {
+		t.Fatalf("Backend = %q, want sol (the fallover target)", sess.Backend)
+	}
+	if sess.UsageTokensWatermark != 26064 {
+		t.Fatalf("UsageTokensWatermark = %d, want 26064 preserved (the jsonl was not rotated)", sess.UsageTokensWatermark)
+	}
+	claude, ok := sess.UsageStreamCursors["claude"]
+	if !ok || claude.TotalTokens != 26064 || claude.BudgetTokens != 21000 {
+		t.Fatalf("claude stream cursor = %+v (present=%v), want {TotalTokens:26064 BudgetTokens:21000} preserved", claude, ok)
+	}
+	if sess.TokenBudgetTokensWatermark != 0 {
+		t.Fatalf("TokenBudgetTokensWatermark = %d, want 0: an absolute per-attempt ceiling must not be inherited by the replacement worker", sess.TokenBudgetTokensWatermark)
 	}
 	if sess.TokensUsedAttempt != 0 || sess.TokenBudgetTokensAttempt != 0 {
 		t.Fatalf("attempt counters = %d/%d, want 0/0 for the new attempt",

--- a/internal/worker/checkpoint_test.go
+++ b/internal/worker/checkpoint_test.go
@@ -298,15 +298,17 @@ func TestBeginSessionAttemptClearsPriorProjectionAndPreservesHistory(t *testing.
 	if sess.FinishedAt != nil || sess.WorkerEndedAt != nil || sess.Model != "" || sess.CostUSDBackend != 0 {
 		t.Fatalf("stale projection retained: finished=%v ended=%v model=%q cost=%v", sess.FinishedAt, sess.WorkerEndedAt, sess.Model, sess.CostUSDBackend)
 	}
-	if sess.TokensUsedAttempt != 0 || sess.TokenBudgetTokensAttempt != 0 || sess.TokenBudgetMeasure != "" || sess.WorkerOutcome != "" {
-		t.Fatalf("attempt counters not reset: attempt=%d budget=%d measure=%q outcome=%q", sess.TokensUsedAttempt, sess.TokenBudgetTokensAttempt, sess.TokenBudgetMeasure, sess.WorkerOutcome)
+	if sess.TokensUsedAttempt != 0 || sess.TokenBudgetTokensAttempt != 0 || sess.TokenBudgetTokensWatermark != 0 || sess.TokenBudgetMeasure != "" || sess.WorkerOutcome != "" {
+		t.Fatalf("attempt counters not reset: attempt=%d budget=%d budget_watermark=%d measure=%q outcome=%q", sess.TokensUsedAttempt, sess.TokenBudgetTokensAttempt, sess.TokenBudgetTokensWatermark, sess.TokenBudgetMeasure, sess.WorkerOutcome)
 	}
-	// #1120: the watermarks are read positions in the append-only usage side
-	// channel, not per-attempt counters. The orchestrator rewinds them when the
-	// parsed stream actually starts over; clearing them here made the next poll
-	// re-add the previous attempt's cumulative total.
-	if sess.UsageTokensWatermark != 1_730_413 || sess.TokenBudgetTokensWatermark != 120_000 {
-		t.Fatalf("usage watermarks cleared: usage=%d budget=%d, want 1730413/120000 preserved", sess.UsageTokensWatermark, sess.TokenBudgetTokensWatermark)
+	// #1120: UsageTokensWatermark is a read position in the append-only usage
+	// side channel, not a per-attempt counter — the replacement process keeps
+	// appending to the same <slot>.jsonl, so clearing it here made the next
+	// orchestrator poll re-add the previous attempt's cumulative total.
+	// TokenBudgetTokensWatermark asserted above is the opposite case: it holds
+	// absolute per-attempt observations and must reset with the attempt.
+	if sess.UsageTokensWatermark != 1_730_413 {
+		t.Fatalf("usage read position cleared: %d, want 1730413 preserved", sess.UsageTokensWatermark)
 	}
 	if sess.TokensUsedTotal != 1_730_413 || sess.Worktree != "/tmp/kept-worktree" || sess.Branch != "feat/kept-branch" || sess.PRNumber != 335 {
 		t.Fatalf("cumulative/session identity changed: total=%d worktree=%q branch=%q PR=%d", sess.TokensUsedTotal, sess.Worktree, sess.Branch, sess.PRNumber)

--- a/internal/worker/checkpoint_test.go
+++ b/internal/worker/checkpoint_test.go
@@ -298,8 +298,15 @@ func TestBeginSessionAttemptClearsPriorProjectionAndPreservesHistory(t *testing.
 	if sess.FinishedAt != nil || sess.WorkerEndedAt != nil || sess.Model != "" || sess.CostUSDBackend != 0 {
 		t.Fatalf("stale projection retained: finished=%v ended=%v model=%q cost=%v", sess.FinishedAt, sess.WorkerEndedAt, sess.Model, sess.CostUSDBackend)
 	}
-	if sess.TokensUsedAttempt != 0 || sess.UsageTokensWatermark != 0 || sess.TokenBudgetTokensAttempt != 0 || sess.TokenBudgetTokensWatermark != 0 || sess.TokenBudgetMeasure != "" || sess.WorkerOutcome != "" {
-		t.Fatalf("attempt counters not reset: attempt=%d watermark=%d budget=%d budget_watermark=%d measure=%q outcome=%q", sess.TokensUsedAttempt, sess.UsageTokensWatermark, sess.TokenBudgetTokensAttempt, sess.TokenBudgetTokensWatermark, sess.TokenBudgetMeasure, sess.WorkerOutcome)
+	if sess.TokensUsedAttempt != 0 || sess.TokenBudgetTokensAttempt != 0 || sess.TokenBudgetMeasure != "" || sess.WorkerOutcome != "" {
+		t.Fatalf("attempt counters not reset: attempt=%d budget=%d measure=%q outcome=%q", sess.TokensUsedAttempt, sess.TokenBudgetTokensAttempt, sess.TokenBudgetMeasure, sess.WorkerOutcome)
+	}
+	// #1120: the watermarks are read positions in the append-only usage side
+	// channel, not per-attempt counters. The orchestrator rewinds them when the
+	// parsed stream actually starts over; clearing them here made the next poll
+	// re-add the previous attempt's cumulative total.
+	if sess.UsageTokensWatermark != 1_730_413 || sess.TokenBudgetTokensWatermark != 120_000 {
+		t.Fatalf("usage watermarks cleared: usage=%d budget=%d, want 1730413/120000 preserved", sess.UsageTokensWatermark, sess.TokenBudgetTokensWatermark)
 	}
 	if sess.TokensUsedTotal != 1_730_413 || sess.Worktree != "/tmp/kept-worktree" || sess.Branch != "feat/kept-branch" || sess.PRNumber != 335 {
 		t.Fatalf("cumulative/session identity changed: total=%d worktree=%q branch=%q PR=%d", sess.TokensUsedTotal, sess.Worktree, sess.Branch, sess.PRNumber)


### PR DESCRIPTION
## Problem

Every fallover respawn re-counted the previous attempt's tokens into `TokensUsedTotal`.

`internal/worker/attribution.go:beginSessionAttempt` cleared `UsageTokensWatermark` (and `TokenBudgetTokensWatermark`) on every new attempt, on the documented assumption that "an attempt log is rotated so a replacement process starts from its own zero". That precondition holds for `RespawnInPlace` (which calls `rotateWorkerAttemptLog`) and for a phase transition (new log path). It does **not** hold for a fallover respawn: `worker.Respawn` recomputes the same `logDir/<slot>.log`, `JSONLPathForLog` yields the same `<slot>.jsonl`, and `RunStreamSplitWithBudget` reopens it with `O_CREATE|O_WRONLY|O_APPEND`. Nothing truncates, removes, or rotates it.

So on the next poll the cumulative parse still saw the previous attempt's frames, the watermark was 0, and `delta = usage.TotalTokens - 0` was added to `TokensUsedTotal` a second time. All four `update*UsageFromJSONL` paths shared the bug, plus `updatePiUsageFromOutput`, which reads the equally append-only `slot.log`. The in-code comments claimed the opposite ("the monotonic UsageTokensWatermark persists across respawns").

Two consequences beyond inflated telemetry:

- `TokenBudgetTokensAttempt` also restarted full, because it accrued the same re-counted cumulative. `terminalizeTokenBudgetIfExceeded` compares that counter against `worker_max_tokens` as its backstop, so a replacement worker could be stopped for a budget its predecessor spent. (The live kill path itself is unaffected — that runs off the generation-scoped `stream_split` monitor/marker.)
- Virtual cost attribution and any burn analysis derived from cumulative session tokens were inflated by roughly the attempt count.

## Fix

The watermarks are read positions into an append-only side channel, not per-attempt counters. Treat them that way:

1. `beginSessionAttempt` no longer clears `UsageTokensWatermark` / `TokenBudgetTokensWatermark`. `TokensUsedAttempt`, `TokenBudgetTokensAttempt` and `TokenBudgetMeasure` still reset — those really are per-attempt.
2. New `resetUsageWatermarksIfStreamRestarted` in `internal/orchestrator/orchestrator.go` rewinds both watermarks when the parsed cumulative total goes backwards. Every parser is cumulative over an append-only file, so that can only happen when the file behind it changed: an in-place respawn rotated it, a phase transition switched paths, or a fallover handed the same `slot.jsonl` to a different backend whose parser sees only its own frames (the common case, since a fallover always changes backend). It is called from all four JSONL paths and from the Pi path, which shares the same watermark field.
3. A cumulative of zero is never treated as a restart — a usage-unreliable terminal frame reports zero, and rewinding on it would let the next real frame be added twice.

Without (1) the previous attempt is double-counted; without (2) a genuinely rotated stream is swallowed until it passes the old attempt's total. Both halves are covered by tests.

The stale comments in `orchestrator.go` and the field doc on `state.Session.UsageTokensWatermark` now describe actual behaviour.

## Evidence

The issue's reproduction hardcodes the buggy reset (`sess.UsageTokensWatermark = 0`), so it cannot be used verbatim against a fix that removes that reset. The equivalent tests drive the production reset instead: `worker.AdoptLiveRuntime` is the exported entry point into `beginSessionAttempt`, the single function every respawn path calls to open a new attempt.

New tests, all in the production call path:

- `TestUpdate{Claude,Codex,Kimi,OpenCode}UsageFromJSONL_RespawnDoesNotRecountPreviousAttempt` — poll, start a new attempt, poll again with the same bytes (total must not move, attempt must be 0), then append genuinely new frames (counted exactly once). Codex additionally asserts `TokenBudgetTokensAttempt`.
- `TestUpdateClaudeUsageFromJSONL_RotatedStreamCountsNewAttemptInFull` and `TestUpdateCodexUsageFromJSONL_RotatedStreamRewindsBudgetWatermark` — the rotated/replaced stream is counted in full and both watermarks rewind.
- `TestBeginSessionAttemptKeepsUsageWatermarksAcrossFallover` (worker) — the attempt boundary keeps the watermarks and zeroes the attempt counters.
- `TestBeginSessionAttemptClearsPriorProjectionAndPreservesHistory` (worker) updated to the corrected contract.

Verified on this branch with `umask 022`, Go 1.x on the runtime host:

```
# fix reverted in internal/worker/attribution.go + internal/orchestrator/orchestrator.go
--- FAIL: TestUpdateClaudeUsageFromJSONL_RespawnDoesNotRecountPreviousAttempt
--- FAIL: TestUpdateCodexUsageFromJSONL_RespawnDoesNotRecountPreviousAttempt
--- FAIL: TestUpdateKimiUsageFromJSONL_RespawnDoesNotRecountPreviousAttempt
--- FAIL: TestUpdateOpenCodeUsageFromJSONL_RespawnDoesNotRecountPreviousAttempt
    orchestrator_test.go: respawn recount: total=1546 attempt=773, want 773/0 (no new worker output)
--- FAIL: TestBeginSessionAttemptKeepsUsageWatermarksAcrossFallover
    attribution_test.go: watermarks = 0/0, want 26064/9000 preserved (the jsonl was not rotated)

# only the orchestrator half reverted (no restart detection)
--- FAIL: TestUpdateClaudeUsageFromJSONL_RotatedStreamCountsNewAttemptInFull
--- FAIL: TestUpdateCodexUsageFromJSONL_RotatedStreamRewindsBudgetWatermark

# full branch
go build ./... && go test ./... -count=1   ->  exit 0 (36 packages)
gofmt -l internal/                          ->  internal/worker/opencode_usage.go (pre-existing on main, untouched)
```

## Not in scope

The legacy text path at the bottom of `updateTokensUsedFromOutput` (`worker.ParseTokensFromOutput`) uses `TokensUsedAttempt` itself as its watermark and has the same shape of problem across a respawn. It is a separate parser with its own semantics and its own test surface, so it is left alone here rather than folded into this fix.

Refs #1120
