### PR TITLE
fix(approvalstore): resolve a re-minted approval instead of dropping it (#1142)

### DIFF
--- a/internal/approvalstore/remint_test.go
+++ b/internal/approvalstore/remint_test.go
@@ -1,0 +1,166 @@
+package approvalstore
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/state"
+)
+
+// remint builds a fresh mint of the SAME decision identity: the id is
+// content-addressed on (action, target) so it repeats, but the record is a new
+// instance with a strictly newer CreatedAt and a fresh pending status. This is
+// what the JSON state produces once the previous instance of the decision is
+// gone from state.json and the supervisor re-evaluates the same gate.
+func remint(id, action string, target *state.SupervisorTarget, b RowBinding, mintedAt time.Time) *state.Approval {
+	a := makeApproval(id, action, target, b)
+	a.CreatedAt = mintedAt
+	a.UpdatedAt = mintedAt
+	a.Audit = []state.ApprovalAudit{{At: mintedAt, Event: state.ApprovalAuditCreated}}
+	a.PayloadHash = a.ComputePayloadHash()
+	return a
+}
+
+// A re-minted approval must replace the row, not be swallowed. With the old
+// `INSERT OR IGNORE` the row kept the FIRST instance's status forever: the
+// mirror reported `approved` for an approval the JSON state had already
+// closed, and the fresh pending record could never be claimed.
+func TestPut_ReMintReplacesStoredRow(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	rb := RowBinding{Project: "owner/repo", Repo: "owner/repo", StateDir: testStateDir}
+	target := &state.SupervisorTarget{PR: 42}
+
+	seedPending(t, s, "rm1", "merge_pr", target)
+	if _, err := s.Approve(ctx, testStateDir, "rm1", time.Now().UTC(), "x", "green"); err != nil {
+		t.Fatalf("approve first instance: %v", err)
+	}
+
+	fresh := remint("rm1", "merge_pr", target, rb, time.Now().UTC().Add(time.Minute))
+	written, err := s.Put(ctx, fresh, rb)
+	if err != nil {
+		t.Fatalf("put re-mint: %v", err)
+	}
+	if !written {
+		t.Fatalf("re-mint reported written=false: the write was dropped")
+	}
+
+	got, err := s.Get(ctx, testStateDir, "rm1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != state.ApprovalStatusPending {
+		t.Fatalf("status = %q after re-mint, want pending (row kept the previous instance's status)", got.Status)
+	}
+	if !got.CreatedAt.Equal(fresh.CreatedAt) {
+		t.Fatalf("created_at = %s after re-mint, want %s", got.CreatedAt, fresh.CreatedAt)
+	}
+	// The re-minted instance carries its own audit trail into the mirror.
+	if n := auditCount(t, s, "rm1"); n != 3 {
+		t.Fatalf("audit rows = %d, want 3 (created + approved + re-mint created)", n)
+	}
+	// The point of the fix: the fresh instance is claimable again. Against a
+	// dropped write the row is still `approved` and this returns
+	// ErrApprovalNotPending.
+	claimed, err := s.Approve(ctx, testStateDir, "rm1", time.Now().UTC(), "oleg", "second cycle")
+	if err != nil {
+		t.Fatalf("approve re-minted instance: %v", err)
+	}
+	if claimed.Status != state.ApprovalStatusApproved {
+		t.Fatalf("claimed status = %q, want approved", claimed.Status)
+	}
+}
+
+// Ids are content-addressed on (action, target) only, so two DIFFERENT
+// projects gating the same action on the same target mint the SAME id. The
+// row identity is scoped by state_dir; a re-mint in one project must not read,
+// update, or resurrect the other project's row.
+func TestPut_ReMintKeepsCrossProjectRowsIndependent(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	const id = "dup-remint"
+	target := &state.SupervisorTarget{PR: 5}
+	bindA := RowBinding{Project: "owner/a", Repo: "owner/a", StateDir: "/tmp/remint-a"}
+	bindB := RowBinding{Project: "owner/b", Repo: "owner/b", StateDir: "/tmp/remint-b"}
+
+	seedPendingScoped(t, s, bindA, id, "merge_pr", target)
+	origB := seedPendingScoped(t, s, bindB, id, "merge_pr", target)
+	if _, err := s.Reject(ctx, bindB.StateDir, id, time.Now().UTC(), "y", "no"); err != nil {
+		t.Fatalf("reject B: %v", err)
+	}
+
+	fresh := remint(id, "merge_pr", target, bindA, time.Now().UTC().Add(time.Minute))
+	if _, err := s.Put(ctx, fresh, bindA); err != nil {
+		t.Fatalf("put re-mint under A: %v", err)
+	}
+
+	gotA, err := s.Get(ctx, bindA.StateDir, id)
+	if err != nil {
+		t.Fatalf("get A: %v", err)
+	}
+	if gotA.Status != state.ApprovalStatusPending || gotA.Project != "owner/a" {
+		t.Fatalf("A after re-mint = (%q, %q), want (pending, owner/a)", gotA.Status, gotA.Project)
+	}
+
+	gotB, err := s.Get(ctx, bindB.StateDir, id)
+	if err != nil {
+		t.Fatalf("get B: %v", err)
+	}
+	if gotB.Status != state.ApprovalStatusRejected {
+		t.Fatalf("B status = %q after A re-mint, want rejected (cross-project leak)", gotB.Status)
+	}
+	if gotB.Project != "owner/b" {
+		t.Fatalf("B project = %q, want owner/b (A's row leaked into B's scope)", gotB.Project)
+	}
+	if !gotB.CreatedAt.Equal(origB.CreatedAt) {
+		t.Fatalf("B created_at = %s, want %s (A's re-mint rewrote B's row)", gotB.CreatedAt, origB.CreatedAt)
+	}
+}
+
+// The one case where NOT writing is correct — a re-seed of the mint the row
+// already holds, e.g. gate.Put right before a claim — must be an explicit,
+// logged branch rather than a silent side effect of the conflict clause.
+func TestPut_SameMintKeepsAdvancedRowAndLogs(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	rb := RowBinding{Project: "owner/repo", Repo: "owner/repo", StateDir: testStateDir}
+
+	a := seedPending(t, s, "keep1", "close_issue", &state.SupervisorTarget{Issue: 3})
+	if _, err := s.Approve(ctx, testStateDir, "keep1", time.Now().UTC(), "x", ""); err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+
+	var buf bytes.Buffer
+	prevOut, prevFlags := log.Writer(), log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	})
+
+	// Same mint (CreatedAt unchanged), still pending in JSON.
+	a.Status = state.ApprovalStatusPending
+	written, err := s.Put(ctx, a, rb)
+	if err != nil {
+		t.Fatalf("re-seed: %v", err)
+	}
+	if written {
+		t.Fatalf("re-seed of the same mint reported written=true; the claim must survive")
+	}
+	got, err := s.Get(ctx, testStateDir, "keep1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != state.ApprovalStatusApproved {
+		t.Fatalf("status = %q after re-seed, want approved (claim must survive)", got.Status)
+	}
+	logged := buf.String()
+	if !strings.Contains(logged, "keeping approval keep1") || !strings.Contains(logged, "stored status=approved") {
+		t.Fatalf("keep branch did not log the dropped write; log = %q", logged)
+	}
+}

