### PR TITLE
Alert and hold on an absolute tmpfs free-byte budget

### DIFF
--- a/cmd/maestro/daemon.go
+++ b/cmd/maestro/daemon.go
@@ -17,6 +17,7 @@ import (
 	"github.com/befeast/maestro/internal/daemon"
 	"github.com/befeast/maestro/internal/emergencystore"
 	"github.com/befeast/maestro/internal/statestore"
+	"github.com/befeast/maestro/internal/tmpfshygiene"
 	"github.com/befeast/maestro/internal/webhook"
 	"github.com/befeast/maestro/internal/webhookstore"
 )
@@ -32,6 +33,9 @@ func daemonCmd(args []string) {
 	runInterval := fs.Duration("run-interval", daemon.DefaultRunInterval, "Orchestrator loop interval")
 	superviseInterval := fs.Duration("supervise-interval", daemon.DefaultSuperviseInterval, "Supervisor loop interval")
 	tmpfsHygieneInterval := fs.Duration("tmpfs-hygiene-interval", daemon.DefaultTmpfsHygieneInterval, "Protect-aware /tmp apply interval")
+	tmpfsPressureInterval := fs.Duration("tmpfs-pressure-interval", daemon.DefaultTmpfsPressureInterval, "Sweep-independent /tmp free-space sampling interval (#1128)")
+	tmpfsPressureFloor := fs.Int64("tmpfs-pressure-floor-bytes", tmpfshygiene.DefaultPressureFreeBytes, "Free bytes on /tmp below which the operator is paged CRITICAL; negative disables (#1128)")
+	tmpfsSpawnFloor := fs.Int64("tmpfs-spawn-floor-bytes", tmpfshygiene.DefaultSpawnFreeBytes, "Free bytes on /tmp below which new worker dispatch pauses; negative disables (#1128)")
 	host := fs.String("host", "127.0.0.1", "Host/interface to bind the fleet web server")
 	port := fs.Int("port", 8786, "Port to bind the fleet web server")
 	promptPath := fs.String("prompt", "", "Path to worker prompt base file")
@@ -62,14 +66,17 @@ func daemonCmd(args []string) {
 	defer store.Close()
 
 	d := daemon.New(store, daemon.Options{
-		Host:                 *host,
-		Port:                 *port,
-		RunInterval:          *runInterval,
-		SuperviseInterval:    *superviseInterval,
-		TmpfsHygieneInterval: *tmpfsHygieneInterval,
-		PromptPath:           *promptPath,
-		Version:              resolveVersion(),
-		ReadOnly:             *readOnly,
+		Host:                    *host,
+		Port:                    *port,
+		RunInterval:             *runInterval,
+		SuperviseInterval:       *superviseInterval,
+		TmpfsHygieneInterval:    *tmpfsHygieneInterval,
+		TmpfsPressureInterval:   *tmpfsPressureInterval,
+		TmpfsPressureFloorBytes: *tmpfsPressureFloor,
+		TmpfsSpawnFloorBytes:    *tmpfsSpawnFloor,
+		PromptPath:              *promptPath,
+		Version:                 resolveVersion(),
+		ReadOnly:                *readOnly,
 		// Centralized self-deploy debounce marker (#758): one shared location next
 		// to the config store so every flow's RequestSelfDeploy debounces on the
 		// same marker, and it survives the daemon being restarted by its own

--- a/docs/tmpfs-hygiene-runbook.md
+++ b/docs/tmpfs-hygiene-runbook.md
@@ -35,7 +35,12 @@ service journal. Important fields are:
 - `protect_hits`: counts for cwd, fd, cmdline, age, configured-path, git,
   socket/lock, ownership, symlink, scan, and filesystem-boundary guards;
 - `use_pct`: tmpfs utilization after the sweep;
-- `attention_code`: `tmpfs_pressure` when post-sweep `use_pct >= 85`.
+- `total_bytes` / `available_bytes`: the post-sweep capacity the pressure
+  verdict was made on;
+- `attention_code`: `tmpfs_pressure` when post-sweep `available_bytes` falls
+  below `pressure_floor_bytes` (default 8GiB). This is an absolute free-byte
+  budget, not a share of the mount (#1128): 85% of a RAM-backed tmpfs says
+  nothing about how close the host is to running out of memory.
 
 Example inspection without printing unrelated service logs:
 
@@ -98,6 +103,8 @@ After every apply, Fleet exposes the exact post-sweep state:
     "mode": "apply",
     "tmpfs": true,
     "use_pct": 87,
+    "available_bytes": 2147483648,
+    "pressure_floor_bytes": 8589934592,
     "pressure": true,
     "attention_code": "tmpfs_pressure"
   }
@@ -107,6 +114,44 @@ After every apply, Fleet exposes the exact post-sweep state:
 If `/tmp` is not tmpfs, or the configured protection paths cannot be loaded,
 the sweep fails closed, deletes nothing, emits an `error` field, and preserves
 that failed result for Fleet inspection.
+
+## Pressure alert and spawn precondition (#1128)
+
+The pressure signal does not depend on a sweep. The daemon samples the tmpfs
+root every `--tmpfs-pressure-interval` (default 30s) and publishes the result as
+`/api/v1/fleet.tmpfs_pressure`, so the signal exists even when the sweeper is
+refused or reclaims nothing:
+
+```json
+{
+  "tmpfs_pressure": {
+    "root": "/tmp",
+    "total_bytes": 16686817280,
+    "available_bytes": 2147483648,
+    "use_pct": 87,
+    "pressure_floor_bytes": 8589934592,
+    "spawn_floor_bytes": 4294967296,
+    "pressure": true,
+    "spawn_hold": true,
+    "held_spawns": 3
+  }
+}
+```
+
+Two independent absolute floors act on that sample:
+
+- `--tmpfs-pressure-floor-bytes` (default 8GiB) — two consecutive samples below
+  it send an ntfy CRITICAL of class `tmpfs_pressure` at priority 5, one page per
+  episode, cleared on recovery. Negative disables the alert.
+- `--tmpfs-spawn-floor-bytes` (default 4GiB) — below it the orchestrator skips
+  its dispatch cycle before listing issues, logging the reason and counting the
+  skip in `held_spawns`. Negative disables the pause.
+
+The spawn precondition is a **throughput pause, never a freeze**: it persists no
+state, requires no approval, produces no `ActionNone` decision, and spends no
+issue retry budget. Every poll re-evaluates it, so dispatch resumes on its own
+as soon as space is reclaimed. It also fails open — a missing or failed sample
+lets dispatch through, because a measurement gap must not park the fleet.
 
 ## 24-hour dogfood verification
 
@@ -120,8 +165,11 @@ Deployment/runtime verification remains an operator step after the code lands:
    `browser_profile`, `worker_scratch`, and `tooling_cache` candidates are
    deleted after their age gates rather than increasing monotonically.
 4. Confirm `/api/v1/fleet.tmpfs_hygiene` advances every interval and that a
-   forced or naturally observed post-sweep utilization of at least 85% reports
-   `attention_code: tmpfs_pressure`.
+   forced or naturally observed post-sweep `available_bytes` below the
+   pressure floor reports `attention_code: tmpfs_pressure`. Confirm
+   `/api/v1/fleet.tmpfs_pressure` advances on its own 30s cadence even when a
+   sweep deleted nothing, and that crossing the spawn floor raises
+   `spawn_hold` with a rising `held_spawns` rather than any stuck state.
 5. Investigate persistent `scan_error`, `mount_boundary`, or high
    `proc_scan_errors` counts before broadening policy. Do not add a catch-all
    pattern or a blanket `/tmp` removal.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -176,6 +176,18 @@ type Options struct {
 	// TmpfsHygieneInterval is the daemon-owned protect-aware /tmp apply cadence.
 	// Non-positive values are clamped to DefaultTmpfsHygieneInterval.
 	TmpfsHygieneInterval time.Duration
+	// TmpfsPressureInterval is the cadence of the sweep-independent /tmp
+	// capacity sample (#1128). Non-positive values are clamped to
+	// DefaultTmpfsPressureInterval.
+	TmpfsPressureInterval time.Duration
+	// TmpfsPressureFloorBytes is the absolute free-byte budget below which the
+	// daemon pages the operator. Zero takes
+	// tmpfshygiene.DefaultPressureFreeBytes; negative disables the alert.
+	TmpfsPressureFloorBytes int64
+	// TmpfsSpawnFloorBytes is the absolute free-byte budget below which new
+	// worker dispatch pauses. Zero takes tmpfshygiene.DefaultSpawnFreeBytes;
+	// negative disables the pause.
+	TmpfsSpawnFloorBytes int64
 
 	// PromptPath is an optional worker prompt base file applied to every flow.
 	PromptPath string
@@ -332,6 +344,10 @@ type Daemon struct {
 	// summary. It is independent of per-project flow state.
 	tmpfsHygiene *tmpfsHygieneRuntime
 
+	// tmpfsPressure owns the sweep-independent /tmp capacity sample backing the
+	// CRITICAL pressure alert and the spawn precondition (#1128).
+	tmpfsPressure *tmpfsPressureRuntime
+
 	// runLoop, superviseLoop, watchdogLoop, and materialProgressLoop build the
 	// per-project loops.
 	// They default to the production orchestrator + supervisor wiring; tests
@@ -409,6 +425,9 @@ func New(store ConfigLoader, opts Options) *Daemon {
 	if opts.TmpfsHygieneInterval <= 0 {
 		opts.TmpfsHygieneInterval = DefaultTmpfsHygieneInterval
 	}
+	if opts.TmpfsPressureInterval <= 0 {
+		opts.TmpfsPressureInterval = DefaultTmpfsPressureInterval
+	}
 	if opts.WatchStore && opts.WatchStoreInterval <= 0 {
 		log.Printf("[daemon] watch-store-interval %s is not positive; clamping to default %s", opts.WatchStoreInterval, DefaultWatchStoreInterval)
 		opts.WatchStoreInterval = DefaultWatchStoreInterval
@@ -423,6 +442,10 @@ func New(store ConfigLoader, opts Options) *Daemon {
 		spawnLimiter: newFleetSpawnLimiter(store),
 	}
 	d.tmpfsHygiene = newTmpfsHygieneRuntime(d)
+	// #1128: the capacity sample shares the hygiene root but not its schedule.
+	// The alert and the spawn precondition must not depend on a sweep that can
+	// legitimately refuse to run or reclaim nothing.
+	d.tmpfsPressure = newTmpfsPressureRuntime(d.tmpfsHygiene.options.Root, opts.TmpfsPressureFloorBytes, opts.TmpfsSpawnFloorBytes)
 	if opts.WatchStore {
 		// Only the richer store (Load + ProjectsFingerprint) can drive hot
 		// add/remove/reload. Degrade loudly rather than silently if an embedder
@@ -526,6 +549,7 @@ func (d *Daemon) Run(ctx context.Context) error {
 	// server.New instances the legacy run/serve paths spun up (#516).
 	fleet := server.NewFleet(projects, d.opts.Host, d.opts.Port, d.opts.ReadOnly)
 	fleet.SetTmpfsHygieneSource(d.tmpfsHygieneSummary)
+	fleet.SetTmpfsPressureSource(d.tmpfsPressureSnapshot)
 	// Back the dashboard project-CRUD endpoint (#761) with the SAME config store
 	// the daemon reads, when the store supports the write API. A UI add/remove
 	// then writes the store and the --watch-store diff-loop reconciles it into a
@@ -725,6 +749,23 @@ func (d *Daemon) Run(ctx context.Context) error {
 			<-hygieneDone
 		}
 	}
+	// #1128: CRITICAL tmpfs pressure watch. It samples free bytes on its own
+	// short cadence instead of riding the 10m sweep, so the operator is paged and
+	// dispatch pauses even on a host where the sweeper reclaims nothing.
+	var stopTmpfsPressure func()
+	if d.tmpfsPressure != nil {
+		pctx, pressureCancel := context.WithCancel(ctx)
+		pressureDone := make(chan struct{})
+		go func() {
+			defer close(pressureDone)
+			d.watchTmpfsPressureLoop(pctx, d.opts.TmpfsPressureInterval)
+		}()
+		log.Printf("[daemon] tmpfs pressure watch enabled — sample every %s (CRITICAL below the free-byte floor)", d.opts.TmpfsPressureInterval)
+		stopTmpfsPressure = func() {
+			pressureCancel()
+			<-pressureDone
+		}
+	}
 	drainWatch := func() {
 		if stopWatch != nil {
 			stopWatch()
@@ -737,6 +778,9 @@ func (d *Daemon) Run(ctx context.Context) error {
 		}
 		if stopTmpfsHygiene != nil {
 			stopTmpfsHygiene()
+		}
+		if stopTmpfsPressure != nil {
+			stopTmpfsPressure()
 		}
 	}
 

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -439,6 +439,11 @@ func (d *Daemon) runOrchestrator(ctx context.Context, cfg *config.Config, opts O
 	// leaves the closure reading a permanently-normal cache, i.e. inert.
 	orch.SetEmergencyHalt(d.emergencySpawnHalt)
 	orch.SetFleetSpawnCeiling(d.fleetSpawnCeilingReached)
+	// Host-resource precondition (#1128): /tmp is a RAM-backed tmpfs, so
+	// dispatching into a nearly-full one turns a space problem into a host
+	// memory outage. Daemon.tmpfsSpawnHold is a self-clearing throughput pause
+	// re-evaluated every poll, not a gate and not an approval.
+	orch.SetSpawnResourceHold(d.tmpfsSpawnHold)
 	orch.SetFleetSpawnReserve(func() (func(string), func(), bool) {
 		return d.reserveFleetSpawn(orchCfg.StateDir)
 	})

--- a/internal/daemon/tmpfs_pressure.go
+++ b/internal/daemon/tmpfs_pressure.go
@@ -1,0 +1,214 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/tmpfshygiene"
+)
+
+// DefaultTmpfsPressureInterval is how often the daemon samples free bytes on
+// the tmpfs root (#1128). It is deliberately decoupled from the 10m hygiene
+// sweep: the sweeper refuses a non-tmpfs root outright and can reclaim nothing
+// at all (#1125), yet the operator alert and the spawn precondition still need
+// a current signal. One statfs at this cadence is negligible.
+const DefaultTmpfsPressureInterval = 30 * time.Second
+
+// tmpfsPressureConfirmSamples mirrors floorBreachConfirmSamples: ~1 minute of
+// sustained pressure before paging, so a momentary spike from one worker that
+// is about to exit does not wake the operator.
+const tmpfsPressureConfirmSamples = 2
+
+// tmpfsPressureRuntime owns the sweep-independent capacity sample plus the two
+// consumers built on it: the CRITICAL ntfy and the spawn precondition.
+type tmpfsPressureRuntime struct {
+	mu       sync.RWMutex
+	snapshot tmpfshygiene.PressureSnapshot
+	set      bool
+	// heldSpawns counts every dispatch the precondition paused. It is the
+	// telemetry that separates a deliberate throughput pause from a fleet that
+	// has quietly stopped working.
+	heldSpawns uint64
+
+	sample func() tmpfshygiene.PressureSnapshot
+
+	// streak/notified/episode debounce the alert exactly like floorBreachState:
+	// one page per pressure episode, reset on recovery, with the episode number
+	// in the body so notify.Alert's identical-body dedup cannot swallow a
+	// genuine recurrence. Only the watch goroutine touches them.
+	streak   int
+	notified bool
+	episode  uint64
+	// floorWarned keeps a floor-larger-than-the-mount misconfiguration to one
+	// log line instead of one per tick.
+	floorWarned bool
+}
+
+func newTmpfsPressureRuntime(root string, pressureFloorBytes, spawnFloorBytes int64) *tmpfsPressureRuntime {
+	if pressureFloorBytes == 0 {
+		pressureFloorBytes = tmpfshygiene.DefaultPressureFreeBytes
+	}
+	if spawnFloorBytes == 0 {
+		spawnFloorBytes = tmpfshygiene.DefaultSpawnFreeBytes
+	}
+	opts := tmpfshygiene.SampleOptions{
+		Root:               root,
+		PressureFloorBytes: pressureFloorBytes,
+		SpawnFloorBytes:    spawnFloorBytes,
+	}
+	return &tmpfsPressureRuntime{
+		sample: func() tmpfshygiene.PressureSnapshot { return tmpfshygiene.Sample(opts) },
+	}
+}
+
+// tmpfsPressureSnapshot is the Fleet-facing view. HeldSpawns is stamped on read
+// so the API reports the live counter, not the value at sample time.
+func (d *Daemon) tmpfsPressureSnapshot() (tmpfshygiene.PressureSnapshot, bool) {
+	if d == nil || d.tmpfsPressure == nil {
+		return tmpfshygiene.PressureSnapshot{}, false
+	}
+	r := d.tmpfsPressure
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	snapshot := r.snapshot
+	snapshot.HeldSpawns = r.heldSpawns
+	return snapshot, r.set
+}
+
+func (d *Daemon) watchTmpfsPressureLoop(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = DefaultTmpfsPressureInterval
+	}
+	// Sample immediately rather than after one interval: restarting into an
+	// already-full /tmp must not leave the precondition failing open for the
+	// whole first tick.
+	d.evaluateTmpfsPressure()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.evaluateTmpfsPressure()
+		}
+	}
+}
+
+func (d *Daemon) evaluateTmpfsPressure() {
+	if d == nil || d.tmpfsPressure == nil || d.tmpfsPressure.sample == nil {
+		return
+	}
+	r := d.tmpfsPressure
+	snapshot := r.sample()
+	r.mu.Lock()
+	r.snapshot = snapshot
+	r.set = true
+	r.mu.Unlock()
+
+	if snapshot.Error != "" {
+		// A broken measurement must not page anyone and must not pause anyone:
+		// Sample already reported neither pressure nor hold, so just say so.
+		log.Printf("[daemon] tmpfs pressure sample failed for %s: %s", snapshot.Root, snapshot.Error)
+		return
+	}
+	if snapshot.TotalBytes > 0 && snapshot.PressureFloorBytes >= snapshot.TotalBytes && !r.floorWarned {
+		r.floorWarned = true
+		log.Printf("[daemon] tmpfs pressure floor %s is not smaller than %s (%s); the pressure alert stays off until it is lowered",
+			formatTmpfsBytes(snapshot.PressureFloorBytes), snapshot.Root, formatTmpfsBytes(snapshot.TotalBytes))
+	}
+	if !snapshot.Pressure {
+		if r.streak > 0 {
+			log.Printf("[daemon] tmpfs pressure cleared: %s free=%s floor=%s",
+				snapshot.Root, formatTmpfsBytes(snapshot.AvailableBytes), formatTmpfsBytes(snapshot.PressureFloorBytes))
+		}
+		r.streak = 0
+		r.notified = false
+		return
+	}
+	if r.streak == 0 {
+		r.episode++
+	}
+	r.streak++
+	if r.streak < tmpfsPressureConfirmSamples {
+		log.Printf("[daemon] tmpfs pressure pending confirm: %s free=%s floor=%s sample=%d/%d",
+			snapshot.Root, formatTmpfsBytes(snapshot.AvailableBytes), formatTmpfsBytes(snapshot.PressureFloorBytes),
+			r.streak, tmpfsPressureConfirmSamples)
+		return
+	}
+	if r.notified {
+		return
+	}
+	body := fmt.Sprintf(
+		"CRITICAL: %s free space below the absolute floor — free=%s floor=%s total=%s use=%d%% for %d consecutive samples "+
+			"(pressure episode %d). This tmpfs is RAM-backed, so exhaustion is a host memory outage. "+
+			"New worker dispatch pauses on its own below %s and resumes when space is reclaimed.",
+		snapshot.Root, formatTmpfsBytes(snapshot.AvailableBytes), formatTmpfsBytes(snapshot.PressureFloorBytes),
+		formatTmpfsBytes(snapshot.TotalBytes), snapshot.UsePct, r.streak, r.episode,
+		formatTmpfsBytes(snapshot.SpawnFloorBytes),
+	)
+	log.Printf("[daemon] %s", body)
+	n := d.floorNotifier
+	if n == nil {
+		r.notified = true
+		return
+	}
+	if err := n.Alert(notify.AlertTmpfsPressure, "fleet:tmpfs_pressure", "maestro CRITICAL: tmpfs free space below floor", body); err != nil {
+		log.Printf("[daemon] tmpfs pressure ntfy failed: %v", err)
+		return
+	}
+	r.notified = true
+}
+
+// tmpfsSpawnHold is the host-resource precondition the orchestrator consults
+// before claiming issues or spawning workers (#1128).
+//
+// It is a throughput pause, never a freeze. It persists no state, needs no
+// approval, produces no ActionNone/human-gate decision, and spends none of the
+// issue retry budget — the orchestrator simply returns for this cycle and
+// re-evaluates on the next poll, so dispatch resumes by itself the moment bytes
+// come back. It also fails OPEN: no sample yet, or a failed one, lets dispatch
+// through, because a measurement gap must never park the fleet.
+func (d *Daemon) tmpfsSpawnHold() (bool, string) {
+	if d == nil || d.tmpfsPressure == nil {
+		return false, ""
+	}
+	r := d.tmpfsPressure
+	r.mu.RLock()
+	snapshot := r.snapshot
+	set := r.set
+	r.mu.RUnlock()
+	if !set || snapshot.Error != "" || !snapshot.SpawnHold {
+		return false, ""
+	}
+	r.mu.Lock()
+	r.heldSpawns++
+	held := r.heldSpawns
+	r.mu.Unlock()
+	return true, fmt.Sprintf(
+		"%s free=%s is below the spawn floor %s (use=%d%%, held_spawns=%d); dispatch resumes automatically once space is reclaimed",
+		snapshot.Root, formatTmpfsBytes(snapshot.AvailableBytes), formatTmpfsBytes(snapshot.SpawnFloorBytes),
+		snapshot.UsePct, held,
+	)
+}
+
+// formatTmpfsBytes renders a byte budget the way the operator reasons about
+// this mount — in binary units, since /tmp is sized in GiB.
+func formatTmpfsBytes(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%dB", bytes)
+	}
+	value := float64(bytes)
+	for _, suffix := range []string{"KiB", "MiB", "GiB", "TiB"} {
+		value /= unit
+		if value < unit {
+			return fmt.Sprintf("%.1f%s", value, suffix)
+		}
+	}
+	return fmt.Sprintf("%.1fPiB", value/unit)
+}

--- a/internal/daemon/tmpfs_pressure_test.go
+++ b/internal/daemon/tmpfs_pressure_test.go
@@ -1,0 +1,151 @@
+package daemon
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/befeast/maestro/internal/notify"
+	"github.com/befeast/maestro/internal/tmpfshygiene"
+)
+
+func pressureDaemon(t *testing.T, ntfyURL string, sample func() tmpfshygiene.PressureSnapshot) *Daemon {
+	t.Helper()
+	d := &Daemon{tmpfsPressure: &tmpfsPressureRuntime{sample: sample}}
+	if ntfyURL != "" {
+		d.floorNotifier = (&notify.Notifier{}).WithNtfy(ntfyURL, "fleet", "")
+	}
+	return d
+}
+
+func lowSpaceSnapshot(availableBytes int64) tmpfshygiene.PressureSnapshot {
+	const total = int64(16) << 30
+	return tmpfshygiene.PressureSnapshot{
+		Root:               "/tmp",
+		Tmpfs:              true,
+		TotalBytes:         total,
+		AvailableBytes:     availableBytes,
+		UsePct:             int((total - availableBytes) * 100 / total),
+		PressureFloorBytes: tmpfshygiene.DefaultPressureFreeBytes,
+		SpawnFloorBytes:    tmpfshygiene.DefaultSpawnFreeBytes,
+		Pressure:           tmpfshygiene.BelowFloor(availableBytes, total, tmpfshygiene.DefaultPressureFreeBytes),
+		SpawnHold:          tmpfshygiene.BelowFloor(availableBytes, total, tmpfshygiene.DefaultSpawnFreeBytes),
+	}
+}
+
+// The whole point of #1128: the sweeper reclaims nothing on this host, so the
+// alert must come from the standalone capacity sample and reach ntfy at the
+// same CRITICAL priority as a floor breach.
+func TestEvaluateTmpfsPressure_AlertsOncePerEpisodeAtPriorityFive(t *testing.T) {
+	var mu sync.Mutex
+	var priorities []string
+	var bodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		priorities = append(priorities, r.Header.Get("Priority"))
+		bodies = append(bodies, string(body))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	available := int64(6) << 30 // below the 8GiB page floor, above the 4GiB spawn floor
+	d := pressureDaemon(t, srv.URL, func() tmpfshygiene.PressureSnapshot { return lowSpaceSnapshot(available) })
+
+	d.evaluateTmpfsPressure()
+	mu.Lock()
+	pending := len(priorities)
+	mu.Unlock()
+	if pending != 0 {
+		t.Fatalf("posts after one sample = %d, want the confirm debounce to hold", pending)
+	}
+	d.evaluateTmpfsPressure()
+	d.evaluateTmpfsPressure()
+	mu.Lock()
+	if len(priorities) != 1 || priorities[0] != "5" {
+		mu.Unlock()
+		t.Fatalf("priorities = %v, want exactly one priority 5 post", priorities)
+	}
+	firstBody := bodies[0]
+	mu.Unlock()
+	if !strings.Contains(firstBody, "free=6.0GiB") || !strings.Contains(firstBody, "floor=8.0GiB") {
+		t.Fatalf("alert body = %q, want the absolute free-byte budget", firstBody)
+	}
+
+	// Recovery resets the debounce; a later recurrence is a new episode and must
+	// not be swallowed by notify.Alert's identical-body dedup.
+	available = 12 << 30
+	d.evaluateTmpfsPressure()
+	if d.tmpfsPressure.streak != 0 || d.tmpfsPressure.notified {
+		t.Fatalf("runtime after recovery = %+v, want the debounce reset", d.tmpfsPressure)
+	}
+	available = 6 << 30
+	d.evaluateTmpfsPressure()
+	d.evaluateTmpfsPressure()
+	mu.Lock()
+	defer mu.Unlock()
+	if len(priorities) != 2 || priorities[1] != "5" {
+		t.Fatalf("priorities after recurrence = %v, want a second priority 5 post", priorities)
+	}
+}
+
+// A pressure episode that never crosses the spawn floor must not pause
+// dispatch: paging and holding are independent budgets.
+func TestTmpfsSpawnHold_HoldsOnlyBelowTheSpawnFloorAndSelfClears(t *testing.T) {
+	available := int64(6) << 30
+	d := pressureDaemon(t, "", func() tmpfshygiene.PressureSnapshot { return lowSpaceSnapshot(available) })
+
+	d.evaluateTmpfsPressure()
+	if hold, reason := d.tmpfsSpawnHold(); hold {
+		t.Fatalf("hold above the spawn floor = %v (%s), want dispatch to continue", hold, reason)
+	}
+
+	available = 2 << 30
+	d.evaluateTmpfsPressure()
+	hold, reason := d.tmpfsSpawnHold()
+	if !hold {
+		t.Fatal("dispatch was not held below the spawn floor")
+	}
+	if !strings.Contains(reason, "free=2.0GiB") || !strings.Contains(reason, "resumes automatically") {
+		t.Fatalf("hold reason = %q, want a visible, self-clearing reason", reason)
+	}
+
+	// Telemetry: every held dispatch is counted and surfaced on the snapshot, so
+	// a throughput pause is distinguishable from a fleet that quietly stopped.
+	if hold, _ := d.tmpfsSpawnHold(); !hold {
+		t.Fatal("second dispatch was not held")
+	}
+	snapshot, ok := d.tmpfsPressureSnapshot()
+	if !ok || snapshot.HeldSpawns != 2 || !snapshot.SpawnHold {
+		t.Fatalf("snapshot = %+v ok=%v, want held_spawns=2", snapshot, ok)
+	}
+
+	// No operator action, no approval, no restart: the next sample clears it.
+	available = 12 << 30
+	d.evaluateTmpfsPressure()
+	if hold, reason := d.tmpfsSpawnHold(); hold {
+		t.Fatalf("hold after recovery = %v (%s), want it to clear itself", hold, reason)
+	}
+}
+
+// A daemon that has not sampled yet, or whose sample failed, must let dispatch
+// through — a measurement gap must never park the fleet.
+func TestTmpfsSpawnHold_FailsOpen(t *testing.T) {
+	d := pressureDaemon(t, "", func() tmpfshygiene.PressureSnapshot {
+		return tmpfshygiene.PressureSnapshot{Root: "/tmp", Error: "statfs boom"}
+	})
+	if hold, _ := d.tmpfsSpawnHold(); hold {
+		t.Fatal("dispatch was held before any sample was taken")
+	}
+	d.evaluateTmpfsPressure()
+	if hold, _ := d.tmpfsSpawnHold(); hold {
+		t.Fatal("dispatch was held on a failed sample")
+	}
+	if snapshot, ok := d.tmpfsPressureSnapshot(); !ok || snapshot.HeldSpawns != 0 {
+		t.Fatalf("snapshot = %+v ok=%v, want no held spawns", snapshot, ok)
+	}
+}

--- a/internal/notify/alert.go
+++ b/internal/notify/alert.go
@@ -24,6 +24,11 @@ const (
 	AlertDeliveryAdvance AlertClass = "delivery_advance"
 	// AlertEmergency: notify_red-grade — emergency stop / supervisor degraded.
 	AlertEmergency AlertClass = "emergency"
+	// AlertTmpfsPressure: free space on the host tmpfs root fell below the
+	// absolute free-byte floor. Priority 5 / CRITICAL — that tmpfs is RAM-backed,
+	// so running it out is a host memory outage for every live worker. Until
+	// #1128 the signal terminated at a dashboard pill nobody was watching.
+	AlertTmpfsPressure AlertClass = "tmpfs_pressure"
 )
 
 // AlertRoute is the transport-shaping metadata a class maps to.
@@ -44,6 +49,7 @@ var alertRoutes = map[AlertClass]AlertRoute{
 	AlertFloorBreach:              {Priority: 5, Tags: []string{"rotating_light", "sos", "warning"}},
 	AlertDeliveryAdvance:          {Priority: 3, Tags: []string{"white_check_mark", "rocket"}},
 	AlertEmergency:                {Priority: 5, Tags: []string{"rotating_light", "sos"}},
+	AlertTmpfsPressure:            {Priority: 5, Tags: []string{"rotating_light", "floppy_disk", "warning"}},
 }
 
 // defaultRoute is used for an unknown class so an unmapped alert still sends at

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -171,6 +171,12 @@ type Orchestrator struct {
 	fleetSpawnCeilingFn func() bool
 	fleetSpawnReserveFn func() (commit func(slot string), release func(), ok bool)
 
+	// spawnResourceHoldFn is the host-resource precondition (#1128): it reports
+	// whether the host is too short on tmpfs space to accept another worker, and
+	// why. nil = no precondition. It is a throughput pause only — see
+	// SetSpawnResourceHold.
+	spawnResourceHoldFn func() (hold bool, reason string)
+
 	// Restart-required signal. Some config fields (currently routing.*) cannot be
 	// hot-applied because their runtime components are built once at startup. When
 	// such a field changes during a config reload we do not apply it; instead we raise this
@@ -289,6 +295,18 @@ func (o *Orchestrator) SetEmergencyHalt(fn func() bool) {
 // nil disables the gate for legacy single-project callers and tests.
 func (o *Orchestrator) SetFleetSpawnCeiling(fn func() bool) {
 	o.fleetSpawnCeilingFn = fn
+}
+
+// SetSpawnResourceHold wires the host-resource spawn precondition (#1128). fn
+// is consulted at the top of startNewWorkers; when it reports a hold the
+// orchestrator lists nothing and spawns nothing for this cycle.
+//
+// It is deliberately a throughput pause and not a gate: no state is written, no
+// approval is requested, no ActionNone decision is produced, and no issue's
+// retry budget is touched. The next poll re-evaluates fn, so dispatch resumes
+// on its own as soon as the host recovers. Passing nil clears the precondition.
+func (o *Orchestrator) SetSpawnResourceHold(fn func() (bool, string)) {
+	o.spawnResourceHoldFn = fn
 }
 
 // SetFleetSpawnReserve wires the daemon's atomic one-worker reservation. The
@@ -10135,6 +10153,17 @@ func (o *Orchestrator) startNewWorkers(s *state.State, slots int) {
 	if o.fleetSpawnCeilingFn != nil && o.fleetSpawnCeilingFn() {
 		log.Printf("[orch] fleet live-worker ceiling reached: not listing or spawning new work (local_running=%d)", s.RunningSessionCount())
 		return
+	}
+	// Host-resource precondition (#1128): the host tmpfs is RAM-backed, so
+	// spawning into a nearly-full one is how a space problem becomes an
+	// out-of-memory outage. This sits before issue listing so a held cycle also
+	// costs no GitHub quota. It is a pause, not a freeze: nothing is persisted,
+	// no retry budget is spent, and the next poll re-checks and resumes.
+	if o.spawnResourceHoldFn != nil {
+		if hold, reason := o.spawnResourceHoldFn(); hold {
+			log.Printf("[orch] spawn held on host resources: %s (local_running=%d) — retrying next cycle", reason, s.RunningSessionCount())
+			return
+		}
 	}
 	// Graceful drain (#541): while a drain is requested, refuse to claim new
 	// issues or spawn new workers. In-flight workers keep running; the

--- a/internal/orchestrator/spawn_resource_hold_test.go
+++ b/internal/orchestrator/spawn_resource_hold_test.go
@@ -1,0 +1,60 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// The host-resource precondition must stop dispatch before the GitHub list, so
+// a held cycle also costs no API quota (#1128).
+func TestStartNewWorkers_ResourceHoldBlocksBeforeGitHubList(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	issues := []github.Issue{makeIssue(1128, "ready issue")}
+	o, started, labels := newStartWorkersOrchestrator(cfg, issues)
+	listed := false
+	o.listOpenIssuesFn = func([]string) ([]github.Issue, error) {
+		listed = true
+		return issues, nil
+	}
+	o.SetSpawnResourceHold(func() (bool, string) { return true, "/tmp free=2.0GiB below the spawn floor 4.0GiB" })
+
+	s := state.NewState()
+	o.startNewWorkers(s, 5)
+
+	if listed {
+		t.Fatal("startNewWorkers listed GitHub issues while dispatch was held on host resources")
+	}
+	if len(*started) != 0 {
+		t.Fatalf("started = %v, want no workers", *started)
+	}
+	if len(*labels) != 0 {
+		t.Fatalf("labels = %v, want no label churn for a held cycle", *labels)
+	}
+}
+
+// The hold is a throughput pause, not a freeze: it burns no retry budget, needs
+// no operator action, and the very next cycle dispatches the same issue.
+func TestStartNewWorkers_ResourceHoldSpendsNoRetryBudgetAndSelfClears(t *testing.T) {
+	cfg := cfgWithBackends("claude", "claude")
+	issues := []github.Issue{makeIssue(1128, "ready issue")}
+	o, started, _ := newStartWorkersOrchestrator(cfg, issues)
+	held := true
+	o.SetSpawnResourceHold(func() (bool, string) { return held, "host tmpfs below the spawn floor" })
+
+	s := state.NewState()
+	o.startNewWorkers(s, 5)
+	if len(s.Sessions) != 0 || s.FailedAttemptsForIssue(1128) != 0 {
+		t.Fatalf("state after a held cycle = %+v, want the issue's retry budget untouched", s)
+	}
+	if s.PauseActive() || s.DrainActive() {
+		t.Fatal("the resource hold persisted an operator-visible pause/drain state")
+	}
+
+	held = false
+	o.startNewWorkers(s, 5)
+	if len(*started) != 1 || (*started)[0] != 1128 {
+		t.Fatalf("started = %v, want the held issue to dispatch as soon as the host recovers", *started)
+	}
+}

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -391,6 +391,12 @@ type FleetServer struct {
 	// FleetServer. Plain `serve --fleet` leaves it nil and omits the block.
 	tmpfsHygieneMu     sync.RWMutex
 	tmpfsHygieneSource func() (tmpfshygiene.Summary, bool)
+
+	// tmpfsPressureSource exposes the daemon's sweep-independent /tmp capacity
+	// sample (#1128), including how many spawns the free-byte precondition has
+	// paused. Nil (plain `serve --fleet`) omits the block.
+	tmpfsPressureMu     sync.RWMutex
+	tmpfsPressureSource func() (tmpfshygiene.PressureSnapshot, bool)
 }
 
 // EmergencySwitch is the write side of the fleet-wide EMERGENCY STOP store the
@@ -458,6 +464,32 @@ func (s *FleetServer) tmpfsHygieneSnapshot() *tmpfshygiene.Summary {
 		return nil
 	}
 	return &summary
+}
+
+// SetTmpfsPressureSource wires the daemon's sweep-independent /tmp capacity
+// sample into /api/v1/fleet (#1128). Unlike the hygiene summary this exists
+// even when no sweep has run, and it carries the held-spawn counter.
+func (s *FleetServer) SetTmpfsPressureSource(src func() (tmpfshygiene.PressureSnapshot, bool)) {
+	if s == nil {
+		return
+	}
+	s.tmpfsPressureMu.Lock()
+	s.tmpfsPressureSource = src
+	s.tmpfsPressureMu.Unlock()
+}
+
+func (s *FleetServer) tmpfsPressureSnapshot() *tmpfshygiene.PressureSnapshot {
+	s.tmpfsPressureMu.RLock()
+	src := s.tmpfsPressureSource
+	s.tmpfsPressureMu.RUnlock()
+	if src == nil {
+		return nil
+	}
+	snapshot, ok := src()
+	if !ok {
+		return nil
+	}
+	return &snapshot
 }
 
 // SetEmergencyStore wires the write side used by POST /api/v1/fleet/emergency
@@ -1053,6 +1085,11 @@ type fleetResponse struct {
 	// utilization, allowing API and Mission Control consumers to alert without
 	// treating host pressure as a synthetic worker session.
 	TmpfsHygiene *tmpfshygiene.Summary `json:"tmpfs_hygiene,omitempty"`
+
+	// TmpfsPressure is the sweep-independent /tmp capacity sample (#1128): the
+	// absolute free-byte budget, both floors, whether dispatch is currently
+	// paused, and how many spawns that pause has held.
+	TmpfsPressure *tmpfshygiene.PressureSnapshot `json:"tmpfs_pressure,omitempty"`
 }
 
 // fleetEmergency is the fleet-wide big-red-button state on the snapshot (#840).
@@ -2812,6 +2849,7 @@ func (s *FleetServer) snapshot() fleetResponse {
 	resp.Mirror = s.mirrorStatsSnapshot()
 	resp.Emergency = s.emergencySnapshot()
 	resp.TmpfsHygiene = s.tmpfsHygieneSnapshot()
+	resp.TmpfsPressure = s.tmpfsPressureSnapshot()
 	return resp
 }
 

--- a/internal/server/fleet_tmpfs_hygiene_test.go
+++ b/internal/server/fleet_tmpfs_hygiene_test.go
@@ -56,3 +56,46 @@ func TestFleetAPIOmitsTmpfsHygieneWhenNotDaemonWired(t *testing.T) {
 		t.Fatalf("plain fleet unexpectedly exposed tmpfs_hygiene: %s", rec.Body.String())
 	}
 }
+
+// The capacity sample is published even when no sweep summary exists, because
+// the sweeper is a verified no-op on this host (#1125, #1128).
+func TestFleetAPISurfacesTmpfsPressureWithoutASweepSummary(t *testing.T) {
+	srv := NewFleet(nil, "127.0.0.1", 0, true)
+	srv.SetTmpfsPressureSource(func() (tmpfshygiene.PressureSnapshot, bool) {
+		return tmpfshygiene.PressureSnapshot{
+			Timestamp:          time.Date(2026, 7, 25, 18, 0, 0, 0, time.UTC),
+			Root:               "/tmp",
+			Tmpfs:              true,
+			TotalBytes:         16 << 30,
+			AvailableBytes:     2 << 30,
+			UsePct:             88,
+			PressureFloorBytes: 8 << 30,
+			SpawnFloorBytes:    4 << 30,
+			Pressure:           true,
+			SpawnHold:          true,
+			HeldSpawns:         3,
+		}, true
+	})
+
+	rec := httptest.NewRecorder()
+	srv.handleFleet(rec, httptest.NewRequest(http.MethodGet, "/api/v1/fleet", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	var body struct {
+		TmpfsHygiene  *tmpfshygiene.Summary          `json:"tmpfs_hygiene"`
+		TmpfsPressure *tmpfshygiene.PressureSnapshot `json:"tmpfs_pressure"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body.TmpfsHygiene != nil {
+		t.Fatalf("tmpfs_hygiene = %+v, want it absent when no sweep has run", body.TmpfsHygiene)
+	}
+	if body.TmpfsPressure == nil || !body.TmpfsPressure.SpawnHold || body.TmpfsPressure.HeldSpawns != 3 {
+		t.Fatalf("tmpfs_pressure = %+v, want the hold and its held-spawn count", body.TmpfsPressure)
+	}
+	if body.TmpfsPressure.PressureFloorBytes != 8<<30 {
+		t.Fatalf("tmpfs_pressure floor = %d, want an absolute byte budget", body.TmpfsPressure.PressureFloorBytes)
+	}
+}

--- a/internal/tmpfshygiene/pressure_test.go
+++ b/internal/tmpfshygiene/pressure_test.go
@@ -1,0 +1,87 @@
+package tmpfshygiene
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// Sample must stand on its own: the sweeper refuses non-tmpfs roots and can
+// reclaim nothing at all (#1125), so the pressure signal cannot be a by-product
+// of a completed sweep (#1128).
+func TestSampleEvaluatesBothFloorsWithoutRunningASweep(t *testing.T) {
+	now := time.Date(2026, 7, 25, 12, 0, 0, 0, time.UTC)
+	const total = int64(16) << 30
+
+	cases := []struct {
+		name          string
+		available     int64
+		wantPressure  bool
+		wantSpawnHold bool
+	}{
+		{name: "healthy", available: 12 << 30},
+		{name: "below pressure floor only", available: 6 << 30, wantPressure: true},
+		{name: "below both floors", available: 3 << 30, wantPressure: true, wantSpawnHold: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			available := tc.available
+			snapshot := Sample(SampleOptions{
+				Root:               "/fake/tmp",
+				PressureFloorBytes: DefaultPressureFreeBytes,
+				SpawnFloorBytes:    DefaultSpawnFreeBytes,
+				Now:                func() time.Time { return now },
+				InspectMount: func(string) (MountUsage, error) {
+					return MountUsage{Tmpfs: true, TotalBytes: total, UsedBytes: total - available, AvailableBytes: available}, nil
+				},
+			})
+			if snapshot.Error != "" {
+				t.Fatalf("snapshot error = %q", snapshot.Error)
+			}
+			if snapshot.Pressure != tc.wantPressure || snapshot.SpawnHold != tc.wantSpawnHold {
+				t.Fatalf("snapshot = %+v, want pressure=%v spawn_hold=%v", snapshot, tc.wantPressure, tc.wantSpawnHold)
+			}
+			if snapshot.AvailableBytes != available || snapshot.PressureFloorBytes != DefaultPressureFreeBytes {
+				t.Fatalf("snapshot budget = %+v, want the absolute bytes it decided on", snapshot)
+			}
+		})
+	}
+}
+
+// A measurement failure must page nobody and pause nobody: an unreadable mount
+// is a bug in the sample, not evidence that the host is out of memory.
+func TestSampleFailsOpenWhenTheMountCannotBeRead(t *testing.T) {
+	snapshot := Sample(SampleOptions{
+		Root:               "/fake/tmp",
+		PressureFloorBytes: DefaultPressureFreeBytes,
+		SpawnFloorBytes:    DefaultSpawnFreeBytes,
+		InspectMount:       func(string) (MountUsage, error) { return MountUsage{}, errors.New("statfs boom") },
+	})
+	if snapshot.Error == "" {
+		t.Fatal("snapshot did not record the sample failure")
+	}
+	if snapshot.Pressure || snapshot.SpawnHold {
+		t.Fatalf("snapshot = %+v, want both signals off on a failed sample", snapshot)
+	}
+}
+
+func TestBelowFloorRejectsUnusableFloors(t *testing.T) {
+	if BelowFloor(0, 16<<30, 0) {
+		t.Fatal("a zero floor must disable the signal")
+	}
+	if BelowFloor(0, 16<<30, -1) {
+		t.Fatal("a negative floor must disable the signal")
+	}
+	// A floor at or above the mount could only ever report "always breached",
+	// which is a permanent page and a permanent pause. Ignore it instead.
+	if BelowFloor(1<<30, 2<<30, 4<<30) {
+		t.Fatal("a floor larger than the mount must be ignored, not always true")
+	}
+	if !BelowFloor(1<<30, 16<<30, 4<<30) {
+		t.Fatal("a usable floor must still fire")
+	}
+	// An unknown mount size leaves the floor applied as given.
+	if !BelowFloor(1<<30, 0, 4<<30) {
+		t.Fatal("an unknown total must not disable the floor")
+	}
+}

--- a/internal/tmpfshygiene/sweeper.go
+++ b/internal/tmpfshygiene/sweeper.go
@@ -115,6 +115,9 @@ func Sweep(ctx context.Context, opts Options) (Summary, error) {
 	}
 	summary.Tmpfs = usage.Tmpfs
 	summary.UsePct = usage.UsePct
+	summary.TotalBytes = usage.TotalBytes
+	summary.AvailableBytes = usage.AvailableBytes
+	summary.PressureFloorBytes = opts.PressureFloorBytes
 	if !usage.Tmpfs {
 		return fail(fmt.Errorf("refusing tmpfs hygiene: %s is not tmpfs", opts.Root))
 	}
@@ -364,7 +367,12 @@ func Sweep(ctx context.Context, opts Options) (Summary, error) {
 	}
 	summary.Tmpfs = finalUsage.Tmpfs
 	summary.UsePct = finalUsage.UsePct
-	summary.Pressure = finalUsage.UsePct >= PressureThresholdPct
+	summary.TotalBytes = finalUsage.TotalBytes
+	summary.AvailableBytes = finalUsage.AvailableBytes
+	// Pressure is an absolute free-byte budget, not a share of the mount
+	// (#1128). A percentage of a RAM-backed tmpfs says nothing about how close
+	// the host is to running out of memory.
+	summary.Pressure = BelowFloor(finalUsage.AvailableBytes, finalUsage.TotalBytes, opts.PressureFloorBytes)
 	if summary.Pressure {
 		summary.AttentionCode = "tmpfs_pressure"
 	}
@@ -380,6 +388,9 @@ func normalizeOptions(opts Options) Options {
 		opts.ProcRoot = "/proc"
 	}
 	opts.ProcRoot = filepath.Clean(opts.ProcRoot)
+	if opts.PressureFloorBytes == 0 {
+		opts.PressureFloorBytes = DefaultPressureFreeBytes
+	}
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}

--- a/internal/tmpfshygiene/sweeper_test.go
+++ b/internal/tmpfshygiene/sweeper_test.go
@@ -557,7 +557,12 @@ func fakeOptions(root, proc string, now time.Time, mode string, usePct int, tmpf
 		Mode:     mode,
 		Now:      func() time.Time { return now },
 		InspectMount: func(string) (MountUsage, error) {
-			return MountUsage{Tmpfs: tmpfs, UsePct: usePct, TotalBytes: 100, UsedBytes: int64(usePct)}, nil
+			// Model the real mount: a 16GiB RAM-backed /tmp. The pressure verdict
+			// is measured in absolute free bytes (#1128), so the fixture has to
+			// express a plausible capacity rather than a 100-byte stub.
+			const total = int64(16) << 30
+			used := total * int64(usePct) / 100
+			return MountUsage{Tmpfs: tmpfs, UsePct: usePct, TotalBytes: total, UsedBytes: used, AvailableBytes: total - used}, nil
 		},
 		EffectiveUID: os.Geteuid,
 		processID:    func() int { return -1 },
@@ -703,4 +708,42 @@ func TestSweepFailsClosedOnSameUIDPermissionDenial(t *testing.T) {
 		t.Fatalf("summary = %+v, want no deletion while the scan is incomplete", summary)
 	}
 	assertExists(t, stale)
+}
+
+// The 2026-07-25 event: 8.5GB used of a ~15GiB RAM-backed /tmp. That is only
+// 55% of the mount, so the old "85% utilization" rule stayed silent while 8.5GB
+// of a 24GiB host's RAM was already gone. Pressure is decided on the remaining
+// absolute bytes (#1128).
+func TestSweepPressureUsesFreeByteBudgetNotUtilizationPct(t *testing.T) {
+	root, proc, now := fakeRoots(t)
+
+	tight := fakeOptions(root, proc, now, ModeApply, 55, true)
+	tight.InspectMount = func(string) (MountUsage, error) {
+		const total = int64(15) << 30
+		const used = int64(8_500_000_000)
+		return MountUsage{Tmpfs: true, UsePct: 55, TotalBytes: total, UsedBytes: used, AvailableBytes: total - used}, nil
+	}
+	summary, err := Sweep(context.Background(), tight)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !summary.Pressure || summary.AttentionCode != "tmpfs_pressure" {
+		t.Fatalf("summary at %d%% use with %d free bytes = %+v, want pressure", summary.UsePct, summary.AvailableBytes, summary)
+	}
+
+	// And the mirror image: a high utilization ratio on a mount that still has
+	// tens of gigabytes free is not an emergency and must not page anyone.
+	roomy := fakeOptions(root, proc, now, ModeApply, 92, true)
+	roomy.InspectMount = func(string) (MountUsage, error) {
+		const total = int64(400) << 30
+		const available = int64(32) << 30
+		return MountUsage{Tmpfs: true, UsePct: 92, TotalBytes: total, UsedBytes: total - available, AvailableBytes: available}, nil
+	}
+	summary, err = Sweep(context.Background(), roomy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Pressure || summary.AttentionCode != "" {
+		t.Fatalf("summary at %d%% use with %d free bytes = %+v, want no pressure", summary.UsePct, summary.AvailableBytes, summary)
+	}
 }

--- a/internal/tmpfshygiene/types.go
+++ b/internal/tmpfshygiene/types.go
@@ -5,13 +5,26 @@ package tmpfshygiene
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 	"time"
 )
 
 const (
-	// PressureThresholdPct is the post-sweep tmpfs utilization that Fleet
-	// promotes to the tmpfs_pressure attention signal.
-	PressureThresholdPct = 85
+	// DefaultPressureFreeBytes is the absolute free-byte budget below which the
+	// tmpfs root counts as under pressure. It is deliberately NOT a percentage
+	// of the mount (#1128): /tmp on the fleet host is a RAM-backed ~16GiB tmpfs
+	// on a 24GiB machine with zero swap, so the old "85% of the tmpfs" rule only
+	// fired once 13.2GiB — 55% of host RAM — was already gone. The 2026-07-25
+	// event peaked at 8.5GB used and never tripped it. Remaining bytes, not the
+	// utilization ratio, decide whether the next allocation becomes an outage.
+	DefaultPressureFreeBytes int64 = 8 << 30
+
+	// DefaultSpawnFreeBytes is the free-byte budget below which new worker
+	// dispatch pauses. It sits below DefaultPressureFreeBytes on purpose: the
+	// operator is paged first, and throughput is only given up once the
+	// remaining headroom would not comfortably hold another worker's scratch.
+	DefaultSpawnFreeBytes int64 = 4 << 30
 
 	ModeDryRun = "dry-run"
 	ModeApply  = "apply"
@@ -40,29 +53,123 @@ type CategoryStats struct {
 
 // Summary is emitted as one JSON line by every CLI or scheduled sweep.
 type Summary struct {
-	Timestamp        time.Time                `json:"timestamp"`
-	Mode             string                   `json:"mode"`
-	Root             string                   `json:"root"`
-	Tmpfs            bool                     `json:"tmpfs"`
-	UsePct           int                      `json:"use_pct"`
-	Pressure         bool                     `json:"pressure"`
-	AttentionCode    string                   `json:"attention_code,omitempty"`
-	ScannedEntries   int                      `json:"scanned_entries"`
-	MatchedEntries   int                      `json:"matched_entries"`
-	ProtectedEntries int                      `json:"protected_entries"`
-	DeletedEntries   int                      `json:"deleted_entries"`
-	PartialEntries   int                      `json:"partial_entries,omitempty"`
-	ReclaimableBytes int64                    `json:"reclaimable_bytes"`
-	FreedBytes       int64                    `json:"freed_bytes"`
-	Categories       map[string]CategoryStats `json:"categories"`
-	ProtectHits      map[string]int           `json:"protect_hits"`
-	ProcScanErrors   int                      `json:"proc_scan_errors,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+	Mode      string    `json:"mode"`
+	Root      string    `json:"root"`
+	Tmpfs     bool      `json:"tmpfs"`
+	UsePct    int       `json:"use_pct"`
+	// TotalBytes/AvailableBytes carry the post-sweep capacity so the JSONL
+	// metric and the Fleet snapshot show the same absolute budget the pressure
+	// decision was made on, rather than only the ratio (#1128).
+	TotalBytes         int64                    `json:"total_bytes"`
+	AvailableBytes     int64                    `json:"available_bytes"`
+	PressureFloorBytes int64                    `json:"pressure_floor_bytes,omitempty"`
+	Pressure           bool                     `json:"pressure"`
+	AttentionCode      string                   `json:"attention_code,omitempty"`
+	ScannedEntries     int                      `json:"scanned_entries"`
+	MatchedEntries     int                      `json:"matched_entries"`
+	ProtectedEntries   int                      `json:"protected_entries"`
+	DeletedEntries     int                      `json:"deleted_entries"`
+	PartialEntries     int                      `json:"partial_entries,omitempty"`
+	ReclaimableBytes   int64                    `json:"reclaimable_bytes"`
+	FreedBytes         int64                    `json:"freed_bytes"`
+	Categories         map[string]CategoryStats `json:"categories"`
+	ProtectHits        map[string]int           `json:"protect_hits"`
+	ProcScanErrors     int                      `json:"proc_scan_errors,omitempty"`
 	// ProcPermissionSkips counts /proc entries the sweeper could not inspect
 	// because they belong to other users (EACCES). These are expected on any
 	// multi-user host and never blanket-protect candidates; they are surfaced
 	// for observability only.
 	ProcPermissionSkips int    `json:"proc_permission_skips,omitempty"`
 	Error               string `json:"error,omitempty"`
+}
+
+// PressureSnapshot is one capacity reading of the tmpfs root, taken
+// independently of any sweep. Decoupling the sample from Sweep is the point
+// (#1128): the sweeper can refuse a non-tmpfs root or reclaim nothing at all
+// (#1125), and the operator alert plus the spawn precondition must still have a
+// current signal to act on.
+type PressureSnapshot struct {
+	Timestamp          time.Time `json:"timestamp"`
+	Root               string    `json:"root"`
+	Tmpfs              bool      `json:"tmpfs"`
+	TotalBytes         int64     `json:"total_bytes"`
+	AvailableBytes     int64     `json:"available_bytes"`
+	UsePct             int       `json:"use_pct"`
+	PressureFloorBytes int64     `json:"pressure_floor_bytes"`
+	SpawnFloorBytes    int64     `json:"spawn_floor_bytes"`
+	// Pressure is the alert condition: free bytes below PressureFloorBytes.
+	Pressure bool `json:"pressure"`
+	// SpawnHold is the dispatch condition: free bytes below SpawnFloorBytes.
+	SpawnHold bool `json:"spawn_hold"`
+	// HeldSpawns counts dispatches the precondition has paused since the daemon
+	// started. It is how an operator tells a deliberate throughput pause apart
+	// from a silently idle fleet.
+	HeldSpawns uint64 `json:"held_spawns"`
+	Error      string `json:"error,omitempty"`
+}
+
+// SampleOptions configures one sweep-independent capacity reading.
+type SampleOptions struct {
+	Root               string
+	PressureFloorBytes int64
+	SpawnFloorBytes    int64
+	Now                func() time.Time
+	InspectMount       func(string) (MountUsage, error)
+}
+
+// Sample takes one capacity reading of the tmpfs root and evaluates both
+// absolute floors against it.
+//
+// A failed reading yields Pressure=false and SpawnHold=false with Error set:
+// the measurement failing must never page the operator, and it must never park
+// the fleet. Both signals fail open.
+func Sample(opts SampleOptions) PressureSnapshot {
+	if strings.TrimSpace(opts.Root) == "" {
+		opts.Root = "/tmp"
+	}
+	opts.Root = filepath.Clean(opts.Root)
+	if opts.Now == nil {
+		opts.Now = time.Now
+	}
+	if opts.InspectMount == nil {
+		opts.InspectMount = InspectLinuxMount
+	}
+	snapshot := PressureSnapshot{
+		Timestamp:          opts.Now().UTC(),
+		Root:               opts.Root,
+		PressureFloorBytes: opts.PressureFloorBytes,
+		SpawnFloorBytes:    opts.SpawnFloorBytes,
+	}
+	usage, err := opts.InspectMount(opts.Root)
+	if err != nil {
+		snapshot.Error = err.Error()
+		return snapshot
+	}
+	snapshot.Tmpfs = usage.Tmpfs
+	snapshot.TotalBytes = usage.TotalBytes
+	snapshot.AvailableBytes = usage.AvailableBytes
+	snapshot.UsePct = usage.UsePct
+	snapshot.Pressure = BelowFloor(usage.AvailableBytes, usage.TotalBytes, opts.PressureFloorBytes)
+	snapshot.SpawnHold = BelowFloor(usage.AvailableBytes, usage.TotalBytes, opts.SpawnFloorBytes)
+	return snapshot
+}
+
+// BelowFloor reports whether availableBytes sits under an absolute floor.
+//
+// A non-positive floor disables the signal. A floor at or above the mount's own
+// size is a misconfiguration that could only ever report "always breached", so
+// it is ignored rather than turned into a permanent page or a permanent freeze;
+// callers log it once. totalBytes==0 means the caller did not supply a size and
+// the floor is applied as given.
+func BelowFloor(availableBytes, totalBytes, floorBytes int64) bool {
+	if floorBytes <= 0 {
+		return false
+	}
+	if totalBytes > 0 && floorBytes >= totalBytes {
+		return false
+	}
+	return availableBytes < floorBytes
 }
 
 type removalResult struct {
@@ -77,10 +184,14 @@ type Options struct {
 	ProcRoot       string
 	Mode           string
 	ProtectedPaths []string
-	Now            func() time.Time
-	InspectMount   func(string) (MountUsage, error)
-	EffectiveUID   func() int
-	processID      func() int
-	beforeApply    func(string) // deterministic isolation/revalidation test hook
-	removeEntry    func(context.Context, int, string, uint64) (removalResult, error)
+	// PressureFloorBytes is the absolute free-byte budget the post-sweep
+	// pressure verdict is measured against. Zero takes
+	// DefaultPressureFreeBytes; negative disables the verdict.
+	PressureFloorBytes int64
+	Now                func() time.Time
+	InspectMount       func(string) (MountUsage, error)
+	EffectiveUID       func() int
+	processID          func() int
+	beforeApply        func(string) // deterministic isolation/revalidation test hook
+	removeEntry        func(context.Context, int, string, uint64) (removalResult, error)
 }


### PR DESCRIPTION
## Problem

`/tmp` on the fleet host is a RAM-backed ~16GiB tmpfs on a 24GiB machine with
0 B swap, so exhausting it is a memory outage — and three things were missing:

1. **No alert class.** `internal/notify/alert.go` had a closed `AlertClass` enum
   with seven members, none of them tmpfs/disk/memory. The `tmpfs_hygiene`
   summary therefore terminated at the Mission Control pill; the journal shows
   `pressure:true` 66 times peaking at 98% between 2026-07-22 and 2026-07-23
   with nothing reaching the operator.
2. **Wrong unit.** `PressureThresholdPct = 85` is 85% of a 15.54GiB tmpfs, i.e.
   13.2GiB — by which point 55% of the host's RAM is already gone. The
   2026-07-25 event peaked at 8.5GB (54.7%) and never tripped it.
3. **No spawn-time precondition.** `Statfs` had two call sites (the sweeper and
   the worker-lease scratch check) and neither gated dispatch, so on resume the
   daemon refilled the 5–10 live band regardless of `/tmp` state.

## Fix

**Absolute free-byte budget.** `Summary.Pressure` is now
`BelowFloor(available, total, PressureFloorBytes)` with a default of 8GiB free,
not a share of the mount. `Summary` carries `total_bytes`, `available_bytes`,
and `pressure_floor_bytes` so the JSONL metric and the Fleet snapshot show the
budget the verdict was made on. A floor at or above the mount is ignored and
logged once rather than paging forever; a negative floor disables the signal.

**`tmpfs_pressure` alert class** at priority 5 — the same CRITICAL route as
`floor_breach` — emitted by a new daemon watch with the floor-watch debounce
shape: two consecutive samples before paging, one page per episode, reset on
recovery, episode number in the body so `notify.Alert`'s body dedup cannot
swallow a recurrence.

**Sampling decoupled from `Sweep()`.** `tmpfshygiene.Sample` takes one statfs
reading and evaluates both floors. The daemon runs it every 30s
(`--tmpfs-pressure-interval`) instead of riding the 10m sweep, because the
sweeper can refuse a non-tmpfs root and is a verified no-op on this host
(#1125) — the acceptance criterion is an alert "on a host where the sweeper
reclaims nothing". The result is published as `/api/v1/fleet.tmpfs_pressure`
with both floors, the hold state, and the held-spawn counter.

**Spawn precondition.** `Orchestrator.SetSpawnResourceHold` is consulted at the
top of `startNewWorkers`, next to the emergency-stop and fleet-ceiling gates and
*before* issue listing, so a held cycle also costs no GitHub quota. The daemon
wires it to `Daemon.tmpfsSpawnHold`, which holds below a separate 4GiB spawn
floor (`--tmpfs-spawn-floor-bytes`).

### On the critical constraint

The hold is a **throughput pause, never a freeze**:

- it persists nothing — no `DispatchHold`, no pause/drain flag, no supervisor
  decision, so it cannot produce an exclusive `ActionNone` or a human gate;
- it spends **no retry budget** — the cycle returns before any issue is claimed
  or any worker starts, so no session is recorded and
  `FailedAttemptsForIssue` is untouched;
- it is **self-clearing** — every poll re-evaluates it, so dispatch resumes with
  no operator action the moment bytes come back;
- it **fails open** — no sample yet, or a failed statfs, lets dispatch through,
  because a measurement gap must not park the fleet;
- the two floors are **independent**, so a pressure page does not by itself stop
  the fleet: at 6GiB free the operator is paged and dispatch continues.

Both floors are operator-configurable on the daemon invocation; negative
disables either.

## Evidence

Whole suite green under `umask 022`: `go build ./...` clean,
`go test ./... -count=1` exit 0 across 36 packages. `gofmt -l` reports only the
pre-existing `internal/worker/opencode_usage.go`.

Each new test was confirmed to fail against the unfixed behaviour by reverting
the corresponding change in place:

| Reverted | Failing test |
|---|---|
| `Pressure` back to `finalUsage.UsePct >= 85` | `TestSweepPressureUsesFreeByteBudgetNotUtilizationPct` — `55% use, 7606127360 free bytes … want pressure` |
| the `startNewWorkers` hold block deleted | `TestStartNewWorkers_ResourceHoldBlocksBeforeGitHubList` (listed issues) and `…SpendsNoRetryBudgetAndSelfClears` (a session was created) |
| the `AlertTmpfsPressure` route row deleted | `TestEvaluateTmpfsPressure_AlertsOncePerEpisodeAtPriorityFive` — `priorities = [3], want exactly one priority 5 post` |

Also covered: `Sample` evaluating both floors with no sweep involved, both
signals failing open on an unreadable mount, `BelowFloor` rejecting unusable
floors, the hold self-clearing with a rising `held_spawns`, and the fleet API
serving `tmpfs_pressure` when no sweep summary exists at all.

The runbook `docs/tmpfs-hygiene-runbook.md` is updated: the 85% rule is replaced
by the byte budget, the new block and both flags are documented, and the
24-hour verification step now checks the sweep-independent cadence.

No config-store row, unit, or running service was touched; the fleet stays
stopped.

Refs #1128
