### PR TITLE
Move the Telegram bot token behind the *_env indirection

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,52 @@ When `auth.token_env` resolves to a non-empty value, every request — `GET /api
 
 The authenticated identity replaces any `actor` field in the request body — operators cannot impersonate one another even if they share the token.
 
+### Secrets in config: `*_env` indirection
+
+The same rule applies to **every** credential Maestro consumes, not just the dashboard token: config rows carry the *name* of an environment variable, never the secret. Config rows are dumped verbatim by `maestro config-store export` and copied into every DB backup, so anything stored inline leaks with them.
+
+| Credential | Config field | Value lives in |
+|---|---|---|
+| Dashboard bearer token | `server.auth.token_env` | environment (secret manager) |
+| Self-deploy health token | `self_deploy.health_token_env` (defaults to `server.auth.token_env`) | environment |
+| ntfy bearer token | `notify.ntfy.token_env` | environment |
+| Telegram bot token | `telegram.bot_token_env` | environment |
+| GitHub App private key | `github_app.private_key_path` | a PEM file on disk |
+| MCP HTTP bearer token | `model.backends.<name>.mcp.servers.<server>.bearer_token_env_var` | environment |
+
+`telegram.bot_token` (the plaintext form) still works so pre-existing rows keep notifying, but it is deprecated: `bot_token_env` wins whenever it resolves to a non-empty value, and a row that still stores plaintext logs a load-time warning naming the field. The same warning fires for an MCP `headers`/`env` entry whose key names a credential (`Authorization`, `*_TOKEN`, `*_KEY`, ...) and whose value is a literal rather than a `$VAR` reference. Warning text never echoes the secret.
+
+**Migrating `telegram.bot_token` → `telegram.bot_token_env`:**
+
+1. Put the token in the secret manager (this fleet uses Infisical, e.g. `external/prod/telegram/<project>-bot-token`; Vaultwarden is the fallback). Configs keep a reference only.
+2. Hand it to the daemon as an environment variable. For the systemd unit, prefer a root-owned `EnvironmentFile` over an inline `Environment=` line so the value never lands in `systemctl show` output for unprivileged users:
+
+   ```ini
+   # /etc/systemd/system/maestro.service.d/secrets.conf   (chmod 0600 the env file)
+   [Service]
+   EnvironmentFile=/etc/maestro/secrets.env
+   ```
+
+   ```sh
+   # /etc/maestro/secrets.env
+   OK_GOBOT_TELEGRAM_TOKEN=123456:the-real-token
+   ```
+
+3. Point the row at the variable and drop the plaintext field:
+
+   ```yaml
+   telegram:
+     target: "YOUR_TELEGRAM_CHAT_ID"
+     bot_token_env: OK_GOBOT_TELEGRAM_TOKEN
+   ```
+
+4. Reload the unit and restart the daemon so the new environment is inherited (`systemctl daemon-reload`, then restart `maestro.service`).
+5. Verify:
+   - `maestro config-store export --db ~/.maestro/maestro.db --dir /tmp/cfg-check && grep -r bot_token /tmp/cfg-check` shows only `bot_token_env:` lines, no token material;
+   - the daemon logs no `telegram.bot_token` warning at load;
+   - a notification actually arrives (any action that emits one, e.g. a supervisor alert).
+
+
 To watch workers live in a tmux dashboard:
 ```bash
 maestro watch
@@ -289,6 +335,7 @@ exclude_labels:
   - blocked
 telegram:
   target: "YOUR_TELEGRAM_CHAT_ID" # Telegram user ID