--- a/internal/approvalstore/remint_test.go
+++ b/internal/approvalstore/remint_test.go
@@ -25,6 +25,42 @@ func remint(id, action string, target *state.SupervisorTarget, b RowBinding, min
 	return a
 }
 
+// An approval whose CreatedAt was never set must NOT count as a newer mint.
+// normalize() maps a zero time to time.Now(), so without an explicit guard such
+// a record always looks strictly newer and resets an already-claimed row back
+// to pending — re-opening the claim-once gate and allowing a second merge_pr or
+// close_issue. Approval.CreatedAt is a plain json field, so a legacy or
+// hand-edited state.json decodes it to zero, and Put is exported.
+func TestPut_ZeroMintNeverResetsClaimedRow(t *testing.T) {
+	s := openTestStore(t)
+	ctx := context.Background()
+	rb := RowBinding{Project: "owner/repo", Repo: "owner/repo", StateDir: testStateDir}
+	target := &state.SupervisorTarget{PR: 91}
+
+	seedPending(t, s, "zc1", "merge_pr", target)
+	if _, err := s.Approve(ctx, testStateDir, "zc1", time.Now().UTC(), "x", "green"); err != nil {
+		t.Fatalf("approve first instance: %v", err)
+	}
+
+	zero := makeApproval("zc1", "merge_pr", target, rb)
+	zero.CreatedAt = time.Time{}
+	zero.UpdatedAt = time.Time{}
+	zero.Status = state.ApprovalStatusPending
+	zero.PayloadHash = zero.ComputePayloadHash()
+
+	if _, err := s.Put(ctx, zero, rb); err != nil {
+		t.Fatalf("put zero-mint: %v", err)
+	}
+
+	got, err := s.Get(ctx, testStateDir, "zc1")
+	if err != nil {
+		t.Fatalf("get after zero-mint: %v", err)
+	}
+	if got.Status != state.ApprovalStatusApproved {
+		t.Fatalf("status = %s, want approved: a zero CreatedAt reset a claimed row and re-opened the gate", got.Status)
+	}
+}
+
 // A re-minted approval must replace the row, not be swallowed. With the old
 // `INSERT OR IGNORE` the row kept the FIRST instance's status forever: the
 // mirror reported `approved` for an approval the JSON state had already

