### PR TITLE
Keep the lease integration binary off the shadowed /tmp

### DIFF
--- a/internal/workerlease/systemd_integration_test.go
+++ b/internal/workerlease/systemd_integration_test.go
@@ -32,7 +32,14 @@ func TestSystemdLeaseForcedKillReapsReparentedDescendantAndKeepsNeighbor(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	maestroBin := filepath.Join(t.TempDir(), "maestro")
+	// NOT t.TempDir(): that follows TMPDIR, which is /tmp by default, and every
+	// lease binds its private scratch over /tmp for the unit. ExecStopPost then
+	// runs in a namespace where the host /tmp is shadowed and systemd fails the
+	// step with "Unable to locate executable", so the scratch is never cleaned
+	// and the test blames the production path for its own setup. diskTestDir
+	// puts the binary next to the repo, which the namespace can still see;
+	// production is unaffected because maestroBin is /usr/local/bin/maestro.
+	maestroBin := filepath.Join(diskTestDir(t), "maestro")
 	build := exec.Command("go", "build", "-o", maestroBin, "./cmd/maestro/")
 	build.Dir = repoRoot
 	if out, err := build.CombinedOutput(); err != nil {


### PR DESCRIPTION
Step 1 of `docs/worker-runtime-runbook.md` is the forced-kill integration test, and it fails on this host for a reason that has nothing to do with the production path — which means it was gating the `worker_runtime: isolated` rollout on a phantom failure.

## What happens

The test builds its cleanup binary into `t.TempDir()`, which follows `TMPDIR` and is `/tmp` by default. Every lease sets `BindPaths=<scratch>/tmp:/tmp` on its unit, so `ExecStopPost` runs in a mount namespace where the host `/tmp` is shadowed:

    maestro-worker-...-g2.service: Unable to locate executable
      '/tmp/TestSystemdLeaseForcedKill.../001/maestro': No such file or directory
    maestro-worker-...-g2.service: Failed at step EXEC spawning ...

The scratch is therefore never cleaned and the test reports `timed out waiting for target scratch cleaned by ExecStopPost` — blaming the production path for its own setup.

## Proof it is the test, not the feature

Same commit, only `TMPDIR` moved off `/tmp`:

    $ MAESTRO_SYSTEMD_INTEGRATION=1 go test ./internal/workerlease -run TestSystemdLeaseForcedKill
    --- FAIL: ... timed out waiting for target scratch cleaned by ExecStopPost

    $ TMPDIR=/var/tmp/lease-test MAESTRO_SYSTEMD_INTEGRATION=1 go test ./internal/workerlease -run TestSystemdLeaseForcedKill
    --- PASS: TestSystemdLeaseForcedKillReapsReparentedDescendantAndKeepsNeighbor (0.82s)

Production is unaffected: `maestroBin` there is `/usr/local/bin/maestro`, outside `/tmp` and visible in the namespace.

## Fix

Use `diskTestDir`, which already exists for exactly this reason and was already used for the scratch root — it just was not used for the binary.

Verified: the test passes with the default `TMPDIR`; full suite green, 36 packages, exit 0.