+  bot_token_env: MAESTRO_TELEGRAM_BOT_TOKEN  # env var name; the token never enters config (#1143)
   openclaw_url: "http://localhost:18789"  # OpenClaw gateway
 ```
 

--- a/cmd/maestro/digest.go
+++ b/cmd/maestro/digest.go
@@ -65,7 +65,7 @@ func digestCmd(args []string) {
 		if notifierCfg == nil {
 			log.Printf("digest: %d decision(s) pending but no project has a notifier target configured", report.DecideTodayCount())
 		} else {
-			n := notify.NewWithToken(notifierCfg.Telegram.BotToken, notifierCfg.Telegram.Target, notifierCfg.Telegram.Mode, notifierCfg.Telegram.OpenclawURL)
+			n := notify.NewWithToken(notifierCfg.Telegram.Token(), notifierCfg.Telegram.Target, notifierCfg.Telegram.Mode, notifierCfg.Telegram.OpenclawURL)
 			if err := n.Send(report.NotifySummary(writtenPath)); err != nil {
 				log.Printf("digest: notifier send failed: %v", err)
 			}

--- a/cmd/maestro/emergency.go
+++ b/cmd/maestro/emergency.go
@@ -218,7 +218,7 @@ func notifyEmergency(ef *emergencyFlags, msg string) {
 		if cfg == nil || (strings.TrimSpace(cfg.Telegram.Target) == "" && !cfg.Notify.Ntfy.Enabled()) {
 			continue
 		}
-		n := notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
+		n := notify.NewWithToken(cfg.Telegram.Token(), cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
 		n.WithNtfy(cfg.Notify.Ntfy.BaseURL, cfg.Notify.Ntfy.Topic, cfg.Notify.Ntfy.Token())
 		// Alert covers both transports: ntfy when configured, otherwise the
 		// base Telegram/OpenClaw send. Keyed by message so a repeated identical

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -2866,7 +2866,7 @@ func killCmd(args []string) {
 			log.Fatalf("save state: %v", err)
 		}
 
-		n := notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
+		n := notify.NewWithToken(cfg.Telegram.Token(), cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
 		n.Sendf("maestro: manually killed worker %s (issue #%d: %s)", slotName, sess.IssueNumber, sess.IssueTitle)
 
 		fmt.Printf("Killed session %s (issue #%d: %s)\n", slotName, sess.IssueNumber, sess.IssueTitle)

--- a/docs/project-setup-runbook.md
+++ b/docs/project-setup-runbook.md
@@ -267,7 +267,7 @@ delivery:
 # Telegram notifications (optional, via OpenClaw gateway)
 telegram:
   target: "YOUR_TELEGRAM_CHAT_ID"
-  bot_token: "YOUR_BOT_TOKEN"
+  bot_token_env: OK_GOBOT_TELEGRAM_TOKEN  # env var name; the token itself never enters config (#1143)
   openclaw_url: "http://localhost:18789"
 ```
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,12 +25,59 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// TelegramConfig configures the Telegram notification channel.
+//
+// The bot token is a credential and MUST NOT be stored in config (#1143) --
+// the same rule ServerAuthConfig states for the dashboard token. Set
+// BotTokenEnv to the name of an environment variable the operator populates
+// from a secret manager (Infisical, 1Password, ...); the process reads the
+// value at send time and the config store only ever holds the variable name,
+// so `maestro config-store export` and every DB backup stay credential-free.
+//
+// The legacy plaintext BotToken still works so existing rows keep notifying,
+// but Config.Warnings() names the field at load time so an operator migrates.
+// When BotTokenEnv resolves to a non-empty value it wins over BotToken.
 type TelegramConfig struct {
-	Target      string `yaml:"target"`
-	BotToken    string `yaml:"bot_token"`
+	Target string `yaml:"target"`
+	// BotToken is the DEPRECATED plaintext form of the bot token (#1143).
+	// Prefer BotTokenEnv; a non-empty value here raises a config warning.
+	BotToken string `yaml:"bot_token"`
+	// BotTokenEnv names an environment variable holding the bot token; the
+	// token itself is never stored here.
+	BotTokenEnv string `yaml:"bot_token_env"`
 	Mode        string `yaml:"mode"`         // "direct" (Telegram Bot API) or "openclaw" (OpenClaw relay); default: "direct"
 	OpenclawURL string `yaml:"openclaw_url"` // only needed when mode=openclaw
 	DigestMode  bool   `yaml:"digest_mode"`  // batch notifications per cycle instead of sending immediately
+}
+
+// Token resolves the Telegram bot token. BotTokenEnv is consulted first: when
+// it names an environment variable that holds a non-empty value, that value is
+// used and the plaintext BotToken is ignored. Otherwise the legacy plaintext
+// BotToken is returned so pre-#1143 rows keep working. Returns "" when neither
+// source yields a value, which callers treat as "Telegram direct mode not
+// configured" (the openclaw relay path is unaffected).
+func (c TelegramConfig) Token() string {
+	if env := strings.TrimSpace(c.BotTokenEnv); env != "" {
+		if v := strings.TrimSpace(os.Getenv(env)); v != "" {
+			return v
+		}
+	}
+	return strings.TrimSpace(c.BotToken)
+}
+
+// PlaintextTokenActive reports whether the plaintext BotToken is the value
+// Token() would return -- i.e. the credential is really being read out of the
+// config store rather than the environment.
+func (c TelegramConfig) PlaintextTokenActive() bool {
+	if strings.TrimSpace(c.BotToken) == "" {
+		return false
+	}
+	if env := strings.TrimSpace(c.BotTokenEnv); env != "" {
+		if strings.TrimSpace(os.Getenv(env)) != "" {
+			return false
+		}
+	}
+	return true
 }
 
 // NotifyConfig (#1018) carries lightweight push-notification transports that