--- a/internal/approvalstore/store.go
+++ b/internal/approvalstore/store.go
@@ -36,6 +36,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -467,12 +468,19 @@ func intersectColumns(have, want []string) []string {
 	return out
 }
 
-// Put seeds an approval into the store WITHOUT overwriting an existing row
-// (INSERT OR IGNORE). Returning inserted=false means a row for this id was
-// already present — crucially, a concurrent claim that already advanced the
-// status MUST NOT be reset back to pending, so Put never updates an existing
-// row. When the row is newly inserted, the approval's existing audit entries
-// are mirrored into approval_audit so the table is a faithful trail.
+// Put seeds an approval into the store. A row that already exists under
+// (state_dir, id) is either REPLACED by a strictly newer mint or explicitly
+// kept — never dropped silently (#1142). Ids are content-addressed on
+// (action, target), so the same id legitimately recurs once the earlier
+// instance of that decision is gone from the JSON state; the old
+// `INSERT OR IGNORE` swallowed the write and the row kept the first
+// instance's status forever while JSON moved on.
+//
+// Returning inserted=false means the pre-existing row was kept: a re-seed of
+// the SAME mint (equal CreatedAt) must not reset a status that a concurrent
+// claim already advanced. Returning true means the row now holds this
+// approval — a fresh insert or an accepted re-mint — and the approval's audit
+// entries are mirrored into approval_audit so the table is a faithful trail.
 //
 // Put is the write-through seed used during the JSON→SQLite transition: the
 // JSON state remains the mint source; Put copies a pending approval into
