### PR TITLE
Bound the supervise cycle: timeout every gh subprocess, context-aware RunOnce, working watchdog kick

### DIFF
--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -938,8 +938,13 @@ func superviseCmd(args []string) {
 		cfg.Supervisor.DryRun = true
 	}
 	gh := github.New(cfg.Repo)
+	// The cycle is context-aware (#1119): a cancelled ctx stops it at the next
+	// phase boundary. SIGINT/SIGTERM cancel it for the looping command below;
+	// --once inherits the same ctx and cancels it on return.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	runOnce := func() error {
-		decision, err := supervisor.RunOnce(cfg, gh, supervisor.WithApprovalsDBPath(*approvalsDB))
+		decision, err := supervisor.RunOnce(ctx, cfg, gh, supervisor.WithApprovalsDBPath(*approvalsDB))
 		if err != nil {
 			return err
 		}
@@ -952,15 +957,13 @@ func superviseCmd(args []string) {
 	// initialized (and, for a persistent command, launched) before this network/
 	// LLM-dependent cycle so a blocked first RunOnce cannot pause it (#887).
 	if *once {
-		if err := runInitialSuperviseCycle(context.Background(), cfg, true, *dryRun, runOnce,
+		if err := runInitialSuperviseCycle(ctx, cfg, true, *dryRun, runOnce,
 			supervisor.EvaluateMaterialProgressOnce, supervisor.RunMaterialProgressEvaluator); err != nil {
 			log.Fatalf("supervise: %v", err)
 		}
 		return
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	if err := runInitialSuperviseCycle(ctx, cfg, false, *dryRun, runOnce,
 		supervisor.EvaluateMaterialProgressOnce, supervisor.RunMaterialProgressEvaluator); err != nil {
 		cancel()
@@ -984,7 +987,10 @@ func superviseCmd(args []string) {
 	// been bumped in 3*interval. The warning persists into state
 	// (SupervisorStuck=true) so the Fleet API and dashboards can
 	// surface it without grepping the journal.
-	go supervisor.Watchdog(ctx, cfg.SessionPrefix, cfg.StateDir, *interval)
+	// nil kick channel: this loop calls RunOnce inline, so there is no separable
+	// cycle to cancel and the watchdog stays warn-only. The daemon's per-flow
+	// loops wire a real one (#1119).
+	go supervisor.Watchdog(ctx, cfg.SessionPrefix, cfg.StateDir, *interval, nil)
 	ticker := time.NewTicker(*interval)
 	defer ticker.Stop()
 	for {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -341,9 +341,13 @@ type Daemon struct {
 	// closure rather than a fixed *config.Config so it reads the flow's current
 	// config each cycle through the shared holder — a config-store edit reaches
 	// the supervise loop live, not just the orchestrator (#768).
+	//
+	// kickCh is the watchdog's self-heal signal, shared between watchdogLoop
+	// (sender) and superviseLoop (receiver) per flow: a confirmed wedge asks the
+	// supervise loop to cancel its in-flight cycle and run a fresh one (#1119).
 	runLoop              func(ctx context.Context, cfg *config.Config, opts Options, reloadCh <-chan *config.Config)
-	superviseLoop        func(ctx context.Context, name string, getCfg func() *config.Config, opts Options)
-	watchdogLoop         func(ctx context.Context, name, stateDir string, interval time.Duration)
+	superviseLoop        func(ctx context.Context, name string, getCfg func() *config.Config, opts Options, kickCh <-chan struct{})
+	watchdogLoop         func(ctx context.Context, name, stateDir string, interval time.Duration, kickCh chan<- struct{})
 	materialProgressLoop func(ctx context.Context, name string, getCfg func() *config.Config)
 }
 
@@ -434,7 +438,7 @@ func New(store ConfigLoader, opts Options) *Daemon {
 		}
 	}
 	d.runLoop = d.runOrchestrator
-	d.superviseLoop = func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
+	d.superviseLoop = func(ctx context.Context, name string, getCfg func() *config.Config, opts Options, kickCh <-chan struct{}) {
 		// #826: build the flow's mirror-first read source (nil when the mirror is
 		// disabled). Its escape hatch reads getCfg() — the holder the reload pump
 		// swaps — so a config-store edit flips the supervisor between mirror-first
@@ -443,7 +447,7 @@ func New(store ConfigLoader, opts Options) *Daemon {
 		if src := d.newReadSource(getCfg().Repo, getCfg); src != nil {
 			reader = src
 		}
-		runSupervise(ctx, name, getCfg, reader, opts.SuperviseInterval, opts.ApprovalsDBPath, d.emergencyLLMHalt)
+		runSupervise(ctx, name, getCfg, reader, opts.SuperviseInterval, opts.ApprovalsDBPath, d.emergencyLLMHalt, kickCh)
 	}
 	d.watchdogLoop = supervisor.Watchdog
 	d.materialProgressLoop = supervisor.RunMaterialProgressEvaluator

--- a/internal/daemon/daemon_drain_test.go
+++ b/internal/daemon/daemon_drain_test.go
@@ -273,8 +273,10 @@ func TestTwelveFlowShutdownKeepsHealthDuringDrainAndDetachesHungFlow(t *testing.
 		}
 		<-ctx.Done()
 	}
-	d.superviseLoop = func(ctx context.Context, _ string, _ func() *config.Config, _ Options) { <-ctx.Done() }
-	d.watchdogLoop = func(context.Context, string, string, time.Duration) {}
+	d.superviseLoop = func(ctx context.Context, _ string, _ func() *config.Config, _ Options, _ <-chan struct{}) {
+		<-ctx.Done()
+	}
+	d.watchdogLoop = func(context.Context, string, string, time.Duration, chan<- struct{}) {}
 	d.materialProgressLoop = func(context.Context, string, func() *config.Config) {}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -348,8 +350,10 @@ func TestTwelveFlowShutdownKeepsHealthDuringDrainAndDetachesHungFlow(t *testing.
 	// bounded handoff; health recovery does not wait for an external second signal.
 	replacement := New(fakeLoader{cfgs: cfgs}, Options{Host: "127.0.0.1", Port: port})
 	replacement.runLoop = func(ctx context.Context, _ *config.Config, _ Options, _ <-chan *config.Config) { <-ctx.Done() }
-	replacement.superviseLoop = func(ctx context.Context, _ string, _ func() *config.Config, _ Options) { <-ctx.Done() }
-	replacement.watchdogLoop = func(context.Context, string, string, time.Duration) {}
+	replacement.superviseLoop = func(ctx context.Context, _ string, _ func() *config.Config, _ Options, _ <-chan struct{}) {
+		<-ctx.Done()
+	}
+	replacement.watchdogLoop = func(context.Context, string, string, time.Duration, chan<- struct{}) {}
 	replacement.materialProgressLoop = func(context.Context, string, func() *config.Config) {}
 	replacementCtx, stopReplacement := context.WithCancel(context.Background())
 	replacementDone := make(chan error, 1)

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -54,7 +54,7 @@ func (lt *loopTracker) loop(ctx context.Context, cfg *config.Config, opts Option
 // superviseLoop is the supervise-shaped stub (the supervise loop takes the
 // flow's unique name and a current-config getter, #764/#768). It records the
 // same counters.
-func (lt *loopTracker) superviseLoop(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
+func (lt *loopTracker) superviseLoop(ctx context.Context, name string, getCfg func() *config.Config, opts Options, kickCh <-chan struct{}) {
 	atomic.AddInt64(&lt.started, 1)
 	<-ctx.Done()
 	atomic.AddInt64(&lt.stopped, 1)
@@ -64,7 +64,7 @@ func (lt *loopTracker) superviseLoop(ctx context.Context, name string, getCfg fu
 // configs. Both watchdog loops are stubbed to no-ops so flows started through
 // this helper stay isolated from real state writers. Tests that assert watchdog
 // behaviour install their own stubs.
-func newTestDaemon(loader ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, func() *config.Config, Options)) *Daemon {
+func newTestDaemon(loader ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, func() *config.Config, Options, <-chan struct{})) *Daemon {
 	d := New(loader, Options{Host: "127.0.0.1", Port: 0})
 	if run != nil {
 		d.runLoop = run
@@ -72,7 +72,7 @@ func newTestDaemon(loader ConfigLoader, run func(context.Context, *config.Config
 	if supervise != nil {
 		d.superviseLoop = supervise
 	}
-	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {}
+	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration, kickCh chan<- struct{}) {}
 	d.materialProgressLoop = func(ctx context.Context, name string, getCfg func() *config.Config) {}
 	return d
 }
@@ -347,7 +347,7 @@ func TestFlowPanicCancelsFlow(t *testing.T) {
 	// on its own; no one calls stopFlow.
 	cfg := testConfig(t, "owner/panicky")
 	var supStarted, supStopped int64
-	supervise := func(ctx context.Context, name string, getCfg func() *config.Config, o Options) {
+	supervise := func(ctx context.Context, name string, getCfg func() *config.Config, o Options, kickCh <-chan struct{}) {
 		atomic.AddInt64(&supStarted, 1)
 		<-ctx.Done()
 		atomic.AddInt64(&supStopped, 1)
@@ -410,10 +410,10 @@ func TestRunSurfacesFleetBindErrorImmediately(t *testing.T) {
 	}
 	d := New(fakeLoader{cfgs: []*config.Config{cfg}}, Options{Host: "127.0.0.1", Port: port})
 	d.runLoop = blockingLoop
-	d.superviseLoop = func(ctx context.Context, name string, getCfg func() *config.Config, o Options) {
+	d.superviseLoop = func(ctx context.Context, name string, getCfg func() *config.Config, o Options, kickCh <-chan struct{}) {
 		blockingLoop(ctx, getCfg(), o, nil)
 	}
-	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {}
+	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration, kickCh chan<- struct{}) {}
 
 	// ctx is intentionally never cancelled within the deadline.
 	ctx, cancel := context.WithCancel(context.Background())
@@ -469,7 +469,7 @@ func TestStopFlowDrainsWatchdog(t *testing.T) {
 
 	var wdStarted, wdStopped int64
 	var gotName, gotStateDir string
-	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {
+	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration, kickCh chan<- struct{}) {
 		gotName, gotStateDir = name, stateDir
 		atomic.AddInt64(&wdStarted, 1)
 		<-ctx.Done()

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -94,6 +94,11 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 	d.flows[flow.key] = flow
 	d.mu.Unlock()
 
+	// Per-flow watchdog → supervise kick channel (#1119). Buffered by one so a
+	// watchdog tick never blocks on a loop that has not drained the previous
+	// kick; the send side is non-blocking anyway.
+	kickCh := make(chan struct{}, 1)
+
 	var wg sync.WaitGroup
 	wg.Add(2)
 	go func() {
@@ -112,7 +117,7 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 		// its decision/cycle logs on it so two same-basename repos are
 		// distinguishable in the journal, matching the watchdog (#764). It reads
 		// the flow's CURRENT config through the holder each cycle (#768).
-		d.superviseLoop(fctx, flow.name, flow.holder.Load, d.opts)
+		d.superviseLoop(fctx, flow.name, flow.holder.Load, d.opts, kickCh)
 	}()
 	// Reload pump (#768): consume the store watcher and fan a config-store edit
 	// out to the holder (supervisor + dashboard) and the orchestrator. Tracked
@@ -137,7 +142,7 @@ func (d *Daemon) startFlow(parent context.Context, storeName string, proj server
 		go func() {
 			defer wg.Done()
 			defer recoverFlow(flow, "watchdog")
-			d.watchdogLoop(fctx, flow.name, cfg.StateDir, d.opts.SuperviseInterval)
+			d.watchdogLoop(fctx, flow.name, cfg.StateDir, d.opts.SuperviseInterval, kickCh)
 		}()
 	}
 	// #887: the material-progress evaluator owns a separate per-project clock.

--- a/internal/daemon/material_progress_runtime_test.go
+++ b/internal/daemon/material_progress_runtime_test.go
@@ -27,10 +27,10 @@ func TestStartFlowMaterialProgressIndependentFromSupervisorFailure(t *testing.T)
 		<-ctx.Done()
 	}
 	var supervisorReturned int64
-	d.superviseLoop = func(context.Context, string, func() *config.Config, Options) {
+	d.superviseLoop = func(context.Context, string, func() *config.Config, Options, <-chan struct{}) {
 		atomic.StoreInt64(&supervisorReturned, 1) // models an unrecoverable first-cycle failure
 	}
-	d.watchdogLoop = func(context.Context, string, string, time.Duration) {}
+	d.watchdogLoop = func(context.Context, string, string, time.Duration, chan<- struct{}) {}
 
 	flow := d.startFlow(context.Background(), "", server.NewFleetProjectWithGitHub(cfg))
 	defer d.stopFlow(flow.key)

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -23,6 +23,16 @@ const superviseJitterCap = 60 * time.Second
 // can make the offset deterministic.
 var superviseJitterFrac = rand.Float64
 
+// superviseCycleCancelGrace bounds how long the loop waits for a cancelled
+// cycle to unwind before abandoning it (#1119). A cycle that honors its context
+// returns almost immediately; one that does not must not hold up the watchdog
+// kick or flow shutdown behind it. A package var so tests can shrink it.
+var superviseCycleCancelGrace = 10 * time.Second
+
+// superviseRunOnce is the supervisor entry point the loop drives, indirected
+// through a package var so tests can wedge a cycle deterministically (#1119).
+var superviseRunOnce = supervisor.RunOnce
+
 // superviseStartupJitter returns a random phase offset in
 // [0, min(interval, cap)) used to de-synchronize this flow's supervise GitHub
 // reads from the rest of the fleet — and the ticker anchored to the first
@@ -63,7 +73,13 @@ func computeSuperviseJitter(interval time.Duration, frac float64) time.Duration 
 // flow restart (#768). The GitHub client is built once from the startup repo —
 // repo is a restart-required field the orchestrator refuses to hot-apply, so it
 // is stable for the flow's lifetime.
-func runSupervise(ctx context.Context, name string, getCfg func() *config.Config, reader supervisor.Reader, interval time.Duration, approvalsDBPath string, emergencyLLMHalt func() bool) {
+//
+// kickCh is the watchdog's self-heal signal (#1119), nil for callers that do not
+// wire one. A kick means "your cycle is wedged": the loop cancels the in-flight
+// cycle and moves on, rather than waiting on the very goroutine that is stuck —
+// waiting is what made the earlier attempt (#820) a no-op that relocated the
+// block instead of clearing it.
+func runSupervise(ctx context.Context, name string, getCfg func() *config.Config, reader supervisor.Reader, interval time.Duration, approvalsDBPath string, emergencyLLMHalt func() bool, kickCh <-chan struct{}) {
 	// reader is the flow's read surface. The daemon passes a mirror-first source
 	// when github_mirror.source is mirror-first (#826); it satisfies
 	// supervisor.Reader and serves the poll reads locally when the mirror is warm,
@@ -77,7 +93,7 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 	// supervisor do that" trail was dropped — turning debugging into journal
 	// archaeology (#764). Logs key on the unique fleet name (not the possibly
 	// shared session prefix) so two same-basename repos stay distinguishable.
-	runOnce := func() error {
+	runOnce := func(cycleCtx context.Context) error {
 		// Fleet-wide EMERGENCY STOP (#840): when the switch halts LLM calls, run
 		// the cycle deterministic-only so the supervisor stops spending on its
 		// backend within one cycle. The rest of the cycle (state, GitHub reads,
@@ -86,12 +102,42 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 		if emergencyLLMHalt != nil && emergencyLLMHalt() {
 			opts = append(opts, supervisor.WithEmergencyLLMHalt(true))
 		}
-		decision, err := supervisor.RunOnce(getCfg(), reader, opts...)
+		decision, err := superviseRunOnce(cycleCtx, getCfg(), reader, opts...)
 		if err != nil {
 			return err
 		}
 		logSupervisorDecision(name, decision)
 		return nil
+	}
+
+	// runCycle runs one cycle under its own cancellable context so the loop can
+	// get rid of a wedged one (#1119). Both escape hatches — a watchdog kick and
+	// flow shutdown — cancel first and then wait only a bounded grace: a cycle
+	// that ignores cancellation is abandoned with a loud log instead of pinning
+	// the loop (or the flow's shutdown) to it forever.
+	runCycle := func(first bool) {
+		cycleCtx, cancelCycle := context.WithCancel(ctx)
+		defer cancelCycle()
+		done := make(chan error, 1)
+		go func() { done <- runOnce(cycleCtx) }()
+		select {
+		case err := <-done:
+			if err == nil {
+				return
+			}
+			if first {
+				log.Printf("[%s] supervise: first cycle failed (will retry): %v", name, err)
+				return
+			}
+			log.Printf("[%s] supervise: cycle failed (will retry in %s): %v", name, interval, err)
+		case <-kickCh:
+			log.Printf("[%s] supervise: watchdog kick — cancelling the in-flight cycle", name)
+			cancelCycle()
+			awaitCancelledCycle(name, done)
+		case <-ctx.Done():
+			cancelCycle()
+			awaitCancelledCycle(name, done)
+		}
 	}
 
 	// #794: de-phase this flow's supervise reads from the rest of the fleet.
@@ -113,9 +159,7 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 		}
 	}
 
-	if err := runOnce(); err != nil {
-		log.Printf("[%s] supervise: first cycle failed (will retry): %v", name, err)
-	}
+	runCycle(true)
 
 	if interval <= 0 {
 		return
@@ -128,13 +172,32 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			// #689: a failed cycle is logged and retried on the next tick,
-			// never fatal — a transient GitHub/decision-layer failure must
-			// not crash the daemon.
-			if err := runOnce(); err != nil {
-				log.Printf("[%s] supervise: cycle failed (will retry in %s): %v", name, interval, err)
-			}
+		case <-kickCh:
+			// The previous cycle was already cancelled by the kick that
+			// interrupted it (or none was running); either way the loop
+			// answers a wedge with a fresh cycle instead of idling until
+			// the next tick.
+			log.Printf("[%s] supervise: watchdog kick — starting a fresh cycle", name)
 		}
+		// #689: a failed cycle is logged and retried on the next tick,
+		// never fatal — a transient GitHub/decision-layer failure must
+		// not crash the daemon.
+		runCycle(false)
+	}
+}
+
+// awaitCancelledCycle waits a bounded grace for an already-cancelled supervise
+// cycle to unwind, then gives up on it (#1119). Abandoning is the point: the
+// caller cancels precisely because the cycle is suspected wedged, so waiting
+// for it unconditionally would put the block back where the kick — or flow
+// shutdown — was supposed to remove it.
+func awaitCancelledCycle(name string, done <-chan error) {
+	timer := time.NewTimer(superviseCycleCancelGrace)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+		log.Printf("[%s] supervise: WARNING cancelled cycle did not return within %s — abandoning it", name, superviseCycleCancelGrace)
 	}
 }
 

--- a/internal/daemon/supervise_delivery_test.go
+++ b/internal/daemon/supervise_delivery_test.go
@@ -83,7 +83,7 @@ func TestRunSuperviseThreadsConfiguredApprovalsDB(t *testing.T) {
 		latest:   []github.PRMergeInfo{{SHA: sha, MergedAt: now}},
 		checkout: approver.NewLocalFixtureCheckoutPreparer(cfg.Repo, origin),
 	}
-	runSupervise(t.Context(), "daemon-delivery", func() *config.Config { return cfg }, reader, 0, customDB, nil)
+	runSupervise(t.Context(), "daemon-delivery", func() *config.Config { return cfg }, reader, 0, customDB, nil, nil)
 
 	loaded, err := state.Load(cfg.StateDir)
 	if err != nil {

--- a/internal/daemon/supervise_kick_test.go
+++ b/internal/daemon/supervise_kick_test.go
@@ -1,0 +1,170 @@
+package daemon
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/state"
+	"github.com/befeast/maestro/internal/supervisor"
+)
+
+// wedgeCycles replaces the supervise loop's cycle entry point with a fake that
+// blocks, so a wedged cycle can be reproduced without a real GitHub/LLM stall.
+// It returns the started-cycle counter. honorCancel=false models the worst case
+// the loop must survive: a cycle that never observes its context at all.
+func wedgeCycles(t *testing.T, honorCancel bool) (started *atomic.Int64, cancelled *atomic.Int64) {
+	t.Helper()
+	started = &atomic.Int64{}
+	cancelled = &atomic.Int64{}
+	// Closed on cleanup so the deliberately-ignored cycles cannot outlive the test.
+	release := make(chan struct{})
+	restore := superviseRunOnce
+	superviseRunOnce = func(ctx context.Context, _ *config.Config, _ supervisor.Reader, _ ...supervisor.RunOption) (state.SupervisorDecision, error) {
+		started.Add(1)
+		if honorCancel {
+			select {
+			case <-ctx.Done():
+				cancelled.Add(1)
+				return state.SupervisorDecision{}, ctx.Err()
+			case <-release:
+				return state.SupervisorDecision{}, nil
+			}
+		}
+		<-release
+		return state.SupervisorDecision{}, nil
+	}
+	t.Cleanup(func() {
+		superviseRunOnce = restore
+		close(release)
+	})
+	return started, cancelled
+}
+
+// waitForCycles blocks until the loop has started at least want cycles.
+func waitForCycles(t *testing.T, started *atomic.Int64, want int64, why string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for started.Load() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("%s: %d cycle(s) started, want %d", why, started.Load(), want)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// superviseTestConfig builds a throwaway flow config and pins the startup
+// jitter to zero so the first cycle runs immediately.
+func superviseTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	restore := superviseJitterFrac
+	superviseJitterFrac = func() float64 { return 0 }
+	t.Cleanup(func() { superviseJitterFrac = restore })
+	return &config.Config{Repo: "owner/wedged", StateDir: t.TempDir()}
+}
+
+// TestRunSuperviseKickCancelsWedgedCycleAndRunsAFreshOne pins the self-heal the
+// earlier attempt (#820) claimed and did not deliver: a kick must CANCEL the
+// wedged cycle, not wait on it. The interval is long enough that the ticker
+// cannot fire during the test, so every cycle observed here is kick-driven.
+func TestRunSuperviseKickCancelsWedgedCycleAndRunsAFreshOne(t *testing.T) {
+	started, cancelled := wedgeCycles(t, true)
+	cfg := superviseTestConfig(t)
+	kickCh := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runSupervise(ctx, "kick", func() *config.Config { return cfg }, nil, time.Hour, "", nil, kickCh)
+	}()
+
+	waitForCycles(t, started, 1, "first cycle never started")
+
+	// Kick #1 interrupts the wedged cycle.
+	kickCh <- struct{}{}
+	deadline := time.Now().Add(3 * time.Second)
+	for cancelled.Load() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("the kick did not cancel the wedged cycle — it only waited on it, which is the #820 no-op")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Kick #2 proves the loop is alive and runs a fresh cycle afterwards.
+	kickCh <- struct{}{}
+	waitForCycles(t, started, 2, "the loop did not run a fresh cycle after the kick")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runSupervise did not return after ctx cancellation")
+	}
+}
+
+// TestRunSuperviseKickDoesNotWaitOnACycleThatIgnoresCancellation covers the
+// pathological case: the cycle never observes its context. The kick must still
+// return promptly and the loop must keep running fresh cycles, because a wedge
+// that cancellation cannot reach is exactly when the self-heal has to work.
+func TestRunSuperviseKickDoesNotWaitOnACycleThatIgnoresCancellation(t *testing.T) {
+	restoreGrace := superviseCycleCancelGrace
+	superviseCycleCancelGrace = 50 * time.Millisecond
+	t.Cleanup(func() { superviseCycleCancelGrace = restoreGrace })
+
+	started, _ := wedgeCycles(t, false)
+	cfg := superviseTestConfig(t)
+	kickCh := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runSupervise(ctx, "kick-ignored", func() *config.Config { return cfg }, nil, time.Hour, "", nil, kickCh)
+	}()
+
+	waitForCycles(t, started, 1, "first cycle never started")
+	kickCh <- struct{}{}
+	kickCh <- struct{}{}
+	waitForCycles(t, started, 2, "the loop stayed blocked on a cycle that ignores cancellation")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runSupervise did not return after ctx cancellation")
+	}
+}
+
+// TestRunSuperviseShutdownDoesNotBlockOnWedgedCycle pins the other half of the
+// contract: flow shutdown cancels the cycle and, if it does not unwind within
+// the grace, abandons it. Before this, shutdown waited on the wedged goroutine
+// and the whole flow hung with it.
+func TestRunSuperviseShutdownDoesNotBlockOnWedgedCycle(t *testing.T) {
+	restoreGrace := superviseCycleCancelGrace
+	superviseCycleCancelGrace = 50 * time.Millisecond
+	t.Cleanup(func() { superviseCycleCancelGrace = restoreGrace })
+
+	started, _ := wedgeCycles(t, false)
+	cfg := superviseTestConfig(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runSupervise(ctx, "shutdown", func() *config.Config { return cfg }, nil, time.Hour, "", nil, nil)
+	}()
+
+	waitForCycles(t, started, 1, "first cycle never started")
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("runSupervise blocked on a wedged cycle during shutdown")
+	}
+}

--- a/internal/daemon/watch_test.go
+++ b/internal/daemon/watch_test.go
@@ -80,7 +80,7 @@ func (f *fakeWatchStore) ProjectsFingerprint(ctx context.Context) (map[string]ti
 	return out, nil
 }
 
-func newWatchDaemon(store ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, func() *config.Config, Options)) *Daemon {
+func newWatchDaemon(store ConfigLoader, run func(context.Context, *config.Config, Options, <-chan *config.Config), supervise func(context.Context, string, func() *config.Config, Options, <-chan struct{})) *Daemon {
 	d := New(store, Options{Host: "127.0.0.1", Port: 0, WatchStore: true, WatchStoreInterval: 25 * time.Millisecond})
 	if run != nil {
 		d.runLoop = run
@@ -88,7 +88,7 @@ func newWatchDaemon(store ConfigLoader, run func(context.Context, *config.Config
 	if supervise != nil {
 		d.superviseLoop = supervise
 	}
-	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration) {}
+	d.watchdogLoop = func(ctx context.Context, name, stateDir string, interval time.Duration, kickCh chan<- struct{}) {}
 	return d
 }
 
@@ -210,7 +210,9 @@ func TestWatchStoreWiresReloadChannel(t *testing.T) {
 		}
 		<-ctx.Done()
 	}
-	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) { <-ctx.Done() }
+	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options, kickCh <-chan struct{}) {
+		<-ctx.Done()
+	}
 	d := newWatchDaemon(store, run, sup)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -270,7 +272,7 @@ func TestWatchStoreMaxLiveWorkersOnlyReconfiguresRunningOrchestrator(t *testing.
 			}
 		}
 	}
-	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
+	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options, kickCh <-chan struct{}) {
 		<-ctx.Done()
 	}
 	d := newWatchDaemon(store, run, sup)
@@ -427,7 +429,7 @@ func TestWatchStoreLiveReloadReachesSupervisorAndDashboard(t *testing.T) {
 	run := func(ctx context.Context, c *config.Config, opts Options, reloadCh <-chan *config.Config) {
 		<-ctx.Done()
 	}
-	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options) {
+	sup := func(ctx context.Context, name string, getCfg func() *config.Config, opts Options, kickCh <-chan struct{}) {
 		tick := time.NewTicker(3 * time.Millisecond)
 		defer tick.Stop()
 		for {

--- a/internal/github/gh_command_bound_test.go
+++ b/internal/github/gh_command_bound_test.go
@@ -1,0 +1,108 @@
+package github
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestGhCommandCarriesADeadline pins the #1119 invariant at the construction
+// site: every plain `gh` call in this package goes through ghCommand, so
+// ghCommand must never hand back a command that can run forever. Before the fix
+// it was a bare exec.Command — no context, no deadline, no way to kill it — and
+// a gh that never returned wedged the whole supervise cycle.
+func TestGhCommandCarriesADeadline(t *testing.T) {
+	cmd := ghCommand("api", "rate_limit")
+	if cmd.Cancel == nil {
+		t.Error("ghCommand returned a command with no Cancel hook: it was not built from a deadline context, so a hung gh can never be killed (#1119)")
+	}
+	if cmd.WaitDelay <= 0 {
+		t.Error("ghCommand returned a command with no WaitDelay: a child holding the output pipe still blocks Wait after the deadline kill (#1119)")
+	}
+}
+
+// TestGhCommandKillsProcessGroupOnDeadline runs the real ghCommand path against
+// a stub that outlives its deadline and leaves a background child holding the
+// output pipe — the shape that makes an unbounded gh hang a cycle. The call must
+// return on the deadline, and the child must die with the group: killing only
+// the leader leaves the pipe open and Wait blocked.
+func TestGhCommandKillsProcessGroupOnDeadline(t *testing.T) {
+	childPID := filepath.Join(t.TempDir(), "child.pid")
+	stubGHExecutable(t, "#!/bin/sh\nsleep 60 &\necho $! > "+childPID+"\nsleep 60\n")
+
+	restoreTimeout := ghTimeout
+	ghTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { ghTimeout = restoreTimeout })
+
+	type result struct {
+		err     error
+		elapsed time.Duration
+	}
+	done := make(chan result, 1)
+	go func() {
+		start := time.Now()
+		_, err := ghCommand("api", "rate_limit").CombinedOutput()
+		done <- result{err: err, elapsed: time.Since(start)}
+	}()
+
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("ghCommand never returned: the gh subprocess is unbounded, which is exactly the wedge in #1119")
+	}
+	if got.err == nil {
+		t.Fatalf("ghCommand succeeded after %s, want a deadline failure", got.elapsed)
+	}
+	if got.elapsed > 10*time.Second {
+		t.Fatalf("ghCommand returned after %s, want ~%s: the deadline did not bound it", got.elapsed, ghTimeout)
+	}
+
+	pid := readStubChildPID(t, childPID)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if err := syscall.Kill(pid, 0); err == syscall.ESRCH {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("gh child pid %d survived the deadline: only the process leader was killed, so a child can still hold the output pipe open (#1119)", pid)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// stubGHExecutable points ghExecutable at a throwaway script so a bound can be
+// exercised without spawning the real CLI (and without touching the network).
+func stubGHExecutable(t *testing.T, script string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gh-stub")
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatalf("write gh stub: %v", err)
+	}
+	restore := ghExecutable
+	ghExecutable = path
+	t.Cleanup(func() { ghExecutable = restore })
+}
+
+// readStubChildPID waits for the stub to record its background child's pid; the
+// stub writes it after the fork, so a plain read can lose the race.
+func readStubChildPID(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		raw, err := os.ReadFile(path)
+		if err == nil {
+			if pid, convErr := strconv.Atoi(strings.TrimSpace(string(raw))); convErr == nil && pid > 0 {
+				return pid
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("gh stub never recorded its child pid at %s", path)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -258,12 +258,41 @@ var ghAPIRunner = func(args ...string) ([]byte, error) {
 	return ghCommand(args...).CombinedOutput()
 }
 
-// ghCommand builds an exec.Command for `gh <args...>` with GitHub App auth
+// ghTimeout is the maximum wall time allowed for a single gh subprocess call.
+// It is the package-wide bound: ghCommand applies it to every plain `gh` call
+// site, and the GraphQL Projects calls in github_projects.go pass it to their
+// own contexts. A var rather than a const only so tests can shrink it;
+// production never reassigns it.
+var ghTimeout = 30 * time.Second
+
+// ghExecutable is the gh binary, resolved through PATH exactly like the bare
+// exec.Command call it replaced. A var only so a test can point the bounded
+// wiring at a stub instead of the real CLI.
+var ghExecutable = "gh"
+
+// ghCommand builds a bounded exec.Cmd for `gh <args...>` with GitHub App auth
 // injected when configured. All direct `gh` call sites in this package use it
-// instead of exec.Command so installation-token auth is uniform (#823).
+// instead of exec.Command so installation-token auth is uniform (#823) and so
+// no single gh invocation can hang a supervise cycle forever (#1119): this was
+// a plain exec.Command with no deadline behind 20 call sites — the entire read
+// surface the supervisor cycle depends on — so a gh that never returned wedged
+// RunOnce with nothing above it able to abort the subprocess.
+//
+// The deadline context deliberately outlives this function: exec.CommandContext
+// requires its context to stay live until Wait returns, so cancel cannot be
+// deferred here. It is invoked from Cancel when the deadline fires; when the
+// process exits first the context is released by its own timer at the deadline,
+// so the retained resource is one armed timer for at most ghTimeout. Note the
+// clock starts when the command is built, not when it is started — every call
+// site in this package builds and runs in a single expression.
 func ghCommand(args ...string) *exec.Cmd {
-	cmd := exec.Command("gh", args...)
-	ghApplyAuth(cmd)
+	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
+	cmd := ghCommandContext(ctx, args...)
+	kill := cmd.Cancel
+	cmd.Cancel = func() error {
+		defer cancel()
+		return kill()
+	}
 	return cmd
 }
 
@@ -271,7 +300,29 @@ func ghCommand(args ...string) *exec.Cmd {
 // GraphQL Projects calls in github_projects.go so they authenticate with the
 // installation token when App auth is active (#823).
 func ghCommandContext(ctx context.Context, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "gh", args...)
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := exec.CommandContext(ctx, ghExecutable, args...)
+	// Kill the whole process group, not just gh itself (#1119). gh spawns
+	// helpers (credential, pager, hooks) and a surviving child that inherited
+	// the output pipe keeps Wait blocked long after the leader is gone — the
+	// same hang the deadline exists to prevent. Mirrors the delivery-freshness
+	// fence in trustedGHCommandContext.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	// Bound the post-kill wait too: Wait blocks until the output pipes close,
+	// so a stray descriptor holder must not turn a deadline into a hang.
+	cmd.WaitDelay = 2 * time.Second
 	ghApplyAuth(cmd)
 	return cmd
 }

--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -8,11 +8,7 @@ import (
 	"net/url"
 	"os/exec"
 	"strings"
-	"time"
 )
-
-// ghTimeout is the maximum time allowed for a single gh subprocess call.
-const ghTimeout = 30 * time.Second
 
 // ProjectStatus represents the status to set on a GitHub Project item.
 // Kept for backward compatibility — callers map these to real column names.

--- a/internal/supervisor/delivery_execution_test.go
+++ b/internal/supervisor/delivery_execution_test.go
@@ -62,7 +62,7 @@ func TestRunOnceDeliveryUsesConfiguredApprovalsDB(t *testing.T) {
 		t.Fatal(err)
 	}
 	reader := newDeliveryExecutionReader(t, cfg, repoDir, sha, now)
-	if _, err := RunOnce(cfg, reader, WithApprovalsDBPath(customDB)); err != nil {
+	if _, err := RunOnce(context.Background(), cfg, reader, WithApprovalsDBPath(customDB)); err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
 
@@ -149,7 +149,7 @@ func TestRunOnceImportsStoreAuthoritativeDeliveryBeforeApprovedScan(t *testing.T
 	}
 
 	reader := newDeliveryExecutionReader(t, cfg, repoDir, sha, now)
-	if _, err := RunOnce(cfg, reader, WithApprovalsDBPath(customDB)); err != nil {
+	if _, err := RunOnce(context.Background(), cfg, reader, WithApprovalsDBPath(customDB)); err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
 	loaded, err := state.Load(cfg.StateDir)

--- a/internal/supervisor/dependency_unblock_test.go
+++ b/internal/supervisor/dependency_unblock_test.go
@@ -1,6 +1,7 @@
 package supervisor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -237,7 +238,7 @@ func TestRunOnceDependencyUnblockAppliesSafeLabelMutations(t *testing.T) {
 		closedIssues: map[int]bool{147: true},
 	}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -286,7 +287,7 @@ supervisor:
 		closedIssues: map[int]bool{150: true},
 	}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -641,7 +642,7 @@ func TestRunOnce_DependencyUnblockExecutesMutations(t *testing.T) {
 		closedIssues: map[int]bool{147: true},
 	}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -659,7 +660,7 @@ func TestRunOnce_DependencyUnblockExecutesMutations(t *testing.T) {
 	}
 
 	// Second cycle must be a no-op (idempotency).
-	if _, err := RunOnce(cfg, reader); err != nil {
+	if _, err := RunOnce(context.Background(), cfg, reader); err != nil {
 		t.Fatalf("RunOnce(2): %v", err)
 	}
 	if len(reader.removedLabels) != 1 || len(reader.addedLabels) != 1 || len(reader.comments) != 1 {

--- a/internal/supervisor/emergency_stop_test.go
+++ b/internal/supervisor/emergency_stop_test.go
@@ -1,6 +1,7 @@
 package supervisor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/befeast/maestro/internal/config"
@@ -78,7 +79,7 @@ func TestRunOnce_WithEmergencyLLMHalt(t *testing.T) {
 	// RunOnce builds its own engine + backend client; with the halt set it must
 	// not shell out. A real backend call would fail (no backend configured), so a
 	// clean deterministic decision is itself evidence the LLM path was skipped.
-	decision, err := RunOnce(cfg, reader, WithEmergencyLLMHalt(true))
+	decision, err := RunOnce(context.Background(), cfg, reader, WithEmergencyLLMHalt(true))
 	if err != nil {
 		t.Fatalf("RunOnce with emergency halt: %v", err)
 	}

--- a/internal/supervisor/llm_short_circuit_test.go
+++ b/internal/supervisor/llm_short_circuit_test.go
@@ -1,6 +1,7 @@
 package supervisor
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -218,7 +219,7 @@ func TestRunOnce_SafeIdleDecision_RecordedWithoutBackendCall(t *testing.T) {
 		t.Fatalf("seed state: %v", err)
 	}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}

--- a/internal/supervisor/run_once_context_test.go
+++ b/internal/supervisor/run_once_context_test.go
@@ -1,0 +1,69 @@
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// cancellingReader cancels the cycle from inside the first GitHub read, which
+// is where a real cancellation lands: mid-Decide, not between calls.
+type cancellingReader struct {
+	*fakeReader
+	cancel context.CancelFunc
+	reads  int
+}
+
+func (r *cancellingReader) ListOpenIssues(labels []string) ([]github.Issue, error) {
+	r.reads++
+	r.cancel()
+	return r.fakeReader.ListOpenIssues(labels)
+}
+
+// TestRunOnceReturnsOnAnAlreadyCancelledContext pins the cheapest half of the
+// #1119 contract: a cycle whose context is dead before it starts does no work.
+func TestRunOnceReturnsOnAnAlreadyCancelledContext(t *testing.T) {
+	cfg := testConfig(t)
+	reader := &fakeReader{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if _, err := RunOnce(ctx, cfg, reader); !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunOnce error = %v, want context.Canceled", err)
+	}
+	if reader.issueCalls != 0 {
+		t.Errorf("cancelled cycle still read %d issue page(s) from GitHub", reader.issueCalls)
+	}
+}
+
+// TestRunOnceStopsAtThePhaseBoundaryAfterCancellation covers the case the
+// daemon actually relies on: the cancel arrives while the cycle is already
+// running, and RunOnce abandons it at the next phase boundary instead of
+// carrying on into the mutating phase and stamping a heartbeat for a cycle
+// that was told to stop.
+func TestRunOnceStopsAtThePhaseBoundaryAfterCancellation(t *testing.T) {
+	cfg := testConfig(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	reader := &cancellingReader{fakeReader: &fakeReader{}, cancel: cancel}
+
+	if _, err := RunOnce(ctx, cfg, reader); !errors.Is(err, context.Canceled) {
+		t.Fatalf("RunOnce error = %v, want context.Canceled", err)
+	}
+	if reader.reads == 0 {
+		t.Fatal("the cycle never reached the GitHub read, so this test did not exercise a mid-cycle cancel")
+	}
+	st, err := state.Load(cfg.StateDir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if !st.LastRunOnceAt.IsZero() {
+		t.Error("a cancelled cycle stamped LastRunOnceAt: it ran through the mutating phase instead of stopping at the boundary")
+	}
+	if latest := st.LatestSupervisorDecision(); latest != nil {
+		t.Error("a cancelled cycle recorded a decision: it ran through the mutating phase instead of stopping at the boundary")
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -312,10 +312,25 @@ func WithApprovalsDBPath(path string) RunOption {
 
 // RunOnce records one supervisor decision in Maestro state and applies any safe
 // queue mutations selected by the decision.
-func RunOnce(cfg *config.Config, reader Reader, opts ...RunOption) (state.SupervisorDecision, error) {
+//
+// ctx bounds the cycle (#1119). It is checked at each phase boundary — before
+// the state load, before Decide, and before the mutating phase — so a cancelled
+// cycle stops advancing instead of running to completion; the caller (the
+// daemon supervise loop) can therefore abandon a wedged cycle and recover.
+// Cancellation is deliberately NOT honored inside the mutating phase: once
+// approvals/labels/comments start landing, aborting halfway would leave GitHub
+// mutated with the matching state unsaved. The reads themselves are bounded by
+// the gh subprocess deadline in internal/github, so a phase cannot outlive it.
+func RunOnce(ctx context.Context, cfg *config.Config, reader Reader, opts ...RunOption) (state.SupervisorDecision, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var ro runOptions
 	for _, opt := range opts {
 		opt(&ro)
+	}
+	if err := ctx.Err(); err != nil {
+		return state.SupervisorDecision{}, err
 	}
 	st, err := state.Load(cfg.StateDir)
 	if err != nil {
@@ -341,6 +356,9 @@ func RunOnce(cfg *config.Config, reader Reader, opts ...RunOption) (state.Superv
 	// the same approvals on every cycle. We move the call there.
 	recordOutcomeHealth(cfg, st)
 
+	if err := ctx.Err(); err != nil {
+		return state.SupervisorDecision{}, err
+	}
 	engine := NewEngine(cfg, reader)
 	engine.SetEmergencyLLMHalt(ro.emergencyLLMHalt)
 	decision, err := engine.Decide(st)
@@ -369,6 +387,9 @@ func RunOnce(cfg *config.Config, reader Reader, opts ...RunOption) (state.Superv
 	}
 	state.PrepareSupervisorRecommendation(&decision)
 	decision.Quiescent = supervisorDecisionQuiescent(decision)
+	if err := ctx.Err(); err != nil {
+		return state.SupervisorDecision{}, err
+	}
 	if !cfg.Supervisor.DryRun {
 		// Execute any approvals that were transitioned to status=approved
 		// outside this loop (CLI approve already executes inline; this

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1,6 +1,7 @@
 package supervisor
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -1681,11 +1682,11 @@ func TestRunOnce_BlockedIssueWithOpenPRIsQuiescentUntilGuardTransition(t *testin
 		t.Fatalf("save initial state: %v", err)
 	}
 
-	first, err := RunOnce(cfg, reader)
+	first, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("first RunOnce: %v", err)
 	}
-	second, err := RunOnce(cfg, reader)
+	second, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("second RunOnce: %v", err)
 	}
@@ -1704,7 +1705,7 @@ func TestRunOnce_BlockedIssueWithOpenPRIsQuiescentUntilGuardTransition(t *testin
 	}
 
 	reader.issues = []github.Issue{testIssue(331, "canonical PR #335")}
-	edge, err := RunOnce(cfg, reader)
+	edge, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("guard exit RunOnce: %v", err)
 	}
@@ -2213,7 +2214,7 @@ func TestRunOnceRecordsDecision(t *testing.T) {
 	cfg := testConfig(t)
 	reader := &fakeReader{}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -2244,7 +2245,7 @@ func TestRunOnce_StampsLastRunOnceAt(t *testing.T) {
 	reader := &fakeReader{}
 
 	before := time.Now().UTC()
-	if _, err := RunOnce(cfg, reader); err != nil {
+	if _, err := RunOnce(context.Background(), cfg, reader); err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
 	after := time.Now().UTC()
@@ -2308,7 +2309,7 @@ func TestRunOnce_ClearsSupervisorStuckFlag(t *testing.T) {
 		t.Fatalf("Save: %v", err)
 	}
 
-	if _, err := RunOnce(cfg, reader); err != nil {
+	if _, err := RunOnce(context.Background(), cfg, reader); err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
 
@@ -2337,7 +2338,7 @@ func TestRunOnceRecordsOutcomeHealth(t *testing.T) {
 	}
 	reader := &fakeReader{}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -2359,7 +2360,7 @@ func TestRunOnceRecordsPendingApprovalForRiskyDecision(t *testing.T) {
 	cfg.IssueLabels = []string{"maestro-ready"}
 	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -2400,11 +2401,11 @@ func TestRunOnceRecommendationDedupKeepsApprovalMintingStable(t *testing.T) {
 	cfg.IssueLabels = []string{"maestro-ready"}
 	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
 
-	first, err := RunOnce(cfg, reader)
+	first, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("first RunOnce: %v", err)
 	}
-	second, err := RunOnce(cfg, reader)
+	second, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("second RunOnce: %v", err)
 	}
@@ -2438,7 +2439,7 @@ func TestRunOnceDecisionSurvivesStaleRunLoopSave(t *testing.T) {
 	}
 
 	reader := &fakeReader{issues: []github.Issue{testIssue(302, "Prevent state lost-update", "maestro-ready")}}
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -2686,7 +2687,7 @@ func TestRunOnceDynamicWaveAddsReadyOnlyToBestCandidateAndCleansStale(t *testing
 		testIssue(20, "best candidate", "p0"),
 	}}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -3005,7 +3006,7 @@ func TestRunOnceLabelsNextIssueReadyAndComments(t *testing.T) {
 	cfg.Supervisor.QueueComments = true
 	reader := &fakeReader{issues: []github.Issue{testIssue(308, "implement supervisor")}}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -3043,7 +3044,7 @@ func TestRunOnceLabelsNextIssueReadyAndComments(t *testing.T) {
 		t.Fatalf("latest decision = %#v, want succeeded decision with mutations", latest)
 	}
 
-	second, err := RunOnce(cfg, reader)
+	second, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("second RunOnce: %v", err)
 	}
@@ -3063,7 +3064,7 @@ func TestRunOnceOrderedQueueRemovesBlockedLabelWhenPolicyAllows(t *testing.T) {
 	cfg.Supervisor.SafeActions = []string{config.SupervisorActionRemoveBlockedLabel}
 	reader := &fakeReader{issues: []github.Issue{testIssue(42, "was blocked", "maestro-ready", "blocked")}}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -3090,7 +3091,7 @@ func TestRunOnceOrderedQueueUsesConfiguredSupervisorBlockedLabel(t *testing.T) {
 	cfg.Supervisor.SafeActions = []string{config.SupervisorActionRemoveBlockedLabel}
 	reader := &fakeReader{issues: []github.Issue{testIssue(42, "waiting work", "maestro-ready", "waiting")}}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -3117,7 +3118,7 @@ func TestRunOnceDynamicWaveNeverRemovesBlockedLabel(t *testing.T) {
 		testIssue(2, "regular", "p1"),
 	}}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -3146,7 +3147,7 @@ func TestRunOnceDoesNotRemoveBlockedLabelWithOpenBlocker(t *testing.T) {
 		closedIssues: map[int]bool{10: false},
 	}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -3175,7 +3176,7 @@ func TestRunOnceRunningWorkerDoesNotLabelAtCapacity(t *testing.T) {
 	}
 	reader := &fakeReader{issues: []github.Issue{testIssue(308, "next")}}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -3197,7 +3198,7 @@ func TestRunOnceAlreadyReadyDoesNotDuplicateQueueAction(t *testing.T) {
 	cfg.Supervisor.SafeActions = []string{config.SupervisorActionAddReadyLabel, config.SupervisorActionAddIssueComment}
 	reader := &fakeReader{issues: []github.Issue{testIssue(42, "ready work", "maestro-ready")}}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -3219,7 +3220,7 @@ func TestRunOnceGitHubFailureRecordsFailedMutation(t *testing.T) {
 		addLabelErr: errors.New("boom"),
 	}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -3601,7 +3602,7 @@ func TestRunOnceDryRunDoesNotRecordDecision(t *testing.T) {
 	cfg.Supervisor.DryRun = true
 	reader := &fakeReader{}
 
-	if _, err := RunOnce(cfg, reader); err != nil {
+	if _, err := RunOnce(context.Background(), cfg, reader); err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
 	st, err := state.Load(cfg.StateDir)
@@ -3835,7 +3836,7 @@ func TestRunOnce_SpawnWorker_RecommendedActionRequiresApprovalReflectsGate(t *te
 	}
 	reader := &fakeReader{issues: []github.Issue{testIssue(119, "fix CI flake", "maestro-ready")}}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}
@@ -3887,7 +3888,7 @@ func TestRunOnce_SpawnWorker_AutonomousModeReportsNoApprovalRequired(t *testing.
 	cfg.Supervisor.ApprovalRequiredActions = []string{ActionMergePR}
 	reader := &fakeReader{issues: []github.Issue{testIssue(119, "fix CI flake", "maestro-ready")}}
 
-	decision, err := RunOnce(cfg, reader)
+	decision, err := RunOnce(context.Background(), cfg, reader)
 	if err != nil {
 		t.Fatalf("RunOnce: %v", err)
 	}

--- a/internal/supervisor/watchdog.go
+++ b/internal/supervisor/watchdog.go
@@ -24,7 +24,13 @@ import (
 // name (project / session prefix) is woven into every log line so that, with N
 // flows in one daemon, an operator can tell whose LastRunOnceAt went stale
 // (#764) instead of reading N identical `[supervise/watchdog]` prefixes.
-func Watchdog(ctx context.Context, name, stateDir string, interval time.Duration) {
+//
+// kickCh, when non-nil, turns the watchdog from a reporter into a self-heal
+// trigger (#1119): after two consecutive stuck ticks (one warning plus a
+// confirmation) it signals the supervise loop, which cancels the wedged cycle
+// and runs a fresh one. The single-project CLI passes nil and stays warn-only,
+// because its loop calls RunOnce inline and has no cycle to cancel.
+func Watchdog(ctx context.Context, name, stateDir string, interval time.Duration, kickCh chan<- struct{}) {
 	if interval <= 0 {
 		return
 	}
@@ -37,6 +43,11 @@ func Watchdog(ctx context.Context, name, stateDir string, interval time.Duration
 
 	tick := time.NewTicker(interval)
 	defer tick.Stop()
+
+	// Consecutive stuck ticks, reset by any tick that sees a fresh
+	// LastRunOnceAt. Two in a row are required before kicking so a single
+	// slow-but-progressing cycle is never interrupted.
+	var consecutiveStuck int
 
 	for {
 		select {
@@ -62,6 +73,8 @@ func Watchdog(ctx context.Context, name, stateDir string, interval time.Duration
 			log.Printf("[%s] WARNING: no RunOnce has stamped state.LastRunOnceAt since the daemon started %s ago; check whether RunOnce is wedged",
 				logPrefix, time.Since(startedAt).Round(time.Second))
 			persistSupervisorStuck(logPrefix, stateDir, "no RunOnce has completed since daemon start")
+			consecutiveStuck++
+			tryKick(logPrefix, kickCh, consecutiveStuck)
 			continue
 		}
 		gap := time.Since(st.LastRunOnceAt)
@@ -70,7 +83,26 @@ func Watchdog(ctx context.Context, name, stateDir string, interval time.Duration
 				st.LastRunOnceAt.Format(time.RFC3339), gap.Round(time.Second), stuckThreshold)
 			log.Printf("[%s] WARNING: supervise loop appears stuck — %s", logPrefix, reason)
 			persistSupervisorStuck(logPrefix, stateDir, reason)
+			consecutiveStuck++
+			tryKick(logPrefix, kickCh, consecutiveStuck)
+			continue
 		}
+		consecutiveStuck = 0
+	}
+}
+
+// tryKick signals the supervise loop to cancel its wedged cycle and start a
+// fresh one, once the wedge is confirmed by a second consecutive stuck tick
+// (#1119). The send is non-blocking against a buffered channel so a loop that
+// has not drained the previous kick can never stall the watchdog.
+func tryKick(logPrefix string, kickCh chan<- struct{}, consecutiveStuck int) {
+	if kickCh == nil || consecutiveStuck < 2 {
+		return
+	}
+	select {
+	case kickCh <- struct{}{}:
+		log.Printf("[%s] kick: supervise loop is wedged after %d consecutive stuck ticks — asking it to cancel the in-flight cycle", logPrefix, consecutiveStuck)
+	default:
 	}
 }
 

--- a/internal/supervisor/watchdog_kick_test.go
+++ b/internal/supervisor/watchdog_kick_test.go
@@ -1,0 +1,106 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// TestWatchdogKicksOnlyAfterAConfirmedWedge pins the self-heal trigger (#1119):
+// the watchdog escalates from "warn" to "ask the supervise loop to cancel its
+// cycle" only once a second consecutive tick still sees a stale LastRunOnceAt,
+// so one slow-but-progressing cycle is never interrupted.
+func TestWatchdogKicksOnlyAfterAConfirmedWedge(t *testing.T) {
+	dir := t.TempDir()
+	st := state.NewState()
+	st.LastRunOnceAt = time.Now().UTC().Add(-time.Hour)
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	interval := 25 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	kickCh := make(chan struct{}, 1)
+	go Watchdog(ctx, "wedged", dir, interval, kickCh)
+
+	// Startup grace is 3*interval, then two stuck ticks are needed.
+	select {
+	case <-kickCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("watchdog never kicked despite a permanently stale LastRunOnceAt")
+	}
+}
+
+// TestWatchdogDoesNotKickWhileCyclesLand verifies the watchdog stays quiet — and
+// resets its stuck streak — while the supervise loop keeps stamping fresh cycles.
+func TestWatchdogDoesNotKickWhileCyclesLand(t *testing.T) {
+	dir := t.TempDir()
+	interval := 25 * time.Millisecond
+
+	stamp := func() {
+		st, err := state.Load(dir)
+		if err != nil {
+			t.Fatalf("load state: %v", err)
+		}
+		st.LastRunOnceAt = time.Now().UTC()
+		if err := state.Save(dir, st); err != nil {
+			t.Fatalf("save state: %v", err)
+		}
+	}
+	stamp()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	kickCh := make(chan struct{}, 1)
+	go Watchdog(ctx, "healthy", dir, interval, kickCh)
+
+	deadline := time.Now().Add(10 * interval)
+	for time.Now().Before(deadline) {
+		select {
+		case <-kickCh:
+			t.Fatal("watchdog kicked a healthy supervise loop")
+		default:
+		}
+		stamp()
+		time.Sleep(interval / 2)
+	}
+}
+
+// TestWatchdogNilKickChannelStaysWarnOnly covers the single-project CLI wiring:
+// it passes no kick channel, so the watchdog must keep warning without panicking
+// on the nil send.
+func TestWatchdogNilKickChannelStaysWarnOnly(t *testing.T) {
+	dir := t.TempDir()
+	st := state.NewState()
+	st.LastRunOnceAt = time.Now().UTC().Add(-time.Hour)
+	if err := state.Save(dir, st); err != nil {
+		t.Fatalf("save state: %v", err)
+	}
+
+	interval := 20 * time.Millisecond
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		Watchdog(ctx, "cli", dir, interval, nil)
+	}()
+
+	time.Sleep(8 * interval)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog did not return after ctx cancellation")
+	}
+
+	loaded, err := state.Load(dir)
+	if err != nil {
+		t.Fatalf("load state: %v", err)
+	}
+	if !loaded.SupervisorStuck {
+		t.Error("watchdog with a nil kick channel must still persist SupervisorStuck")
+	}
+}


### PR DESCRIPTION
## Problem

A supervise cycle could wedge indefinitely and nothing bounded it.

- `ghCommand` (`internal/github/github.go`) was a bare `exec.Command`: no context, no timeout, no way to kill it. It backs **20 production call sites** (19 in `github.go`, 1 in `review_threads.go`) — the whole `Reader` surface a supervise cycle depends on. Only `ghCommandContext` (6 GraphQL Projects call sites) was bounded.
- `supervisor.RunOnce` took no context, so nothing above it could cancel a cycle.
- Consequently the watchdog could only warn. The earlier self-heal attempt (#820) could not work: its kick branch and its `ctx.Done()` branch both did `<-done` on the wedged goroutine, so the kick relocated the block instead of clearing it, and flow shutdown started hanging on the same cycle.

## Fix

**1. Bound the subprocess (`internal/github`).** `ghCommand` now builds its command through `ghCommandContext` with the package-wide `ghTimeout` (30s), so all 20 call sites are bounded with no interface churn. `ghCommandContext` gained the process-group fence already used by the delivery-freshness path: `Setpgid`, a `Cancel` that `SIGKILL`s `-pid`, and a `WaitDelay` — killing only the leader leaves a child holding the output pipe and `Wait` still blocked, which is the same hang. `ghTimeout` moved from `github_projects.go` to `github.go`; it is no longer projects-specific.

On the `exec.CommandContext` contract the issue flagged: the deadline context deliberately outlives `ghCommand` (it must stay live until `Wait` returns, so `cancel` cannot be deferred there). It is invoked from `Cancel` when the deadline fires; when the process exits first the context is released by its own timer, so the retained resource is one armed timer for at most `ghTimeout`. The clock starting at build time is a non-issue here: every call site in the package builds and runs in one expression.

**2. Context-aware `RunOnce` (`internal/supervisor`).** `RunOnce(ctx, cfg, reader, opts...)` checks the context at each phase boundary — before the state load, before `Decide`, before the mutating phase. Cancellation is deliberately *not* honored inside the mutating phase: aborting once approvals/labels/comments start landing would leave GitHub mutated with the matching state unsaved.

**3. The watchdog kick, inverted (`internal/daemon`, `supervisor.Watchdog`).** `Watchdog` gains a `kickCh` and sends after two consecutive stuck ticks; `startFlow` creates one buffered channel per flow and passes it to both the watchdog (sender) and the supervise loop (receiver); the single-project CLI passes `nil` and stays warn-only. In `runSupervise` each cycle runs under its own cancellable context, and both escape hatches — kick and flow shutdown — **cancel first and then wait only a bounded grace** (`superviseCycleCancelGrace`, 10s), abandoning with a loud log a cycle that ignores cancellation. That is the difference from #820: the kick terminates the cycle instead of queueing behind it.

Deliberately **not** done: ctx-carrying `Reader`/`Mutator` variants. The issue lists them as a proposal, not an acceptance criterion; they would churn ~15 optional reader interfaces, and the guarantee they buy (an in-flight read cannot outrun its bound) is already delivered by the subprocess deadline plus the loop-level abandon.

## Acceptance criteria

| Criterion | Where |
|---|---|
| No `gh` invocation runs without a timeout; a test pins that `ghCommand` produces a bounded command | `internal/github/gh_command_bound_test.go` |
| `RunOnce` accepts a context and returns promptly once cancelled | `internal/supervisor/run_once_context_test.go` |
| A test wedges a cycle and asserts a watchdog kick and a flow cancellation both return without waiting on it | `internal/daemon/supervise_kick_test.go` |
| Flow shutdown does not block on a wedged cycle | `TestRunSuperviseShutdownDoesNotBlockOnWedgedCycle` |

## Evidence that the tests fail on unfixed code

Each new test was run against a targeted revert of the code it covers, then the code was restored.

`ghCommand` reverted to the plain `exec.Command` form:

```
--- FAIL: TestGhCommandCarriesADeadline (0.00s)
    ghCommand returned a command with no Cancel hook: it was not built from a deadline context
--- FAIL: TestGhCommandKillsProcessGroupOnDeadline (15.01s)
    ghCommand never returned: the gh subprocess is unbounded, which is exactly the wedge in #1119
```

The three `ctx.Err()` phase guards removed from `RunOnce`:

```
--- FAIL: TestRunOnceReturnsOnAnAlreadyCancelledContext (0.00s)
    RunOnce error = <nil>, want context.Canceled
--- FAIL: TestRunOnceStopsAtThePhaseBoundaryAfterCancellation (0.00s)
    RunOnce error = <nil>, want context.Canceled
```

The kick/shutdown branches reverted to #820's `<-done` shape:

```
--- FAIL: TestRunSuperviseKickCancelsWedgedCycleAndRunsAFreshOne (3.01s)
    the kick did not cancel the wedged cycle — it only waited on it, which is the #820 no-op
--- FAIL: TestRunSuperviseKickDoesNotWaitOnACycleThatIgnoresCancellation (3.01s)
    the loop stayed blocked on a cycle that ignores cancellation: 1 cycle(s) started, want 2
--- FAIL: TestRunSuperviseShutdownDoesNotBlockOnWedgedCycle (3.01s)
    runSupervise blocked on a wedged cycle during shutdown
```

`tryKick` neutered:

```
--- FAIL: TestWatchdogKicksOnlyAfterAConfirmedWedge (3.00s)
    watchdog never kicked despite a permanently stale LastRunOnceAt
```

## Verification

`go build ./...`, `go vet ./...` and `go test ./... -count=1` are green (36 packages, exit 0), plus `go test -race` on `internal/github`, `internal/supervisor`, `internal/daemon`. `gofmt -l` reports only the pre-existing `internal/worker/opencode_usage.go`.

Refs #1119