@@ -3261,7 +3308,109 @@ func (c *Config) Warnings() []string {
 		warnings = append(warnings, msg)
 	}
 	warnings = append(warnings, c.deliveryWarnings()...)
+	warnings = append(warnings, c.credentialWarnings()...)
 	return warnings
+}
+
+// credentialWarnings surfaces config fields that still carry credential
+// material in plaintext (#1143). Plaintext keeps working -- refusing to load
+// would strand every pre-migration row -- but the value is visible in
+// `maestro config-store export`, in any YAML dumped from the store, and in
+// every DB backup, so the operator is told which field to move.
+//
+// Audit of every credential-bearing field in internal/config, for the record:
+//
+//   - telegram.bot_token          -- plaintext; migrate to telegram.bot_token_env (below)
+//   - server.auth.token_env       -- env-only already (#487)
+//   - notify.ntfy.token_env       -- env-only already (#1018)
+//   - self_deploy.health_token_env -- env-only already
+//   - github_app.private_key_path -- a path; the PEM never enters config (#823)
+//   - model.backends.*.mcp.servers.*.bearer_token_env_var -- env-only already
+//   - model.backends.*.mcp.servers.*.{headers,env} -- free-form maps handed to
+//     the worker harness verbatim, so a literal secret pasted there is stored
+//     just like telegram.bot_token was. Warned about below.
+func (c *Config) credentialWarnings() []string {
+	if c == nil {
+		return nil
+	}
+	var out []string
+	if strings.TrimSpace(c.Telegram.BotToken) != "" {
+		if c.Telegram.PlaintextTokenActive() {
+			out = append(out, "config: telegram.bot_token stores the bot token in plaintext — it is visible in `maestro config-store export` and in every DB backup. Move the token into a secret manager, expose it to the daemon as an environment variable, and set telegram.bot_token_env to that variable name instead.")
+		} else {
+			out = append(out, fmt.Sprintf("config: telegram.bot_token still holds a plaintext credential but is unused because telegram.bot_token_env (%s) resolves — delete telegram.bot_token from the config store.", strings.TrimSpace(c.Telegram.BotTokenEnv)))
+		}
+	}
+	out = append(out, c.mcpCredentialWarnings()...)
+	return out
+}
+
+// credentialKeyHints are substrings that mark a header/env key as carrying a
+// credential. Matched case-insensitively against the key only; values are
+// never logged.
+var credentialKeyHints = []string{"authorization", "token", "secret", "password", "passwd", "apikey", "api_key", "access_key", "private_key", "credential"}
+
+// looksLikeCredentialKey reports whether a header or env key names a secret.
+func looksLikeCredentialKey(key string) bool {
+	k := strings.ToLower(strings.TrimSpace(key))
+	if k == "" {
+		return false
+	}
+	for _, hint := range credentialKeyHints {
+		if strings.Contains(k, hint) {
+			return true
+		}
+	}
+	// "key" alone is too generic to match as a substring (it hits "keyword",
+	// "monkey"), so only an exact/suffixed form counts.
+	return k == "key" || strings.HasSuffix(k, "-key") || strings.HasSuffix(k, "_key")
+}
+
+// isEnvReference reports whether a value is an indirection ($VAR or ${VAR})
+// rather than the credential itself.
+func isEnvReference(value string) bool {
+	v := strings.TrimSpace(value)
+	return strings.HasPrefix(v, "$")
+}
+
+// mcpCredentialWarnings names MCP server headers/env entries whose key marks a
+// credential and whose value is a literal rather than an environment
+// reference. The value is never echoed.
+func (c *Config) mcpCredentialWarnings() []string {
+	var out []string
+	for _, backend := range sortedKeys(c.Model.Backends) {
+		servers := c.Model.Backends[backend].MCP.Servers
+		for _, server := range sortedKeys(servers) {
+			def := servers[server]
+			for _, block := range []struct {
+				name   string
+				values map[string]string
+			}{{"headers", def.Headers}, {"env", def.Env}} {
+				for _, key := range sortedKeys(block.values) {
+					value := strings.TrimSpace(block.values[key])
+					if value == "" || !looksLikeCredentialKey(key) || isEnvReference(value) {
+						continue
+					}
+					out = append(out, fmt.Sprintf("config: model.backends.%s.mcp.servers.%s.%s.%s stores a credential in plaintext — it is visible in `maestro config-store export` and in every DB backup. Keep the secret in the environment and reference it (for an HTTP server use bearer_token_env_var).", backend, server, block.name, key))
+				}
+			}
+		}
+	}
+	return out
+}
+
+// sortedKeys returns the map keys in deterministic order so warning output is
+// stable across loads.
+func sortedKeys[V any](m map[string]V) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // deliveryWarnings surfaces the #872 delivery-block misconfigurations at load