@@ -498,10 +506,11 @@ func (s *Store) Put(ctx context.Context, a *state.Approval, b RowBinding) (inser
 	if a.Action == state.ApprovalActionDeployProject {
 		persisted = state.CanonicalDeliveryApprovalForWrite(a)
 	}
-	ins, err := putApprovalTx(ctx, tx, persisted, b)
+	outcome, err := putApprovalTx(ctx, tx, persisted, b)
 	if err != nil {
 		return false, err
 	}
+	ins := outcome != approvalPutKept
 	if ins {
 		for i := range persisted.Audit {
 			if err := insertAuditTx(ctx, tx, persisted.ID, b, persisted.Audit[i]); err != nil {
@@ -644,10 +653,11 @@ WHERE state_dir = ? AND action = ? AND id <> ?`,
 	}
 
 	candidate = *state.CanonicalDeliveryApprovalForWrite(&candidate)
-	inserted, err = putApprovalTx(ctx, tx, &candidate, b)
+	outcome, err := putApprovalTx(ctx, tx, &candidate, b)
 	if err != nil {
 		return false, err
 	}
+	inserted = outcome != approvalPutKept
 	if inserted {
 		for i := range candidate.Audit {
 			if err := insertAuditTx(ctx, tx, candidate.ID, b, candidate.Audit[i]); err != nil {
@@ -1242,35 +1252,126 @@ func (s *Store) MarkStale(ctx context.Context, stateDir, id string, now time.Tim
 
 // --- tx helpers -------------------------------------------------------------
 
-func putApprovalTx(ctx context.Context, tx *sql.Tx, a *state.Approval, b RowBinding) (bool, error) {
+// approvalPutOutcome says what putApprovalTx did with the row. It exists so
+// the drop case is a named, logged branch instead of an invisible side effect
+// of a conflict clause (#1142).
+type approvalPutOutcome int
+
+const (
+	// approvalPutInserted: no row existed for (state_dir, id).
+	approvalPutInserted approvalPutOutcome = iota
+	// approvalPutReminted: a strictly newer mint replaced the stored row.
+	approvalPutReminted
+	// approvalPutKept: the stored row was deliberately preserved because the
+	// incoming record is a re-seed of the same (or an older) mint.
+	approvalPutKept
+)
+
+// putApprovalTx writes an approval row, resolving a (state_dir, id) collision
+// by mint time rather than by dropping the write.
+//
+// Ids are content-addressed on (action, target) and the row identity is scoped
+// by state_dir (see the package comment: two DIFFERENT projects mint the SAME
+// id, and the state_dir scope is what keeps their rows independent). Nothing
+// here widens that scope — every statement stays keyed on (state_dir, id), so
+// cross-project isolation is unchanged.
+//
+// Within one project the same id recurs when an earlier instance of the same
+// decision has left the JSON state and the decision is minted again. CreatedAt
+// separates the two cases, and it is the only signal that does so safely:
+//
+//   - incoming CreatedAt strictly after the stored one → a genuinely new mint;
+//     replace the row (ON CONFLICT DO UPDATE). Without this the row keeps the
+//     first instance's status forever — the drift this fixes.
+//   - otherwise → a re-seed of the mint the row already holds (Put is called
+//     on every claim from the same JSON record). Keep the row: resetting it
+//     would re-open a claim that already advanced past pending.
+//
+// Statuses are deliberately NOT the predicate: `approved` and
+// `awaiting_dispatch` are legitimately open, so a status-based rule would
+// either reset a live claim or leave exactly the stale-approved rows this
+// fixes. CreatedAt is compared as time.Time, never as SQL text: RFC3339Nano
+// trims trailing zeros, so string ordering is wrong.
+func putApprovalTx(ctx context.Context, tx *sql.Tx, a *state.Approval, b RowBinding) (approvalPutOutcome, error) {
 	persisted := a
 	if a.Action == state.ApprovalActionDeployProject {
 		persisted = state.CanonicalDeliveryApprovalForWrite(a)
 	}
 	blob, err := json.Marshal(persisted)
 	if err != nil {
-		return false, fmt.Errorf("marshal approval %s: %w", a.ID, err)
+		return approvalPutKept, fmt.Errorf("marshal approval %s: %w", a.ID, err)
 	}
 	recordHash := ""
 	if persisted.Action == state.ApprovalActionDeployProject {
 		recordHash, err = computeDeliveryRecordHash(persisted, b)
 		if err != nil {
-			return false, err
+			return approvalPutKept, err
 		}
 	}
-	res, err := tx.ExecContext(ctx, `
-INSERT OR IGNORE INTO approvals(id, decision_id, project, repo, state_dir, action, status, payload_hash, record_hash, created_at, updated_at, approval_json)
-VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+
+	// Read-then-write is atomic here: the DSN opens every transaction with
+	// _txlock=immediate, so this tx already holds the write lock and no other
+	// connection can insert the row between the SELECT and the INSERT.
+	existingStatus, existingCreated, found, err := lookupApprovalMintTx(ctx, tx, b.StateDir, persisted.ID)
+	if err != nil {
+		return approvalPutKept, err
+	}
+	mintedAt := normalize(persisted.CreatedAt)
+	if found && !mintedAt.After(existingCreated) {
+		// Explicit keep branch — the one case where not writing is correct.
+		if string(persisted.Status) != existingStatus {
+			log.Printf("[approvalstore] keeping approval %s (state_dir=%s): stored status=%s, re-seed says %s; same mint %s, an advanced row is never reset",
+				persisted.ID, b.StateDir, existingStatus, persisted.Status, formatTime(existingCreated))
+		}
+		return approvalPutKept, nil
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO approvals(id, decision_id, project, repo, state_dir, action, status, payload_hash, record_hash, created_at, updated_at, approval_json)
+VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(state_dir, id) DO UPDATE SET
+	decision_id   = excluded.decision_id,
+	project       = excluded.project,
+	repo          = excluded.repo,
+	action        = excluded.action,
+	status        = excluded.status,
+	payload_hash  = excluded.payload_hash,
+	record_hash   = excluded.record_hash,
+	created_at    = excluded.created_at,
+	updated_at    = excluded.updated_at,
+	approval_json = excluded.approval_json`,
 		persisted.ID, persisted.DecisionID, b.Project, b.Repo, b.StateDir, persisted.Action, string(persisted.Status), persisted.PayloadHash, recordHash,
-		formatTime(normalize(persisted.CreatedAt)), formatTime(normalize(persisted.UpdatedAt)), string(blob))
-	if err != nil {
-		return false, err
+		formatTime(mintedAt), formatTime(normalize(persisted.UpdatedAt)), string(blob)); err != nil {
+		return approvalPutKept, err
 	}
-	n, err := res.RowsAffected()
-	if err != nil {
-		return false, err
+	if !found {
+		return approvalPutInserted, nil
 	}
-	return n == 1, nil
+	log.Printf("[approvalstore] re-minted approval %s (state_dir=%s): status %s -> %s, mint %s -> %s",
+		persisted.ID, b.StateDir, existingStatus, persisted.Status, formatTime(existingCreated), formatTime(mintedAt))
+	return approvalPutReminted, nil
+}
+
+// lookupApprovalMintTx returns the stored status and mint time of the row
+// under (state_dir, id). It reads the columns directly rather than going
+// through loadApprovalTx so a delivery-integrity failure on an unrelated
+// pre-existing row cannot block seeding a new approval.
+func lookupApprovalMintTx(ctx context.Context, tx *sql.Tx, stateDir, id string) (string, time.Time, bool, error) {
+	var status, createdAt string
+	err := tx.QueryRowContext(ctx,
+		`SELECT status, created_at FROM approvals WHERE state_dir = ? AND id = ?`, stateDir, id).
+		Scan(&status, &createdAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", time.Time{}, false, nil
+	}
+	if err != nil {
+		return "", time.Time{}, false, err
+	}
+	created, perr := time.Parse(time.RFC3339Nano, createdAt)
+	if perr != nil {
+		return "", time.Time{}, false, fmt.Errorf("approval %s (state_dir=%s) has unparsable created_at %q: %w", id, stateDir, createdAt, perr)
+	}
+	return status, created.UTC(), true, nil
 }
 
 func writeApprovalJSONTx(ctx context.Context, tx *sql.Tx, b RowBinding, a *state.Approval) error {

--- a/internal/approvalstore/store.go
+++ b/internal/approvalstore/store.go
@@ -24,8 +24,8 @@
 // and every claim predicate are therefore scoped by state_dir (the JSON state
 // directory, which is 1:1 with a project — repo can be shared by two configs,
 // the project name can be aliased, but the state dir is unique). Without that
-// scope the second project's INSERT OR IGNORE would be dropped and an
-// approve/reject would consume or block the first project's claim.
+// scope the second project's write would collide with the first project's row
+// and an approve/reject would consume or block the wrong project's claim.
 package approvalstore
 
 import (
@@ -65,8 +65,8 @@ CREATE TABLE IF NOT EXISTS approvals (
 	approval_json TEXT NOT NULL,
 	-- Scope the row identity by state_dir: ids are content-addressed on
 	-- (action, target) only, so two projects can mint the same id. Without
-	-- (state_dir, id) the second project's INSERT OR IGNORE is dropped and a
-	-- claim consumes the wrong project's approval.
+	-- (state_dir, id) the second project's write collides with the first
+	-- project's row and a claim consumes the wrong project's approval.
 	PRIMARY KEY (state_dir, id)
 );`
 
@@ -372,9 +372,10 @@ func canonicalStateDir(path string) (string, error) {
 // were scoped by state_dir. The original table used `id TEXT PRIMARY KEY`, so
 // CREATE TABLE IF NOT EXISTS above is a no-op against it and the composite
 // PRIMARY KEY (state_dir, id) is never installed. In that unscoped table two
-// projects that mint the same content-addressed id collide: the second
-// project's INSERT OR IGNORE is dropped and a scoped claim cannot find — or is
-// blocked by — the wrong project's row. This detects the legacy primary key
+// projects that mint the same content-addressed id collide: the write path
+// resolves the conflict on (state_dir, id), which an unscoped `id PRIMARY KEY`
+// table does not have, so the statement ERRORS at runtime instead of writing —
+// and a scoped claim cannot find, or is blocked by, the wrong project's row. This detects the legacy primary key
 // and rebuilds the table in place (rename → recreate → copy → drop), so the
 // fix reaches already-created databases, not only fresh ones. No-op once the
 // table already carries the composite key.
@@ -1316,8 +1317,15 @@ func putApprovalTx(ctx context.Context, tx *sql.Tx, a *state.Approval, b RowBind
 	if err != nil {
 		return approvalPutKept, err
 	}
+	// A zero CreatedAt is NOT a newer mint. normalize() maps zero to time.Now(),
+	// so without this an approval whose CreatedAt never got set - a legacy or
+	// hand-edited state.json decodes the plain `created_at` field to zero, and
+	// Put is exported - would always look strictly newer and reset an already
+	// claimed row back to pending, re-opening the claim-once gate this package
+	// exists to protect. Unknown provenance keeps the row.
+	mintKnown := !persisted.CreatedAt.IsZero()
 	mintedAt := normalize(persisted.CreatedAt)
-	if found && !mintedAt.After(existingCreated) {
+	if found && (!mintKnown || !mintedAt.After(existingCreated)) {
 		// Explicit keep branch — the one case where not writing is correct.
 		if string(persisted.Status) != existingStatus {
 			log.Printf("[approvalstore] keeping approval %s (state_dir=%s): stored status=%s, re-seed says %s; same mint %s, an advanced row is never reset",

--- a/internal/approvalstore/store_test.go
+++ b/internal/approvalstore/store_test.go
@@ -413,7 +413,7 @@ func TestPut_DoesNotResetStatus(t *testing.T) {
 		t.Fatalf("re-put: %v", err)
 	}
 	if inserted {
-		t.Fatalf("re-put reported inserted; INSERT OR IGNORE must keep the existing row")
+		t.Fatalf("re-put reported inserted; a same-mint re-seed must keep the existing row")
 	}
 	got, err := s.Get(context.Background(), testStateDir, "p1")
 	if err != nil {


### PR DESCRIPTION
## Problem

`putApprovalTx` (`internal/approvalstore/store.go`) wrote with `INSERT OR IGNORE`.
Approval ids are content-addressed on `(action, target)` and the row identity is
`(state_dir, id)`, so within one project a second mint of the same decision
hashes to the same id and the write was dropped without error. The row kept the
**first** instance's status forever while the JSON state moved on — live that is
33 rows (31 `approved` + 2 `awaiting_dispatch`) the JSON state no longer
considers open.

It is not only observability drift. The claim predicate is
`UPDATE ... WHERE id = ? AND status = 'pending'`, so once the row is stuck at
`approved`, the freshly minted **pending** instance of that same gate can never
be claimed: `gate.approveOrReject` seeds it with `Put`, the seed is swallowed,
and `Approve` returns `ErrApprovalNotPending` against the old row. The new test
`TestPut_ReMintReplacesStoredRow` fails on that assertion without the fix.

## Fix

The conflict is resolved by **mint time**, in three named branches:

| stored row | incoming | action |
|---|---|---|
| none | anything | `INSERT` |
| exists, incoming `CreatedAt` strictly newer | genuine re-mint | `ON CONFLICT(state_dir, id) DO UPDATE` — replaces status/payload/json/created_at, logged |
| exists, same-or-older mint | re-seed of the record the row already holds | keep the row, logged when the re-seeded status disagrees |

Keeping is still correct for the third case — `gate.Put` runs on every claim from
the same JSON record, and resetting the row would re-open a claim that already
advanced past pending — but it is now an explicit branch with a `log.Printf`,
not an invisible side effect of the conflict clause. `TestPut_DoesNotResetStatus`
(pre-existing) still guards it.

Two deliberate choices, both documented at the function:

- **Status is not the predicate.** `approved` and `awaiting_dispatch` are
  legitimately open, so a status-based rule would either reset a live claim or
  leave exactly the stale-`approved` rows this fixes. `CreatedAt` distinguishes
  "new instance of the same decision" from "re-seed of this instance" without
  either failure mode: `refreshPendingApproval` (#750) preserves `CreatedAt`, so
  in-place refreshes never look like a re-mint.
- **`CreatedAt` is compared as `time.Time`, never as SQL text.** `RFC3339Nano`
  trims trailing zeros, so `ORDER BY created_at` / `excluded.created_at >
  approvals.created_at` is wrong (`...:00Z` sorts above `...:00.5Z`). The
  decision is made in Go; the write is still a single
  `INSERT ... ON CONFLICT DO UPDATE`.

**Cross-project isolation is untouched** — the property the package header
explains: two different projects mint the *same* id, and only the `state_dir`
scope keeps their rows independent. Every statement here stays keyed on
`(state_dir, id)`, including the new lookup and the conflict target.
`TestPut_ReMintKeepsCrossProjectRowsIndependent` asserts a re-mint under project
A leaves B's same-id row at its own status, project, and mint time; it passes
before and after the change (it is a guard, not a regression test).

The read-then-write is atomic: the DSN opens every transaction with
`_txlock=immediate`, so the tx already holds the write lock and no other
connection can insert between the `SELECT` and the `INSERT`.

## Evidence

Fix reverted, tests kept — red:

```
--- FAIL: TestPut_ReMintReplacesStoredRow (0.00s)
    remint_test.go:49: re-mint reported written=false: the write was dropped
--- FAIL: TestPut_SameMintKeepsAdvancedRowAndLogs (0.00s)
    remint_test.go:164: keep branch did not log the dropped write; log = ""
FAIL	github.com/befeast/maestro/internal/approvalstore
```

Fix restored — green, plus the log lines the issue asked for:

```
=== RUN   TestPut_ReMintReplacesStoredRow
[approvalstore] re-minted approval rm1 (state_dir=/tmp/sd): status approved -> pending, mint 2026-07-27T02:54:10.912714007Z -> 2026-07-27T02:55:10.91293327Z
--- PASS: TestPut_ReMintReplacesStoredRow (0.00s)
=== RUN   TestPut_ReMintKeepsCrossProjectRowsIndependent
--- PASS: TestPut_ReMintKeepsCrossProjectRowsIndependent (0.00s)
=== RUN   TestPut_SameMintKeepsAdvancedRowAndLogs
--- PASS: TestPut_SameMintKeepsAdvancedRowAndLogs (0.00s)
=== RUN   TestPut_DoesNotResetStatus
[approvalstore] keeping approval p1 (state_dir=/tmp/sd): stored status=approved, re-seed says pending; same mint 2026-07-27T02:54:10.916549669Z, an advanced row is never reset
--- PASS: TestPut_DoesNotResetStatus (0.00s)
```

Whole suite: `go build ./... && go test ./... -count=1` — 36 packages `ok`,
exit 0. `go vet ./internal/approvalstore/` clean. `gofmt -l .` reports only the
pre-existing `internal/worker/opencode_usage.go`.

## The migration is a follow-up, deliberately

The issue's third acceptance criterion (bring the existing 33 rows into line
with `state.json`) is **not** in this PR:

1. **Order matters.** Reconciling before the write path is fixed and deployed
   just re-drifts on the next mint. The correctness fix has to land first.
2. **It is a different kind of change.** A reconcile has to enumerate every
   project's `state_dir`, load each `state.json`, classify per-row, and mutate
   the live unified `maestro.db` — it needs its own operator surface, a dry-run,
   and evidence per row. Bolting that onto a 121-line store fix would make both
   harder to review, and the sweep is exactly the kind of thing that should be
   reviewed on its own.
3. **This PR shrinks the backlog on its own.** Any of the 33 rows whose
   `(action, target)` is minted again now self-heals on the next `Put` instead
   of staying wrong forever. Only rows for decisions that never recur need the
   explicit sweep.
4. The fleet is stopped and this branch is not permitted to mutate
   `/home/god/.maestro/`, so a migration written here could not be verified
   against the real 33 rows anyway.

Refs #1142
