### PR TITLE
Pluggable llm-review gate: opus + terra stream pair replacing Greptile as primary (#1148)

### DIFF
--- a/.github/workflows/llm-review.yml
+++ b/.github/workflows/llm-review.yml
@@ -29,11 +29,14 @@ permissions:
 jobs:
   review:
     # Gated off by default. For issue_comment, only a "/llm-review" comment on
-    # a PR triggers a run.
+    # a PR from a repo member/owner/collaborator triggers a run — anyone else
+    # commenting the magic string must not be able to spend review tokens.
     if: >-
       vars.LLM_REVIEW_ENABLED == 'true' &&
       (github.event_name == 'pull_request' ||
-       (github.event.issue.pull_request && startsWith(github.event.comment.body, '/llm-review')))
+       (github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/llm-review') &&
+        contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'), github.event.comment.author_association)))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/llm-review.yml
+++ b/.github/workflows/llm-review.yml
@@ -21,6 +21,14 @@ on:
   issue_comment:
     types: [created]
 
+# One run per PR at a time: a superseded run (new push, duplicate trigger) is
+# cancelled instead of racing the fresh one. Together with the stale-pending
+# retry in scripts/llm-review.sh this self-heals a run that died after
+# posting its pending statuses (#1148 round 2).
+concurrency:
+  group: llm-review-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/llm-review.yml
+++ b/.github/workflows/llm-review.yml
@@ -1,0 +1,53 @@
+# llm-review — the glue workflow for the llm-review gate (#1148).
+#
+# DISABLED BY DEFAULT: every job is gated on the repository variable
+# LLM_REVIEW_ENABLED == 'true'. Set it (Settings → Secrets and variables →
+# Actions → Variables) to turn the workflow on. The daemon-side trigger is a
+# follow-up; until then this workflow (or a manual scripts/llm-review.sh run
+# on any host with the claude CLI) is what produces the statuses the gate
+# reads.
+#
+# Secrets used when enabled:
+#   LLM_REVIEW_TERRA_BASE_URL   — CLIProxy endpoint for the terra pass
+#   LLM_REVIEW_TERRA_AUTH_TOKEN — CLIProxy key for the terra pass
+#   ANTHROPIC_API_KEY           — auth for the opus pass (subscription seats
+#                                 do not exist on CI runners)
+
+name: llm-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  review:
+    # Gated off by default. For issue_comment, only a "/llm-review" comment on
+    # a PR triggers a run.
+    if: >-
+      vars.LLM_REVIEW_ENABLED == 'true' &&
+      (github.event_name == 'pull_request' ||
+       (github.event.issue.pull_request && startsWith(github.event.comment.body, '/llm-review')))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install claude CLI
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Run llm-review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          LLM_REVIEW_TERRA_BASE_URL: ${{ secrets.LLM_REVIEW_TERRA_BASE_URL }}
+          LLM_REVIEW_TERRA_AUTH_TOKEN: ${{ secrets.LLM_REVIEW_TERRA_AUTH_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
+          bash scripts/llm-review.sh "$PR_NUMBER" "$GH_REPO"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2384,8 +2384,8 @@ type Config struct {
 	Delivery                        DeliveryConfig                `yaml:"delivery"`                           // #872: approval-gated post-merge delivery (disabled|approval_required|automatic)
 	MergeStrategy                   string                        `yaml:"merge_strategy"`                     // "sequential" | "parallel"
 	MergeIntervalSeconds            int                           `yaml:"merge_interval_seconds"`             // minimum seconds between merges in sequential mode
-	ReviewGate                      string                        `yaml:"review_gate"`                        // "greptile" (default) | "none"
-	ReviewGateStreams               []string                      `yaml:"review_gate_streams"`                // optional review dimensions; default ["greptile"], opt-in ["greptile","simplicity"]
+	ReviewGate                      string                        `yaml:"review_gate"`                        // "greptile" (default) | "llm-review" (#1148 opus+terra pair) | "none"
+	ReviewGateStreams               []string                      `yaml:"review_gate_streams"`                // optional review dimensions; default follows review_gate ("greptile" → ["greptile"], "llm-review" → ["llm-review-opus","llm-review-terra"]); "llm-review" is a pair alias
 	ReviewRetrigger                 ReviewRetriggerConfig         `yaml:"review_retrigger"`                   // #691: re-post "@greptile review" when the gate wedges at pending with no review on head
 	AutoRetryReviewFeedback         bool                          `yaml:"auto_retry_review_feedback"`         // close PRs with review comments and respawn a fixer
 	MergeExhaustedNonCriticalReview *bool                         `yaml:"merge_exhausted_noncritical_review"` // #565: merge a green PR after review-feedback retries exhaust when only non-critical (P1/P2/P3) findings remain (no P0 on head). nil = default-on.
@@ -2961,6 +2961,9 @@ func parse(data []byte) (*Config, error) {
 		cfg.ReviewGate = "greptile"
 	case "none", "off", "disabled":
 		cfg.ReviewGate = "none"
+	case "llm-review", "llm_review", "llmreview":
+		// #1148: the llm-review pair (opus + terra lenses) as the primary gate.
+		cfg.ReviewGate = "llm-review"
 	default:
 		cfg.ReviewGate = "greptile"
 	}
@@ -3054,32 +3057,46 @@ func validateDeliverySafeLabel(name, value string, maxRunes int) error {
 }
 
 func normalizeReviewGateStreams(reviewGate string, streams []string) []string {
-	if strings.EqualFold(strings.TrimSpace(reviewGate), "none") {
+	gate := strings.ToLower(strings.TrimSpace(reviewGate))
+	if gate == "none" {
 		return nil
 	}
+	// The gate value picks the default stream set when review_gate_streams is
+	// not configured explicitly: "llm-review" means the model pair (#1148),
+	// everything else keeps the historical greptile default.
+	defaults := []string{"greptile"}
+	if gate == "llm-review" {
+		defaults = []string{"llm-review-opus", "llm-review-terra"}
+	}
 	if len(streams) == 0 {
-		return []string{"greptile"}
+		return defaults
 	}
 	out := make([]string, 0, len(streams))
 	seen := make(map[string]struct{}, len(streams))
+	add := func(name string) {
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+	}
 	for _, raw := range streams {
 		name := strings.ToLower(strings.TrimSpace(raw))
 		switch name {
 		case "", "off", "disabled", "none":
 			continue
-		case "greptile", "simplicity":
-			// supported as configured
+		case "greptile", "simplicity", "llm-review-opus", "llm-review-terra":
+			add(name)
+		case "llm-review":
+			// Pair alias (#1148): both model lenses.
+			add("llm-review-opus")
+			add("llm-review-terra")
 		default:
 			continue
 		}
-		if _, ok := seen[name]; ok {
-			continue
-		}
-		seen[name] = struct{}{}
-		out = append(out, name)
 	}
 	if len(out) == 0 {
-		return []string{"greptile"}
+		return defaults
 	}
 	return out
 }

--- a/internal/config/llm_review_gate_test.go
+++ b/internal/config/llm_review_gate_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+// review_gate: llm-review (#1148) normalizes to the pair of model streams.
+func TestParse_ReviewGateLLMReviewDefaultsToPair(t *testing.T) {
+	yaml := `
+repo: owner/repo
+review_gate: llm-review
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.ReviewGate != "llm-review" {
+		t.Fatalf("ReviewGate = %q, want llm-review", cfg.ReviewGate)
+	}
+	want := []string{"llm-review-opus", "llm-review-terra"}
+	if got := cfg.EffectiveReviewGateStreams(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("EffectiveReviewGateStreams() = %#v, want %v", got, want)
+	}
+}
+
+// The underscore/compact spellings normalize to the canonical gate value.
+func TestParse_ReviewGateLLMReviewSpellings(t *testing.T) {
+	for _, spelling := range []string{"llm-review", "llm_review", "llmreview", "LLM-Review"} {
+		cfg, err := parse([]byte("repo: owner/repo\nreview_gate: " + spelling + "\n"))
+		if err != nil {
+			t.Fatalf("parse(%q): %v", spelling, err)
+		}
+		if cfg.ReviewGate != "llm-review" {
+			t.Errorf("ReviewGate for %q = %q, want llm-review", spelling, cfg.ReviewGate)
+		}
+	}
+}
+
+// Explicit streams may mix the llm pair alias with other streams; the alias
+// expands and dedupes.
+func TestParse_ReviewGateStreamsLLMReviewAlias(t *testing.T) {
+	yaml := `
+repo: owner/repo
+review_gate: llm-review
+review_gate_streams:
+  - llm-review
+  - greptile
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []string{"llm-review-opus", "llm-review-terra", "greptile"}
+	if got := cfg.EffectiveReviewGateStreams(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("EffectiveReviewGateStreams() = %#v, want %v", got, want)
+	}
+}
+
+// Greptile stays the default and existing rows keep working unchanged.
+func TestParse_ReviewGateDefaultStillGreptile(t *testing.T) {
+	cfg, err := parse([]byte("repo: owner/repo\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.ReviewGate != "greptile" {
+		t.Fatalf("ReviewGate = %q, want greptile (default unchanged)", cfg.ReviewGate)
+	}
+	if got := cfg.EffectiveReviewGateStreams(); !reflect.DeepEqual(got, []string{"greptile"}) {
+		t.Fatalf("EffectiveReviewGateStreams() = %#v, want [greptile]", got)
+	}
+}
+
+// review_gate: none still disables every stream, llm-review included.
+func TestParse_ReviewGateNoneDisablesLLMStreams(t *testing.T) {
+	yaml := `
+repo: owner/repo
+review_gate: none
+review_gate_streams:
+  - llm-review
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got := cfg.EffectiveReviewGateStreams(); got != nil {
+		t.Fatalf("EffectiveReviewGateStreams() = %#v, want nil for gate none", got)
+	}
+}
+
+// Unknown stream names are dropped; an all-unknown list falls back to the
+// gate's default set — the pair for llm-review.
+func TestParse_ReviewGateLLMReviewUnknownStreamsFallBackToPair(t *testing.T) {
+	yaml := `
+repo: owner/repo
+review_gate: llm-review
+review_gate_streams:
+  - not-a-stream
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []string{"llm-review-opus", "llm-review-terra"}
+	if got := cfg.EffectiveReviewGateStreams(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("EffectiveReviewGateStreams() = %#v, want %v", got, want)
+	}
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2743,8 +2743,21 @@ func isGreptileLogin(login string) bool {
 
 func isReviewBotLogin(login string) bool {
 	lower := strings.ToLower(strings.TrimSpace(login))
-	return strings.Contains(lower, "greptile") || strings.Contains(lower, "codex")
+	return strings.Contains(lower, "greptile") || strings.Contains(lower, "codex") || isLLMReviewBotLogin(login)
 }
+
+// isLLMReviewBotLogin reports whether the login belongs to the bot that posts
+// llm-review findings (#1148). The glue runner posts under the fleet bot
+// account ("okbot" by default); any login containing "llm-review" also counts
+// so a dedicated reviewer account works without a code change.
+func isLLMReviewBotLogin(login string) bool {
+	lower := strings.ToLower(strings.TrimSpace(login))
+	return containsAny(lower, llmReviewBotLogins)
+}
+
+// llmReviewBotLogins are the login substrings attributed to the llm-review
+// glue runner (#1148).
+var llmReviewBotLogins = []string{"okbot", "llm-review"}
 
 func hasGreptileInlineCommentOnHead(comments []greptileReviewComment, sha string) bool {
 	for _, comment := range comments {
@@ -2780,31 +2793,39 @@ func reviewCommentTargetsHead(comment greptileReviewComment, sha string) bool {
 
 // isHighSeverity checks if a review comment is P0 or P1 severity.
 // P2/P3 comments are informational and should not block merge.
+// Matches both the Greptile badge markup (img alt / badge URLs) and the
+// plain-text markers the llm-review glue emits (#1148): "[P0]" / "[P1]"
+// and "severity: P0" / "severity: P1".
 func isHighSeverity(body string) bool {
-	lower := strings.ToLower(body)
-	if strings.Contains(lower, "alt=\"p0\"") || strings.Contains(lower, "alt=\"p1\"") {
-		return true
-	}
-	if strings.Contains(lower, "/p0") || strings.Contains(lower, "/p1") {
-		return true
-	}
-	if strings.Contains(lower, "badge/p0") || strings.Contains(lower, "badge/p1") {
-		return true
-	}
-	return false
+	return hasSeverityMarker(body, "p0") || hasSeverityMarker(body, "p1")
 }
 
 // isCriticalSeverity reports whether a review comment is P0 (critical) only.
 // P1/P2/P3 are non-critical for the #565 convergence-merge escape.
 func isCriticalSeverity(body string) bool {
+	return hasSeverityMarker(body, "p0")
+}
+
+// hasSeverityMarker reports whether the comment body carries the given
+// severity level ("p0"/"p1"/...) in any of the recognized encodings:
+// Greptile badge markup (alt="P0", shields "badge/P0", ".../P0"), or the
+// plain-text forms "[P0]" and "severity: P0" that a simple glue script can
+// emit without any HTML (#1148).
+func hasSeverityMarker(body, level string) bool {
 	lower := strings.ToLower(body)
-	if strings.Contains(lower, "alt=\"p0\"") {
+	if strings.Contains(lower, "alt=\""+level+"\"") {
 		return true
 	}
-	if strings.Contains(lower, "/p0") {
+	if strings.Contains(lower, "/"+level) {
 		return true
 	}
-	if strings.Contains(lower, "badge/p0") {
+	if strings.Contains(lower, "badge/"+level) {
+		return true
+	}
+	if strings.Contains(lower, "["+level+"]") {
+		return true
+	}
+	if strings.Contains(lower, "severity: "+level) || strings.Contains(lower, "severity:"+level) {
 		return true
 	}
 	return false
@@ -3852,6 +3873,8 @@ func (c *Client) PRReviewGateVerdict(prNumber int, streams []string) (ReviewGate
 				CheckContains: []string{"simplicity", "over-engineering", "overengineering"},
 				UserContains:  []string{"simplicity", "maestro-simplicity", "over-engineering", "overengineering"},
 			})
+		case "llm-review-opus", "llm-review-terra":
+			sv, err = c.namedReviewStreamVerdict(prNumber, llmReviewStreamSpec(stream))
 		default:
 			continue
 		}
@@ -3901,6 +3924,13 @@ func (c *Client) PRBlockingReviewFindingsOnHead(prNumber int, streams []string) 
 		}
 		if streamEnabled(streams, "simplicity") && isSimplicityReviewerLogin(login) && isActionableReviewComment(ReviewComment{Path: cm.Path, Line: cm.Line, Body: body, User: login}) {
 			findings = append(findings, ReviewComment{Path: cm.Path, Line: cm.Line, Body: body, User: login})
+			continue
+		}
+		// llm-review (#1148): only P0/P1 block, whichever of the two model
+		// streams posted the finding — the repair scope is the union.
+		if (streamEnabled(streams, "llm-review-opus") || streamEnabled(streams, "llm-review-terra")) &&
+			isLLMReviewBotLogin(login) && isHighSeverity(body) {
+			findings = append(findings, ReviewComment{Path: cm.Path, Line: cm.Line, Body: body, User: login})
 		}
 	}
 	return sha, findings, len(findings) > 0, nil
@@ -3910,6 +3940,35 @@ type reviewStreamSpec struct {
 	Name          string
 	CheckContains []string
 	UserContains  []string
+	// BodyContains, when non-empty, additionally requires an inline comment
+	// body to contain one of these markers before it is attributed to this
+	// stream. The llm-review streams share one bot login, so the per-model
+	// marker embedded in each comment is what tells the two streams apart.
+	BodyContains []string
+	// HighSeverityOnly makes only P0/P1 findings block this stream. P2/P3
+	// comments stay advisory (#1148 severity contract). Streams without it
+	// keep the historical behavior: any actionable comment blocks.
+	HighSeverityOnly bool
+	// AllowCommitStatus lets the stream's external verdict arrive as a plain
+	// commit status (POST /statuses/{sha}) in addition to a check run. Check
+	// runs require a GitHub App; the llm-review glue posts statuses with a
+	// normal token (#1148).
+	AllowCommitStatus bool
+}
+
+// llmReviewStreamSpec builds the spec for one of the two llm-review streams
+// (#1148): the external verdict is the commit status / check run named after
+// the stream, and inline findings are the bot's comments carrying the
+// stream's marker. Only P0/P1 findings block; P2/P3 stay advisory.
+func llmReviewStreamSpec(name string) reviewStreamSpec {
+	return reviewStreamSpec{
+		Name:              name,
+		CheckContains:     []string{name},
+		UserContains:      llmReviewBotLogins,
+		BodyContains:      []string{name},
+		HighSeverityOnly:  true,
+		AllowCommitStatus: true,
+	}
 }
 
 func (c *Client) greptileReviewStreamVerdict(prNumber int) (ReviewStreamVerdict, error) {
@@ -3926,6 +3985,17 @@ func (c *Client) namedReviewStreamVerdict(prNumber int, spec reviewStreamSpec) (
 	if checkErr == nil {
 		checkFound, checkPassed, checkPending = namedCheckDecision(checks, spec.CheckContains)
 	}
+	// The llm-review glue posts plain commit statuses (a normal token cannot
+	// create check runs — those need a GitHub App). When no check run spoke
+	// for this stream, look at the combined status for the same needles.
+	var statusErr error
+	if spec.AllowCommitStatus && !checkFound {
+		var combined combinedStatusResponse
+		combined, statusErr = c.combinedStatusForSHA(sha)
+		if statusErr == nil {
+			checkFound, checkPassed, checkPending = namedStatusDecision(combined, spec.CheckContains)
+		}
+	}
 	findings, commentsErr := c.reviewFindingsForStream(prNumber, sha, spec)
 	if commentsErr != nil && checkErr != nil {
 		return ReviewStreamVerdict{}, commentsErr
@@ -3935,7 +4005,7 @@ func (c *Client) namedReviewStreamVerdict(prNumber int, spec reviewStreamSpec) (
 	// for this head. The default branch below is the silent case — but only a
 	// successful read can prove silence.
 	sv.Observed = checkFound || checkPending || len(findings) > 0
-	sv.LookupFailed = checkErr != nil || commentsErr != nil
+	sv.LookupFailed = checkErr != nil || commentsErr != nil || statusErr != nil
 	switch {
 	case checkPending:
 		sv.Pending = true
@@ -3974,11 +4044,38 @@ func namedCheckDecision(checks []greptileCheckRun, needles []string) (found bool
 	return false, false, false
 }
 
+// namedStatusDecision is namedCheckDecision for plain commit statuses: the
+// combined status already reports the latest status per context, so the first
+// matching context is the stream's verdict.
+func namedStatusDecision(combined combinedStatusResponse, needles []string) (found bool, passed bool, pending bool) {
+	for _, st := range combined.Statuses {
+		if !containsAny(strings.ToLower(st.Context), needles) {
+			continue
+		}
+		switch strings.ToLower(strings.TrimSpace(st.State)) {
+		case "success":
+			return true, true, false
+		case "pending":
+			return true, false, true
+		default: // "failure", "error"
+			return true, false, false
+		}
+	}
+	return false, false, false
+}
+
 func (c *Client) reviewFindingsForStream(prNumber int, sha string, spec reviewStreamSpec) ([]ReviewComment, error) {
 	comments, err := c.greptileReviewComments(prNumber)
 	if err != nil {
 		return nil, err
 	}
+	return filterStreamFindings(comments, sha, spec), nil
+}
+
+// filterStreamFindings selects the inline comments on the given head that this
+// stream attributes to itself and considers blocking. Pure so the attribution
+// and severity rules are testable without the API reads.
+func filterStreamFindings(comments []greptileReviewComment, sha string, spec reviewStreamSpec) []ReviewComment {
 	var findings []ReviewComment
 	for _, cm := range comments {
 		if !reviewCommentTargetsHead(cm, sha) {
@@ -3987,13 +4084,19 @@ func (c *Client) reviewFindingsForStream(prNumber int, sha string, spec reviewSt
 		if !containsAny(strings.ToLower(cm.User.Login), spec.UserContains) {
 			continue
 		}
+		if len(spec.BodyContains) > 0 && !containsAny(strings.ToLower(cm.Body), spec.BodyContains) {
+			continue
+		}
+		if spec.HighSeverityOnly && !isHighSeverity(cm.Body) {
+			continue
+		}
 		comment := ReviewComment{Path: cm.Path, Line: cm.Line, Body: cm.Body, User: cm.User.Login}
 		if !isActionableReviewComment(comment) {
 			continue
 		}
 		findings = append(findings, comment)
 	}
-	return findings, nil
+	return findings
 }
 
 func normalizeReviewStreams(streams []string) []string {
@@ -4002,18 +4105,25 @@ func normalizeReviewStreams(streams []string) []string {
 	}
 	out := make([]string, 0, len(streams))
 	seen := map[string]struct{}{}
-	for _, raw := range streams {
-		name := strings.ToLower(strings.TrimSpace(raw))
-		switch name {
-		case "greptile", "simplicity":
-		default:
-			continue
-		}
+	add := func(name string) {
 		if _, ok := seen[name]; ok {
-			continue
+			return
 		}
 		seen[name] = struct{}{}
 		out = append(out, name)
+	}
+	for _, raw := range streams {
+		name := strings.ToLower(strings.TrimSpace(raw))
+		switch name {
+		case "greptile", "simplicity", "llm-review-opus", "llm-review-terra":
+			add(name)
+		case "llm-review":
+			// The pair alias (#1148): "llm-review" means both model lenses.
+			add("llm-review-opus")
+			add("llm-review-terra")
+		default:
+			continue
+		}
 	}
 	return out
 }

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2741,15 +2741,27 @@ func isGreptileLogin(login string) bool {
 	return strings.Contains(strings.ToLower(strings.TrimSpace(login)), "greptile")
 }
 
+// isReviewBotLogin is the GLOBAL reviewer set for the gate-independent
+// feedback consumers (CollectReviewFeedback and the issue-comment summary
+// path), which run on every project regardless of the configured review
+// streams. The llm-review bot logins deliberately do NOT belong here: the
+// glue posts under the fleet bot account ("okbot"), and folding it into the
+// global set made every fleet-bot comment with a file:line look like review
+// feedback on greptile-gated projects too, triggering retry/close churn.
+// llm-review attribution is scoped to the stream-verdict paths
+// (reviewStreamSpec.UserContains) and to PRBlockingReviewFindingsOnHead /
+// PRHasCriticalReviewOnHead when the llm streams are configured.
 func isReviewBotLogin(login string) bool {
 	lower := strings.ToLower(strings.TrimSpace(login))
-	return strings.Contains(lower, "greptile") || strings.Contains(lower, "codex") || isLLMReviewBotLogin(login)
+	return strings.Contains(lower, "greptile") || strings.Contains(lower, "codex")
 }
 
 // isLLMReviewBotLogin reports whether the login belongs to the bot that posts
 // llm-review findings (#1148). The glue runner posts under the fleet bot
 // account ("okbot" by default); any login containing "llm-review" also counts
-// so a dedicated reviewer account works without a code change.
+// so a dedicated reviewer account works without a code change. Only consulted
+// on paths that know the llm streams are configured — never globally (see
+// isReviewBotLogin).
 func isLLMReviewBotLogin(login string) bool {
 	lower := strings.ToLower(strings.TrimSpace(login))
 	return containsAny(lower, llmReviewBotLogins)
@@ -2831,37 +2843,47 @@ func hasSeverityMarker(body, level string) bool {
 	return false
 }
 
-// hasGreptileCriticalCommentOnHead reports whether any Greptile inline comment
-// on the current head SHA is P0 (critical).
-func hasGreptileCriticalCommentOnHead(comments []greptileReviewComment, sha string) bool {
+// hasCriticalReviewCommentOnHead reports whether any configured review stream
+// left a finding on the current head that the #565 convergence-merge escape
+// must not bypass: a Greptile P0, or — when the llm-review streams are
+// configured — a P0/P1 from the llm-review bot (P0/P1 is that gate's entire
+// blocking contract; the glue never posts anything blocking below P1).
+// Streams pass through normalizeReviewStreams, so an empty list keeps the
+// historical greptile-only behavior.
+func hasCriticalReviewCommentOnHead(comments []greptileReviewComment, sha string, streams []string) bool {
+	greptileEnabled := streamEnabled(streams, "greptile")
+	llmEnabled := streamEnabled(streams, "llm-review-opus") || streamEnabled(streams, "llm-review-terra")
 	for _, comment := range comments {
-		if !isGreptileLogin(comment.User.Login) {
-			continue
-		}
 		if !reviewCommentTargetsHead(comment, sha) {
 			continue
 		}
-		if isCriticalSeverity(comment.Body) {
+		login := comment.User.Login
+		if greptileEnabled && isGreptileLogin(login) && isCriticalSeverity(comment.Body) {
+			return true
+		}
+		if llmEnabled && isLLMReviewBotLogin(login) && isHighSeverity(comment.Body) {
 			return true
 		}
 	}
 	return false
 }
 
-// PRHasCriticalReviewOnHead reports whether the PR has a P0 (critical) Greptile
-// inline comment on its current head SHA. Used by the orchestrator #565
-// convergence-merge escape: a retry-exhausted green PR with only non-critical
-// findings may merge, but a P0 on head hard-blocks.
-func (c *Client) PRHasCriticalReviewOnHead(prNumber int) (bool, error) {
+// PRHasCriticalReviewOnHead reports whether the PR has a merge-blocking
+// critical review comment on its current head SHA for the configured streams.
+// Used by the orchestrator #565 convergence-merge escape: a retry-exhausted
+// green PR with only non-critical findings may merge, but a critical finding
+// on head hard-blocks. For the greptile stream that means a P0; for the
+// llm-review streams it means the bot's P0/P1 blocking findings.
+func (c *Client) PRHasCriticalReviewOnHead(prNumber int, streams []string) (bool, error) {
 	sha, err := c.pullHeadSHA(prNumber)
 	if err != nil {
 		return false, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
 	}
 	comments, err := c.greptileReviewComments(prNumber)
 	if err != nil {
-		return false, fmt.Errorf("greptile review comments for PR %d: %w", prNumber, err)
+		return false, fmt.Errorf("review comments for PR %d: %w", prNumber, err)
 	}
-	return hasGreptileCriticalCommentOnHead(comments, sha), nil
+	return hasCriticalReviewCommentOnHead(comments, sha, streams), nil
 }
 
 // PRHighSeverityReviewOnHead returns the head SHA and the list of P0/P1

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2749,8 +2749,9 @@ func isGreptileLogin(login string) bool {
 // global set made every fleet-bot comment with a file:line look like review
 // feedback on greptile-gated projects too, triggering retry/close churn.
 // llm-review attribution is scoped to the stream-verdict paths
-// (reviewStreamSpec.UserContains) and to PRBlockingReviewFindingsOnHead /
-// PRHasCriticalReviewOnHead when the llm streams are configured.
+// (reviewStreamSpec.UserContains) and — when the llm streams are configured —
+// to PRBlockingReviewFindingsOnHead, PRHasCriticalReviewOnHead, and the
+// feedback collectors (via isCollectableReviewFeedbackLogin).
 func isReviewBotLogin(login string) bool {
 	lower := strings.ToLower(strings.TrimSpace(login))
 	return strings.Contains(lower, "greptile") || strings.Contains(lower, "codex")
@@ -2770,6 +2771,31 @@ func isLLMReviewBotLogin(login string) bool {
 // llmReviewBotLogins are the login substrings attributed to the llm-review
 // glue runner (#1148).
 var llmReviewBotLogins = []string{"okbot", "llm-review"}
+
+// llmReviewStreamsConfigured reports whether at least one llm-review model
+// stream is part of the configured review streams (the "llm-review" pair
+// alias normalizes to both model streams).
+func llmReviewStreamsConfigured(streams []string) bool {
+	return streamEnabled(streams, "llm-review-opus") || streamEnabled(streams, "llm-review-terra")
+}
+
+// isCollectableReviewFeedbackLogin decides whose comments the feedback
+// collectors (CollectReviewFeedback / CollectPRReviewFeedback) treat as
+// review feedback. The global reviewer set (greptile/codex) is collected on
+// every project; the llm-review bot ("okbot") is collected ONLY when the
+// project's configured streams include an llm-review stream. Without the
+// stream scoping one of two failure modes wins: folding okbot into the
+// global set turns every fleet-bot comment with a file:line into review
+// feedback on greptile rows (#1148 round 1, P1-3 churn), while dropping it
+// entirely severs the repair circuit on llm-review rows — feedback comes
+// back empty, AutoRetryReviewFeedback never fires, sessions never reach
+// retry_exhausted, and the PR hangs forever (#1148 round 2, P1).
+func isCollectableReviewFeedbackLogin(login string, streams []string) bool {
+	if isReviewBotLogin(login) {
+		return true
+	}
+	return llmReviewStreamsConfigured(streams) && isLLMReviewBotLogin(login)
+}
 
 func hasGreptileInlineCommentOnHead(comments []greptileReviewComment, sha string) bool {
 	for _, comment := range comments {
@@ -2843,22 +2869,24 @@ func hasSeverityMarker(body, level string) bool {
 	return false
 }
 
-// hasCriticalReviewCommentOnHead reports whether any configured review stream
-// left a finding on the current head that the #565 convergence-merge escape
-// must not bypass: a Greptile P0, or — when the llm-review streams are
-// configured — a P0/P1 from the llm-review bot (P0/P1 is that gate's entire
-// blocking contract; the glue never posts anything blocking below P1).
-// Streams pass through normalizeReviewStreams, so an empty list keeps the
-// historical greptile-only behavior.
+// hasCriticalReviewCommentOnHead reports whether a review finding on the
+// current head must not be bypassed by the #565 convergence-merge escape.
+// A Greptile P0 blocks UNCONDITIONALLY — regardless of the configured
+// streams — preserving the pre-#1148 behavior: the Greptile app keeps
+// reviewing a repo it is installed on even after the project row migrates to
+// another gate, and a config migration must not silently downgrade a P0 from
+// hard-block to advisory (#1148 round 2, P2). On top of that, when the
+// llm-review streams are configured, a P0/P1 from the llm-review bot blocks
+// too (P0/P1 is that gate's entire blocking contract; the glue never posts
+// anything blocking below P1).
 func hasCriticalReviewCommentOnHead(comments []greptileReviewComment, sha string, streams []string) bool {
-	greptileEnabled := streamEnabled(streams, "greptile")
-	llmEnabled := streamEnabled(streams, "llm-review-opus") || streamEnabled(streams, "llm-review-terra")
+	llmEnabled := llmReviewStreamsConfigured(streams)
 	for _, comment := range comments {
 		if !reviewCommentTargetsHead(comment, sha) {
 			continue
 		}
 		login := comment.User.Login
-		if greptileEnabled && isGreptileLogin(login) && isCriticalSeverity(comment.Body) {
+		if isGreptileLogin(login) && isCriticalSeverity(comment.Body) {
 			return true
 		}
 		if llmEnabled && isLLMReviewBotLogin(login) && isHighSeverity(comment.Body) {
@@ -2869,11 +2897,12 @@ func hasCriticalReviewCommentOnHead(comments []greptileReviewComment, sha string
 }
 
 // PRHasCriticalReviewOnHead reports whether the PR has a merge-blocking
-// critical review comment on its current head SHA for the configured streams.
-// Used by the orchestrator #565 convergence-merge escape: a retry-exhausted
-// green PR with only non-critical findings may merge, but a critical finding
-// on head hard-blocks. For the greptile stream that means a P0; for the
-// llm-review streams it means the bot's P0/P1 blocking findings.
+// critical review comment on its current head SHA. Used by the orchestrator
+// #565 convergence-merge escape: a retry-exhausted green PR with only
+// non-critical findings may merge, but a critical finding on head
+// hard-blocks. A Greptile P0 blocks regardless of the configured streams;
+// the llm-review bot's P0/P1 blocking findings count only when those
+// streams are configured (see hasCriticalReviewCommentOnHead).
 func (c *Client) PRHasCriticalReviewOnHead(prNumber int, streams []string) (bool, error) {
 	sha, err := c.pullHeadSHA(prNumber)
 	if err != nil {
@@ -3842,8 +3871,12 @@ func (v ReviewGateVerdict) Summary() string {
 
 var reviewLocationPattern = regexp.MustCompile(`(?mi)(^|\s)([A-Za-z0-9_./-]+\.[A-Za-z0-9]+:\d+|file:\s*\S+)`)
 
-// CollectReviewFeedback collects actionable inline review comments from Greptile and Codex on a PR.
-func (c *Client) CollectReviewFeedback(prNumber int) ([]ReviewComment, error) {
+// CollectReviewFeedback collects actionable inline review comments on a PR
+// from the global reviewer set (Greptile/Codex) and — when the project's
+// configured review streams include an llm-review stream — from the
+// llm-review bot (see isCollectableReviewFeedbackLogin for why the bot is
+// stream-scoped).
+func (c *Client) CollectReviewFeedback(prNumber int, streams []string) ([]ReviewComment, error) {
 	// Get HEAD SHA — only return comments on the latest commit. Errors are
 	// tolerated (empty SHA matches all comments, as before); the shared
 	// wrapper (#797) gives the read backoff + conditional caching.
@@ -3856,7 +3889,7 @@ func (c *Client) CollectReviewFeedback(prNumber int) ([]ReviewComment, error) {
 	var result []ReviewComment
 	for _, cm := range comments {
 		login := cm.User.Login
-		if !isReviewBotLogin(login) {
+		if !isCollectableReviewFeedbackLogin(login, streams) {
 			continue
 		}
 		// Skip comments that were originally left on older commits — they may already be fixed.
@@ -3950,8 +3983,7 @@ func (c *Client) PRBlockingReviewFindingsOnHead(prNumber int, streams []string) 
 		}
 		// llm-review (#1148): only P0/P1 block, whichever of the two model
 		// streams posted the finding — the repair scope is the union.
-		if (streamEnabled(streams, "llm-review-opus") || streamEnabled(streams, "llm-review-terra")) &&
-			isLLMReviewBotLogin(login) && isHighSeverity(body) {
+		if llmReviewStreamsConfigured(streams) && isLLMReviewBotLogin(login) && isHighSeverity(body) {
 			findings = append(findings, ReviewComment{Path: cm.Path, Line: cm.Line, Body: body, User: login})
 		}
 	}
@@ -4372,11 +4404,13 @@ func (c *Client) CIFailureSummary(prNumber int) (string, error) {
 	return s, nil
 }
 
-// CollectPRReviewFeedback collects actionable Greptile/Codex review feedback
-// from a PR, including inline review comments and issue-level summary comments.
-// Returns a formatted string ready to inject into a worker prompt, or empty
-// string if no actionable review feedback exists.
-func (c *Client) CollectPRReviewFeedback(prNumber int) (string, error) {
+// CollectPRReviewFeedback collects actionable review feedback from a PR —
+// inline review comments and issue-level summary comments — for the global
+// reviewer set plus, when the configured streams include an llm-review
+// stream, the llm-review bot. Returns a formatted string ready to inject
+// into a worker prompt, or empty string if no actionable review feedback
+// exists.
+func (c *Client) CollectPRReviewFeedback(prNumber int, streams []string) (string, error) {
 	var sections []string
 
 	// 1. Fetch issue-level comments (Greptile summary with confidence score),
@@ -4391,7 +4425,7 @@ func (c *Client) CollectPRReviewFeedback(prNumber int) (string, error) {
 		}
 		if json.Unmarshal(issueCommentsOut, &comments) == nil {
 			for _, cm := range comments {
-				if isReviewBotLogin(cm.User.Login) && isActionableReviewSummary(cm.Body) {
+				if isCollectableReviewFeedbackLogin(cm.User.Login, streams) && isActionableReviewSummary(cm.Body) {
 					sections = append(sections, cm.Body)
 				}
 			}
@@ -4399,7 +4433,7 @@ func (c *Client) CollectPRReviewFeedback(prNumber int) (string, error) {
 	}
 
 	// 2. Fetch inline review comments
-	inlineComments, err := c.CollectReviewFeedback(prNumber)
+	inlineComments, err := c.CollectReviewFeedback(prNumber, streams)
 	if err == nil && len(inlineComments) > 0 {
 		sections = append(sections, FormatReviewFeedback(inlineComments))
 	}

--- a/internal/github/llm_review_script_test.go
+++ b/internal/github/llm_review_script_test.go
@@ -1,0 +1,320 @@
+package github
+
+// Regression tests for scripts/llm-review.sh — the glue runner behind the
+// llm-review gate (#1148). The script is run for real with stubbed `gh` and
+// `claude` binaries on PATH; the gh stub evaluates the script's --jq
+// expressions with the actual jq, so the idempotency query is exercised
+// against real combined-status JSON rather than a canned answer.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func llmReviewScriptPath(t *testing.T) string {
+	t.Helper()
+	p, err := filepath.Abs(filepath.Join("..", "..", "scripts", "llm-review.sh"))
+	if err != nil {
+		t.Fatalf("resolve script path: %v", err)
+	}
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("scripts/llm-review.sh not found at %s: %v", p, err)
+	}
+	return p
+}
+
+const llmScriptHeadSHA = "headsha4567890abcdef"
+
+// ghStub answers the script's gh invocations. Every call is appended to
+// $STUB_DIR/calls so tests can assert ordering (pending statuses must precede
+// comments). The combined-status endpoint pipes $STUB_DIR/combined-status.json
+// through the REAL jq with the script's own --jq expression.
+const ghStub = `#!/usr/bin/env bash
+set -u
+printf '%s\n' "$*" >> "$STUB_DIR/calls"
+cmd="${1:-}"; sub="${2:-}"
+if [[ "$cmd" == "pr" && "$sub" == "view" ]]; then
+    printf '{"headRefOid":"headsha4567890abcdef","baseRefName":"main","title":"test PR","number":7}\n'
+elif [[ "$cmd" == "pr" && "$sub" == "diff" ]]; then
+    cat "$STUB_DIR/diff"
+elif [[ "$cmd" == "pr" && "$sub" == "comment" ]]; then
+    exit 0
+elif [[ "$cmd" == "api" ]]; then
+    endpoint="$sub"
+    case "$endpoint" in
+        */commits/*/status)
+            expr=""
+            prev=""
+            for a in "$@"; do
+                if [[ "$prev" == "--jq" ]]; then expr="$a"; fi
+                prev="$a"
+            done
+            jq -r "$expr" < "$STUB_DIR/combined-status.json"
+            ;;
+        *)
+            exit 0
+            ;;
+    esac
+fi
+exit 0
+`
+
+const claudeStub = `#!/usr/bin/env bash
+printf 'claude %s\n' "$*" >> "$STUB_DIR/calls"
+cat "$STUB_DIR/claude-output"
+exit 0
+`
+
+type llmScriptResult struct {
+	exitCode int
+	calls    []string
+	output   string
+}
+
+// runLLMReviewScript executes the script with stub binaries. claudeOutput is
+// what both model passes "print"; combinedStatus is the pre-existing commit
+// status JSON on the head; terraCreds toggles the CLIProxy env pair.
+func runLLMReviewScript(t *testing.T, claudeOutput, combinedStatus string, terraCreds bool, extraEnv ...string) llmScriptResult {
+	t.Helper()
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not in PATH")
+	}
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq not in PATH")
+	}
+
+	stubDir := t.TempDir()
+	writeStubFile(t, filepath.Join(stubDir, "gh"), ghStub, 0o755)
+	writeStubFile(t, filepath.Join(stubDir, "claude"), claudeStub, 0o755)
+	writeStubFile(t, filepath.Join(stubDir, "claude-output"), claudeOutput, 0o644)
+	writeStubFile(t, filepath.Join(stubDir, "combined-status.json"), combinedStatus, 0o644)
+	writeStubFile(t, filepath.Join(stubDir, "diff"), "diff --git a/a.go b/a.go\n+real change\n", 0o644)
+	writeStubFile(t, filepath.Join(stubDir, "calls"), "", 0o644)
+
+	cmd := exec.Command("bash", llmReviewScriptPath(t), "7", "owner/repo")
+	cmd.Env = append([]string{
+		"PATH=" + stubDir + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"HOME=" + stubDir,
+		"TMPDIR=" + stubDir,
+		"STUB_DIR=" + stubDir,
+	}, extraEnv...)
+	if terraCreds {
+		cmd.Env = append(cmd.Env,
+			"LLM_REVIEW_TERRA_BASE_URL=http://proxy.test",
+			"LLM_REVIEW_TERRA_AUTH_TOKEN=stub-token")
+	}
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if err != nil {
+		exitErr, ok := err.(*exec.ExitError)
+		if !ok {
+			t.Fatalf("run script: %v\n%s", err, out)
+		}
+		code = exitErr.ExitCode()
+	}
+	callsRaw, readErr := os.ReadFile(filepath.Join(stubDir, "calls"))
+	if readErr != nil {
+		t.Fatalf("read calls log: %v", readErr)
+	}
+	var calls []string
+	for _, line := range strings.Split(string(callsRaw), "\n") {
+		if strings.TrimSpace(line) != "" {
+			calls = append(calls, line)
+		}
+	}
+	return llmScriptResult{exitCode: code, calls: calls, output: string(out)}
+}
+
+func writeStubFile(t *testing.T, path, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+const emptyStatus = `{"state":"pending","statuses":[]}`
+
+func callsMatching(calls []string, needles ...string) []string {
+	var out []string
+	for _, call := range calls {
+		ok := true
+		for _, needle := range needles {
+			if !strings.Contains(call, needle) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			out = append(out, call)
+		}
+	}
+	return out
+}
+
+// P1-4 regression: model output with neither a finding line nor the
+// NO_FINDINGS sentinel must fail CLOSED — an error status, never success.
+func TestLLMReviewScript_UnparseableOutputFailsClosed(t *testing.T) {
+	res := runLLMReviewScript(t, "I'm sorry, I cannot review this diff.\n", emptyStatus, true)
+	if res.exitCode == 0 {
+		t.Fatalf("exit = 0, want non-zero for unparseable output\n%s", res.output)
+	}
+	for _, stream := range []string{"llm-review-opus", "llm-review-terra"} {
+		if len(callsMatching(res.calls, "statuses/"+llmScriptHeadSHA, "state=error", "context="+stream, "review output unparseable")) == 0 {
+			t.Errorf("no error status with 'review output unparseable' for %s\ncalls:\n%s", stream, strings.Join(res.calls, "\n"))
+		}
+		if len(callsMatching(res.calls, "state=success", "context="+stream)) != 0 {
+			t.Errorf("%s posted success on unparseable output (fail-open)\ncalls:\n%s", stream, strings.Join(res.calls, "\n"))
+		}
+	}
+}
+
+// P1-4: a fenced NO_FINDINGS sentinel still counts as a clean review.
+func TestLLMReviewScript_FencedNoFindingsIsSuccess(t *testing.T) {
+	res := runLLMReviewScript(t, "```\nNO_FINDINGS\n```\n", emptyStatus, true)
+	if res.exitCode != 0 {
+		t.Fatalf("exit = %d, want 0\n%s", res.exitCode, res.output)
+	}
+	for _, stream := range []string{"llm-review-opus", "llm-review-terra"} {
+		if len(callsMatching(res.calls, "state=success", "context="+stream)) == 0 {
+			t.Errorf("no success status for %s on a fenced NO_FINDINGS\ncalls:\n%s", stream, strings.Join(res.calls, "\n"))
+		}
+	}
+}
+
+// P1-4: findings wrapped in markdown fences must still parse and block.
+func TestLLMReviewScript_FencedFindingsParse(t *testing.T) {
+	res := runLLMReviewScript(t, "```\n[P0] internal/foo.go:12 — nil deref on empty verdict\n```\n", emptyStatus, true)
+	if res.exitCode != 0 {
+		t.Fatalf("exit = %d, want 0 (a blocking finding is a successful run)\n%s", res.exitCode, res.output)
+	}
+	if len(callsMatching(res.calls, "state=failure", "context=llm-review-opus", "1 blocking")) == 0 {
+		t.Fatalf("no failure status with the blocking count for opus\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+	if len(callsMatching(res.calls, "pulls/7/comments", "[P0]")) == 0 {
+		t.Fatalf("no inline comment carrying the [P0] marker\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+}
+
+// P1-2 (glue side) regression: missing terra creds must post an explicit
+// error status — a silent skip left the pair half-observed and wedged the
+// Maestro gate forever.
+func TestLLMReviewScript_MissingTerraCredsPostsErrorStatus(t *testing.T) {
+	res := runLLMReviewScript(t, "NO_FINDINGS\n", emptyStatus, false)
+	if res.exitCode == 0 {
+		t.Fatalf("exit = 0, want non-zero when a configured model cannot run\n%s", res.output)
+	}
+	if len(callsMatching(res.calls, "state=error", "context=llm-review-terra", "skipped: credentials not configured")) == 0 {
+		t.Fatalf("no explicit skipped-creds error status for terra\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+	// The opus pass must still complete normally.
+	if len(callsMatching(res.calls, "state=success", "context=llm-review-opus")) == 0 {
+		t.Fatalf("opus did not finish despite terra being skipped\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+}
+
+// P2 regression: an error status is retryable, not settled — a re-run must
+// replace it. Only success/failure are the idempotency key.
+func TestLLMReviewScript_ErrorStatusIsNotSettled(t *testing.T) {
+	preexisting := `{"state":"error","statuses":[
+		{"context":"llm-review-opus","state":"error"},
+		{"context":"llm-review-terra","state":"pending"}]}`
+	res := runLLMReviewScript(t, "NO_FINDINGS\n", preexisting, true)
+	if res.exitCode != 0 {
+		t.Fatalf("exit = %d, want 0\n%s", res.exitCode, res.output)
+	}
+	for _, stream := range []string{"llm-review-opus", "llm-review-terra"} {
+		if len(callsMatching(res.calls, "state=success", "context="+stream)) == 0 {
+			t.Errorf("%s was not re-run over its error/stale-pending status\ncalls:\n%s", stream, strings.Join(res.calls, "\n"))
+		}
+	}
+}
+
+// A genuinely settled status (success or failure) still short-circuits.
+func TestLLMReviewScript_SettledStatusSkips(t *testing.T) {
+	preexisting := `{"state":"failure","statuses":[
+		{"context":"llm-review-opus","state":"success"},
+		{"context":"llm-review-terra","state":"failure"}]}`
+	res := runLLMReviewScript(t, "NO_FINDINGS\n", preexisting, true)
+	if res.exitCode != 0 {
+		t.Fatalf("exit = %d, want 0\n%s", res.exitCode, res.output)
+	}
+	if len(callsMatching(res.calls, "claude ")) != 0 {
+		t.Fatalf("a settled pair must not re-run any model\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+}
+
+// P2 regression (pending-first protocol): both models' pending statuses must
+// be on the head BEFORE any inline comment is posted, so Maestro can never
+// observe comments from a stream that has no status yet.
+func TestLLMReviewScript_PendingStatusesPrecedeComments(t *testing.T) {
+	res := runLLMReviewScript(t, "[P1] internal/foo.go:12 — leaked handle\n", emptyStatus, true)
+	if res.exitCode != 0 {
+		t.Fatalf("exit = %d, want 0\n%s", res.exitCode, res.output)
+	}
+	firstComment := -1
+	pendingIdx := map[string]int{}
+	for i, call := range res.calls {
+		if strings.Contains(call, "pulls/7/comments") && firstComment == -1 {
+			firstComment = i
+		}
+		for _, stream := range []string{"llm-review-opus", "llm-review-terra"} {
+			if strings.Contains(call, "state=pending") && strings.Contains(call, "context="+stream) {
+				if _, seen := pendingIdx[stream]; !seen {
+					pendingIdx[stream] = i
+				}
+			}
+		}
+	}
+	if firstComment == -1 {
+		t.Fatalf("no inline comment was posted\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+	for _, stream := range []string{"llm-review-opus", "llm-review-terra"} {
+		idx, ok := pendingIdx[stream]
+		if !ok {
+			t.Fatalf("no pending status for %s\ncalls:\n%s", stream, strings.Join(res.calls, "\n"))
+		}
+		if idx > firstComment {
+			t.Errorf("pending status for %s (call %d) landed after the first comment (call %d)", stream, idx, firstComment)
+		}
+	}
+}
+
+// P2 regression: a truncated diff must be visible in the final status
+// description — a verdict over partial input is weaker evidence.
+func TestLLMReviewScript_TruncationWarningInStatus(t *testing.T) {
+	res := runLLMReviewScript(t, "NO_FINDINGS\n", emptyStatus, true,
+		"LLM_REVIEW_MAX_DIFF_BYTES=10")
+	if res.exitCode != 0 {
+		t.Fatalf("exit = %d, want 0\n%s", res.exitCode, res.output)
+	}
+	if len(callsMatching(res.calls, "state=success", "context=llm-review-opus", "diff truncated")) == 0 {
+		t.Fatalf("final status description carries no truncation warning\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+}
+
+// P2 regression: the /llm-review comment trigger must be restricted to
+// member/owner/collaborator authors — anyone must not be able to spend
+// review tokens by commenting the magic string.
+func TestLLMReviewWorkflowCommentTriggerGatedOnAuthor(t *testing.T) {
+	p, err := filepath.Abs(filepath.Join("..", "..", ".github", "workflows", "llm-review.yml"))
+	if err != nil {
+		t.Fatalf("resolve workflow path: %v", err)
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	wf := string(data)
+	if !strings.Contains(wf, "github.event.comment.author_association") {
+		t.Fatal("workflow does not gate the comment trigger on author_association")
+	}
+	for _, role := range []string{"MEMBER", "OWNER", "COLLABORATOR"} {
+		if !strings.Contains(wf, fmt.Sprintf("%q", role)) {
+			t.Errorf("workflow author gate is missing the %s role", role)
+		}
+	}
+}

--- a/internal/github/llm_review_script_test.go
+++ b/internal/github/llm_review_script_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func llmReviewScriptPath(t *testing.T) string {
@@ -54,6 +55,10 @@ elif [[ "$cmd" == "api" ]]; then
                 prev="$a"
             done
             jq -r "$expr" < "$STUB_DIR/combined-status.json"
+            ;;
+        */statuses/*)
+            if [[ -n "${STUB_FAIL_STATUS_POST:-}" ]]; then exit 1; fi
+            exit 0
             ;;
         *)
             exit 0
@@ -233,6 +238,75 @@ func TestLLMReviewScript_ErrorStatusIsNotSettled(t *testing.T) {
 	}
 }
 
+// Crashed-pending self-heal (#1148 round 2): a pending status older than
+// REVIEW_PENDING_STALE_MINUTES means the run that posted it died mid-flight
+// — a re-run must treat it as retryable and replace it.
+func TestLLMReviewScript_StalePendingIsRetried(t *testing.T) {
+	stale := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
+	preexisting := fmt.Sprintf(`{"state":"pending","statuses":[
+		{"context":"llm-review-opus","state":"success","created_at":%q},
+		{"context":"llm-review-terra","state":"pending","created_at":%q}]}`, stale, stale)
+	res := runLLMReviewScript(t, "NO_FINDINGS\n", preexisting, true)
+	if res.exitCode != 0 {
+		t.Fatalf("exit = %d, want 0\n%s", res.exitCode, res.output)
+	}
+	if len(callsMatching(res.calls, "state=success", "context=llm-review-terra")) == 0 {
+		t.Fatalf("terra was not re-run over its stale pending status\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+	if len(callsMatching(res.calls, "state=pending", "context=llm-review-opus")) != 0 {
+		t.Fatalf("settled opus must not be re-run\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+}
+
+// The other side of the self-heal boundary: a FRESH pending (younger than the
+// stale threshold) means another run is mid-flight — skip instead of racing
+// it with duplicate reviews and comments.
+func TestLLMReviewScript_FreshPendingSkips(t *testing.T) {
+	fresh := time.Now().UTC().Add(-1 * time.Minute).Format(time.RFC3339)
+	preexisting := fmt.Sprintf(`{"state":"pending","statuses":[
+		{"context":"llm-review-opus","state":"success","created_at":%q},
+		{"context":"llm-review-terra","state":"pending","created_at":%q}]}`, fresh, fresh)
+	res := runLLMReviewScript(t, "NO_FINDINGS\n", preexisting, true)
+	if res.exitCode != 0 {
+		t.Fatalf("exit = %d, want 0 (a legitimate skip is not a failure)\n%s", res.exitCode, res.output)
+	}
+	if len(callsMatching(res.calls, "claude ")) != 0 {
+		t.Fatalf("a fresh pending must not trigger a duplicate model run\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+}
+
+// The threshold is env-overridable: with REVIEW_PENDING_STALE_MINUTES=1 even
+// a few-minutes-old pending is already stale and retried.
+func TestLLMReviewScript_PendingStaleMinutesOverride(t *testing.T) {
+	recent := time.Now().UTC().Add(-5 * time.Minute).Format(time.RFC3339)
+	preexisting := fmt.Sprintf(`{"state":"pending","statuses":[
+		{"context":"llm-review-opus","state":"success","created_at":%q},
+		{"context":"llm-review-terra","state":"pending","created_at":%q}]}`, recent, recent)
+	res := runLLMReviewScript(t, "NO_FINDINGS\n", preexisting, true,
+		"REVIEW_PENDING_STALE_MINUTES=1")
+	if res.exitCode != 0 {
+		t.Fatalf("exit = %d, want 0\n%s", res.exitCode, res.output)
+	}
+	if len(callsMatching(res.calls, "state=success", "context=llm-review-terra")) == 0 {
+		t.Fatalf("terra was not re-run with the lowered stale threshold\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+}
+
+// prepare_model conflation fix (#1148 round 2): a transient gh failure while
+// posting the pending status must abort the run with a non-zero exit — it is
+// NOT the settled-skip case, and a green no-op run here would hide a review
+// that never happened.
+func TestLLMReviewScript_PendingPostFailureAbortsNonZero(t *testing.T) {
+	res := runLLMReviewScript(t, "NO_FINDINGS\n", emptyStatus, true,
+		"STUB_FAIL_STATUS_POST=1")
+	if res.exitCode == 0 {
+		t.Fatalf("exit = 0, want non-zero when the pending status cannot be posted\n%s", res.output)
+	}
+	if len(callsMatching(res.calls, "claude ")) != 0 {
+		t.Fatalf("no model may run when phase 1 (pending-first) failed\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+}
+
 // A genuinely settled status (success or failure) still short-circuits.
 func TestLLMReviewScript_SettledStatusSkips(t *testing.T) {
 	preexisting := `{"state":"failure","statuses":[
@@ -316,5 +390,29 @@ func TestLLMReviewWorkflowCommentTriggerGatedOnAuthor(t *testing.T) {
 		if !strings.Contains(wf, fmt.Sprintf("%q", role)) {
 			t.Errorf("workflow author gate is missing the %s role", role)
 		}
+	}
+}
+
+// Crashed-pending self-heal, workflow side (#1148 round 2): one run per PR at
+// a time, superseded runs cancelled — a duplicate trigger must not race a
+// live run into posting conflicting statuses.
+func TestLLMReviewWorkflowHasPerPRConcurrencyGroup(t *testing.T) {
+	p, err := filepath.Abs(filepath.Join("..", "..", ".github", "workflows", "llm-review.yml"))
+	if err != nil {
+		t.Fatalf("resolve workflow path: %v", err)
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	wf := string(data)
+	if !strings.Contains(wf, "concurrency:") {
+		t.Fatal("workflow has no concurrency block")
+	}
+	if !strings.Contains(wf, "llm-review-${{ github.event.pull_request.number || github.event.issue.number }}") {
+		t.Fatal("concurrency group is not keyed per PR (pull_request.number || issue.number)")
+	}
+	if !strings.Contains(wf, "cancel-in-progress: true") {
+		t.Fatal("superseded runs must be cancelled (cancel-in-progress: true)")
 	}
 }

--- a/internal/github/llm_review_stream_test.go
+++ b/internal/github/llm_review_stream_test.go
@@ -1,0 +1,354 @@
+package github
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// --- severity parser (#1148: plain-text markers join the Greptile badges) ---
+
+func TestIsHighSeverity_PlainTextMarkers(t *testing.T) {
+	blocking := []string{
+		"[P0] internal/github/github.go:42 — nil deref on empty verdict",
+		"[P1] cmd/maestro/main.go:10 — leaked file handle",
+		"severity: P0 — data loss on restart",
+		"Severity: P1 — wrong stream attribution",
+		"severity:p1 compact form",
+	}
+	for _, body := range blocking {
+		if !isHighSeverity(body) {
+			t.Errorf("isHighSeverity(%q) = false, want true", body)
+		}
+	}
+	advisory := []string{
+		"[P2] internal/config/config.go:7 — naming nit",
+		"[P3] docs typo",
+		"severity: P2 — advisory only",
+		"looks good to me",
+		"",
+	}
+	for _, body := range advisory {
+		if isHighSeverity(body) {
+			t.Errorf("isHighSeverity(%q) = true, want false", body)
+		}
+	}
+}
+
+// Regression: the Greptile badge encodings must keep matching after the
+// plain-text extension.
+func TestIsHighSeverity_GreptileBadgesStillMatch(t *testing.T) {
+	badges := []string{
+		`<img alt="P0" src="x">`,
+		`<img alt="P1" src="x">`,
+		`https://img.shields.io/badge/P0-critical-red`,
+		`something/P1 marker`,
+	}
+	for _, body := range badges {
+		if !isHighSeverity(body) {
+			t.Errorf("isHighSeverity(%q) = false, want true (badge regression)", body)
+		}
+	}
+}
+
+func TestIsCriticalSeverity_PlainTextMarkers(t *testing.T) {
+	if !isCriticalSeverity("[P0] boom") {
+		t.Error("[P0] plain-text marker must read as critical")
+	}
+	if !isCriticalSeverity("severity: P0") {
+		t.Error("severity: P0 must read as critical")
+	}
+	if isCriticalSeverity("[P1] bad but not critical") {
+		t.Error("[P1] must not read as critical")
+	}
+	if isCriticalSeverity("[P2] nit") {
+		t.Error("[P2] must not read as critical")
+	}
+}
+
+// --- stream whitelist + pair alias ------------------------------------------
+
+func TestNormalizeReviewStreams_LLMReviewNames(t *testing.T) {
+	got := normalizeReviewStreams([]string{"llm-review-opus", "llm-review-terra", "greptile"})
+	want := []string{"llm-review-opus", "llm-review-terra", "greptile"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("normalizeReviewStreams = %v, want %v", got, want)
+	}
+}
+
+func TestNormalizeReviewStreams_PairAliasExpands(t *testing.T) {
+	got := normalizeReviewStreams([]string{"llm-review"})
+	want := []string{"llm-review-opus", "llm-review-terra"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("normalizeReviewStreams(llm-review) = %v, want %v", got, want)
+	}
+}
+
+func TestNormalizeReviewStreams_AliasDedupesAgainstExplicitNames(t *testing.T) {
+	got := normalizeReviewStreams([]string{"llm-review-opus", "llm-review"})
+	want := []string{"llm-review-opus", "llm-review-terra"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("normalizeReviewStreams = %v, want %v", got, want)
+	}
+}
+
+func TestStreamEnabled_LLMReviewAlias(t *testing.T) {
+	streams := []string{"llm-review"}
+	if !streamEnabled(streams, "llm-review-opus") || !streamEnabled(streams, "llm-review-terra") {
+		t.Fatal("the llm-review alias must enable both model streams")
+	}
+	if streamEnabled(streams, "greptile") {
+		t.Fatal("the llm-review alias must not enable greptile")
+	}
+}
+
+// --- external verdict decisions ---------------------------------------------
+
+func TestNamedCheckDecision_LLMReviewCheckNames(t *testing.T) {
+	checks := []greptileCheckRun{
+		{Name: "llm-review-opus", Status: "completed", Conclusion: "success"},
+		{Name: "llm-review-terra", Status: "completed", Conclusion: "failure"},
+	}
+	found, passed, pending := namedCheckDecision(checks, []string{"llm-review-opus"})
+	if !found || !passed || pending {
+		t.Fatalf("opus check: found=%v passed=%v pending=%v, want true/true/false", found, passed, pending)
+	}
+	found, passed, pending = namedCheckDecision(checks, []string{"llm-review-terra"})
+	if !found || passed || pending {
+		t.Fatalf("terra check: found=%v passed=%v pending=%v, want true/false/false", found, passed, pending)
+	}
+}
+
+func TestNamedStatusDecision_CommitStatusStates(t *testing.T) {
+	var combined combinedStatusResponse
+	combined.Statuses = []struct {
+		Context     string `json:"context"`
+		State       string `json:"state"`
+		Description string `json:"description"`
+		TargetURL   string `json:"target_url"`
+	}{
+		{Context: "llm-review-opus", State: "success"},
+		{Context: "llm-review-terra", State: "failure"},
+		{Context: "ci/build", State: "pending"},
+	}
+
+	found, passed, pending := namedStatusDecision(combined, []string{"llm-review-opus"})
+	if !found || !passed || pending {
+		t.Fatalf("opus status: found=%v passed=%v pending=%v, want true/true/false", found, passed, pending)
+	}
+	found, passed, pending = namedStatusDecision(combined, []string{"llm-review-terra"})
+	if !found || passed || pending {
+		t.Fatalf("terra status: found=%v passed=%v pending=%v, want true/false/false", found, passed, pending)
+	}
+	found, _, _ = namedStatusDecision(combined, []string{"llm-review-grok"})
+	if found {
+		t.Fatal("an absent context must not be found")
+	}
+	found, passed, pending = namedStatusDecision(combined, []string{"ci/build"})
+	if !found || passed || !pending {
+		t.Fatalf("pending status: found=%v passed=%v pending=%v, want true/false/true", found, passed, pending)
+	}
+}
+
+// --- inline finding attribution + severity contract --------------------------
+
+func llmComment(login, body, sha string) greptileReviewComment {
+	cm := greptileReviewComment{Body: body, Path: "internal/foo.go", Line: 12, CommitID: sha}
+	cm.User.Login = login
+	return cm
+}
+
+func TestFilterStreamFindings_LLMReviewBlocksOnlyHighSeverity(t *testing.T) {
+	spec := llmReviewStreamSpec("llm-review-opus")
+	sha := "headsha"
+	comments := []greptileReviewComment{
+		llmComment("okbot", "[P0] nil deref\n\n<sub>llm-review-opus @ headsha</sub>", sha),
+		llmComment("okbot", "[P2] naming nit\n\n<sub>llm-review-opus @ headsha</sub>", sha),
+		llmComment("okbot", "[P3] typo\n\n<sub>llm-review-opus @ headsha</sub>", sha),
+	}
+	findings := filterStreamFindings(comments, sha, spec)
+	if len(findings) != 1 {
+		t.Fatalf("findings = %d, want 1 (only the P0 blocks; P2/P3 stay advisory)", len(findings))
+	}
+	if !strings.Contains(findings[0].Body, "[P0]") {
+		t.Fatalf("finding body = %q, want the P0 comment", findings[0].Body)
+	}
+}
+
+func TestFilterStreamFindings_StreamMarkerAttribution(t *testing.T) {
+	spec := llmReviewStreamSpec("llm-review-opus")
+	sha := "headsha"
+	comments := []greptileReviewComment{
+		llmComment("okbot", "[P1] opus finding\n\n<sub>llm-review-opus @ headsha</sub>", sha),
+		llmComment("okbot", "[P1] terra finding\n\n<sub>llm-review-terra @ headsha</sub>", sha),
+	}
+	findings := filterStreamFindings(comments, sha, spec)
+	if len(findings) != 1 || !strings.Contains(findings[0].Body, "opus finding") {
+		t.Fatalf("findings = %+v, want only the opus-marked comment", findings)
+	}
+}
+
+func TestFilterStreamFindings_IgnoresOtherLoginsAndOldHeads(t *testing.T) {
+	spec := llmReviewStreamSpec("llm-review-opus")
+	comments := []greptileReviewComment{
+		llmComment("random-human", "[P0] scary but not the bot\n<sub>llm-review-opus</sub>", "headsha"),
+		llmComment("okbot", "[P0] stale head\n<sub>llm-review-opus</sub>", "oldsha"),
+	}
+	if findings := filterStreamFindings(comments, "headsha", spec); len(findings) != 0 {
+		t.Fatalf("findings = %+v, want none (wrong login / stale head)", findings)
+	}
+}
+
+func TestIsLLMReviewBotLogin(t *testing.T) {
+	for _, login := range []string{"okbot", "OKBot", "llm-review-bot", "acme-llm-review"} {
+		if !isLLMReviewBotLogin(login) {
+			t.Errorf("isLLMReviewBotLogin(%q) = false, want true", login)
+		}
+	}
+	for _, login := range []string{"greptile-apps[bot]", "kossoy", ""} {
+		if isLLMReviewBotLogin(login) {
+			t.Errorf("isLLMReviewBotLogin(%q) = true, want false", login)
+		}
+	}
+}
+
+// The llm-review bot is part of the actionable-feedback reviewer set.
+func TestIsReviewBotLogin_IncludesLLMReviewBot(t *testing.T) {
+	if !isReviewBotLogin("okbot") {
+		t.Fatal("okbot must count as a review bot login")
+	}
+	if !isReviewBotLogin("greptile-apps[bot]") {
+		t.Fatal("greptile regression: existing bot logins must keep matching")
+	}
+}
+
+// --- full verdict through the gh seam ----------------------------------------
+
+// stubLLMReviewAPI dispatches stubbed gh api responses by endpoint. Responses
+// are plain JSON bodies (no header block): resolveConditional trusts a
+// successful run's raw output, so nothing is etag-cached between tests.
+func stubLLMReviewAPI(t *testing.T, sha string, statuses string, comments string) {
+	t.Helper()
+	orig := ghAPIRunner
+	resetPrimaryLimitForTest()
+	ghAPIRunner = func(args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		switch {
+		case strings.Contains(joined, "/pulls/7/comments"):
+			return []byte(comments), nil
+		case strings.Contains(joined, "/check-runs"):
+			return []byte(`{"check_runs":[]}`), nil
+		case strings.Contains(joined, "/commits/"+sha+"/status"):
+			return []byte(statuses), nil
+		case strings.Contains(joined, "/pulls/7"):
+			return []byte(fmt.Sprintf(`{"number":7,"head":{"sha":%q}}`, sha)), nil
+		}
+		return nil, fmt.Errorf("unexpected gh call: %s", joined)
+	}
+	t.Cleanup(func() {
+		ghAPIRunner = orig
+		resetPrimaryLimitForTest()
+	})
+}
+
+func TestPRReviewGateVerdict_LLMReviewPairPassesOnGreenStatuses(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha,
+		`{"state":"success","statuses":[
+			{"context":"llm-review-opus","state":"success"},
+			{"context":"llm-review-terra","state":"success"}]}`,
+		`[]`)
+	c := &Client{Repo: "owner/repo"}
+	verdict, err := c.PRReviewGateVerdict(7, []string{"llm-review"})
+	if err != nil {
+		t.Fatalf("PRReviewGateVerdict: %v", err)
+	}
+	if !verdict.Passed || verdict.Pending {
+		t.Fatalf("verdict = %+v, want passed and not pending", verdict)
+	}
+	if !verdict.Observed {
+		t.Fatal("two green statuses must count as an observed gate")
+	}
+	if len(verdict.Streams) != 2 {
+		t.Fatalf("streams = %d, want 2 (opus + terra)", len(verdict.Streams))
+	}
+}
+
+func TestPRReviewGateVerdict_LLMReviewOneRedStatusBlocks(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha,
+		`{"state":"failure","statuses":[
+			{"context":"llm-review-opus","state":"success"},
+			{"context":"llm-review-terra","state":"failure"}]}`,
+		`[]`)
+	c := &Client{Repo: "owner/repo"}
+	verdict, err := c.PRReviewGateVerdict(7, []string{"llm-review"})
+	if err != nil {
+		t.Fatalf("PRReviewGateVerdict: %v", err)
+	}
+	if verdict.Passed {
+		t.Fatal("a red terra status must block the gate")
+	}
+	if verdict.Pending {
+		t.Fatal("a settled failure is not pending")
+	}
+}
+
+func TestPRReviewGateVerdict_LLMReviewP0CommentBlocksDespiteGreenStatus(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha,
+		`{"state":"success","statuses":[
+			{"context":"llm-review-opus","state":"success"},
+			{"context":"llm-review-terra","state":"success"}]}`,
+		`[{"body":"[P0] nil deref\n\n<sub>llm-review-opus @ abcdef123456</sub>",
+		   "path":"internal/foo.go","line":3,"commit_id":"abcdef1234567890",
+		   "user":{"login":"okbot"}}]`)
+	c := &Client{Repo: "owner/repo"}
+	verdict, err := c.PRReviewGateVerdict(7, []string{"llm-review"})
+	if err != nil {
+		t.Fatalf("PRReviewGateVerdict: %v", err)
+	}
+	if verdict.Passed {
+		t.Fatal("a P0 inline finding must block even when the statuses are green")
+	}
+}
+
+func TestPRReviewGateVerdict_LLMReviewAbsentStatusesArePending(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha, `{"state":"pending","statuses":[]}`, `[]`)
+	c := &Client{Repo: "owner/repo"}
+	verdict, err := c.PRReviewGateVerdict(7, []string{"llm-review"})
+	if err != nil {
+		t.Fatalf("PRReviewGateVerdict: %v", err)
+	}
+	if !verdict.Pending {
+		t.Fatal("a silent llm-review gate must read as pending")
+	}
+	if verdict.Observed {
+		t.Fatal("no status, no check run, no comment — the gate was not observed (missing_after_minutes owns the escape)")
+	}
+	if verdict.LookupFailed {
+		t.Fatal("clean reads must not be marked as lookup failures")
+	}
+}
+
+// PRBlockingReviewFindingsOnHead is what scopes the auto-review-repair prompt.
+func TestPRBlockingReviewFindingsOnHead_LLMReviewOnlyHighSeverity(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha, `{"state":"success","statuses":[]}`,
+		`[{"body":"[P1] leaked handle\n<sub>llm-review-terra</sub>","path":"a.go","line":1,
+		   "commit_id":"abcdef1234567890","user":{"login":"okbot"}},
+		  {"body":"[P2] nit\n<sub>llm-review-terra</sub>","path":"a.go","line":2,
+		   "commit_id":"abcdef1234567890","user":{"login":"okbot"}}]`)
+	c := &Client{Repo: "owner/repo"}
+	_, findings, has, err := c.PRBlockingReviewFindingsOnHead(7, []string{"llm-review"})
+	if err != nil {
+		t.Fatalf("PRBlockingReviewFindingsOnHead: %v", err)
+	}
+	if !has || len(findings) != 1 {
+		t.Fatalf("findings = %+v, want exactly the P1", findings)
+	}
+	if !strings.Contains(findings[0].Body, "[P1]") {
+		t.Fatalf("finding = %q, want the P1 comment", findings[0].Body)
+	}
+}

--- a/internal/github/llm_review_stream_test.go
+++ b/internal/github/llm_review_stream_test.go
@@ -212,13 +212,138 @@ func TestIsLLMReviewBotLogin(t *testing.T) {
 	}
 }
 
-// The llm-review bot is part of the actionable-feedback reviewer set.
-func TestIsReviewBotLogin_IncludesLLMReviewBot(t *testing.T) {
-	if !isReviewBotLogin("okbot") {
-		t.Fatal("okbot must count as a review bot login")
+// #1148 review round 1, P1-3: the llm-review bot logins must NOT be part of
+// the global reviewer set. The glue posts as the fleet bot ("okbot"), which
+// also comments on PRs for reasons that have nothing to do with reviews;
+// folding it into isReviewBotLogin made every fleet-bot comment with a
+// file:line reference look like review feedback on ALL projects, including
+// greptile-gated rows, and triggered retry/close churn.
+func TestIsReviewBotLogin_ExcludesLLMReviewBot(t *testing.T) {
+	for _, login := range []string{"okbot", "OKBot", "llm-review-bot"} {
+		if isReviewBotLogin(login) {
+			t.Errorf("isReviewBotLogin(%q) = true, want false — llm-review logins are stream-scoped, not global", login)
+		}
 	}
 	if !isReviewBotLogin("greptile-apps[bot]") {
 		t.Fatal("greptile regression: existing bot logins must keep matching")
+	}
+	if !isReviewBotLogin("chatgpt-codex-connector[bot]") {
+		t.Fatal("codex regression: existing bot logins must keep matching")
+	}
+}
+
+// P1-3 regression through the real collector: a fleet-bot-style comment with a
+// file:line position on a greptile row must NOT be collected as review
+// feedback (pre-PR behavior), while a genuine Greptile comment still is.
+func TestCollectReviewFeedback_FleetBotCommentNotCollected(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha, `{"state":"success","statuses":[]}`,
+		`[{"body":"deploy note: rollout toggle lives in internal/foo.go:12",
+		   "path":"internal/foo.go","line":12,"commit_id":"abcdef1234567890",
+		   "user":{"login":"okbot"}},
+		  {"body":"[P1] leaked handle","path":"a.go","line":3,
+		   "commit_id":"abcdef1234567890","user":{"login":"greptile-apps[bot]"}}]`)
+	c := &Client{Repo: "owner/repo"}
+	feedback, err := c.CollectReviewFeedback(7)
+	if err != nil {
+		t.Fatalf("CollectReviewFeedback: %v", err)
+	}
+	if len(feedback) != 1 {
+		t.Fatalf("feedback = %+v, want exactly the greptile comment — fleet-bot comments must not be review feedback", feedback)
+	}
+	if feedback[0].User != "greptile-apps[bot]" {
+		t.Fatalf("feedback user = %q, want greptile-apps[bot]", feedback[0].User)
+	}
+}
+
+// --- convergence-merge critical check (#565 escape × #1148 streams) ----------
+
+// P1-1 regression: on an llm-review row, the bot's P0 on head must hard-block
+// the convergence merge exactly like a Greptile P0 does.
+func TestPRHasCriticalReviewOnHead_LLMReviewP0Blocks(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha, `{"state":"success","statuses":[]}`,
+		`[{"body":"[P0] nil deref\n\n<sub>llm-review-opus @ abcdef123456</sub>",
+		   "path":"internal/foo.go","line":3,"commit_id":"abcdef1234567890",
+		   "user":{"login":"okbot"}}]`)
+	c := &Client{Repo: "owner/repo"}
+	critical, err := c.PRHasCriticalReviewOnHead(7, []string{"llm-review"})
+	if err != nil {
+		t.Fatalf("PRHasCriticalReviewOnHead: %v", err)
+	}
+	if !critical {
+		t.Fatal("an llm-review P0 on head must block the convergence merge")
+	}
+}
+
+// P0/P1 is the llm-review gate's entire blocking contract, so a P1 blocks the
+// convergence escape too (unlike greptile, where only P0 is critical).
+func TestPRHasCriticalReviewOnHead_LLMReviewP1Blocks(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha, `{"state":"success","statuses":[]}`,
+		`[{"body":"[P1] auth bypass on the retry path\n\n<sub>llm-review-terra @ abcdef123456</sub>",
+		   "path":"internal/foo.go","line":3,"commit_id":"abcdef1234567890",
+		   "user":{"login":"okbot"}}]`)
+	c := &Client{Repo: "owner/repo"}
+	critical, err := c.PRHasCriticalReviewOnHead(7, []string{"llm-review"})
+	if err != nil {
+		t.Fatalf("PRHasCriticalReviewOnHead: %v", err)
+	}
+	if !critical {
+		t.Fatal("an llm-review P1 on head must block the convergence merge — P0/P1 is that gate's blocking contract")
+	}
+}
+
+// Advisory llm-review findings (P2/P3) must not block the convergence escape.
+func TestPRHasCriticalReviewOnHead_LLMReviewAdvisoryDoesNotBlock(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha, `{"state":"success","statuses":[]}`,
+		`[{"body":"[P2] naming nit\n\n<sub>llm-review-opus @ abcdef123456</sub>",
+		   "path":"internal/foo.go","line":3,"commit_id":"abcdef1234567890",
+		   "user":{"login":"okbot"}}]`)
+	c := &Client{Repo: "owner/repo"}
+	critical, err := c.PRHasCriticalReviewOnHead(7, []string{"llm-review"})
+	if err != nil {
+		t.Fatalf("PRHasCriticalReviewOnHead: %v", err)
+	}
+	if critical {
+		t.Fatal("a P2 advisory finding must not block the convergence merge")
+	}
+}
+
+// The stream scoping cuts both ways: on a greptile row a fleet-bot P0-looking
+// comment is not part of the gate and must not block, while a Greptile P0
+// still does (and P1 stays non-critical for greptile).
+func TestPRHasCriticalReviewOnHead_StreamScoping(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha, `{"state":"success","statuses":[]}`,
+		`[{"body":"[P0] scary-looking fleet-bot note",
+		   "path":"internal/foo.go","line":3,"commit_id":"abcdef1234567890",
+		   "user":{"login":"okbot"}},
+		  {"body":"<img alt=\"P1\" src=\"x\"> real greptile finding","path":"a.go","line":4,
+		   "commit_id":"abcdef1234567890","user":{"login":"greptile-apps[bot]"}}]`)
+	c := &Client{Repo: "owner/repo"}
+	critical, err := c.PRHasCriticalReviewOnHead(7, []string{"greptile"})
+	if err != nil {
+		t.Fatalf("PRHasCriticalReviewOnHead: %v", err)
+	}
+	if critical {
+		t.Fatal("greptile row: a fleet-bot comment must not block, and a greptile P1 is not critical")
+	}
+}
+
+func TestPRHasCriticalReviewOnHead_GreptileP0StillBlocks(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha, `{"state":"success","statuses":[]}`,
+		`[{"body":"<img alt=\"P0\" src=\"x\"> data loss on restart","path":"a.go","line":4,
+		   "commit_id":"abcdef1234567890","user":{"login":"greptile-apps[bot]"}}]`)
+	c := &Client{Repo: "owner/repo"}
+	critical, err := c.PRHasCriticalReviewOnHead(7, []string{"greptile"})
+	if err != nil {
+		t.Fatalf("PRHasCriticalReviewOnHead: %v", err)
+	}
+	if !critical {
+		t.Fatal("greptile P0 regression: the legacy critical block must keep working")
 	}
 }
 

--- a/internal/github/llm_review_stream_test.go
+++ b/internal/github/llm_review_stream_test.go
@@ -244,7 +244,7 @@ func TestCollectReviewFeedback_FleetBotCommentNotCollected(t *testing.T) {
 		  {"body":"[P1] leaked handle","path":"a.go","line":3,
 		   "commit_id":"abcdef1234567890","user":{"login":"greptile-apps[bot]"}}]`)
 	c := &Client{Repo: "owner/repo"}
-	feedback, err := c.CollectReviewFeedback(7)
+	feedback, err := c.CollectReviewFeedback(7, []string{"greptile"})
 	if err != nil {
 		t.Fatalf("CollectReviewFeedback: %v", err)
 	}
@@ -253,6 +253,51 @@ func TestCollectReviewFeedback_FleetBotCommentNotCollected(t *testing.T) {
 	}
 	if feedback[0].User != "greptile-apps[bot]" {
 		t.Fatalf("feedback user = %q, want greptile-apps[bot]", feedback[0].User)
+	}
+}
+
+// #1148 round 2, P1 — the complement of the fleet-bot regression above: on a
+// row whose configured streams include llm-review, the bot's [P0] inline
+// finding MUST be collected as review feedback. Round 1 removed okbot from
+// the global reviewer set without adding the stream-scoped path, which left
+// feedback permanently empty on llm-review rows: AutoRetryReviewFeedback
+// never fired, sessions never reached retry_exhausted, and convergence
+// (#565), review-repair, and the exhaustion notification were unreachable.
+func TestCollectReviewFeedback_LLMReviewRowCollectsBotFinding(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha, `{"state":"success","statuses":[]}`,
+		`[{"body":"[P0] nil deref on empty verdict\n\n<sub>llm-review-opus @ abcdef123456</sub>",
+		   "path":"internal/foo.go","line":12,"commit_id":"abcdef1234567890",
+		   "user":{"login":"okbot"}}]`)
+	c := &Client{Repo: "owner/repo"}
+	feedback, err := c.CollectReviewFeedback(7, []string{"llm-review"})
+	if err != nil {
+		t.Fatalf("CollectReviewFeedback: %v", err)
+	}
+	if len(feedback) != 1 {
+		t.Fatalf("feedback = %+v, want the bot's P0 finding — the llm-review repair circuit depends on it", feedback)
+	}
+	if feedback[0].User != "okbot" || !strings.Contains(feedback[0].Body, "[P0]") {
+		t.Fatalf("feedback = %+v, want the okbot [P0] comment", feedback[0])
+	}
+}
+
+// Same circuit one level up: CollectPRReviewFeedback on an llm-review row
+// returns a non-empty prompt-ready string for a bot [P0] inline finding, so
+// the orchestrator's AutoRetryReviewFeedback path has something to act on.
+func TestCollectPRReviewFeedback_LLMReviewRowFeedbackNonEmpty(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha, `{"state":"success","statuses":[]}`,
+		`[{"body":"[P0] nil deref on empty verdict\n\n<sub>llm-review-opus @ abcdef123456</sub>",
+		   "path":"internal/foo.go","line":12,"commit_id":"abcdef1234567890",
+		   "user":{"login":"okbot"}}]`)
+	c := &Client{Repo: "owner/repo"}
+	feedback, err := c.CollectPRReviewFeedback(7, []string{"llm-review"})
+	if err != nil {
+		t.Fatalf("CollectPRReviewFeedback: %v", err)
+	}
+	if !strings.Contains(feedback, "[P0]") || !strings.Contains(feedback, "internal/foo.go") {
+		t.Fatalf("feedback = %q, want the formatted P0 finding with its path", feedback)
 	}
 }
 
@@ -332,6 +377,26 @@ func TestPRHasCriticalReviewOnHead_StreamScoping(t *testing.T) {
 	}
 }
 
+// #1148 round 2, P2: a Greptile P0 on head blocks the convergence merge even
+// when greptile is NOT among the configured streams. The Greptile app keeps
+// reviewing repos it is installed on after a project row migrates to another
+// gate; the stream migration must not silently downgrade its P0 from
+// hard-block to advisory.
+func TestPRHasCriticalReviewOnHead_GreptileP0BlocksOutsideConfiguredStreams(t *testing.T) {
+	sha := "abcdef1234567890"
+	stubLLMReviewAPI(t, sha, `{"state":"success","statuses":[]}`,
+		`[{"body":"<img alt=\"P0\" src=\"x\"> data loss on restart","path":"a.go","line":4,
+		   "commit_id":"abcdef1234567890","user":{"login":"greptile-apps[bot]"}}]`)
+	c := &Client{Repo: "owner/repo"}
+	critical, err := c.PRHasCriticalReviewOnHead(7, []string{"simplicity"})
+	if err != nil {
+		t.Fatalf("PRHasCriticalReviewOnHead: %v", err)
+	}
+	if !critical {
+		t.Fatal("a greptile P0 must block unconditionally — migration off the greptile stream must not downgrade it")
+	}
+}
+
 func TestPRHasCriticalReviewOnHead_GreptileP0StillBlocks(t *testing.T) {
 	sha := "abcdef1234567890"
 	stubLLMReviewAPI(t, sha, `{"state":"success","statuses":[]}`,
@@ -361,6 +426,8 @@ func stubLLMReviewAPI(t *testing.T, sha string, statuses string, comments string
 		switch {
 		case strings.Contains(joined, "/pulls/7/comments"):
 			return []byte(comments), nil
+		case strings.Contains(joined, "/issues/7/comments"):
+			return []byte(`[]`), nil
 		case strings.Contains(joined, "/check-runs"):
 			return []byte(`{"check_runs":[]}`), nil
 		case strings.Contains(joined, "/commits/"+sha+"/status"):

--- a/internal/orchestrator/attribution_merge_guard_test.go
+++ b/internal/orchestrator/attribution_merge_guard_test.go
@@ -180,7 +180,7 @@ func TestAutoMergePRs_ConcurrentWorkerPushWithNarrowFetchDoesNotRewriteOrStarveR
 	}
 	o.ghPRHeadSHAFn = func(int) (string, error) { return currentHead, nil }
 	feedbackReads := 0
-	o.ghCollectPRReviewFeedbackFn = func(int) (string, error) {
+	o.ghCollectPRReviewFeedbackFn = func(int, []string) (string, error) {
 		feedbackReads++
 		if feedbackReads == 1 {
 			currentHead = advanceAttributionGuardBranch(t, origin, branch)

--- a/internal/orchestrator/failing_check_test.go
+++ b/internal/orchestrator/failing_check_test.go
@@ -304,7 +304,7 @@ func TestHandleCIFailureRetry_CapturesFailingCheck(t *testing.T) {
 			cfg:                         &config.Config{Repo: "owner/repo", MaxRetriesPerIssue: 3, MaxRetryBackoffMs: 300000},
 			notifier:                    &notify.Notifier{},
 			ghPRChecksOutputFn:          func(int) (string, error) { return "agent-lint\tfailure\nbuild\tsuccess\n", nil },
-			ghCollectPRReviewFeedbackFn: func(int) (string, error) { return "", nil },
+			ghCollectPRReviewFeedbackFn: func(int, []string) (string, error) { return "", nil },
 			ghPRFailingChecksFn:         func(int) ([]github.FailingCheck, error) { return failing, nil },
 			ghClosePRFn:                 func(int, string) error { return nil },
 			workerStopFn:                func(*config.Config, string, *state.Session) error { return nil },

--- a/internal/orchestrator/llm_review_gate_test.go
+++ b/internal/orchestrator/llm_review_gate_test.go
@@ -1,0 +1,180 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+)
+
+// llmReviewTestConfig is a project on the #1148 llm-review gate (opus + terra
+// pair) with the bounded absent-reviewer escape configured.
+func llmReviewTestConfig() *config.Config {
+	cfg := &config.Config{
+		Repo:              "owner/repo",
+		ReviewGate:        "llm-review",
+		ReviewGateStreams: []string{"llm-review-opus", "llm-review-terra"},
+	}
+	return cfg
+}
+
+func llmPendingVerdict(observed bool) github.ReviewGateVerdict {
+	return github.ReviewGateVerdict{
+		Passed:   false,
+		Pending:  true,
+		Observed: observed,
+		Streams: []github.ReviewStreamVerdict{
+			{Name: "llm-review-opus", Pending: true, Observed: observed},
+			{Name: "llm-review-terra", Pending: true, Observed: observed},
+		},
+	}
+}
+
+// The "@greptile review" re-trigger comment is greptile-specific: a pending
+// llm-review stream must never post it — the generic bounded escape
+// (review_retrigger.missing_after_minutes, #1115) owns the absent-reviewer
+// case for these streams.
+func TestReviewRetrigger_LLMReviewPendingStreamDoesNotPostGreptileComment(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	o, comments := newRetriggerTestOrchestrator(llmReviewTestConfig(), prs, "abc123def456789")
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return llmPendingVerdict(false), nil
+	}
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(45 * time.Minute) // far past the 10m default threshold
+
+	o.autoMergePRs(s)
+
+	if len(*comments) != 0 {
+		t.Fatalf("comments = %v, want none — the greptile nudge must not fire for llm-review streams", *comments)
+	}
+}
+
+// End-to-end #1148 acceptance: an llm-review gate that has produced no signal
+// at all on the head for longer than missing_after_minutes yields the
+// non-blocking escape and the green PR merges.
+func TestAutoMergePRs_LLMReviewAbsentPastGraceMerges(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := llmReviewTestConfig()
+	cfg.ReviewRetrigger.MissingAfterMinutes = 60
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return llmPendingVerdict(false), nil // silent: no status, no check, no comment
+	}
+	o.ghPRHeadSHAFn = func(int) (string, error) { return "abc123def456789", nil }
+
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(90 * time.Minute)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 1 || (*merged)[0] != 10 {
+		t.Fatalf("merged = %v, want PR #10 merged past the absent llm-review gate", *merged)
+	}
+}
+
+// Inside the grace the PR keeps waiting — the escape is bounded, not a bypass.
+func TestAutoMergePRs_LLMReviewAbsentInsideGraceWaits(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := llmReviewTestConfig()
+	cfg.ReviewRetrigger.MissingAfterMinutes = 60
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return llmPendingVerdict(false), nil
+	}
+	o.ghPRHeadSHAFn = func(int) (string, error) { return "abc123def456789", nil }
+
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(10 * time.Minute)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 0 {
+		t.Fatalf("merged = %v, want none inside the grace window", *merged)
+	}
+}
+
+// An llm-review stream that actually spoke (pending status observed on the
+// head) never expires: only true silence is bounded.
+func TestAutoMergePRs_LLMReviewObservedPendingNeverExpires(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := llmReviewTestConfig()
+	cfg.ReviewRetrigger.MissingAfterMinutes = 60
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return llmPendingVerdict(true), nil // the reviewer is alive and working
+	}
+	o.ghPRHeadSHAFn = func(int) (string, error) { return "abc123def456789", nil }
+
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(48 * time.Hour)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 0 {
+		t.Fatalf("merged = %v, want none — an observed reviewer must keep blocking", *merged)
+	}
+}
+
+// A settled llm-review rejection blocks the merge outright.
+func TestAutoMergePRs_LLMReviewRejectionBlocks(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := llmReviewTestConfig()
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return github.ReviewGateVerdict{
+			Passed:   false,
+			Pending:  false,
+			Observed: true,
+			Streams: []github.ReviewStreamVerdict{
+				{Name: "llm-review-opus", Passed: true, Observed: true},
+				{Name: "llm-review-terra", Passed: false, Observed: true,
+					Findings: []github.ReviewComment{{Path: "a.go", Line: 3, Body: "[P0] boom", User: "okbot"}}},
+			},
+		}, nil
+	}
+	o.ghPRHeadSHAFn = func(int) (string, error) { return "abc123def456789", nil }
+
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 0 {
+		t.Fatalf("merged = %v, want none — a P0 rejection must block", *merged)
+	}
+}
+
+// Both streams green — the pair gate passes and the PR merges.
+func TestAutoMergePRs_LLMReviewPairGreenMerges(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := llmReviewTestConfig()
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return github.ReviewGateVerdict{
+			Passed:   true,
+			Observed: true,
+			Streams: []github.ReviewStreamVerdict{
+				{Name: "llm-review-opus", Passed: true, Observed: true},
+				{Name: "llm-review-terra", Passed: true, Observed: true},
+			},
+		}, nil
+	}
+	o.ghPRHeadSHAFn = func(int) (string, error) { return "abc123def456789", nil }
+
+	s := makeTestState(prs)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 1 || (*merged)[0] != 10 {
+		t.Fatalf("merged = %v, want PR #10", *merged)
+	}
+}

--- a/internal/orchestrator/llm_review_gate_test.go
+++ b/internal/orchestrator/llm_review_gate_test.go
@@ -1,11 +1,14 @@
 package orchestrator
 
 import (
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
 )
 
 // llmReviewTestConfig is a project on the #1148 llm-review gate (opus + terra
@@ -330,6 +333,65 @@ func TestAutoMergePRs_HalfObservedPairWaitsInsideGrace(t *testing.T) {
 
 	if len(*merged) != 0 {
 		t.Fatalf("merged = %v, want none inside the grace window", *merged)
+	}
+}
+
+// #1148 round 2, P1 — the repair circuit end to end at the orchestrator: on
+// an llm-review row a bot [P0] inline finding must reach the retry pipeline.
+// collectPRReviewFeedback threads the configured streams into the collector,
+// the feedback comes back non-empty, and handleReviewFeedbackRetry schedules
+// the bounded review repair. Round 1 left this circuit dead: with okbot out
+// of the global reviewer set and no stream-scoped path, feedback was always
+// empty on llm-review rows, so retries, retry_exhausted, convergence (#565)
+// and the exhaustion notification were all unreachable.
+func TestAutoMergePRs_LLMReviewBotFindingEntersRetryPipeline(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a", Mergeable: "MERGEABLE"}}
+	cfg := llmReviewTestConfig()
+	cfg.MergeStrategy = "parallel"
+	cfg.AutoRetryReviewFeedback = true
+	cfg.MaxRetriesPerIssue = 3
+	cfg.MaxRetryBackoffMs = 300000
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	head := strings.Repeat("a", 40)
+	o.ghPRCheckRollupFn = func(int) (github.PRCheckRollup, error) {
+		return github.PRCheckRollup{HeadSHA: head, Verdict: "success", Fingerprint: strings.Repeat("1", 16), Complete: true}, nil
+	}
+	o.ghPRHeadSHAFn = func(int) (string, error) { return head, nil }
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return github.ReviewGateVerdict{
+			Passed:   false,
+			Observed: true,
+			Streams: []github.ReviewStreamVerdict{
+				{Name: "llm-review-opus", Passed: false, Observed: true, Verdict: "repair_required",
+					Findings: []github.ReviewComment{{Path: "internal/foo.go", Line: 12, Body: "[P0] nil deref", User: "okbot"}}},
+				{Name: "llm-review-terra", Passed: true, Observed: true},
+			},
+		}, nil
+	}
+	var collectedStreams []string
+	o.ghCollectPRReviewFeedbackFn = func(_ int, streams []string) (string, error) {
+		collectedStreams = streams
+		return "## Review Feedback\n\ninternal/foo.go:12 [P0] nil deref (okbot)", nil
+	}
+	st := makeTestState(prs)
+	st.Sessions["slot-0"].Worktree = "/tmp/maestro-slot-0"
+
+	o.autoMergePRs(st)
+
+	if len(*merged) != 0 {
+		t.Fatalf("a blocking llm-review finding must not merge: %v", *merged)
+	}
+	for _, stream := range []string{"llm-review-opus", "llm-review-terra"} {
+		if !slices.Contains(collectedStreams, stream) {
+			t.Fatalf("collector streams = %v, want %s threaded from the project config", collectedStreams, stream)
+		}
+	}
+	sess := st.Sessions["slot-0"]
+	if sess.Status != state.StatusDead || sess.MaintenanceRetryCount != 1 || sess.NextRetryAt == nil {
+		t.Fatalf("bounded review repair not scheduled: status=%q maintenance=%d next=%v", sess.Status, sess.MaintenanceRetryCount, sess.NextRetryAt)
+	}
+	if !strings.Contains(sess.PreviousAttemptFeedback, "internal/foo.go:12") {
+		t.Fatalf("repair context lost the concrete finding: %q", sess.PreviousAttemptFeedback)
 	}
 }
 

--- a/internal/orchestrator/llm_review_gate_test.go
+++ b/internal/orchestrator/llm_review_gate_test.go
@@ -153,6 +153,186 @@ func TestAutoMergePRs_LLMReviewRejectionBlocks(t *testing.T) {
 	}
 }
 
+// llmHalfObservedVerdict is the #1148 review round 1 P1-2 shape: opus settled
+// green, terra never reported anything. Aggregate: Pending (terra) + Observed
+// (opus) — the state that used to wedge forever.
+func llmHalfObservedVerdict() github.ReviewGateVerdict {
+	return github.ReviewGateVerdict{
+		Passed:   false,
+		Pending:  true,
+		Observed: true,
+		Streams: []github.ReviewStreamVerdict{
+			{Name: "llm-review-opus", Passed: true, Observed: true},
+			{Name: "llm-review-terra", Pending: true, Observed: false},
+		},
+	}
+}
+
+// P1-2 regression (unit): one stream settled green, the other silent past the
+// grace — the silent stream must expire instead of the aggregate Observed bit
+// blocking the escape forever.
+func TestMissingReviewGateElapsed_HalfObservedPairExpires(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	sess := pendingSince(90*time.Minute, now)
+	verdict := llmHalfObservedVerdict()
+
+	// Realistic flow: the tracker has already recorded the observed opus
+	// stream (aggregate sticky bit AND per-stream memory) on this head.
+	o.trackReviewGateHead(sess, "deadbeef", verdict, now)
+	if !sess.ReviewGateObserved || !sess.ReviewGateStreamObserved["llm-review-opus"] {
+		t.Fatal("precondition: the opus observation was not recorded")
+	}
+
+	silentFor, missing := o.missingReviewGateElapsed(sess, verdict, now)
+	if !missing {
+		t.Fatal("half-observed pair: the never-reporting stream must stop blocking past the grace")
+	}
+	if silentFor < 89*time.Minute {
+		t.Fatalf("silentFor = %v, want ~90m", silentFor)
+	}
+}
+
+// An OBSERVED pending stream still hard-blocks at any duration — only true
+// per-stream silence is bounded.
+func TestMissingReviewGateElapsed_ObservedPendingStreamNeverExpires(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	sess := pendingSince(48*time.Hour, now)
+	verdict := github.ReviewGateVerdict{
+		Passed:   false,
+		Pending:  true,
+		Observed: true,
+		Streams: []github.ReviewStreamVerdict{
+			{Name: "llm-review-opus", Passed: true, Observed: true},
+			{Name: "llm-review-terra", Pending: true, Observed: true}, // pending status posted
+		},
+	}
+	o.trackReviewGateHead(sess, "deadbeef", verdict, now)
+
+	if _, missing := o.missingReviewGateElapsed(sess, verdict, now); missing {
+		t.Fatal("a stream that posted a pending signal must keep blocking regardless of elapsed time")
+	}
+}
+
+// Sticky per-stream memory: a stream seen once on this head keeps blocking
+// even when a later read comes back unobserved for it.
+func TestMissingReviewGateElapsed_StickyStreamObservationBlocksExpiry(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	sess := pendingSince(90*time.Minute, now)
+
+	// terra was genuinely observed pending earlier on this head.
+	o.trackReviewGateHead(sess, "deadbeef", github.ReviewGateVerdict{
+		Pending: true, Observed: true,
+		Streams: []github.ReviewStreamVerdict{
+			{Name: "llm-review-opus", Passed: true, Observed: true},
+			{Name: "llm-review-terra", Pending: true, Observed: true},
+		},
+	}, now)
+
+	// This cycle's read degrades terra to unobserved (e.g. the statuses read
+	// fell through) — the sticky memory must keep blocking.
+	if _, missing := o.missingReviewGateElapsed(sess, llmHalfObservedVerdict(), now); missing {
+		t.Fatal("a single unobserved read expired a stream that was observed earlier on the same head")
+	}
+}
+
+// A settled REJECTION from any stream disables the escape outright: merging
+// past an absent reviewer must never also merge past a live red verdict.
+func TestMissingReviewGateElapsed_SettledFailureBlocksEscape(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	sess := pendingSince(90*time.Minute, now)
+	verdict := github.ReviewGateVerdict{
+		Passed:   false,
+		Pending:  true,
+		Observed: true,
+		Streams: []github.ReviewStreamVerdict{
+			{Name: "llm-review-opus", Passed: false, Observed: true}, // settled red
+			{Name: "llm-review-terra", Pending: true, Observed: false},
+		},
+	}
+	o.trackReviewGateHead(sess, "deadbeef", verdict, now)
+
+	if _, missing := o.missingReviewGateElapsed(sess, verdict, now); missing {
+		t.Fatal("the absent-stream escape must not merge past a settled failing stream")
+	}
+}
+
+// State written by a pre-#1148 binary: aggregate sticky bit set, no per-stream
+// attribution. Must stay conservative and keep blocking.
+func TestMissingReviewGateElapsed_LegacyAggregateStickyBlocks(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	sess := pendingSince(90*time.Minute, now)
+	sess.ReviewGateObserved = true // old binary recorded this without a map
+
+	if _, missing := o.missingReviewGateElapsed(sess, llmHalfObservedVerdict(), now); missing {
+		t.Fatal("aggregate-only sticky state must be treated as observed, not expired")
+	}
+}
+
+// A head change resets the per-stream memory together with the aggregate bit.
+func TestTrackReviewGateHead_NewHeadResetsStreamMemory(t *testing.T) {
+	now := time.Now().UTC()
+	o := missingReviewOrchestrator(60)
+	sess := pendingSince(90*time.Minute, now)
+	sess.ReviewGateStreamObserved = map[string]bool{"llm-review-opus": true}
+
+	o.trackReviewGateHead(sess, "cafebabe", github.ReviewGateVerdict{Pending: true}, now)
+
+	if len(sess.ReviewGateStreamObserved) != 0 {
+		t.Fatalf("stream memory = %v, want empty after a head change", sess.ReviewGateStreamObserved)
+	}
+}
+
+// P1-2 regression (end to end): the half-observed pair merges past the grace
+// through autoMergePRs, and waits inside it.
+func TestAutoMergePRs_HalfObservedPairMergesPastGrace(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := llmReviewTestConfig()
+	cfg.ReviewRetrigger.MissingAfterMinutes = 60
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return llmHalfObservedVerdict(), nil
+	}
+	o.ghPRHeadSHAFn = func(int) (string, error) { return "abc123def456789", nil }
+
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(90 * time.Minute)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 1 || (*merged)[0] != 10 {
+		t.Fatalf("merged = %v, want PR #10 — a stream that never reported must not wedge the PR forever", *merged)
+	}
+}
+
+func TestAutoMergePRs_HalfObservedPairWaitsInsideGrace(t *testing.T) {
+	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}
+	cfg := llmReviewTestConfig()
+	cfg.ReviewRetrigger.MissingAfterMinutes = 60
+	o, merged := newMergeTestOrchestrator(cfg, prs)
+	o.ghPRReviewGateVerdictFn = func(int, []string) (github.ReviewGateVerdict, error) {
+		return llmHalfObservedVerdict(), nil
+	}
+	o.ghPRHeadSHAFn = func(int) (string, error) { return "abc123def456789", nil }
+
+	s := makeTestState(prs)
+	sess := s.Sessions["slot-0"]
+	sess.ReviewPendingHeadSHA = "abc123def456789"
+	sess.ReviewPendingSince = backdated(10 * time.Minute)
+
+	o.autoMergePRs(s)
+
+	if len(*merged) != 0 {
+		t.Fatalf("merged = %v, want none inside the grace window", *merged)
+	}
+}
+
 // Both streams green — the pair gate passes and the PR merges.
 func TestAutoMergePRs_LLMReviewPairGreenMerges(t *testing.T) {
 	prs := []github.PR{{Number: 10, HeadRefName: "feat/a"}}

--- a/internal/orchestrator/operator_gate_test.go
+++ b/internal/orchestrator/operator_gate_test.go
@@ -335,7 +335,7 @@ func TestAutoMergePRs_AmbiguousFailureRetriesAfterGateOpens(t *testing.T) {
 	o.getIssueFn = func(number int) (github.Issue, error) { return makeIssue(number, "android gate"), nil }
 	o.ghPRLabelsFn = func(int) ([]string, error) { return nil, nil }
 	o.ghPRChecksOutputFn = func(int) (string, error) { return "ordinary CI\tfailure\n", nil }
-	o.ghCollectPRReviewFeedbackFn = func(int) (string, error) { return "", nil }
+	o.ghCollectPRReviewFeedbackFn = func(int, []string) (string, error) { return "", nil }
 	o.ghPRFailingChecksFn = func(int) ([]github.FailingCheck, error) { return nil, nil }
 	closed := 0
 	o.ghClosePRFn = func(int, string) error {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -844,7 +844,10 @@ func (o *Orchestrator) prHasCriticalReview(prNumber int) (bool, error) {
 		// Fail safe: cannot determine criticality -> caller must NOT auto-merge.
 		return false, fmt.Errorf("no github client configured for critical-review check")
 	}
-	return o.gh.PRHasCriticalReviewOnHead(prNumber)
+	// The check must cover whatever streams actually gate this project: an
+	// llm-review P0/P1 on head blocks the #565 convergence merge exactly like
+	// a Greptile P0 does (#1148 review round 1, P1-1).
+	return o.gh.PRHasCriticalReviewOnHead(prNumber, o.cfg.EffectiveReviewGateStreams())
 }
 
 func (o *Orchestrator) prUnresolvedReviewThreadsOnHead(prNumber int) (string, []github.ReviewThread, error) {
@@ -6320,9 +6323,24 @@ func (o *Orchestrator) trackReviewGateHead(sess *state.Session, head string, ver
 		sess.ReviewPendingSince = nil
 		sess.ReviewRetriggerCount = 0
 		sess.ReviewGateObserved = false
+		sess.ReviewGateStreamObserved = nil
 	}
 	if verdict.Observed {
 		sess.ReviewGateObserved = true
+	}
+	// Per-stream sticky memory (#1148 review round 1, P1-2): a multi-stream
+	// gate can be half-observed — one stream settled, the other never spoke.
+	// The absent-stream escape needs to know WHICH streams were ever seen on
+	// this head, so an observed stream keeps hard-blocking while a silent one
+	// can expire.
+	for _, stream := range verdict.Streams {
+		if !stream.Observed || stream.Name == "" {
+			continue
+		}
+		if sess.ReviewGateStreamObserved == nil {
+			sess.ReviewGateStreamObserved = make(map[string]bool)
+		}
+		sess.ReviewGateStreamObserved[stream.Name] = true
 	}
 	if verdict.Pending && sess.ReviewPendingSince == nil {
 		started := now
@@ -6363,17 +6381,26 @@ func (o *Orchestrator) notifyMissingReviewGate(prNumber int, silentFor time.Dura
 	}
 }
 
-// missingReviewGateElapsed reports whether the review gate has been completely
-// silent — no check run, no comment, nothing — on this head for longer than
-// review_retrigger.missing_after_minutes. A gate that produced ANY signal is
-// never "missing": a reviewer working, or one that reported findings, keeps
-// blocking exactly as before. Opt-in: 0 keeps today's block-forever behavior.
+// missingReviewGateElapsed reports whether every stream still holding the gate
+// at pending has been completely silent — no check run, no status, no comment
+// — on this head for longer than review_retrigger.missing_after_minutes.
+//
+// The evaluation is per-stream (#1148 review round 1, P1-2): a multi-stream
+// gate can be half-observed — one stream posted its status while the other
+// never reported at all. The aggregate used to be Pending+Observed forever in
+// that state, so the escape never fired and no re-trigger existed: the PR was
+// wedged for good. Now a pending stream that was never seen on this head (this
+// read or the sticky per-stream memory) can expire, while a stream that DID
+// produce any signal keeps blocking at any duration, and a settled rejection
+// from any stream disables the escape outright.
+//
+// Opt-in: 0 keeps today's block-forever behavior.
 func (o *Orchestrator) missingReviewGateElapsed(sess *state.Session, verdict github.ReviewGateVerdict, now time.Time) (time.Duration, bool) {
 	if o == nil || o.cfg == nil || sess == nil {
 		return 0, false
 	}
 	grace := o.cfg.ReviewRetrigger.MissingReviewGraceOrZero()
-	if grace <= 0 || verdict.Observed || !verdict.Pending {
+	if grace <= 0 || !verdict.Pending {
 		return 0, false
 	}
 	// A degraded read cannot prove silence. Without this, a GitHub check-runs
@@ -6383,14 +6410,38 @@ func (o *Orchestrator) missingReviewGateElapsed(sess *state.Session, verdict git
 	if verdict.LookupFailed {
 		return 0, false
 	}
-	// Sticky memory: a reviewer seen on this head keeps blocking even if this
-	// read came back unobserved (e.g. a failed check-runs lookup fell through
-	// to the comment path).
-	if sess.ReviewGateObserved {
-		return 0, false
-	}
 	if sess.ReviewPendingSince == nil {
 		return 0, false
+	}
+	if len(verdict.Streams) == 0 {
+		// Legacy aggregate-only verdict (narrow test hooks): keep the
+		// original whole-gate semantics, including the sticky memory.
+		if verdict.Observed || sess.ReviewGateObserved {
+			return 0, false
+		}
+	} else {
+		// State written by a pre-#1148 binary has the aggregate sticky bit
+		// without per-stream attribution — treat it conservatively as "some
+		// stream was seen" and keep blocking.
+		if len(sess.ReviewGateStreamObserved) == 0 && sess.ReviewGateObserved {
+			return 0, false
+		}
+		for _, stream := range verdict.Streams {
+			// A stream that settled as failed is a live rejection, not an
+			// absent reviewer; the escape must never merge past it.
+			if !stream.Pending && !stream.Passed {
+				return 0, false
+			}
+			if !stream.Pending {
+				continue
+			}
+			// Sticky per-stream memory: a reviewer seen on this head keeps
+			// blocking even if this read came back unobserved (e.g. a failed
+			// check-runs lookup fell through to the comment path).
+			if stream.Observed || sess.ReviewGateStreamObserved[stream.Name] {
+				return 0, false
+			}
+		}
 	}
 	silentFor := now.Sub(*sess.ReviewPendingSince)
 	if silentFor < grace {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -200,7 +200,7 @@ type Orchestrator struct {
 	ghClosePRFn                  func(prNumber int, comment string) error
 	ghPRChecksOutputFn           func(prNumber int) (string, error)
 	ghPRFailingChecksFn          func(prNumber int) ([]github.FailingCheck, error)
-	ghCollectPRReviewFeedbackFn  func(prNumber int) (string, error)
+	ghCollectPRReviewFeedbackFn  func(prNumber int, streams []string) (string, error)
 	ghCloseIssueFn               func(number int, comment string) error
 	ghPRHeadSHAFn                func(prNumber int) (string, error)
 	ghPRDetailsFn                func(prNumber int) (github.PR, error)
@@ -954,10 +954,16 @@ func (o *Orchestrator) prChecksOutput(prNumber int) (string, error) {
 }
 
 func (o *Orchestrator) collectPRReviewFeedback(prNumber int) (string, error) {
+	// The configured review streams scope which bot logins count as review
+	// feedback: on llm-review rows the bot's inline findings must reach the
+	// retry pipeline (otherwise AutoRetryReviewFeedback never fires and the
+	// PR hangs), while on greptile-only rows fleet-bot comments stay
+	// invisible (#1148 round 2, P1).
+	streams := o.cfg.EffectiveReviewGateStreams()
 	if o.ghCollectPRReviewFeedbackFn != nil {
-		return o.ghCollectPRReviewFeedbackFn(prNumber)
+		return o.ghCollectPRReviewFeedbackFn(prNumber, streams)
 	}
-	return o.gh.CollectPRReviewFeedback(prNumber)
+	return o.gh.CollectPRReviewFeedback(prNumber, streams)
 }
 
 func (o *Orchestrator) prFailingChecks(prNumber int) ([]github.FailingCheck, error) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7199,6 +7199,8 @@ func (o *Orchestrator) reviewGate() string {
 	switch strings.ToLower(strings.TrimSpace(o.cfg.ReviewGate)) {
 	case "none", "off", "disabled":
 		return "none"
+	case "llm-review":
+		return "llm-review"
 	default:
 		return "greptile"
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2147,7 +2147,7 @@ func TestAutoMergePRs_PassedReviewGateDoesNotRetryAdvisoryFeedback(t *testing.T)
 		AutoRetryReviewFeedback: true,
 	}
 	o, merged := newMergeTestOrchestrator(cfg, prs)
-	o.ghCollectPRReviewFeedbackFn = func(int) (string, error) {
+	o.ghCollectPRReviewFeedbackFn = func(int, []string) (string, error) {
 		return "P1 advisory finding on a head Greptile has approved", nil
 	}
 	s := makeTestState(prs)
@@ -2188,7 +2188,7 @@ func TestAutoMergePRs_GreptileThreeOfFiveEntersBoundedRepairWithFindings(t *test
 			}},
 		}, nil
 	}
-	o.ghCollectPRReviewFeedbackFn = func(int) (string, error) {
+	o.ghCollectPRReviewFeedbackFn = func(int, []string) (string, error) {
 		return "## Review Feedback\n\ninternal/foo.go:42 P1: nil pointer panic", nil
 	}
 	st := makeTestState(prs)
@@ -2393,7 +2393,7 @@ func TestAutoMergePRs_ReviewFeedbackKeepsPROpenAndSchedulesInPlaceRetry(t *testi
 		ghPRCIStatusFn: func(prNumber int) (string, error) {
 			return "success", nil
 		},
-		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+		ghCollectPRReviewFeedbackFn: func(prNumber int, _ []string) (string, error) {
 			return "docs/ROADMAP.md:34 remove false cost-budget claim", nil
 		},
 		ghClosePRFn: func(prNumber int, comment string) error {
@@ -2460,7 +2460,7 @@ func TestAutoMergePRs_ReviewFeedbackFallsBackToCloseWhenWorktreeMissing(t *testi
 		ghPRCIStatusFn: func(prNumber int) (string, error) {
 			return "success", nil
 		},
-		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+		ghCollectPRReviewFeedbackFn: func(prNumber int, _ []string) (string, error) {
 			return "docs/ROADMAP.md:34 remove false cost-budget claim", nil
 		},
 		ghClosePRFn: func(prNumber int, comment string) error {
@@ -2501,7 +2501,7 @@ func TestAutoMergePRs_ReviewFeedbackImplementationRetryLimitStillSchedulesMainte
 		ghPRCIStatusFn: func(prNumber int) (string, error) {
 			return "success", nil
 		},
-		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+		ghCollectPRReviewFeedbackFn: func(prNumber int, _ []string) (string, error) {
 			return "docs/ROADMAP.md:34 remove false cost-budget claim", nil
 		},
 	}
@@ -2550,7 +2550,7 @@ func TestAutoMergePRs_ReviewFeedbackMaintenanceBudgetMarksTerminal(t *testing.T)
 		ghPRCIStatusFn: func(prNumber int) (string, error) {
 			return "success", nil
 		},
-		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+		ghCollectPRReviewFeedbackFn: func(prNumber int, _ []string) (string, error) {
 			return "docs/ROADMAP.md:34 remove false cost-budget claim", nil
 		},
 	}
@@ -2602,7 +2602,7 @@ func TestAutoMergePRs_RetryExhaustedGreenPRNoFeedbackMerges(t *testing.T) {
 		ghPRCIStatusFn: func(prNumber int) (string, error) {
 			return "success", nil
 		},
-		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+		ghCollectPRReviewFeedbackFn: func(prNumber int, _ []string) (string, error) {
 			return "", nil
 		},
 		ghMergePRFn: func(prNumber int) error {
@@ -2660,7 +2660,7 @@ func TestAutoMergePRs_RetryExhaustedActionableFeedbackGetsMaintenancePass(t *tes
 		ghPRCIStatusFn: func(prNumber int) (string, error) {
 			return "success", nil
 		},
-		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+		ghCollectPRReviewFeedbackFn: func(prNumber int, _ []string) (string, error) {
 			return "## Review Feedback\n\ninternal/foo.go:42 P1: nil pointer panic", nil
 		},
 		ghMergePRFn: func(prNumber int) error {
@@ -2740,7 +2740,7 @@ func TestAutoMergePRs_RetryExhaustedFeedback_NoReSyncAfterSettled(t *testing.T) 
 		ghPRCIStatusFn: func(prNumber int) (string, error) {
 			return "success", nil
 		},
-		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+		ghCollectPRReviewFeedbackFn: func(prNumber int, _ []string) (string, error) {
 			return "## Review Feedback\n\ninternal/foo.go:42 P1: unaddressed nil pointer", nil
 		},
 		rateLimitFn: func() (github.RateLimitStatus, error) {
@@ -3020,7 +3020,7 @@ func TestAutoMergePRs_CIFailureBlocksMerge(t *testing.T) {
 		ghPRChecksOutputFn: func(prNumber int) (string, error) {
 			return "Build failed: exit code 1", nil
 		},
-		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+		ghCollectPRReviewFeedbackFn: func(prNumber int, _ []string) (string, error) {
 			return "", nil
 		},
 		ghCloseIssueFn: func(number int, comment string) error {
@@ -4229,7 +4229,7 @@ func TestAutoMergePRs_RetryExhaustedConflictDoesNotLoopHaltQueue(t *testing.T) {
 		ghPRCIStatusFn: func(prNumber int) (string, error) {
 			return "success", nil
 		},
-		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+		ghCollectPRReviewFeedbackFn: func(prNumber int, _ []string) (string, error) {
 			return "P3 nit: rename foo", nil
 		},
 		ghPRHasCriticalReviewFn: func(prNumber int) (bool, error) {
@@ -9182,7 +9182,7 @@ func newCIFailureRetryOrchestrator(cfg *config.Config, prs []github.PR, ciStatus
 		workerStopFn: func(cfg *config.Config, slotName string, sess *state.Session) error {
 			return nil
 		},
-		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+		ghCollectPRReviewFeedbackFn: func(prNumber int, _ []string) (string, error) {
 			return "", nil
 		},
 	}, &merged, &closedPRs
@@ -9398,7 +9398,7 @@ func TestAutoMergePRs_CIFailure_DoesNotDependOnClosePR(t *testing.T) {
 		ghPRChecksOutputFn: func(prNumber int) (string, error) {
 			return "some CI output", nil
 		},
-		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+		ghCollectPRReviewFeedbackFn: func(prNumber int, _ []string) (string, error) {
 			return "", nil
 		},
 		ghCloseIssueFn: func(number int, comment string) error {
@@ -9453,7 +9453,7 @@ func TestAutoMergePRs_CIFailure_AlreadyNotified_NoDoubleRetry(t *testing.T) {
 		ghPRChecksOutputFn: func(prNumber int) (string, error) {
 			return "CI output", nil
 		},
-		ghCollectPRReviewFeedbackFn: func(prNumber int) (string, error) {
+		ghCollectPRReviewFeedbackFn: func(prNumber int, _ []string) (string, error) {
 			return "", nil
 		},
 		ghCloseIssueFn: func(number int, comment string) error {
@@ -10196,7 +10196,7 @@ func TestAutoMergePRs_CIFailure_CollectsReviewFeedback(t *testing.T) {
 	o, _, _ := newCIFailureRetryOrchestrator(cfg, prs, map[int]string{10: "failure"})
 
 	// Override with review feedback
-	o.ghCollectPRReviewFeedbackFn = func(prNumber int) (string, error) {
+	o.ghCollectPRReviewFeedbackFn = func(prNumber int, _ []string) (string, error) {
 		return "Confidence 3/5 — Not safe to merge\nP2: null dereference on pool.interface", nil
 	}
 
@@ -10220,7 +10220,7 @@ func TestAutoMergePRs_CIFailure_NoGreptileFeedback_FeedbackEmpty(t *testing.T) {
 	o, _, _ := newCIFailureRetryOrchestrator(cfg, prs, map[int]string{10: "failure"})
 
 	// No review feedback (returns empty)
-	o.ghCollectPRReviewFeedbackFn = func(prNumber int) (string, error) {
+	o.ghCollectPRReviewFeedbackFn = func(prNumber int, _ []string) (string, error) {
 		return "", nil
 	}
 
@@ -10581,7 +10581,7 @@ func TestAutoMergePRs_ConvergenceMergesRetryExhaustedNonCritical(t *testing.T) {
 		notifier:                    &notify.Notifier{},
 		listOpenPRsFn:               func() ([]github.PR, error) { return []github.PR{pr}, nil },
 		ghPRCIStatusFn:              func(int) (string, error) { return "success", nil },
-		ghCollectPRReviewFeedbackFn: func(int) (string, error) { return "P1: non-blocking nit", nil },
+		ghCollectPRReviewFeedbackFn: func(int, []string) (string, error) { return "P1: non-blocking nit", nil },
 		ghPRHasCriticalReviewFn:     func(int) (bool, error) { return false, nil },
 		ghPRGreptileApprovedFn:      func(int) (bool, bool, error) { return false, false, nil },
 		ghMergePRFn:                 func(n int) error { merged = append(merged, n); return nil },
@@ -10610,7 +10610,7 @@ func TestAutoMergePRs_ConvergenceHoldsOnCritical(t *testing.T) {
 		notifier:                    &notify.Notifier{},
 		listOpenPRsFn:               func() ([]github.PR, error) { return []github.PR{pr}, nil },
 		ghPRCIStatusFn:              func(int) (string, error) { return "success", nil },
-		ghCollectPRReviewFeedbackFn: func(int) (string, error) { return "P0: critical", nil },
+		ghCollectPRReviewFeedbackFn: func(int, []string) (string, error) { return "P0: critical", nil },
 		ghPRHasCriticalReviewFn:     func(int) (bool, error) { return true, nil },
 		ghMergePRFn:                 func(n int) error { merged = append(merged, n); return nil },
 		ghCloseIssueFn:              func(int, string) error { return nil },

--- a/internal/orchestrator/pr_gate_progress_test.go
+++ b/internal/orchestrator/pr_gate_progress_test.go
@@ -169,7 +169,7 @@ func TestAutoMergePRs_HeadChangeAfterFailedRollupDoesNotScheduleStaleRetry(t *te
 		t.Fatal("stale failed head must not be consumed into a repair prompt")
 		return "", nil
 	}
-	o.ghCollectPRReviewFeedbackFn = func(int) (string, error) {
+	o.ghCollectPRReviewFeedbackFn = func(int, []string) (string, error) {
 		t.Fatal("stale failed head must not read review feedback for a repair")
 		return "", nil
 	}
@@ -217,7 +217,7 @@ func TestAutoMergePRs_HeadChangeWhileCollectingFailureContextDoesNotScheduleStal
 		return newHead, nil
 	}
 	o.ghPRChecksOutputFn = func(int) (string, error) { return "old head failed", nil }
-	o.ghCollectPRReviewFeedbackFn = func(int) (string, error) { return "old head review", nil }
+	o.ghCollectPRReviewFeedbackFn = func(int, []string) (string, error) { return "old head review", nil }
 	o.ghPRFailingChecksFn = func(int) ([]github.FailingCheck, error) {
 		return []github.FailingCheck{{Name: "old-check", Conclusion: "failure", Excerpt: "old head"}}, nil
 	}

--- a/internal/orchestrator/zombie_respawn_test.go
+++ b/internal/orchestrator/zombie_respawn_test.go
@@ -134,7 +134,7 @@ func TestRespawnDueRetries_PROpenDuringCIRetryThenMerged_NoRespawn(t *testing.T)
 	respawned := false
 	o := zombieRetryOrchestrator(t, &respawned)
 	o.ghPRChecksOutputFn = func(prNumber int) (string, error) { return "build failed", nil }
-	o.ghCollectPRReviewFeedbackFn = func(prNumber int) (string, error) { return "", nil }
+	o.ghCollectPRReviewFeedbackFn = func(prNumber int, _ []string) (string, error) { return "", nil }
 	o.ghClosePRFn = func(prNumber int, comment string) error { return nil }
 	o.workerStopFn = func(cfg *config.Config, slotName string, sess *state.Session) error { return nil }
 

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -4877,6 +4877,10 @@ func fleetPRReviewStreamSummary(stream fleetPRReviewStream) string {
 	name := strings.TrimSpace(stream.Name)
 	if strings.EqualFold(name, "greptile") {
 		name = "Greptile"
+	} else if strings.EqualFold(name, "llm-review-opus") {
+		name = "LLM review (opus)"
+	} else if strings.EqualFold(name, "llm-review-terra") {
+		name = "LLM review (terra)"
 	} else if name != "" {
 		name = strings.ToUpper(name[:1]) + name[1:]
 	} else {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -407,6 +407,14 @@ type Session struct {
 	// without this memory that single blip would look like "the reviewer never
 	// showed up" and expire a gate that is genuinely working.
 	ReviewGateObserved bool `json:"review_gate_observed,omitempty"`
+	// ReviewGateStreamObserved is the per-stream refinement of
+	// ReviewGateObserved (#1148): stream name -> ever seen on
+	// ReviewPendingHeadSHA. A multi-stream gate can be half-observed (one
+	// stream settled, the other never reported); the absent-reviewer escape
+	// lets only never-seen streams expire, so it needs attribution, not just
+	// the aggregate bit. Reset together with ReviewGateObserved on a head
+	// change.
+	ReviewGateStreamObserved map[string]bool `json:"review_gate_stream_observed,omitempty"`
 
 	// #426: distinguish agent execution time from workflow elapsed time.
 	// WorkerEndedAt is stamped the FIRST time the worker process exits

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -2132,7 +2132,7 @@ func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR, cache *re
 				fmt.Sprintf("PR #%d checks=failure", pr.Number)))
 		}
 
-		if e.cfg.ReviewGate == "greptile" && (ciStatus == "" || ciStatus == "success") {
+		if (e.cfg.ReviewGate == "greptile" || e.cfg.ReviewGate == "llm-review") && (ciStatus == "" || ciStatus == "success") {
 			streams := e.cfg.EffectiveReviewGateStreams()
 			if reviewReader, ok := e.reader.(prReviewGateVerdictReader); ok && !onlyGreptileReviewStream(streams) {
 				verdict, err := reviewReader.PRReviewGateVerdict(pr.Number, streams)
@@ -2150,7 +2150,7 @@ func (e *Engine) detectPRStuckStates(st *state.State, prs []github.PR, cache *re
 							fmt.Sprintf("PR #%d review_gate=%s", pr.Number, verdict.Summary())))
 					}
 				}
-			} else if greptileReader, ok := e.reader.(prGreptileReader); ok {
+			} else if greptileReader, ok := e.reader.(prGreptileReader); ok && e.cfg.ReviewGate == "greptile" {
 				approved, pending, err := greptileReader.PRGreptileApproved(pr.Number)
 				if err == nil {
 					switch {
@@ -3296,11 +3296,20 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 		}
 	}
 
-	// Greptile gate — when the reader exposes Greptile signal, require
-	// approved=true and pending=false. Missing reader -> proceed (some
-	// projects don't use Greptile and the cautious gate still requires
-	// human approval before merge_pr executes).
-	if greptileReader, ok := e.reader.(prGreptileReader); ok {
+	// Review gate — when the reader exposes the review signal, require it to
+	// have settled approved. Missing reader -> proceed (some projects don't
+	// use a review bot and the cautious gate still requires human approval
+	// before merge_pr executes). For the stream-based llm-review gate
+	// (#1148) the aggregate verdict is the signal; the historical
+	// greptile-only setup keeps the Greptile read.
+	if e.cfg != nil && e.cfg.ReviewGate == "llm-review" {
+		if reviewReader, ok := e.reader.(prReviewGateVerdictReader); ok {
+			verdict, err := reviewReader.PRReviewGateVerdict(pr.Number, e.cfg.EffectiveReviewGateStreams())
+			if err != nil || verdict.Pending || !verdict.Passed {
+				return false, "", nil
+			}
+		}
+	} else if greptileReader, ok := e.reader.(prGreptileReader); ok {
 		approved, pending, err := greptileReader.PRGreptileApproved(pr.Number)
 		if err != nil {
 			return false, "", nil
@@ -3423,7 +3432,17 @@ func (e *Engine) monitorOpenPRReasons(slot string, sess *state.Session, pr githu
 			reasons = append(reasons, "CI status could not be read")
 		}
 	}
-	if greptileReader, ok := e.reader.(prGreptileReader); ok {
+	if e.cfg != nil && e.cfg.ReviewGate == "llm-review" {
+		if reviewReader, ok := e.reader.(prReviewGateVerdictReader); ok {
+			if verdict, err := reviewReader.PRReviewGateVerdict(pr.Number, e.cfg.EffectiveReviewGateStreams()); err == nil {
+				if verdict.Pending {
+					reasons = append(reasons, "llm-review pending")
+				} else if !verdict.Passed {
+					reasons = append(reasons, "llm-review not approved")
+				}
+			}
+		}
+	} else if greptileReader, ok := e.reader.(prGreptileReader); ok {
 		if approved, pending, err := greptileReader.PRGreptileApproved(pr.Number); err == nil {
 			if pending {
 				reasons = append(reasons, "Greptile review pending")

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -32,11 +32,26 @@ auto_rebase: true                  # auto-rebase conflicting PR branches (defaul
 #   credentials_file: /run/user/UID/maestro-runner/worker.env
 merge_strategy: sequential         # "sequential" (default) or "parallel"
 merge_interval_seconds: 30         # minimum seconds between sequential merges (default: 30)
-review_gate: greptile              # "greptile" (default) or "none"
+review_gate: greptile              # "greptile" (default), "llm-review" (#1148 opus+terra pair), or "none"
 review_retrigger:                  # self-heal greptile webhook misses (#691)
   enabled: true                    # post "@greptile review" when the gate wedges at pending (default: true)
   pending_minutes: 10              # re-trigger after this long pending on one head SHA (default: 10)
   cooldown_minutes: 30             # minimum gap between re-trigger comments (default: 30)
+
+# llm-review gate (#1148) — two LLM lenses (claude-opus-5 + gpt-5.6-terra)
+# replace Greptile as the primary review gate. The glue runner
+# (scripts/llm-review.sh, or .github/workflows/llm-review.yml when the
+# LLM_REVIEW_ENABLED repo variable is set) posts a commit status
+# `llm-review-opus` / `llm-review-terra` per PR head SHA plus inline [P0]-[P3]
+# findings; Maestro blocks on P0/P1 only, P2/P3 stay advisory.
+# The `llm-review` gate value expands to both streams; list them in
+# review_gate_streams explicitly to mix with greptile/simplicity.
+# review_retrigger.missing_after_minutes bounds an absent reviewer: a gate
+# with NO signal at all on the head becomes non-blocking after this many
+# minutes (0 = block forever; #1115).
+# review_gate: llm-review
+# review_retrigger:
+#   missing_after_minutes: 60
 auto_retry_review_feedback: false  # retry PRs with actionable review comments
 auto_retry_rebase_conflicts: false # retry PRs whose auto-rebase fails with conflicts
 

--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -62,19 +62,27 @@ if [[ ! -s "$DIFF_FILE" ]]; then
     exit 0
 fi
 diff_size=$(wc -c <"$DIFF_FILE")
+TRUNC_NOTE=""
 if (( diff_size > MAX_DIFF_BYTES )); then
     echo "llm-review: diff is $diff_size bytes; truncating to $MAX_DIFF_BYTES" >&2
     truncate -s "$MAX_DIFF_BYTES" "$DIFF_FILE"
+    # Surfaced in the final status description: a verdict over a truncated
+    # diff is weaker evidence and the operator must be able to see that.
+    TRUNC_NOTE="; warning: diff truncated to $MAX_DIFF_BYTES bytes"
 fi
 
 # --- helpers ----------------------------------------------------------------
 
-# status_exists <context> — true when a commit status with this context is
-# already present on the head SHA (the idempotency key).
-status_exists() {
+# status_settled <context> — true when a commit status with this context has
+# already SETTLED (success/failure) on the head SHA: that is the idempotency
+# key. error statuses (run failed, creds missing, unparseable output) and
+# stale pending statuses (a previous run died mid-flight) are retryable — a
+# re-run replaces them instead of treating them as done.
+status_settled() {
     local context="$1"
     gh api "repos/$REPO/commits/$HEAD_SHA/status" --jq \
-        "[.statuses[].context] | index(\"$context\") != null" 2>/dev/null | grep -qx true
+        "[.statuses[] | select(.context == \"$context\") | .state] | map(select(. == \"success\" or . == \"failure\")) | length > 0" \
+        2>/dev/null | grep -qx true
 }
 
 # post_status <context> <state> <description>
@@ -128,17 +136,42 @@ preamble, no summary, no markdown fences.
 DIFF:
 '
 
+# prepare_model <stream-name> <mode>
+# Phase 1 of the pending-first protocol: decide whether this model runs and
+# publish its status BEFORE any model output or comment lands. A pending
+# status for every model that will run means Maestro never observes the
+# half-state "comments exist but a stream has no status yet" (the gate would
+# read that stream as absent), and advisory comments posted mid-run cannot
+# race a still-missing verdict.
+# Return: 0 = run it, 1 = settled already (skip), 2 = skipped for missing
+# creds (error status posted — the pair must not wedge on a silent stream).
+prepare_model() {
+    local stream="$1" mode="$2"
+
+    if status_settled "$stream"; then
+        echo "llm-review: $stream already settled on $HEAD_SHA — skipping (idempotent)"
+        return 1
+    fi
+
+    if [[ "$mode" == terra && ( -z "${LLM_REVIEW_TERRA_BASE_URL:-}" || -z "${LLM_REVIEW_TERRA_AUTH_TOKEN:-}" ) ]]; then
+        echo "llm-review: LLM_REVIEW_TERRA_BASE_URL/AUTH_TOKEN not set — skipping $stream" >&2
+        # An explicit error status instead of silence: with one stream settled
+        # and the other absent, Maestro's aggregate used to sit at
+        # Pending+Observed forever with no escape (#1148 review round 1, P1-2).
+        post_status "$stream" error "skipped: credentials not configured"
+        return 2
+    fi
+
+    post_status "$stream" pending "review in progress"
+    return 0
+}
+
 # run_model <stream-name> <mode>
 # mode "opus":  subscription seat — ANTHROPIC_* endpoint vars must be unset.
 # mode "terra": CLIProxy — ANTHROPIC_BASE_URL/AUTH_TOKEN + --model.
 run_model() {
     local stream="$1" mode="$2"
     local context="$stream"
-
-    if status_exists "$context"; then
-        echo "llm-review: $context already reported on $HEAD_SHA — skipping (idempotent)"
-        return 0
-    fi
 
     local prompt
     # shellcheck disable=SC2059
@@ -158,10 +191,6 @@ run_model() {
             fi
             ;;
         terra)
-            if [[ -z "${LLM_REVIEW_TERRA_BASE_URL:-}" || -z "${LLM_REVIEW_TERRA_AUTH_TOKEN:-}" ]]; then
-                echo "llm-review: LLM_REVIEW_TERRA_BASE_URL/AUTH_TOKEN not set — skipping $context" >&2
-                return 0
-            fi
             if ! output="$(ANTHROPIC_BASE_URL="$LLM_REVIEW_TERRA_BASE_URL" \
                     ANTHROPIC_AUTH_TOKEN="$LLM_REVIEW_TERRA_AUTH_TOKEN" \
                     claude -p --model "$TERRA_MODEL" "$prompt$(cat "$DIFF_FILE")" 2>&1)"; then
@@ -176,9 +205,23 @@ run_model() {
             ;;
     esac
 
-    # Parse findings: only lines matching the contract count.
-    local findings
-    findings="$(grep -E '^\[P[0-3]\] ' <<<"$output" || true)"
+    # Strip markdown fences (models love wrapping output in ```-blocks) and
+    # leading indentation so fenced findings and a fenced NO_FINDINGS still
+    # parse, then keep only lines matching the contract.
+    local parsed findings
+    parsed="$(sed -e '/^[[:space:]]*```/d' -e 's/^[[:space:]]*//' <<<"$output")"
+    findings="$(grep -E '^\[P[0-3]\] ' <<<"$parsed" || true)"
+
+    # Fail closed on unparseable output (#1148 review round 1, P1-4): success
+    # requires either at least one parsed finding line or the explicit
+    # NO_FINDINGS sentinel. A refusal, an apology, or a format drift must
+    # never read as "clean review".
+    if [[ -z "$findings" ]] && ! grep -qE '^NO_FINDINGS[[:space:]]*$' <<<"$parsed"; then
+        echo "llm-review: $context output matched neither findings nor NO_FINDINGS:" >&2
+        echo "$output" >&2
+        post_status "$context" error "review output unparseable"
+        return 1
+    fi
 
     local blocking=0 total=0
     if [[ -n "$findings" ]]; then
@@ -201,13 +244,29 @@ run_model() {
     fi
 
     if (( blocking > 0 )); then
-        post_status "$context" failure "$blocking blocking (P0/P1) of $total findings"
+        post_status "$context" failure "$blocking blocking (P0/P1) of $total findings$TRUNC_NOTE"
     else
-        post_status "$context" success "$total advisory findings, none blocking"
+        post_status "$context" success "$total advisory findings, none blocking$TRUNC_NOTE"
     fi
 }
 
+# Phase 1: settle every model's status (pending / skipped-error) before any
+# model runs or any comment is posted, so the pair is never half-observed.
 rc=0
-run_model "llm-review-opus" opus || rc=1
-run_model "llm-review-terra" terra || rc=1
+RUN_OPUS=0
+RUN_TERRA=0
+prep_rc=0
+prepare_model "llm-review-opus" opus || prep_rc=$?
+if (( prep_rc == 0 )); then RUN_OPUS=1; elif (( prep_rc == 2 )); then rc=1; fi
+prep_rc=0
+prepare_model "llm-review-terra" terra || prep_rc=$?
+if (( prep_rc == 0 )); then RUN_TERRA=1; elif (( prep_rc == 2 )); then rc=1; fi
+
+# Phase 2: run the reviews and flip each pending status to its final state.
+if (( RUN_OPUS )); then
+    run_model "llm-review-opus" opus || rc=1
+fi
+if (( RUN_TERRA )); then
+    run_model "llm-review-terra" terra || rc=1
+fi
 exit "$rc"

--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -14,9 +14,12 @@
 # surfaces: the status is the stream verdict, the P0/P1 comments are the
 # blocking findings (internal/github/github.go llmReviewStreamSpec).
 #
-# Idempotent per head SHA: a model whose status already exists for the current
-# head is skipped, so re-runs (cron, workflow retries, /llm-review comments)
-# do not duplicate reviews or comments.
+# Idempotent per head SHA: a model whose status already settled
+# (success/failure) on the current head is skipped, so re-runs (cron,
+# workflow retries, /llm-review comments) do not duplicate reviews or
+# comments. A fresh pending status also skips (another run is mid-flight);
+# a pending older than REVIEW_PENDING_STALE_MINUTES (default 30) is treated
+# as a crashed run and retried.
 #
 # Requirements: gh (authenticated), git, jq, claude CLI. For the terra pass:
 # LLM_REVIEW_TERRA_BASE_URL + LLM_REVIEW_TERRA_AUTH_TOKEN (the CLIProxy
@@ -73,25 +76,63 @@ fi
 
 # --- helpers ----------------------------------------------------------------
 
-# status_settled <context> — true when a commit status with this context has
-# already SETTLED (success/failure) on the head SHA: that is the idempotency
-# key. error statuses (run failed, creds missing, unparseable output) and
-# stale pending statuses (a previous run died mid-flight) are retryable — a
-# re-run replaces them instead of treating them as done.
+# status_settled <context> — true when this context needs no run on the head
+# SHA: a SETTLED state (success/failure — the idempotency key), or a FRESH
+# pending (younger than REVIEW_PENDING_STALE_MINUTES: another run is
+# presumably mid-flight, e.g. a manual run racing CI). Retryable instead:
+# error statuses (run failed, creds missing, unparseable output), pendings
+# older than the threshold (the posting run died after phase 1 — the
+# crashed-pending self-heal, #1148 round 2), and pendings whose created_at
+# cannot be parsed (assume crashed rather than wedge). The combined-status
+# endpoint returns one entry per context (the latest), so no dedup is needed.
 status_settled() {
     local context="$1"
-    gh api "repos/$REPO/commits/$HEAD_SHA/status" --jq \
-        "[.statuses[] | select(.context == \"$context\") | .state] | map(select(. == \"success\" or . == \"failure\")) | length > 0" \
-        2>/dev/null | grep -qx true
+    local stale_minutes="${REVIEW_PENDING_STALE_MINUTES:-30}"
+    local line state created_at
+    line="$(gh api "repos/$REPO/commits/$HEAD_SHA/status" --jq \
+        "[.statuses[] | select(.context == \"$context\")][0] // empty | [.state, (.created_at // \"\")] | @tsv" \
+        2>/dev/null)" || line=""
+    [[ -z "$line" ]] && return 1
+    state="${line%%$'\t'*}"
+    created_at="${line#*$'\t'}"
+    case "$state" in
+        success|failure)
+            return 0
+            ;;
+        pending)
+            local created_epoch now_epoch
+            created_epoch="$(date -u -d "$created_at" +%s 2>/dev/null)" || created_epoch=""
+            if [[ -z "$created_epoch" ]]; then
+                echo "llm-review: $context pending with unparseable created_at (${created_at:-<empty>}) — treating as crashed, retrying" >&2
+                return 1
+            fi
+            now_epoch="$(date -u +%s)"
+            if (( now_epoch - created_epoch < stale_minutes * 60 )); then
+                echo "llm-review: $context pending since $created_at (< ${stale_minutes}m) — another run appears to be in flight"
+                return 0
+            fi
+            echo "llm-review: $context pending since $created_at (> ${stale_minutes}m) — treating as crashed, retrying" >&2
+            return 1
+            ;;
+        *)
+            return 1
+            ;;
+    esac
 }
 
 # post_status <context> <state> <description>
+# Returns non-zero when the status API call fails, so callers can distinguish
+# "posted" from "gh error" — a swallowed failure here is what used to let a
+# transient gh error read as a green no-op run.
 post_status() {
     local context="$1" state="$2" description="$3"
-    gh api "repos/$REPO/statuses/$HEAD_SHA" \
+    if ! gh api "repos/$REPO/statuses/$HEAD_SHA" \
         -f state="$state" \
         -f context="$context" \
-        -f description="$description" >/dev/null
+        -f description="$description" >/dev/null; then
+        echo "llm-review: FAILED to post status $context=$state on $HEAD_SHA" >&2
+        return 1
+    fi
     echo "llm-review: status $context=$state on $HEAD_SHA"
 }
 
@@ -144,12 +185,16 @@ DIFF:
 # read that stream as absent), and advisory comments posted mid-run cannot
 # race a still-missing verdict.
 # Return: 0 = run it, 1 = settled already (skip), 2 = skipped for missing
-# creds (error status posted — the pair must not wedge on a silent stream).
+# creds (error status posted — the pair must not wedge on a silent stream),
+# 3 = could not post the pending status (transient gh error) — the caller
+# must abort the run with a non-zero exit instead of pretending phase 1
+# happened; a green no-op run over a failed pending post would hide the
+# protocol violation.
 prepare_model() {
     local stream="$1" mode="$2"
 
     if status_settled "$stream"; then
-        echo "llm-review: $stream already settled on $HEAD_SHA — skipping (idempotent)"
+        echo "llm-review: $stream needs no run on $HEAD_SHA — skipping (idempotent)"
         return 1
     fi
 
@@ -158,11 +203,13 @@ prepare_model() {
         # An explicit error status instead of silence: with one stream settled
         # and the other absent, Maestro's aggregate used to sit at
         # Pending+Observed forever with no escape (#1148 review round 1, P1-2).
-        post_status "$stream" error "skipped: credentials not configured"
+        post_status "$stream" error "skipped: credentials not configured" || true
         return 2
     fi
 
-    post_status "$stream" pending "review in progress"
+    if ! post_status "$stream" pending "review in progress"; then
+        return 3
+    fi
     return 0
 }
 
@@ -257,10 +304,18 @@ RUN_OPUS=0
 RUN_TERRA=0
 prep_rc=0
 prepare_model "llm-review-opus" opus || prep_rc=$?
-if (( prep_rc == 0 )); then RUN_OPUS=1; elif (( prep_rc == 2 )); then rc=1; fi
+case "$prep_rc" in
+    0) RUN_OPUS=1 ;;
+    1) ;;       # settled / in flight — legitimate skip
+    *) rc=1 ;;  # 2 = creds skip (error status posted), 3 = pending post failed
+esac
 prep_rc=0
 prepare_model "llm-review-terra" terra || prep_rc=$?
-if (( prep_rc == 0 )); then RUN_TERRA=1; elif (( prep_rc == 2 )); then rc=1; fi
+case "$prep_rc" in
+    0) RUN_TERRA=1 ;;
+    1) ;;
+    *) rc=1 ;;
+esac
 
 # Phase 2: run the reviews and flip each pending status to its final state.
 if (( RUN_OPUS )); then

--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# llm-review.sh — glue runner for the llm-review gate (#1148).
+#
+# Runs two single-shot LLM reviews of a PR head diff — claude-opus-5 (the
+# subscription seat: plain `claude -p`) and gpt-5.6-terra (via CLIProxy:
+# ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN + --model) — and publishes, per
+# model:
+#   1. inline PR review comments (one per finding, with a [P0]-[P3] severity
+#      marker and the stream marker so Maestro can attribute them), and
+#   2. a commit status `llm-review-opus` / `llm-review-terra` on the head SHA:
+#      success unless the model reported any P0/P1 finding.
+#
+# Maestro's review gate (review_gate: llm-review) reads exactly these two
+# surfaces: the status is the stream verdict, the P0/P1 comments are the
+# blocking findings (internal/github/github.go llmReviewStreamSpec).
+#
+# Idempotent per head SHA: a model whose status already exists for the current
+# head is skipped, so re-runs (cron, workflow retries, /llm-review comments)
+# do not duplicate reviews or comments.
+#
+# Requirements: gh (authenticated), git, jq, claude CLI. For the terra pass:
+# LLM_REVIEW_TERRA_BASE_URL + LLM_REVIEW_TERRA_AUTH_TOKEN (the CLIProxy
+# endpoint/key) — without them the terra pass is skipped with a warning.
+#
+# Usage: llm-review.sh <pr-number> [owner/repo]
+
+set -euo pipefail
+
+PR_NUMBER="${1:-}"
+REPO="${2:-${GH_REPO:-}}"
+
+if [[ -z "$PR_NUMBER" ]]; then
+    echo "usage: $0 <pr-number> [owner/repo]" >&2
+    exit 2
+fi
+if [[ -z "$REPO" ]]; then
+    REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+fi
+
+OPUS_MODEL="${LLM_REVIEW_OPUS_MODEL:-claude-opus-5}"
+TERRA_MODEL="${LLM_REVIEW_TERRA_MODEL:-gpt-5.6-terra}"
+MAX_DIFF_BYTES="${LLM_REVIEW_MAX_DIFF_BYTES:-400000}"
+
+pr_json="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid,baseRefName,title,number)"
+HEAD_SHA="$(jq -r .headRefOid <<<"$pr_json")"
+BASE_REF="$(jq -r .baseRefName <<<"$pr_json")"
+PR_TITLE="$(jq -r .title <<<"$pr_json")"
+
+if [[ -z "$HEAD_SHA" || "$HEAD_SHA" == "null" ]]; then
+    echo "llm-review: could not resolve head SHA for PR #$PR_NUMBER" >&2
+    exit 1
+fi
+
+echo "llm-review: PR #$PR_NUMBER ($REPO) head=$HEAD_SHA base=$BASE_REF"
+
+# --- diff of the PR head against its merge base -----------------------------
+DIFF_FILE="$(mktemp -t llm-review-diff.XXXXXX)"
+trap 'rm -f "$DIFF_FILE"' EXIT
+gh pr diff "$PR_NUMBER" --repo "$REPO" >"$DIFF_FILE"
+if [[ ! -s "$DIFF_FILE" ]]; then
+    echo "llm-review: empty diff for PR #$PR_NUMBER — nothing to review" >&2
+    exit 0
+fi
+diff_size=$(wc -c <"$DIFF_FILE")
+if (( diff_size > MAX_DIFF_BYTES )); then
+    echo "llm-review: diff is $diff_size bytes; truncating to $MAX_DIFF_BYTES" >&2
+    truncate -s "$MAX_DIFF_BYTES" "$DIFF_FILE"
+fi
+
+# --- helpers ----------------------------------------------------------------
+
+# status_exists <context> — true when a commit status with this context is
+# already present on the head SHA (the idempotency key).
+status_exists() {
+    local context="$1"
+    gh api "repos/$REPO/commits/$HEAD_SHA/status" --jq \
+        "[.statuses[].context] | index(\"$context\") != null" 2>/dev/null | grep -qx true
+}
+
+# post_status <context> <state> <description>
+post_status() {
+    local context="$1" state="$2" description="$3"
+    gh api "repos/$REPO/statuses/$HEAD_SHA" \
+        -f state="$state" \
+        -f context="$context" \
+        -f description="$description" >/dev/null
+    echo "llm-review: status $context=$state on $HEAD_SHA"
+}
+
+# post_inline_comment <context> <path> <line> <body>
+# Falls back to a plain PR comment when the position is not in the diff.
+post_inline_comment() {
+    local context="$1" path="$2" line="$3" body="$4"
+    if [[ -n "$path" && "$line" =~ ^[0-9]+$ && "$line" -gt 0 ]]; then
+        if gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
+            -f body="$body" \
+            -f commit_id="$HEAD_SHA" \
+            -f path="$path" \
+            -F line="$line" \
+            -f side=RIGHT >/dev/null 2>&1; then
+            return 0
+        fi
+    fi
+    # Position rejected (line outside the diff, renamed file, ...) — keep the
+    # finding visible as a regular PR comment instead of dropping it.
+    gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body (at \`$path:$line\`)" >/dev/null
+}
+
+REVIEW_PROMPT_TEMPLATE='You are a strict senior code reviewer. Review ONLY the diff below (PR "%s").
+Report genuine defects, not style preferences.
+
+Output format — one line per finding, nothing else:
+[P0] path/to/file.ext:LINE — one-sentence description
+[P1] path/to/file.ext:LINE — one-sentence description
+[P2] path/to/file.ext:LINE — one-sentence description
+[P3] path/to/file.ext:LINE — one-sentence description
+
+Severity contract:
+- P0: guaranteed breakage, data loss, security hole. Blocks merge.
+- P1: real bug or correctness risk on a main path. Blocks merge.
+- P2: minor defect or risky pattern. Advisory only.
+- P3: nitpick. Advisory only.
+
+LINE must be a new-file line number that appears in the diff. If there are no
+findings, output exactly: NO_FINDINGS. Do not output anything else — no
+preamble, no summary, no markdown fences.
+
+DIFF:
+'
+
+# run_model <stream-name> <mode>
+# mode "opus":  subscription seat — ANTHROPIC_* endpoint vars must be unset.
+# mode "terra": CLIProxy — ANTHROPIC_BASE_URL/AUTH_TOKEN + --model.
+run_model() {
+    local stream="$1" mode="$2"
+    local context="$stream"
+
+    if status_exists "$context"; then
+        echo "llm-review: $context already reported on $HEAD_SHA — skipping (idempotent)"
+        return 0
+    fi
+
+    local prompt
+    # shellcheck disable=SC2059
+    prompt="$(printf "$REVIEW_PROMPT_TEMPLATE" "$PR_TITLE")"
+
+    local output
+    case "$mode" in
+        opus)
+            # Unset the CLIProxy redirection so the claude CLI talks to the
+            # real Anthropic endpoint: the subscription seat on an operator
+            # host, or ANTHROPIC_API_KEY on CI.
+            if ! output="$( (env -u ANTHROPIC_BASE_URL -u ANTHROPIC_AUTH_TOKEN \
+                    claude -p --model "$OPUS_MODEL" "$prompt$(cat "$DIFF_FILE")") 2>&1)"; then
+                echo "llm-review: $context run failed: $output" >&2
+                post_status "$context" error "review run failed"
+                return 1
+            fi
+            ;;
+        terra)
+            if [[ -z "${LLM_REVIEW_TERRA_BASE_URL:-}" || -z "${LLM_REVIEW_TERRA_AUTH_TOKEN:-}" ]]; then
+                echo "llm-review: LLM_REVIEW_TERRA_BASE_URL/AUTH_TOKEN not set — skipping $context" >&2
+                return 0
+            fi
+            if ! output="$(ANTHROPIC_BASE_URL="$LLM_REVIEW_TERRA_BASE_URL" \
+                    ANTHROPIC_AUTH_TOKEN="$LLM_REVIEW_TERRA_AUTH_TOKEN" \
+                    claude -p --model "$TERRA_MODEL" "$prompt$(cat "$DIFF_FILE")" 2>&1)"; then
+                echo "llm-review: $context run failed: $output" >&2
+                post_status "$context" error "review run failed"
+                return 1
+            fi
+            ;;
+        *)
+            echo "llm-review: unknown mode $mode" >&2
+            return 1
+            ;;
+    esac
+
+    # Parse findings: only lines matching the contract count.
+    local findings
+    findings="$(grep -E '^\[P[0-3]\] ' <<<"$output" || true)"
+
+    local blocking=0 total=0
+    if [[ -n "$findings" ]]; then
+        while IFS= read -r line; do
+            total=$((total + 1))
+            local sev file_line path lnum msg
+            sev="$(sed -E 's/^\[(P[0-3])\].*/\1/' <<<"$line")"
+            file_line="$(sed -E 's/^\[P[0-3]\] +([^ ]+:[0-9]+).*/\1/' <<<"$line")"
+            path="${file_line%%:*}"
+            lnum="${file_line##*:}"
+            msg="$(sed -E 's/^\[P[0-3]\] +[^ ]+ +[—-]+ *//' <<<"$line")"
+            if [[ "$sev" == "P0" || "$sev" == "P1" ]]; then
+                blocking=$((blocking + 1))
+            fi
+            # The [Px] marker is what Maestro's severity parser matches; the
+            # trailing stream marker attributes the comment to this stream.
+            post_inline_comment "$context" "$path" "$lnum" \
+                "[$sev] $msg"$'\n\n'"<sub>$context @ ${HEAD_SHA:0:12}</sub>" || true
+        done <<<"$findings"
+    fi
+
+    if (( blocking > 0 )); then
+        post_status "$context" failure "$blocking blocking (P0/P1) of $total findings"
+    else
+        post_status "$context" success "$total advisory findings, none blocking"
+    fi
+}
+
+rc=0
+run_model "llm-review-opus" opus || rc=1
+run_model "llm-review-terra" terra || rc=1
+exit "$rc"


### PR DESCRIPTION
Implements #1148: the llm-review gate (claude-opus-5 + gpt-5.6-terra pair) as a pluggable replacement for Greptile as the primary review gate. Greptile remains a fully compatible optional stream; nothing changes for existing rows (`review_gate: greptile` default preserved, verified by tests).

## Edit points

**`internal/github/github.go`**
- Two new named streams `llm-review-opus` / `llm-review-terra` via `reviewStreamSpec` (`llmReviewStreamSpec`), wired into the `PRReviewGateVerdict` switch and the `normalizeReviewStreams` whitelist. `llm-review` is a pair alias expanding to both streams.
- `reviewStreamSpec` grows three fields: `BodyContains` (per-stream comment marker — both streams share one bot login, the marker embedded in each comment tells them apart), `HighSeverityOnly` (only P0/P1 findings block; P2/P3 stay advisory), `AllowCommitStatus` (the stream verdict may arrive as a plain commit status — check runs require a GitHub App, statuses work with a normal token). `namedStatusDecision` mirrors `namedCheckDecision` for the combined-status read; a status lookup failure marks the stream `LookupFailed` so silence stays unproven.
- `isHighSeverity` / `isCriticalSeverity` refactored onto a shared `hasSeverityMarker` that matches the Greptile badge markup **and** plain-text markers `[P0]`/`[P1]` and `severity: P0/P1` (regression tests cover both encodings). `isCriticalSeverity` picks up the plain `[P0]` form too, keeping the #565 convergence escape consistent.
- `PRBlockingReviewFindingsOnHead` scopes repair prompts to the bot's P0/P1 comments when either llm stream is enabled.
- Bot login: `isLLMReviewBotLogin` matches logins containing `okbot` or `llm-review` (also added to `isReviewBotLogin` so `CollectReviewFeedback` sees the comments).

**`internal/config/config.go`** — `review_gate: llm-review` (plus `llm_review`/`llmreview` spellings) normalizes to `llm-review`; `normalizeReviewGateStreams` defaults the stream set from the gate value (`llm-review` → the pair), whitelists the two names, and expands the pair alias with dedup. `none` still disables everything.

**`internal/orchestrator/orchestrator.go`** — `reviewGate()` returns `llm-review` for the new gate (still only compared against `"none"`, so merge-flow behavior is unchanged and driven by the generic stream verdict). The greptile-specific `"@greptile review"` re-trigger was already scoped to the greptile stream via `greptileReviewStreamPending`; a new test pins that it never fires for pending llm streams.

**`internal/supervisor/supervisor.go`** — stuck detection enters the review-gate branch for `llm-review` (generic `review_gate_pending` / `review_gate_not_approved` codes, already in the fleet stuck list); the Greptile-only reader fallback is now gated on `review_gate == "greptile"`; merge-readiness and not-ready reasons use the aggregate stream verdict for the llm gate instead of `PRGreptileApproved` (which would otherwise report pending forever with no Greptile installed).

**`internal/server/fleet.go`** — readable stream names ("LLM review (opus)/(terra)") in the PR gate summary. The stuck-code list needed no change (generic codes already listed).

**`scripts/llm-review.sh`** — glue runner: per model, single-shot review of the PR diff (`gh pr diff | claude -p` with a strict `[P0]`-`[P3]` output contract), inline PR comments per finding (falling back to a plain PR comment when the line is outside the diff), and a commit status `llm-review-<model>` on the head SHA — failure iff any P0/P1. Idempotent per head SHA (existing status ⇒ skip). Opus profile unsets the CLIProxy `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN` redirection (subscription seat on an operator host, `ANTHROPIC_API_KEY` on CI); terra profile sets them from `LLM_REVIEW_TERRA_*`.

**`.github/workflows/llm-review.yml`** — calls the script on `pull_request` + `/llm-review` issue comments, **disabled by default** behind `vars.LLM_REVIEW_ENABLED == 'true'`.

**`maestro.yaml.example`** — commented `review_gate: llm-review` block with `review_retrigger.missing_after_minutes: 60`.

## Absent-reviewer behavior

No new machinery: the generic `review_retrigger.missing_after_minutes` escape (#1115) covers the llm streams. New end-to-end tests pin the acceptance behavior: a silent llm-review gate past the grace merges (with the once-per-PR alert), inside the grace waits, an observed (working or rejecting) reviewer never expires, and the greptile nudge comment never fires for llm streams.

## Tests

- `internal/github/llm_review_stream_test.go` — severity parser (plain-text + badge regression), stream whitelist/alias round-trip, `namedCheckDecision`/`namedStatusDecision`, finding attribution + severity contract, and full `PRReviewGateVerdict` runs through the stubbed `gh` seam (green pair passes, one red status blocks, P0 comment blocks despite green statuses, silent gate reads pending+unobserved).
- `internal/config/llm_review_gate_test.go` — gate normalization round-trip, pair default, alias expansion, `none`, unknown-stream fallback, greptile default unchanged.
- `internal/orchestrator/llm_review_gate_test.go` — retrigger suppression + missing-review escape end-to-end through `autoMergePRs`.

`go test ./...` green (umask 022; the one `internal/worker` failure under umask 002 is a pre-existing environment sensitivity, and `internal/worker/opencode_usage.go` gofmt drift is pre-existing on main — both untouched). Touched files gofmt-clean; `go vet ./...` clean.

## Deviations from the issue sketch

- `server/fleet.go:5879` stuck list and `supervisor.go:2140` codes needed no new entries — the generic `review_gate_*` codes shipped earlier already cover stream gates; the supervisor changes are about *entering* those paths for the new gate value.
- Bot login is matched by substring (`okbot` / `llm-review`) rather than a config field — threading a config value through the `PRReviewGateVerdict(prNumber, streams)` interfaces would touch every reader interface for little gain; a dedicated reviewer account containing `llm-review` works without code changes.
- The glue posts **commit statuses**, not check runs (a normal token cannot create check runs), hence the `AllowCommitStatus` spec extension on the Maestro side.

## Deliberately out of scope (happens at resume)

- Daemon-side trigger for the glue (the workflow / manual script run produces the statuses until then).
- Config-store rollout: flipping `review_gate` to `llm-review` and setting `review_retrigger.missing_after_minutes` on the live rows.

Refs #1148, #1115, #565.


## Review round 1 fixes (`d6c9f1a`)

Adversarial review findings, each fixed with a regression test verified to fail against the pre-fix code:

| Finding | Fix | Test |
|---|---|---|
| **P1-1** convergence-merge (#565) bypassed llm-review blocking findings: `prHasCriticalReview` → `PRHasCriticalReviewOnHead` filtered `isGreptileLogin` only | The check is streams-aware: `PRHasCriticalReviewOnHead(pr, streams)` blocks on the llm bot's **P0/P1** on head when llm streams are configured (P0/P1 is that gate's whole blocking contract), Greptile P0 unchanged; orchestrator passes `EffectiveReviewGateStreams()` | `TestPRHasCriticalReviewOnHead_LLMReviewP0Blocks` / `_LLMReviewP1Blocks` / `_LLMReviewAdvisoryDoesNotBlock` / `_StreamScoping` / `_GreptileP0StillBlocks` (github) |
| **P1-2** half-observed pair wedged forever (one stream settled, the other never reported → aggregate `Pending+Observed`, `missing_after` never fired, no retrigger) | Glue: a creds-skipped terra pass posts an explicit `error` status `skipped: credentials not configured` and exits non-zero. Daemon: `missingReviewGateElapsed` is per-stream — a stream with zero signal on the head (this read + new sticky `Session.ReviewGateStreamObserved`) expires past `missing_after_minutes`; an observed stream hard-blocks at any duration; a settled rejection disables the escape; pre-upgrade aggregate-only sticky state stays conservative | `TestLLMReviewScript_MissingTerraCredsPostsErrorStatus`; `TestMissingReviewGateElapsed_HalfObservedPairExpires` / `_ObservedPendingStreamNeverExpires` / `_StickyStreamObservationBlocksExpiry` / `_SettledFailureBlocksEscape` / `_LegacyAggregateStickyBlocks`; `TestAutoMergePRs_HalfObservedPairMergesPastGrace` / `_WaitsInsideGrace` |
| **P1-3** `okbot`/`llm-review` in global `isReviewBotLogin` leaked into gate-independent consumers on ALL projects (fleet-bot comment with file:line became "review feedback" on greptile rows → retry/close churn) | llm logins removed from the global set; llm-bot matching stays scoped to `reviewStreamSpec.UserContains`, `PRBlockingReviewFindingsOnHead`, and the new streams-aware critical check | `TestIsReviewBotLogin_ExcludesLLMReviewBot`, `TestCollectReviewFeedback_FleetBotCommentNotCollected` |
| **P1-4** glue fail-open: zero `^\[P[0-3]\]` matches posted `success` | Fail-closed: success requires ≥1 parsed finding line or the explicit `NO_FINDINGS` sentinel, else `error` status `review output unparseable`; markdown fences are stripped before parsing so fenced findings/sentinel still parse | `TestLLMReviewScript_UnparseableOutputFailsClosed` / `_FencedNoFindingsIsSuccess` / `_FencedFindingsParse` |
| **P2** `status_exists` treated `error`/stale `pending` as settled | `status_settled`: only `success`/`failure` are the idempotency key; retries replace error/pending statuses | `TestLLMReviewScript_ErrorStatusIsNotSettled` / `_SettledStatusSkips` |
| **P2** `/llm-review` comment trigger open to anyone | Workflow gated on `author_association` ∈ MEMBER/OWNER/COLLABORATOR | `TestLLMReviewWorkflowCommentTriggerGatedOnAuthor` |
| **P2** silent diff truncation | Final status description carries `warning: diff truncated to N bytes` | `TestLLMReviewScript_TruncationWarningInStatus` |
| **P2** comments-before-status race (and advisory-comments-during-review race) | Pending-first protocol: both models' statuses are settled (`pending`, or `error` for a skipped model) **before** any model runs or comment lands, then flipped to final | `TestLLMReviewScript_PendingStatusesPrecedeComments` |

The script tests (`internal/github/llm_review_script_test.go`) execute `scripts/llm-review.sh` for real with stubbed `gh`/`claude` binaries; the `gh` stub evaluates the script's `--jq` expressions with actual `jq` against canned combined-status JSON, so the idempotency query is tested against its real semantics.

New session-state field: `Session.ReviewGateStreamObserved` (`review_gate_stream_observed`, omitempty) — per-stream sticky observation memory, reset on head change together with `ReviewGateObserved`.

`gofmt` clean on touched files, `go vet ./...` clean, `go test ./...` green (umask 022).


## Review round 2 fixes (`3fe57cc`)

Round-2 verify found the round-1 okbot fix introduced a regression; all three items fixed:

| Finding | Fix | Test |
|---|---|---|
| **P1 (confirmed)** dead repair circuit on llm-review rows: round 1 removed `okbot` from the global `isReviewBotLogin` without a stream-scoped replacement, so `CollectPRReviewFeedback` → `CollectReviewFeedback` returned empty on llm-review rows — `AutoRetryReviewFeedback` never fired, sessions never reached `retry_exhausted`, and convergence (#565), supervisor review-repair, and the exhaustion notification were all unreachable (PRs hung forever) | Feedback collection is stream-aware: `CollectReviewFeedback` / `CollectPRReviewFeedback` take the configured streams and collect the llm bot's findings via `isCollectableReviewFeedbackLogin` when an llm-review stream is configured; the orchestrator threads `cfg.EffectiveReviewGateStreams()` into the collect path (test seam included). Greptile-only rows still ignore fleet-bot comments — the round-1 regression test stays green | `TestCollectReviewFeedback_LLMReviewRowCollectsBotFinding`, `TestCollectPRReviewFeedback_LLMReviewRowFeedbackNonEmpty` (github); `TestAutoMergePRs_LLMReviewBotFindingEntersRetryPipeline` (orchestrator, end-to-end into the bounded retry); `TestCollectReviewFeedback_FleetBotCommentNotCollected` still green |
| **P2 (accepted)** greptile P0 silently dropped from convergence when greptile is not in the configured streams | `hasCriticalReviewCommentOnHead` blocks on a Greptile P0 **unconditionally** (pre-branch behavior preserved — migration safety while the Greptile app still reviews the repo), plus llm-stream P0/P1 when llm streams are configured | `TestPRHasCriticalReviewOnHead_GreptileP0BlocksOutsideConfiguredStreams` (simplicity-only streams) |
| **Crashed-pending self-heal** (cheap version) | Workflow: per-PR `concurrency` group (`llm-review-<pr>`) with `cancel-in-progress: true`. Script: `status_settled` parses the pending status `created_at` — a pending older than `REVIEW_PENDING_STALE_MINUTES` (default 30, env-overridable) or with an unparseable timestamp is retryable (crashed run), a fresh pending skips (run in flight). `prepare_model` conflation fixed: "already settled → skip" (rc 1, exit 0) is distinct from "pending post failed → abort non-zero" (rc 3) — `post_status` now propagates gh failures, so a transient gh error can no longer produce a green no-op run | `TestLLMReviewWorkflowHasPerPRConcurrencyGroup`, `TestLLMReviewScript_StalePendingIsRetried` / `_FreshPendingSkips` / `_PendingStaleMinutesOverride` / `_PendingPostFailureAbortsNonZero` |

`gofmt` clean on touched files, `go vet ./...` clean, `go test ./...` green (umask 022).
