### PR TITLE
feat(review): add opt-in cursor lens to the llm-review gate

### DIFF
--- a/.github/workflows/llm-review.yml
+++ b/.github/workflows/llm-review.yml
@@ -12,6 +12,12 @@
 #   LLM_REVIEW_TERRA_AUTH_TOKEN — CLIProxy key for the terra pass
 #   ANTHROPIC_API_KEY           — auth for the opus pass (subscription seats
 #                                 do not exist on CI runners)
+#   CURSOR_API_KEY              — auth for the opt-in cursor lens (mirror of
+#                                 Infisical external/prod/cursor/CURSOR_API_KEY)
+#
+# The cursor lens is opt-in: set the repo variable LLM_REVIEW_STREAMS to include
+# "llm-review-cursor" (e.g. "llm-review-opus,llm-review-cursor") AND provide the
+# CURSOR_API_KEY secret. Unset LLM_REVIEW_STREAMS keeps the opus+terra pair.
 
 name: llm-review
 
@@ -52,6 +58,10 @@ jobs:
       - name: Install claude CLI
         run: npm install -g @anthropic-ai/claude-code
 
+      - name: Install cursor-agent CLI
+        if: contains(vars.LLM_REVIEW_STREAMS, 'llm-review-cursor')
+        run: curl https://cursor.com/install -fsS | bash && echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Run llm-review
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -59,6 +69,8 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           LLM_REVIEW_TERRA_BASE_URL: ${{ secrets.LLM_REVIEW_TERRA_BASE_URL }}
           LLM_REVIEW_TERRA_AUTH_TOKEN: ${{ secrets.LLM_REVIEW_TERRA_AUTH_TOKEN }}
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          LLM_REVIEW_STREAMS: ${{ vars.LLM_REVIEW_STREAMS }}
         run: |
           PR_NUMBER="${{ github.event.pull_request.number || github.event.issue.number }}"
           bash scripts/llm-review.sh "$PR_NUMBER" "$GH_REPO"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2385,7 +2385,7 @@ type Config struct {
 	MergeStrategy                   string                        `yaml:"merge_strategy"`                     // "sequential" | "parallel"
 	MergeIntervalSeconds            int                           `yaml:"merge_interval_seconds"`             // minimum seconds between merges in sequential mode
 	ReviewGate                      string                        `yaml:"review_gate"`                        // "greptile" (default) | "llm-review" (#1148 opus+terra pair) | "none"
-	ReviewGateStreams               []string                      `yaml:"review_gate_streams"`                // optional review dimensions; default follows review_gate ("greptile" → ["greptile"], "llm-review" → ["llm-review-opus","llm-review-terra"]); "llm-review" is a pair alias
+	ReviewGateStreams               []string                      `yaml:"review_gate_streams"`                // optional review dimensions; default follows review_gate ("greptile" → ["greptile"], "llm-review" → ["llm-review-opus","llm-review-terra"]); "llm-review" is a pair alias; "llm-review-cursor" is an opt-in third lens (name it explicitly, e.g. ["llm-review-opus","llm-review-cursor"]). NOTE: the producer (scripts/llm-review.sh via its LLM_REVIEW_STREAMS input) must be configured to emit the same streams, or the gate degrades on an unproduced stream via missing_after_minutes.
 	ReviewRetrigger                 ReviewRetriggerConfig         `yaml:"review_retrigger"`                   // #691: re-post "@greptile review" when the gate wedges at pending with no review on head
 	AutoRetryReviewFeedback         bool                          `yaml:"auto_retry_review_feedback"`         // close PRs with review comments and respawn a fixer
 	MergeExhaustedNonCriticalReview *bool                         `yaml:"merge_exhausted_noncritical_review"` // #565: merge a green PR after review-feedback retries exhaust when only non-critical (P1/P2/P3) findings remain (no P0 on head). nil = default-on.
@@ -3085,10 +3085,12 @@ func normalizeReviewGateStreams(reviewGate string, streams []string) []string {
 		switch name {
 		case "", "off", "disabled", "none":
 			continue
-		case "greptile", "simplicity", "llm-review-opus", "llm-review-terra":
+		case "greptile", "simplicity", "llm-review-opus", "llm-review-terra", "llm-review-cursor":
 			add(name)
 		case "llm-review":
-			// Pair alias (#1148): both model lenses.
+			// Pair alias (#1148): both model lenses. The opt-in cursor lens
+			// (llm-review-cursor) is never pulled in by the alias — it must be
+			// named explicitly in review_gate_streams.
 			add("llm-review-opus")
 			add("llm-review-terra")
 		default:

--- a/internal/config/llm_review_gate_test.go
+++ b/internal/config/llm_review_gate_test.go
@@ -57,6 +57,40 @@ review_gate_streams:
 	}
 }
 
+// The opt-in cursor lens is preserved verbatim when named explicitly, so an
+// operator can run the opus+cursor gate. Without the allowlist entry it would
+// be silently dropped.
+func TestParse_ReviewGateStreamsCursorLensOptIn(t *testing.T) {
+	yaml := `
+repo: owner/repo
+review_gate: llm-review
+review_gate_streams:
+  - llm-review-opus
+  - llm-review-cursor
+`
+	cfg, err := parse([]byte(yaml))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []string{"llm-review-opus", "llm-review-cursor"}
+	if got := cfg.EffectiveReviewGateStreams(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("EffectiveReviewGateStreams() = %#v, want %v", got, want)
+	}
+}
+
+// The "llm-review" pair alias must NOT pull in the cursor lens — cursor stays
+// opt-in and is only present when named explicitly.
+func TestParse_ReviewGateAliasDoesNotIncludeCursor(t *testing.T) {
+	cfg, err := parse([]byte("repo: owner/repo\nreview_gate: llm-review\n"))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := []string{"llm-review-opus", "llm-review-terra"}
+	if got := cfg.EffectiveReviewGateStreams(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("EffectiveReviewGateStreams() = %#v, want %v (cursor must not be pulled in by the alias)", got, want)
+	}
+}
+
 // Greptile stays the default and existing rows keep working unchanged.
 func TestParse_ReviewGateDefaultStillGreptile(t *testing.T) {
 	cfg, err := parse([]byte("repo: owner/repo\n"))

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2776,7 +2776,9 @@ var llmReviewBotLogins = []string{"okbot", "llm-review"}
 // stream is part of the configured review streams (the "llm-review" pair
 // alias normalizes to both model streams).
 func llmReviewStreamsConfigured(streams []string) bool {
-	return streamEnabled(streams, "llm-review-opus") || streamEnabled(streams, "llm-review-terra")
+	return streamEnabled(streams, "llm-review-opus") ||
+		streamEnabled(streams, "llm-review-terra") ||
+		streamEnabled(streams, "llm-review-cursor")
 }
 
 // isCollectableReviewFeedbackLogin decides whose comments the feedback
@@ -3928,7 +3930,7 @@ func (c *Client) PRReviewGateVerdict(prNumber int, streams []string) (ReviewGate
 				CheckContains: []string{"simplicity", "over-engineering", "overengineering"},
 				UserContains:  []string{"simplicity", "maestro-simplicity", "over-engineering", "overengineering"},
 			})
-		case "llm-review-opus", "llm-review-terra":
+		case "llm-review-opus", "llm-review-terra", "llm-review-cursor":
 			sv, err = c.namedReviewStreamVerdict(prNumber, llmReviewStreamSpec(stream))
 		default:
 			continue
@@ -4169,10 +4171,11 @@ func normalizeReviewStreams(streams []string) []string {
 	for _, raw := range streams {
 		name := strings.ToLower(strings.TrimSpace(raw))
 		switch name {
-		case "greptile", "simplicity", "llm-review-opus", "llm-review-terra":
+		case "greptile", "simplicity", "llm-review-opus", "llm-review-terra", "llm-review-cursor":
 			add(name)
 		case "llm-review":
 			// The pair alias (#1148): "llm-review" means both model lenses.
+			// llm-review-cursor is opt-in only, never expanded by the alias.
 			add("llm-review-opus")
 			add("llm-review-terra")
 		default:

--- a/internal/github/llm_review_script_test.go
+++ b/internal/github/llm_review_script_test.go
@@ -74,6 +74,23 @@ cat "$STUB_DIR/claude-output"
 exit 0
 `
 
+// cursorAgentStub mirrors the real cursor-agent (live-verified to read the
+// prompt from stdin): it consumes stdin fully (so the piping printf never hits
+// SIGPIPE under the script's pipefail) AND asserts the prompt actually arrived
+// — an empty stdin means the script stopped piping the prompt+diff, which would
+// otherwise ship a lens that reviews nothing yet posts success. On empty stdin
+// it exits non-zero so the cursor branch errors and the test fails loudly.
+const cursorAgentStub = `#!/usr/bin/env bash
+piped="$(cat)"
+if [[ -z "$piped" ]]; then
+    echo "cursor-agent stub: empty stdin — prompt was not piped" >&2
+    exit 3
+fi
+printf 'cursor-agent %s\n' "$*" >> "$STUB_DIR/calls"
+cat "$STUB_DIR/claude-output"
+exit 0
+`
+
 type llmScriptResult struct {
 	exitCode int
 	calls    []string
@@ -95,6 +112,7 @@ func runLLMReviewScript(t *testing.T, claudeOutput, combinedStatus string, terra
 	stubDir := t.TempDir()
 	writeStubFile(t, filepath.Join(stubDir, "gh"), ghStub, 0o755)
 	writeStubFile(t, filepath.Join(stubDir, "claude"), claudeStub, 0o755)
+	writeStubFile(t, filepath.Join(stubDir, "cursor-agent"), cursorAgentStub, 0o755)
 	writeStubFile(t, filepath.Join(stubDir, "claude-output"), claudeOutput, 0o644)
 	writeStubFile(t, filepath.Join(stubDir, "combined-status.json"), combinedStatus, 0o644)
 	writeStubFile(t, filepath.Join(stubDir, "diff"), "diff --git a/a.go b/a.go\n+real change\n", 0o644)
@@ -218,6 +236,76 @@ func TestLLMReviewScript_MissingTerraCredsPostsErrorStatus(t *testing.T) {
 	// The opus pass must still complete normally.
 	if len(callsMatching(res.calls, "state=success", "context=llm-review-opus")) == 0 {
 		t.Fatalf("opus did not finish despite terra being skipped\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+}
+
+// The cursor lens is opt-in: with no LLM_REVIEW_STREAMS the script runs exactly
+// the opus+terra pair and never invokes cursor-agent or posts a cursor status.
+// This is the behaviour-preserving guarantee for existing rows.
+func TestLLMReviewScript_CursorLensOffByDefault(t *testing.T) {
+	res := runLLMReviewScript(t, "NO_FINDINGS\n", emptyStatus, true, "CURSOR_API_KEY=stub-cursor-key")
+	if res.exitCode != 0 {
+		t.Fatalf("exit = %d, want 0\n%s", res.exitCode, res.output)
+	}
+	if len(callsMatching(res.calls, "cursor-agent ")) != 0 {
+		t.Errorf("cursor-agent ran without LLM_REVIEW_STREAMS opting it in\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+	if len(callsMatching(res.calls, "context=llm-review-cursor")) != 0 {
+		t.Errorf("a cursor status was posted while the lens is off by default\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+}
+
+// When LLM_REVIEW_STREAMS opts the cursor lens in and CURSOR_API_KEY is present,
+// cursor-agent runs and posts an llm-review-cursor status, reusing the shared
+// parser (a fenced NO_FINDINGS reads as a clean success).
+func TestLLMReviewScript_CursorLensRunsWhenEnabled(t *testing.T) {
+	res := runLLMReviewScript(t, "NO_FINDINGS\n", emptyStatus, true,
+		"CURSOR_API_KEY=stub-cursor-key",
+		"LLM_REVIEW_STREAMS=llm-review-opus,llm-review-terra,llm-review-cursor")
+	if res.exitCode != 0 {
+		t.Fatalf("exit = %d, want 0\n%s", res.exitCode, res.output)
+	}
+	if len(callsMatching(res.calls, "cursor-agent ")) == 0 {
+		t.Errorf("cursor-agent was not invoked despite being opted in\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+	if len(callsMatching(res.calls, "state=success", "context=llm-review-cursor")) == 0 {
+		t.Errorf("no success status for the cursor lens\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+}
+
+// The single selector makes the terra-free opus+cursor pairing (the whole
+// point of the change) actually achievable: naming only opus+cursor must run
+// exactly those two and never attempt terra.
+func TestLLMReviewScript_OpusCursorPairingSkipsTerra(t *testing.T) {
+	res := runLLMReviewScript(t, "NO_FINDINGS\n", emptyStatus, false, // terra creds absent on purpose
+		"CURSOR_API_KEY=stub-cursor-key",
+		"LLM_REVIEW_STREAMS=llm-review-opus, llm-review-cursor") // note the space: whitespace tolerated
+	if res.exitCode != 0 {
+		t.Fatalf("exit = %d, want 0 — terra must not run (and thus not error) when unselected\n%s", res.exitCode, res.output)
+	}
+	if len(callsMatching(res.calls, "context=llm-review-terra")) != 0 {
+		t.Errorf("terra was attempted despite not being selected\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+	if len(callsMatching(res.calls, "state=success", "context=llm-review-opus")) == 0 ||
+		len(callsMatching(res.calls, "state=success", "context=llm-review-cursor")) == 0 {
+		t.Errorf("expected opus and cursor to both post success\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+}
+
+// P1-2 parity: an opted-in cursor lens with no CURSOR_API_KEY must post an
+// explicit error status (never a silent skip), exactly like the terra guard,
+// so Maestro's gate settles instead of wedging on an unobserved stream.
+func TestLLMReviewScript_CursorEnabledMissingKeyPostsError(t *testing.T) {
+	res := runLLMReviewScript(t, "NO_FINDINGS\n", emptyStatus, true,
+		"LLM_REVIEW_STREAMS=llm-review-opus,llm-review-cursor")
+	if res.exitCode == 0 {
+		t.Fatalf("exit = 0, want non-zero when the opted-in cursor lens cannot run\n%s", res.output)
+	}
+	if len(callsMatching(res.calls, "state=error", "context=llm-review-cursor", "skipped: credentials not configured")) == 0 {
+		t.Fatalf("no skipped-creds error status for cursor\ncalls:\n%s", strings.Join(res.calls, "\n"))
+	}
+	if len(callsMatching(res.calls, "cursor-agent ")) != 0 {
+		t.Errorf("cursor-agent ran despite a missing key\ncalls:\n%s", strings.Join(res.calls, "\n"))
 	}
 }
 

--- a/internal/github/llm_review_stream_test.go
+++ b/internal/github/llm_review_stream_test.go
@@ -102,6 +102,29 @@ func TestStreamEnabled_LLMReviewAlias(t *testing.T) {
 	}
 }
 
+func TestNormalizeReviewStreams_CursorLensPreserved(t *testing.T) {
+	got := normalizeReviewStreams([]string{"llm-review-opus", "llm-review-cursor"})
+	want := []string{"llm-review-opus", "llm-review-cursor"}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Fatalf("normalizeReviewStreams = %v, want %v (cursor lens must survive normalization)", got, want)
+	}
+}
+
+func TestNormalizeReviewStreams_AliasDoesNotAddCursor(t *testing.T) {
+	got := normalizeReviewStreams([]string{"llm-review"})
+	for _, s := range got {
+		if s == "llm-review-cursor" {
+			t.Fatalf("the llm-review alias must not expand to the opt-in cursor lens; got %v", got)
+		}
+	}
+}
+
+func TestLLMReviewStreamsConfigured_CursorOnly(t *testing.T) {
+	if !llmReviewStreamsConfigured([]string{"llm-review-cursor"}) {
+		t.Fatal("a cursor-only stream set must count as an llm-review gate (feedback collection + blocking-finding scoping depend on this)")
+	}
+}
+
 // --- external verdict decisions ---------------------------------------------
 
 func TestNamedCheckDecision_LLMReviewCheckNames(t *testing.T) {

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -4881,6 +4881,8 @@ func fleetPRReviewStreamSummary(stream fleetPRReviewStream) string {
 		name = "LLM review (opus)"
 	} else if strings.EqualFold(name, "llm-review-terra") {
 		name = "LLM review (terra)"
+	} else if strings.EqualFold(name, "llm-review-cursor") {
+		name = "LLM review (cursor)"
 	} else if name != "" {
 		name = strings.ToUpper(name[:1]) + name[1:]
 	} else {

--- a/scripts/llm-review.sh
+++ b/scripts/llm-review.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 # llm-review.sh — glue runner for the llm-review gate (#1148).
 #
-# Runs two single-shot LLM reviews of a PR head diff — claude-opus-5 (the
-# subscription seat: plain `claude -p`) and gpt-5.6-terra (via CLIProxy:
-# ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN + --model) — and publishes, per
-# model:
+# Runs single-shot LLM reviews of a PR head diff and publishes, per model:
 #   1. inline PR review comments (one per finding, with a [P0]-[P3] severity
 #      marker and the stream marker so Maestro can attribute them), and
-#   2. a commit status `llm-review-opus` / `llm-review-terra` on the head SHA:
-#      success unless the model reported any P0/P1 finding.
+#   2. a commit status `llm-review-<lens>` on the head SHA: success unless the
+#      model reported any P0/P1 finding.
+#
+# Lenses:
+#   opus   — claude-opus-5, the subscription seat: plain `claude -p`. Always run.
+#   terra  — gpt-5.6-terra via CLIProxy (ANTHROPIC_BASE_URL/AUTH_TOKEN + --model).
+#            Always run; skipped-with-error if its creds are absent.
+#   cursor — cursor-agent headless (read-only: --mode ask, empty cwd, stdin).
+#            OPT-IN: run only when LLM_REVIEW_STREAMS names "llm-review-cursor".
 #
 # Maestro's review gate (review_gate: llm-review) reads exactly these two
 # surfaces: the status is the stream verdict, the P0/P1 comments are the
@@ -23,7 +27,9 @@
 #
 # Requirements: gh (authenticated), git, jq, claude CLI. For the terra pass:
 # LLM_REVIEW_TERRA_BASE_URL + LLM_REVIEW_TERRA_AUTH_TOKEN (the CLIProxy
-# endpoint/key) — without them the terra pass is skipped with a warning.
+# endpoint/key) — without them the terra pass is skipped with a warning. For
+# the opt-in cursor pass: the cursor-agent CLI on PATH + CURSOR_API_KEY, and
+# LLM_REVIEW_STREAMS must contain "llm-review-cursor".
 #
 # Usage: llm-review.sh <pr-number> [owner/repo]
 
@@ -42,6 +48,9 @@ fi
 
 OPUS_MODEL="${LLM_REVIEW_OPUS_MODEL:-claude-opus-5}"
 TERRA_MODEL="${LLM_REVIEW_TERRA_MODEL:-gpt-5.6-terra}"
+# composer-2.5 is the Cursor "included usage" pool default (cost-safe); raise
+# via LLM_REVIEW_CURSOR_MODEL for more recall at the paid-pool price.
+CURSOR_MODEL="${LLM_REVIEW_CURSOR_MODEL:-composer-2.5}"
 MAX_DIFF_BYTES="${LLM_REVIEW_MAX_DIFF_BYTES:-400000}"
 
 pr_json="$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefOid,baseRefName,title,number)"
@@ -207,6 +216,14 @@ prepare_model() {
         return 2
     fi
 
+    if [[ "$mode" == cursor && -z "${CURSOR_API_KEY:-}" ]]; then
+        echo "llm-review: CURSOR_API_KEY not set — skipping $stream" >&2
+        # Same anti-wedge rule as terra: post an explicit error status rather
+        # than leaving the cursor stream silently unobserved.
+        post_status "$stream" error "skipped: credentials not configured" || true
+        return 2
+    fi
+
     if ! post_status "$stream" pending "review in progress"; then
         return 3
     fi
@@ -245,6 +262,33 @@ run_model() {
                 post_status "$context" error "review run failed"
                 return 1
             fi
+            ;;
+        cursor)
+            # cursor-agent authenticates via CURSOR_API_KEY from the env. Run it
+            # in an EMPTY temp dir with the prompt+diff piped on stdin so the
+            # only thing it can read is what we feed it — it cannot roam the
+            # repo. --mode ask keeps it read-only (no write/shell tools) and
+            # --trust suppresses the workspace-trust prompt WITHOUT the command
+            # auto-approve that -f/--yolo would grant. stdin (not an argv
+            # element) also sidesteps ARG_MAX on large diffs. --output-format
+            # text feeds the shared [P0]-[P3] parser below unchanged.
+            # Capture stdout (the review text) separately from stderr: only the
+            # final answer must reach the [P0]-[P3] parser, never a stray
+            # progress/telemetry line that could read as a spurious finding.
+            local review_dir cur_err
+            review_dir="$(mktemp -d)"
+            cur_err="$review_dir/stderr"
+            if ! output="$( (cd "$review_dir" && \
+                    printf '%s' "$prompt$(cat "$DIFF_FILE")" | \
+                    CURSOR_API_KEY="$CURSOR_API_KEY" cursor-agent -p \
+                        --output-format text --mode ask --trust \
+                        --model "$CURSOR_MODEL") 2>"$cur_err")"; then
+                echo "llm-review: $context run failed: $(cat "$cur_err" 2>/dev/null)" >&2
+                rm -rf "$review_dir"
+                post_status "$context" error "review run failed"
+                return 1
+            fi
+            rm -rf "$review_dir"
             ;;
         *)
             echo "llm-review: unknown mode $mode" >&2
@@ -297,25 +341,52 @@ run_model() {
     fi
 }
 
-# Phase 1: settle every model's status (pending / skipped-error) before any
-# model runs or any comment is posted, so the pair is never half-observed.
+# The producer runs exactly the lenses named in LLM_REVIEW_STREAMS. This MUST
+# mirror the project's review_gate_streams, because the daemon's gate waits on
+# that set — an unproduced-but-expected stream is not a permanent wedge (the
+# per-stream missing_after_minutes escape settles it, #1148 round 2) but it does
+# degrade the gate, so keep the two in sync. Default is the opus+terra pair, so
+# an unset var reproduces the pre-cursor behavior exactly. Whitespace in the
+# list is tolerated ("opus, cursor"). Today this var is provided by the CI
+# workflow from a repo variable; the planned daemon-side trigger will pass
+# review_gate_streams here directly.
+STREAMS=",${LLM_REVIEW_STREAMS:-llm-review-opus,llm-review-terra},"
+STREAMS="${STREAMS// /}"
+selected() { [[ "$STREAMS" == *",$1,"* ]]; }
+
+# Phase 1: settle every selected lens's status (pending / skipped-error) before
+# any model runs or any comment is posted, so the set is never half-observed.
 rc=0
 RUN_OPUS=0
 RUN_TERRA=0
-prep_rc=0
-prepare_model "llm-review-opus" opus || prep_rc=$?
-case "$prep_rc" in
-    0) RUN_OPUS=1 ;;
-    1) ;;       # settled / in flight — legitimate skip
-    *) rc=1 ;;  # 2 = creds skip (error status posted), 3 = pending post failed
-esac
-prep_rc=0
-prepare_model "llm-review-terra" terra || prep_rc=$?
-case "$prep_rc" in
-    0) RUN_TERRA=1 ;;
-    1) ;;
-    *) rc=1 ;;
-esac
+RUN_CURSOR=0
+if selected llm-review-opus; then
+    prep_rc=0
+    prepare_model "llm-review-opus" opus || prep_rc=$?
+    case "$prep_rc" in
+        0) RUN_OPUS=1 ;;
+        1) ;;       # settled / in flight — legitimate skip
+        *) rc=1 ;;  # 2 = creds skip (error status posted), 3 = pending post failed
+    esac
+fi
+if selected llm-review-terra; then
+    prep_rc=0
+    prepare_model "llm-review-terra" terra || prep_rc=$?
+    case "$prep_rc" in
+        0) RUN_TERRA=1 ;;
+        1) ;;
+        *) rc=1 ;;
+    esac
+fi
+if selected llm-review-cursor; then
+    prep_rc=0
+    prepare_model "llm-review-cursor" cursor || prep_rc=$?
+    case "$prep_rc" in
+        0) RUN_CURSOR=1 ;;
+        1) ;;
+        *) rc=1 ;;
+    esac
+fi
 
 # Phase 2: run the reviews and flip each pending status to its final state.
 if (( RUN_OPUS )); then
@@ -323,5 +394,8 @@ if (( RUN_OPUS )); then
 fi
 if (( RUN_TERRA )); then
     run_model "llm-review-terra" terra || rc=1
+fi
+if (( RUN_CURSOR )); then
+    run_model "llm-review-cursor" cursor || rc=1
 fi
 exit "$rc"


### PR DESCRIPTION
## Summary

Adds an opt-in third review lens — `llm-review-cursor` — to the llm-review gate (#1148), so the gate can run the **opus + cursor** pairing that a hard bake-off on real PRs ranked best.

## Why cursor (data, not vibes)

A two-round bake-off scored 7 engines against reconstructed ground truth on two real Maestro PRs:
- **#791** (model-routing): the 9 defects from the post-merge deep review (#792) that Greptile+tests missed, incl. the key P1 (`appendTierModelEffort` argv leak).
- **#1152-prefix**: the 4 CONFIRMED P1 from llm-review round 1 (convergence-bypass, eternal-wedge, okbot-leak, fail-open) + codex-bot's 2 P1.

Result: **opus-5 #1** (broad recall, caught the key P1), **cursor-agent #2** (perfect precision, uniquely caught the hardest eternal-wedge P1 both halves). glm-5.2/grok/gpt-5.5 were weaker on real code (glm failed structured output AND dismissed real bugs). Full analysis: vault `Dev/Areas/maestro/research/2026-08-10-cursor-vs-greptile-review-gate.md` §7.

## What changed

**Gate (Go, 4 edits):** register `llm-review-cursor` in the two stream allowlists (config + github normalizers), the `PRReviewGateVerdict` dispatch, and `llmReviewStreamsConfigured`. The generic `llmReviewStreamSpec(name)` builder means no per-stream spec is needed; orchestrator per-stream wait and supervisor gate eval are already data-driven off `EffectiveReviewGateStreams()`. The `llm-review` pair alias stays opus+terra — cursor is opt-in only.

**Producer (`scripts/llm-review.sh`):** a single `LLM_REVIEW_STREAMS` selector now drives which of opus/terra/cursor run (default `opus+terra` → unchanged when unset), making the **terra-free opus+cursor pairing achievable**. The cursor lens runs `cursor-agent` headless and **read-only**:
- `--mode ask` (Q&A, no edit/run tools), `--trust` (suppresses the workspace-trust prompt, **not** the `-f/--yolo` command auto-approve),
- an empty `mktemp -d` cwd + prompt/diff piped on **stdin** (live-verified) → it can't roam the repo or hit ARG_MAX,
- stdout/stderr captured separately so telemetry can't leak into the `[P0]-[P3]` parser.

It reuses the shared parser, fail-closed-on-unparseable guard, and pending-first protocol. A selected cursor lens with no `CURSOR_API_KEY` posts an explicit error status like the terra guard (P1-2 parity). `LLM_REVIEW_STREAMS` must mirror `review_gate_streams`; a mismatch degrades via `missing_after_minutes`, not a permanent wedge.

**CI:** cursor-agent install (conditioned on the stream var) + `CURSOR_API_KEY` + `LLM_REVIEW_STREAMS` env.

## Enabling it

Set `review_gate_streams: [llm-review-opus, llm-review-cursor]` (gate) **and** `LLM_REVIEW_STREAMS` + `CURSOR_API_KEY` on the producer (CI repo var/secret; the planned daemon-side trigger will pass `review_gate_streams` directly).

## Verification

- `go build ./...`, `go vet`, `gofmt` clean on all touched files; `go test` green across config/github/server/orchestrator/supervisor.
- `shellcheck -S warning` clean; `bash -n` OK.
- New tests: config + github stream registration; script-level cursor cases (off-by-default / runs-when-enabled with a stub that **asserts stdin delivery** / terra-free opus+cursor pairing / missing-key→error).
- The diff was adversarially reviewed; the review's P1 (a cross-layer opt-in drift) and P2s (terra not opt-out-able, untested stdin contract) are fixed in this revision.

## Notes

- Cursor API key lives in Infisical `external/prod/cursor/CURSOR_API_KEY`; mirror it as the CI `CURSOR_API_KEY` secret when enabling.
- Deploy: the runtime host checkout was stale (`cd303d53`, pre-#1148) at authoring time — it needs a `git pull` before this ships.

Implemented interactively per the dogfood-suspension policy — **not** labelled `maestro-ready`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge-blocking review gate behavior when operators opt in; misaligned gate vs producer config can degrade the gate until missing_after_minutes, though defaults preserve existing opus+terra behavior.
> 
> **Overview**
> Adds an **opt-in third llm-review stream** (`llm-review-cursor`) so projects can run **opus + cursor** (or other mixes) without changing the default **opus + terra** pair.
> 
> **Producer (`scripts/llm-review.sh`):** `LLM_REVIEW_STREAMS` selects which lenses run (default unchanged). The cursor pass uses `cursor-agent` in read-only mode with prompt+diff on stdin, posts `llm-review-cursor` commit statuses, and fails closed with an explicit error if the lens is selected but `CURSOR_API_KEY` is missing (same pattern as terra creds).
> 
> **Gate (Go):** `llm-review-cursor` is allowlisted in config/github stream normalization, verdict dispatch, and llm-review feedback scoping. The `llm-review` alias still expands only to opus+terra—cursor must be named explicitly in `review_gate_streams`, which should match the producer’s `LLM_REVIEW_STREAMS`.
> 
> **CI:** Conditionally installs `cursor-agent` and passes `CURSOR_API_KEY` / `LLM_REVIEW_STREAMS` when the cursor lens is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 366c3839186d5b09635132f283e2cfdb09d5888f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds an opt-in Cursor review stream across configuration, review gating, fleet display, and the review workflow. The Cursor installation path was exercised with a local installer model and confirmed that an untrusted installer response can provide the executable later run with review credentials.

Merge safety conclusion: do not merge until the Cursor CLI installation is pinned and integrity-verified before execution.

<h3>Confidence Score: 4/5</h3>

The change is not merge-safe until the credentialed Cursor CLI installation is made trusted and reproducible.

One verified P2 security finding remains; under the required scoring table, P2-only findings produce a score of 4.

**Files Needing Attention:** .github/workflows/llm-review.yml needs a pinned and integrity-verified Cursor CLI installation mechanism.

<details open><summary><h3>Security Review</h3></summary>

A supply-chain credential-exposure issue remains in the Cursor workflow path. The workflow pipes a mutable installer response into Bash, adds its installation directory to `PATH`, and then runs the resulting binary with GitHub and Cursor credentials. Use a pinned, integrity-verified installer or artifact.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a formal proof for the posted P2 finding and linked it to the corresponding review comment.
- T-Rex prepared a self-contained mutable installer harness to reproduce the scenario.
- T-Rex ran the benign installer path with the harness and captured the benign execution output.
- T-Rex ran the compromised installer path with the harness and captured the compromised execution output.
- T-Rex compared the benign and compromised outputs to validate the finding and document observable differences.

<a href="https://app.greptile.com/trex/runs/18166828/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/llm-review.yml:63
**Unpinned credentialed CLI installer**

The Cursor installer is fetched from a mutable endpoint and immediately piped to Bash. That installer can place an arbitrary `cursor-agent` in `$HOME/.local/bin`, which is added to `GITHUB_PATH`; the subsequent review step invokes that binary while `GH_TOKEN` and `CURSOR_API_KEY` are exported. Pin and integrity-verify the installer or a downloaded artifact before executing it so a compromised installer cannot exfiltrate those credentials.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(review): add opt-in cursor lens to ..."](https://github.com/befeast/maestro/commit/366c3839186d5b09635132f283e2cfdb09d5888f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51925459)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->