--- a/internal/config/credential_env_test.go
+++ b/internal/config/credential_env_test.go
@@ -1,0 +1,213 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// #1143: telegram.bot_token was the one credential still stored in plaintext in
+// the config store. bot_token_env carries the env var name instead; plaintext
+// keeps working but is named in Config.Warnings().
+
+func TestTelegramConfig_TokenPrefersEnv(t *testing.T) {
+	t.Setenv("MAESTRO_TEST_TG_TOKEN", "  env-token  ")
+	cfg := TelegramConfig{BotToken: "plaintext-token", BotTokenEnv: "MAESTRO_TEST_TG_TOKEN"}
+	if got := cfg.Token(); got != "env-token" {
+		t.Fatalf("Token() = %q, want %q (env must win and be trimmed)", got, "env-token")
+	}
+	if cfg.PlaintextTokenActive() {
+		t.Fatalf("PlaintextTokenActive() = true when the env var resolves")
+	}
+}
+
+func TestTelegramConfig_TokenFromEnvOnly(t *testing.T) {
+	t.Setenv("MAESTRO_TEST_TG_TOKEN", "env-only-token")
+	cfg := TelegramConfig{BotTokenEnv: "MAESTRO_TEST_TG_TOKEN"}
+	if got := cfg.Token(); got != "env-only-token" {
+		t.Fatalf("Token() = %q, want %q", got, "env-only-token")
+	}
+	if cfg.PlaintextTokenActive() {
+		t.Fatalf("PlaintextTokenActive() = true with no plaintext token set")
+	}
+}
+
+func TestTelegramConfig_TokenPlaintextStillWorks(t *testing.T) {
+	// Back-compat: an unmigrated row must keep notifying.
+	cfg := TelegramConfig{BotToken: " plaintext-token "}
+	if got := cfg.Token(); got != "plaintext-token" {
+		t.Fatalf("Token() = %q, want %q", got, "plaintext-token")
+	}
+	if !cfg.PlaintextTokenActive() {
+		t.Fatalf("PlaintextTokenActive() = false while the plaintext token is the one in use")
+	}
+}
+
+func TestTelegramConfig_TokenFallsBackWhenEnvVarUnset(t *testing.T) {
+	os.Unsetenv("MAESTRO_TEST_TG_MISSING")
+	cfg := TelegramConfig{BotToken: "plaintext-token", BotTokenEnv: "MAESTRO_TEST_TG_MISSING"}
+	if got := cfg.Token(); got != "plaintext-token" {
+		t.Fatalf("Token() = %q, want the plaintext fallback %q", got, "plaintext-token")
+	}
+	if !cfg.PlaintextTokenActive() {
+		t.Fatalf("PlaintextTokenActive() = false while the env var is unset")
+	}
+}
+
+func TestTelegramConfig_TokenEmptyWhenNothingConfigured(t *testing.T) {
+	if got := (TelegramConfig{}).Token(); got != "" {
+		t.Fatalf("Token() = %q, want empty", got)
+	}
+}
+
+func TestTelegramConfig_BotTokenEnvRoundTripsThroughYAML(t *testing.T) {
+	const doc = "telegram:\n  target: \"123\"\n  bot_token_env: OK_GOBOT_TELEGRAM_TOKEN\n"
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(doc), &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.Telegram.BotTokenEnv != "OK_GOBOT_TELEGRAM_TOKEN" {
+		t.Fatalf("BotTokenEnv = %q, want OK_GOBOT_TELEGRAM_TOKEN", cfg.Telegram.BotTokenEnv)
+	}
+	if cfg.Telegram.BotToken != "" {
+		t.Fatalf("BotToken = %q, want empty", cfg.Telegram.BotToken)
+	}
+
+	// A migrated row must export no credential material.
+	out, err := yaml.Marshal(&cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(out), "bot_token_env: OK_GOBOT_TELEGRAM_TOKEN") {
+		t.Fatalf("marshalled config lost bot_token_env:\n%s", out)
+	}
+}
+
+func hasWarningContaining(warnings []string, substr string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWarnings_NamesPlaintextBotToken(t *testing.T) {
+	cfg := &Config{Telegram: TelegramConfig{BotToken: "12345:secret-bot-token"}}
+	warnings := cfg.Warnings()
+	if !hasWarningContaining(warnings, "telegram.bot_token") {
+		t.Fatalf("Warnings() = %v, want one naming telegram.bot_token", warnings)
+	}
+	if !hasWarningContaining(warnings, "telegram.bot_token_env") {
+		t.Fatalf("Warnings() = %v, want the migration target telegram.bot_token_env named", warnings)
+	}
+	for _, w := range warnings {
+		if strings.Contains(w, "12345:secret-bot-token") {
+			t.Fatalf("warning leaked the credential value: %q", w)
+		}
+	}
+}
+
+func TestWarnings_SilentWhenBotTokenEnvOnly(t *testing.T) {
+	t.Setenv("MAESTRO_TEST_TG_TOKEN", "env-token")
+	cfg := &Config{Telegram: TelegramConfig{BotTokenEnv: "MAESTRO_TEST_TG_TOKEN"}}
+	if hasWarningContaining(cfg.Warnings(), "telegram.bot_token") {
+		t.Fatalf("Warnings() = %v, want no credential warning for a migrated row", cfg.Warnings())
+	}
+}
+
+func TestWarnings_LeftoverPlaintextAlongsideResolvingEnv(t *testing.T) {
+	t.Setenv("MAESTRO_TEST_TG_TOKEN", "env-token")
+	cfg := &Config{Telegram: TelegramConfig{BotToken: "stale", BotTokenEnv: "MAESTRO_TEST_TG_TOKEN"}}
+	if !hasWarningContaining(cfg.Warnings(), "delete telegram.bot_token") {
+		t.Fatalf("Warnings() = %v, want the leftover-plaintext warning", cfg.Warnings())
+	}
+}
+
+func TestWarnings_NamesInlineMCPCredentials(t *testing.T) {
+	cfg := &Config{Model: ModelConfig{Backends: map[string]BackendDef{
+		"claude": {MCP: MCPConfig{Servers: map[string]MCPServerDef{
+			"symbols": {
+				URL:     "https://symbols.example/mcp",
+				Headers: map[string]string{"Authorization": "Bearer literal-secret", "X-Trace": "on"},
+			},
+			"local": {
+				Command: "./mcp",
+				Env:     map[string]string{"SERVICE_API_KEY": "literal-key", "REGION": "eu", "OTHER_TOKEN": "${FROM_ENV}"},
+			},
+		}}},
+	}}}
+	warnings := cfg.Warnings()
+	want := []string{
+		"model.backends.claude.mcp.servers.symbols.headers.Authorization",
+		"model.backends.claude.mcp.servers.local.env.SERVICE_API_KEY",
+	}
+	for _, w := range want {
+		if !hasWarningContaining(warnings, w) {
+			t.Fatalf("Warnings() = %v, want one naming %s", warnings, w)
+		}
+	}
+	for _, w := range warnings {
+		for _, leak := range []string{"literal-secret", "literal-key"} {
+			if strings.Contains(w, leak) {
+				t.Fatalf("warning leaked a credential value: %q", w)
+			}
+		}
+		for _, quiet := range []string{"X-Trace", "REGION", "OTHER_TOKEN"} {
+			if strings.Contains(w, quiet) {
+				t.Fatalf("warning fired on a non-credential / env-referenced field %s: %q", quiet, w)
+			}
+		}
+	}
+}
+
+// TestNoProductionCodeReadsPlaintextBotToken keeps the notifier call sites on
+// TelegramConfig.Token(). Reading cfg.Telegram.BotToken directly would silently
+// bypass bot_token_env and re-break acceptance criterion 1 of #1143.
+func TestNoProductionCodeReadsPlaintextBotToken(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+	selfPkg, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatalf("resolve package dir: %v", err)
+	}
+	var offenders []string
+	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			switch info.Name() {
+			case ".git", "node_modules", "vendor":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		if filepath.Dir(path) == selfPkg {
+			return nil // TelegramConfig itself must read the field
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if strings.Contains(string(data), "Telegram.BotToken") {
+			rel, _ := filepath.Rel(root, path)
+			offenders = append(offenders, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk repo: %v", err)
+	}
+	if len(offenders) > 0 {
+		t.Fatalf("these files read the plaintext telegram bot token directly instead of config.TelegramConfig.Token(): %v", offenders)
+	}
+}

--- a/internal/daemon/emergency.go
+++ b/internal/daemon/emergency.go
@@ -158,7 +158,7 @@ func emergencyNotifierFor(cfgs []*config.Config) *notify.Notifier {
 		if strings.TrimSpace(cfg.Telegram.Target) == "" && !cfg.Notify.Ntfy.Enabled() {
 			continue
 		}
-		n := notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
+		n := notify.NewWithToken(cfg.Telegram.Token(), cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
 		n.WithNtfy(cfg.Notify.Ntfy.BaseURL, cfg.Notify.Ntfy.Topic, cfg.Notify.Ntfy.Token())
 		return n
 	}

--- a/internal/daemon/floor_watch.go
+++ b/internal/daemon/floor_watch.go
@@ -104,7 +104,7 @@ func fleetFloorNotifierFor(cfgs []*config.Config) *notify.Notifier {
 			continue
 		}
 		n := notify.NewWithToken(
-			cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL,
+			cfg.Telegram.Token(), cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL,
 		)
 		n.WithNtfy(cfg.Notify.Ntfy.BaseURL, cfg.Notify.Ntfy.Topic, cfg.Notify.Ntfy.Token())
 		return n

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -244,7 +244,7 @@ type Orchestrator struct {
 
 // New creates a new Orchestrator
 func New(cfg *config.Config) *Orchestrator {
-	n := notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
+	n := notify.NewWithToken(cfg.Telegram.Token(), cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
 	n.WithNtfy(cfg.Notify.Ntfy.BaseURL, cfg.Notify.Ntfy.Topic, cfg.Notify.Ntfy.Token())
 	if cfg.Telegram.DigestMode {
 		n.SetDigestMode(true)

--- a/internal/supervisor/outcome_repair.go
+++ b/internal/supervisor/outcome_repair.go
@@ -57,7 +57,7 @@ var (
 		return github.New(repo)
 	}
 	newFutileRecoveryNotifier = func(cfg *config.Config) futileRecoveryNotifier {
-		n := notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
+		n := notify.NewWithToken(cfg.Telegram.Token(), cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
 		return n.WithNtfy(cfg.Notify.Ntfy.BaseURL, cfg.Notify.Ntfy.Topic, cfg.Notify.Ntfy.Token())
 	}
 )

--- a/internal/supervisor/outcome_streaks.go
+++ b/internal/supervisor/outcome_streaks.go
@@ -133,7 +133,7 @@ func defaultGateFailStreakNotify(cfg *config.Config, event outcome.GateStreakEve
 	if cfg == nil {
 		return nil
 	}
-	notifier := notify.NewWithToken(cfg.Telegram.BotToken, cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
+	notifier := notify.NewWithToken(cfg.Telegram.Token(), cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
 	return notifier.Send(gateFailStreakMessage(event))
 }
 


### PR DESCRIPTION
## Problem

`telegram.bot_token` was the last credential Maestro kept inline in the config store. Config rows are dumped verbatim by `maestro config-store export` and copied into every DB backup, so the token leaks with all of them. One live row carries it today (`befeast-ok-gobot`).

The rule was already written down one struct over — `ServerAuthConfig` (`internal/config/config.go:1530`) says the token "MUST NOT be stored in YAML" and honours it with `token_env`. So the config states the rule and then breaks it a few lines up.

## Fix

Extend the existing `*_env` indirection instead of inventing a mechanism.

- **`telegram.bot_token_env`** names an environment variable the operator populates from a secret manager. `TelegramConfig.Token()` resolves it; when it yields a non-empty value it wins over the plaintext field. All 8 notifier construction sites (`cmd/maestro/{main,digest,emergency}.go`, `internal/{daemon/emergency,daemon/floor_watch,orchestrator/orchestrator,supervisor/outcome_repair,supervisor/outcome_streaks}.go`) now go through the method instead of reading the field.
- **Plaintext keeps working** — refusing to load would strand every unmigrated row — but `Config.Warnings()` names the field at load time. A stale plaintext value sitting next to a *resolving* `bot_token_env` gets a different, accurate message ("unused … delete it") rather than the migrate message. Warning text never echoes the secret.
- **Audit of the rest of `internal/config`** is recorded as a comment on `credentialWarnings()`: `server.auth.token_env`, `notify.ntfy.token_env`, `self_deploy.health_token_env` and `mcp.servers.*.bearer_token_env_var` are already env-only; `github_app.private_key_path` is a path and the PEM never enters config. The one remaining hole is `model.backends.*.mcp.servers.*.{headers,env}` — free-form maps handed to the worker harness verbatim — so a credential-looking key (`Authorization`, `*_TOKEN`, `*_KEY`, `*secret*`, …) whose value is a literal rather than a `$VAR` reference now warns too.
- **Migration path documented** in README under a new "Secrets in config: `*_env` indirection" section, immediately after the existing `token_env` explanation: the field table, where the value goes (Infisical), how the daemon receives it (root-owned `EnvironmentFile=` drop-in rather than inline `Environment=`), and three verification steps. `docs/project-setup-runbook.md` and the README config reference no longer show a plaintext `bot_token`.

No behaviour change for a row that is already configured with plaintext, and nothing in the runtime was touched — the fleet stayed stopped throughout.

## Acceptance criteria

- *Row with `bot_token_env` notifies with the value supplied only through the environment* — `TestTelegramConfig_TokenFromEnvOnly` / `TestTelegramConfig_TokenPrefersEnv`, plus `TestNoProductionCodeReadsPlaintextBotToken` which walks the repo and fails if any non-test file outside `internal/config` reads `Telegram.BotToken` directly (that is what would silently bypass the env var again).
- *Plaintext still works but logs a warning naming the field* — `TestTelegramConfig_TokenPlaintextStillWorks`, `TestWarnings_NamesPlaintextBotToken`.
- *Export on a migrated row carries no credential material* — `TestTelegramConfig_BotTokenEnvRoundTripsThroughYAML` (unmarshal/marshal round-trip keeps `bot_token_env`, `bot_token` stays empty).
- *Migration path written down* — README section above.

## Evidence

Whole suite on the branch: `go build ./... && go test ./... -count=1` → **exit 0, 36 packages ok**. `gofmt -l ./cmd ./internal` reports only `internal/worker/opencode_usage.go`, which is pre-existing on `main`.

Each new test was proven red by reverting the corresponding production change with the tests kept:

1. Call sites back to `cfg.Telegram.BotToken`:
   ```
   --- FAIL: TestNoProductionCodeReadsPlaintextBotToken
       these files read the plaintext telegram bot token directly instead of
       config.TelegramConfig.Token(): [cmd/maestro/digest.go cmd/maestro/emergency.go
       cmd/maestro/main.go internal/daemon/emergency.go internal/daemon/floor_watch.go
       internal/orchestrator/orchestrator.go internal/supervisor/outcome_repair.go
       internal/supervisor/outcome_streaks.go]
   ```
2. `Token()` stripped back to returning the plaintext field:
   ```
   --- FAIL: TestTelegramConfig_TokenPrefersEnv    Token() = "plaintext-token", want "env-token"
   --- FAIL: TestTelegramConfig_TokenFromEnvOnly   Token() = "", want "env-only-token"
   ```
3. `credentialWarnings()` unhooked from `Warnings()`:
   ```
   --- FAIL: TestWarnings_NamesPlaintextBotToken              Warnings() = [], want one naming telegram.bot_token
   --- FAIL: TestWarnings_LeftoverPlaintextAlongsideResolvingEnv  Warnings() = [], want the leftover-plaintext warning
   --- FAIL: TestWarnings_NamesInlineMCPCredentials           Warnings() = [], want one naming model.backends.claude.mcp.servers.symbols.headers.Authorization
   ```

Each revert was restored and the package returned to green.

## Follow-up (not in this PR)

Migrating the live `befeast-ok-gobot` row is an operator action against `/home/god/.maestro/maestro.db` and a systemd drop-in — out of bounds for this change and best done while the fleet is being resumed. The token that is currently in the store and in the backups under `/home/god/.maestro/` should be rotated in BotFather as part of that, since it has already been copied around.

Refs #1143
