### PR TITLE
fix(review): attribute the Forgejo fleet bot (oklabs-bot) in the llm-review gate

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2769,8 +2769,11 @@ func isLLMReviewBotLogin(login string) bool {
 }
 
 // llmReviewBotLogins are the login substrings attributed to the llm-review
-// glue runner (#1148).
-var llmReviewBotLogins = []string{"okbot", "llm-review"}
+// glue runner (#1148). "okbot" is the GitHub fleet bot; "oklabs-bot" is the
+// Forgejo fleet bot (git.oklabs.uk) — note it does NOT contain "okbot"
+// (ok-labs-bot, not ok-bot), so it needs its own entry or Forgejo review
+// comments go unattributed.
+var llmReviewBotLogins = []string{"okbot", "oklabs-bot", "llm-review"}
 
 // llmReviewStreamsConfigured reports whether at least one llm-review model
 // stream is part of the configured review streams (the "llm-review" pair

--- a/internal/github/llm_review_stream_test.go
+++ b/internal/github/llm_review_stream_test.go
@@ -223,7 +223,9 @@ func TestFilterStreamFindings_IgnoresOtherLoginsAndOldHeads(t *testing.T) {
 }
 
 func TestIsLLMReviewBotLogin(t *testing.T) {
-	for _, login := range []string{"okbot", "OKBot", "llm-review-bot", "acme-llm-review"} {
+	// "oklabs-bot" is the Forgejo fleet bot — it does not contain "okbot", so
+	// it must match on its own entry, not incidentally.
+	for _, login := range []string{"okbot", "OKBot", "oklabs-bot", "OkLabs-Bot", "llm-review-bot", "acme-llm-review"} {
 		if !isLLMReviewBotLogin(login) {
 			t.Errorf("isLLMReviewBotLogin(%q) = false, want true", login)
 		}


### PR DESCRIPTION
S1 of #1162 (Go review producer, forge-agnostic).

The gate matches review-bot comment authors by login substring (`llmReviewBotLogins`). GitHub bot = `okbot`; the **Forgejo** fleet bot on git.oklabs.uk is `oklabs-bot`, which does **not** contain `okbot` (ok-**labs**-bot). Without its own entry, Forgejo review comments post unattributed and the gate never treats them as blocking findings.

Adds `oklabs-bot` to the list + covers it in `TestIsLLMReviewBotLogin`. Verified against the live git.oklabs.uk instance (the Forgejo bot user is `oklabs-bot`; `okbot` does not exist there).

Small, correct regardless of the rest; first slice toward the in-daemon Go producer. Interactive dev per dogfood suspension — not `maestro-ready`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> A one-line login allowlist change plus tests; it only broadens llm-review bot detection on stream-scoped paths and does not alter global greptile/codex behavior.
> 
> **Overview**
> Adds **`oklabs-bot`** to **`llmReviewBotLogins`** so llm-review inline comments from the Forgejo fleet bot on git.oklabs.uk count as bot-authored. GitHub uses **`okbot`**; **`oklabs-bot`** does not contain that substring, so without a separate entry those comments were ignored and blocking findings, feedback collection, and stream verdicts never attributed them.
> 
> **`TestIsLLMReviewBotLogin`** now covers **`oklabs-bot`** / **`OkLabs-Bot`** alongside the existing GitHub bot cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7911d310c2f9ea97b7491ff5476ba1d6f535f965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change recognizes the Forgejo fleet bot (`oklabs-bot`) as an llm-review author while keeping that attribution limited to projects with an llm-review stream configured. Focused Go coverage verified lowercase and mixed-case bot logins: P0/P1 comments are attributed and collected for llm-review, but remain excluded from Greptile-only and Codex-only feedback collection. The same behavior was absent on the parent commit and succeeds with this change.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on focused verification of the Forgejo bot attribution and stream-scoping behavior.

No defects remain in the reviewed change. The executed check covered both supported login casings, llm-review finding attribution, feedback collection, and the non-llm isolation controls.

**Files Needing Attention:** None; the modified implementation and its focused tests were covered by the executed check.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the end-to-end test TestTrexOKLabsBotLLMFeedbackEndToEnd on the parent commit and observed zero llm-stream findings for both Forgejo bot login variants, with the harness exiting 1.
- Re-ran the same test for the PR head after the Forgejo bot attribution fix; both login variants passed llm finding attribution and feedback-collection checks, including non-llm exclusion controls, and the harness exited 0.

<a href="https://app.greptile.com/trex/runs/18174703/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(review): attribute the Forgejo fleet..."](https://github.com/befeast/maestro/commit/7911d310c2f9ea97b7491ff5476ba1d6f535f965) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51939625)</sub>

<!-- /greptile_comment -->