### PR TITLE
Rewind only the usage cursors that read the restarted file

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1528,6 +1528,11 @@ const (
 	usageStreamCodex    = "codex"
 	usageStreamKimi     = "kimi"
 	usageStreamOpencode = "opencode"
+
+	// The two files usage parsers read. pi consumes the rendered <slot>.log;
+	// the structured parsers consume the <slot>.jsonl side channel (#1140).
+	usageStreamGroupLog   = "log"
+	usageStreamGroupJSONL = "jsonl"
 )
 
 // usageStreamCursor returns this parser's read position into the worker's
@@ -1566,8 +1571,18 @@ func setUsageStreamCursor(sess *state.Session, stream string, cursor state.Usage
 	sess.UsageTokensWatermark = cursor.TotalTokens
 }
 
-// usageStreamRead returns the read position for stream, first rewinding every
-// cursor when cumulative proves the file behind them restarted.
+// usageStreamGroup names the file a parser reads. The pi parser consumes the
+// rendered <slot>.log; every structured parser consumes the <slot>.jsonl side
+// channel. Two files, so a restart of one must not rewind readers of the other.
+func usageStreamGroup(stream string) string {
+	if stream == usageStreamPi {
+		return usageStreamGroupLog
+	}
+	return usageStreamGroupJSONL
+}
+
+// usageStreamRead returns the read position for stream, first rewinding the
+// cursors that share its file when cumulative proves that file restarted.
 //
 // Each parser is cumulative over an append-only file, so its own total can
 // only shrink when that file was replaced: an in-place respawn rotates
@@ -1576,9 +1591,12 @@ func setUsageStreamCursor(sess *state.Session, stream string, cursor state.Usage
 // file. Nothing rotates the <slot>.jsonl side channel today —
 // rotateWorkerAttemptLog moves <slot>.log and <slot>.log.jsonl, which is not
 // the path JSONLPathForLog derives — so for the structured parsers this is a
-// guard against an out-of-band replacement rather than a routine event. The
-// rewind clears every stream because the file all of them read is the one that
-// went away.
+// guard against an out-of-band replacement rather than a routine event.
+//
+// The rewind is scoped to the restarted file. Clearing every cursor instead
+// meant an in-place respawn, which rotates only <slot>.log, also wiped the
+// structured cursors; the next frame from a .jsonl parser then re-read an
+// un-rotated file from zero and counted it a second time (#1140).
 //
 // A cumulative of zero is never a restart: a terminal frame with missing usage
 // reports zero, and rewinding on it would let the next real frame be counted
@@ -1588,8 +1606,24 @@ func usageStreamRead(sess *state.Session, stream string, cumulative int) state.U
 	if sess == nil || cumulative <= 0 || cumulative >= cursor.TotalTokens {
 		return cursor
 	}
-	sess.UsageStreamCursors = make(map[string]state.UsageStreamCursor, 2)
-	sess.UsageTokensWatermark = 0
+	// Keep the cursors reading the OTHER file; only this file restarted.
+	group := usageStreamGroup(stream)
+	kept := make(map[string]state.UsageStreamCursor, len(sess.UsageStreamCursors))
+	highest := 0
+	for name, c := range sess.UsageStreamCursors {
+		if usageStreamGroup(name) == group {
+			continue
+		}
+		kept[name] = c
+		if c.TotalTokens > highest {
+			highest = c.TotalTokens
+		}
+	}
+	sess.UsageStreamCursors = kept
+	// UsageTokensWatermark mirrors the most advanced surviving cursor. Zeroing
+	// it unconditionally would hand a stale legacy seed to whichever parser
+	// asks next, which is the same double-count by another route.
+	sess.UsageTokensWatermark = highest
 	return state.UsageStreamCursor{}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -12223,6 +12223,65 @@ func TestUpdateClaudeUsageFromJSONL_ReplacedStreamCountsNewAttemptInFull(t *test
 // #1120: the budget read position indexes the same side channel, so it rewinds
 // with it. A budget position left at the previous stream's total would report
 // the replacement worker as having burned nothing.
+// A rotation of <slot>.log must not rewind the cursors reading <slot>.jsonl.
+// worker.rotateWorkerAttemptLog moves <slot>.log on an in-place respawn and
+// leaves the side channel appended to, so wiping every cursor made the next
+// structured frame re-read an un-rotated file from zero and count it twice
+// (#1140).
+func TestUsageStreamRead_LogRestartKeepsJSONLCursors(t *testing.T) {
+	sess := &state.Session{
+		UsageStreamCursors: map[string]state.UsageStreamCursor{
+			usageStreamPi:     {TotalTokens: 500, BudgetTokens: 500},
+			usageStreamClaude: {TotalTokens: 773, BudgetTokens: 773},
+		},
+		UsageTokensWatermark: 773,
+	}
+
+	// pi's own cumulative dropped: <slot>.log was rotated.
+	if got := usageStreamRead(sess, usageStreamPi, 20); got.TotalTokens != 0 {
+		t.Fatalf("restarted pi cursor = %+v, want a zero read position", got)
+	}
+	if _, ok := sess.UsageStreamCursors[usageStreamPi]; ok {
+		t.Fatal("pi cursor survived a rotation of the file it reads")
+	}
+	claude, ok := sess.UsageStreamCursors[usageStreamClaude]
+	if !ok || claude.TotalTokens != 773 {
+		t.Fatalf("claude cursor = %+v ok=%v; the .jsonl side channel did not rotate", claude, ok)
+	}
+	if sess.UsageTokensWatermark != 773 {
+		t.Fatalf("legacy watermark = %d, want the most advanced surviving cursor (773)", sess.UsageTokensWatermark)
+	}
+}
+
+// The mirror case: a replaced .jsonl rewinds every structured parser, because
+// they all read that one file, and leaves pi alone.
+func TestUsageStreamRead_JSONLRestartKeepsPiCursorAndClearsStructured(t *testing.T) {
+	sess := &state.Session{
+		UsageStreamCursors: map[string]state.UsageStreamCursor{
+			usageStreamPi:     {TotalTokens: 500, BudgetTokens: 500},
+			usageStreamClaude: {TotalTokens: 773, BudgetTokens: 773},
+			usageStreamCodex:  {TotalTokens: 640, BudgetTokens: 640},
+		},
+		UsageTokensWatermark: 773,
+	}
+
+	if got := usageStreamRead(sess, usageStreamClaude, 100); got.TotalTokens != 0 {
+		t.Fatalf("restarted claude cursor = %+v, want a zero read position", got)
+	}
+	for _, stream := range []string{usageStreamClaude, usageStreamCodex} {
+		if _, ok := sess.UsageStreamCursors[stream]; ok {
+			t.Fatalf("%s cursor survived a replacement of the .jsonl it reads", stream)
+		}
+	}
+	pi, ok := sess.UsageStreamCursors[usageStreamPi]
+	if !ok || pi.TotalTokens != 500 {
+		t.Fatalf("pi cursor = %+v ok=%v; <slot>.log did not change", pi, ok)
+	}
+	if sess.UsageTokensWatermark != 500 {
+		t.Fatalf("legacy watermark = %d, want the surviving pi cursor (500)", sess.UsageTokensWatermark)
+	}
+}
+
 func TestUpdateCodexUsageFromJSONL_ReplacedStreamRewindsBudgetReadPosition(t *testing.T) {
 	o, sess, jsonlPath := codexTestOrchestrator(t, "sup-1120-replaced-codex")
 


### PR DESCRIPTION
Fixes the cross-file cursor wipe found while re-verifying #1137.

`usageStreamRead` cleared **every** cursor when one parser's cumulative went backwards, on the stated grounds that they all read the same file. They do not: `pi` reads the rendered `<slot>.log`, while `claude`/`codex`/`kimi`/`opencode` read the `<slot>.jsonl` side channel. The same comment block said so correctly three lines earlier and then contradicted itself.

**Reproduced consequence:** claude reaches 773 on the jsonl, fallover to pi, an in-place respawn rotates `<slot>.log` so pi's cumulative drops, the blanket rewind clears claude's cursor, and the fallover back to claude re-adds 773.

This predates #1137 — `origin/main` double-counted identically — so it is an edge left open rather than a regression introduced.

## Change

- Rewind is scoped to the cursors sharing the restarted file.
- `UsageTokensWatermark` now mirrors the most advanced surviving cursor instead of being zeroed. A zero there hands a stale legacy seed to whichever parser asks next, which is the same double count by another route.
- The doc block now describes the scoping and why it exists.

## Verification

Two regression tests, both confirmed to fail with the production change reverted and the tests kept, and to pass with it. Full suite green: 36 packages, exit 0.

Refs #1140
