### PR TITLE
feat(forge): forge-agnostic client surface with a GitHub implementation (#1162 S2)

### DIFF
--- a/internal/forge/forge.go
+++ b/internal/forge/forge.go
@@ -1,0 +1,77 @@
+// Package forge defines the minimal forge-agnostic client surface the
+// llm-review producer needs (#1162): read one PR and its diff, read and write
+// plain commit statuses, and post inline or plain PR comments. GitHub and
+// Forgejo implement it; everything richer (check runs, labels, merges, issue
+// lifecycle) stays on the forge-specific clients because Forgejo has no
+// equivalent surface.
+//
+// The surface is deliberately the exact op set of scripts/llm-review.sh so the
+// producer port (S4) is a transliteration, not a redesign. Implementations:
+// GitHub in internal/github (this slice), Forgejo in a follow-up (S3).
+package forge
+
+import (
+	"context"
+	"time"
+)
+
+// PR is the subset of pull-request metadata the review producer consumes.
+type PR struct {
+	Number  int
+	Title   string
+	HeadSHA string
+	BaseRef string
+}
+
+// StatusState is a commit-status state. The four values below are the write
+// vocabulary both GitHub and Forgejo accept; implementations normalize their
+// read side to the same strings (Forgejo reports a per-status `.status` field,
+// not `.state` — its client maps that here).
+type StatusState string
+
+const (
+	StatusPending StatusState = "pending"
+	StatusSuccess StatusState = "success"
+	StatusError   StatusState = "error"
+	StatusFailure StatusState = "failure"
+)
+
+// Status is one commit status: the write payload of CreateCommitStatus and the
+// read shape of CommitStatuses.
+type Status struct {
+	Context     string
+	State       StatusState
+	Description string
+	TargetURL   string
+	// CreatedAt is read-side only: the producer's stale-pending self-heal
+	// compares it against the retry threshold. Zero when the forge omitted the
+	// timestamp or reported one that does not parse — the producer treats a
+	// pending with no usable age as crashed rather than wedging on it.
+	CreatedAt time.Time
+}
+
+// Client is the forge-agnostic op surface of the review producer. repo is
+// always "owner/name"; index is the PR number in the forge's shared PR/issue
+// number space.
+type Client interface {
+	// GetPR returns the PR's current metadata. Implementations must reject a
+	// response with an empty head SHA: every downstream op keys on it.
+	GetPR(ctx context.Context, repo string, index int) (PR, error)
+	// GetPRDiff returns the PR's unified diff, uninterpreted.
+	GetPRDiff(ctx context.Context, repo string, index int) ([]byte, error)
+	// CommitStatuses returns the commit statuses on one SHA, one entry per
+	// context — the latest per context, which both forges' combined-status
+	// endpoints already guarantee, so callers never dedup.
+	CommitStatuses(ctx context.Context, repo, sha string) ([]Status, error)
+	// CreateCommitStatus posts status.State/Description/TargetURL under
+	// status.Context on the SHA. CreatedAt is ignored.
+	CreateCommitStatus(ctx context.Context, repo, sha string, status Status) error
+	// CreateReviewComment posts an inline PR comment anchored to a new-file
+	// line of the diff at the given head SHA. A position the forge rejects
+	// (line outside the diff, renamed file) surfaces as an error so the
+	// caller can fall back to CreateComment instead of losing the finding.
+	CreateReviewComment(ctx context.Context, repo string, index int, sha, path string, line int, body string) error
+	// CreateComment posts a plain PR comment (the PR/issue comment space is
+	// shared on both forges).
+	CreateComment(ctx context.Context, repo string, index int, body string) error
+}

--- a/internal/github/forge.go
+++ b/internal/github/forge.go
@@ -1,0 +1,176 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/forge"
+)
+
+// Forge implements forge.Client for GitHub on this package's hardened gh
+// transport (#1162 S2): rate-limit classification with backoff, the primary
+// -limit fail-fast gate, conditional-request caching on the eligible reads,
+// App-auth injection, and the bounded subprocess fence all apply unchanged.
+// It is stateless — the repo travels per call, so one value serves every
+// project flow.
+//
+// Context handling matches the rest of this package: ctx is checked before
+// dispatch, and the call itself is bounded by the transport's own deadline
+// (ghTimeout per attempt) rather than by mid-flight ctx propagation.
+type Forge struct{}
+
+// NewForge returns the GitHub forge client.
+func NewForge() *Forge { return &Forge{} }
+
+var _ forge.Client = (*Forge)(nil)
+
+// GetPR returns the PR metadata the review producer keys on. An empty head
+// SHA is rejected here — every downstream op (statuses, inline comments)
+// anchors to it, so serving one would only defer the failure.
+func (f *Forge) GetPR(ctx context.Context, repo string, index int) (forge.PR, error) {
+	if err := ctx.Err(); err != nil {
+		return forge.PR{}, err
+	}
+	out, err := ghAPI(fmt.Sprintf("repos/%s/pulls/%d", repo, index))
+	if err != nil {
+		return forge.PR{}, fmt.Errorf("get PR %s#%d: %w", repo, index, err)
+	}
+	var pull restPull
+	if err := json.Unmarshal(out, &pull); err != nil {
+		return forge.PR{}, fmt.Errorf("parse PR %s#%d: %w", repo, index, err)
+	}
+	sha := strings.TrimSpace(pull.Head.SHA)
+	if sha == "" {
+		return forge.PR{}, fmt.Errorf("PR %s#%d has an empty head sha", repo, index)
+	}
+	return forge.PR{
+		Number:  pull.Number,
+		Title:   pull.Title,
+		HeadSHA: sha,
+		BaseRef: pull.Base.Ref,
+	}, nil
+}
+
+// GetPRDiff returns the PR's unified diff. The Accept override makes gh api
+// return the diff media type; its presence in the args also keeps the call off
+// the conditional-request path, so the raw (non-JSON) body passes through the
+// transport untouched.
+func (f *Forge) GetPRDiff(ctx context.Context, repo string, index int) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d", repo, index),
+		"-H", "Accept: application/vnd.github.diff")
+	if err != nil {
+		return nil, fmt.Errorf("get PR %s#%d diff: %w", repo, index, err)
+	}
+	return out, nil
+}
+
+// restCommitStatus is the per-status element of the combined-status payload,
+// carrying the fields combinedStatusResponse drops (created_at for the
+// producer's stale-pending self-heal, description and target_url for
+// round-tripping).
+type restCommitStatus struct {
+	Context     string `json:"context"`
+	State       string `json:"state"`
+	Description string `json:"description"`
+	TargetURL   string `json:"target_url"`
+	CreatedAt   string `json:"created_at"`
+}
+
+// CommitStatuses returns the statuses on one SHA. The combined-status endpoint
+// reports the latest status per context, so the result needs no dedup. A
+// created_at that is absent or does not parse maps to a zero CreatedAt — the
+// forge.Status contract for "no usable age".
+func (f *Forge) CommitStatuses(ctx context.Context, repo, sha string) ([]forge.Status, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	out, err := ghAPI(fmt.Sprintf("repos/%s/commits/%s/status", repo, sha))
+	if err != nil {
+		return nil, fmt.Errorf("commit statuses for %s@%s: %w", repo, sha, err)
+	}
+	var combined struct {
+		Statuses []restCommitStatus `json:"statuses"`
+	}
+	if err := json.Unmarshal(out, &combined); err != nil {
+		return nil, fmt.Errorf("parse commit statuses for %s@%s: %w", repo, sha, err)
+	}
+	statuses := make([]forge.Status, 0, len(combined.Statuses))
+	for _, st := range combined.Statuses {
+		createdAt, err := time.Parse(time.RFC3339, strings.TrimSpace(st.CreatedAt))
+		if err != nil {
+			createdAt = time.Time{}
+		}
+		statuses = append(statuses, forge.Status{
+			Context:     st.Context,
+			State:       forge.StatusState(strings.ToLower(strings.TrimSpace(st.State))),
+			Description: st.Description,
+			TargetURL:   st.TargetURL,
+			CreatedAt:   createdAt,
+		})
+	}
+	return statuses, nil
+}
+
+// CreateCommitStatus posts one commit status. Errors must reach the caller
+// unswallowed: the producer's pending-first protocol aborts a run whose
+// pending post failed, and a transient error here reading as success is
+// exactly the silent no-op the bash glue was hardened against.
+func (f *Forge) CreateCommitStatus(ctx context.Context, repo, sha string, status forge.Status) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if status.Context == "" || status.State == "" {
+		return fmt.Errorf("create status on %s@%s: context and state are required", repo, sha)
+	}
+	args := []string{
+		"-f", "state=" + string(status.State),
+		"-f", "context=" + status.Context,
+		"-f", "description=" + status.Description,
+	}
+	if status.TargetURL != "" {
+		args = append(args, "-f", "target_url="+status.TargetURL)
+	}
+	if _, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/statuses/%s", repo, sha), args...); err != nil {
+		return fmt.Errorf("create status %s=%s on %s@%s: %w", status.Context, status.State, repo, sha, err)
+	}
+	return nil
+}
+
+// CreateReviewComment posts an inline comment on a new-file line of the diff
+// at the given head. A rejected anchor (line outside the diff, renamed file)
+// returns an error; the caller owns the fall-back to CreateComment.
+func (f *Forge) CreateReviewComment(ctx context.Context, repo string, index int, sha, path string, line int, body string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d/comments", repo, index),
+		"-f", "body="+body,
+		"-f", "commit_id="+sha,
+		"-f", "path="+path,
+		"-F", fmt.Sprintf("line=%d", line),
+		"-f", "side=RIGHT")
+	if err != nil {
+		return fmt.Errorf("create review comment on %s#%d %s:%d: %w", repo, index, path, line, err)
+	}
+	return nil
+}
+
+// CreateComment posts a plain PR comment via the issues endpoint (PRs share
+// the issue number space).
+func (f *Forge) CreateComment(ctx context.Context, repo string, index int, body string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	_, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments", repo, index),
+		"-f", "body="+body)
+	if err != nil {
+		return fmt.Errorf("create comment on %s#%d: %w", repo, index, err)
+	}
+	return nil
+}

--- a/internal/github/forge_test.go
+++ b/internal/github/forge_test.go
@@ -1,0 +1,266 @@
+package github
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/forge"
+)
+
+// The forge.Client implementation is exercised through the same ghAPIRunner
+// seam as every other read in this package: plain JSON bodies pass the
+// conditional layer untouched (see stubLLMReviewAPI), so each test dispatches
+// canned responses by endpoint and asserts on the recorded args.
+
+func forgeCallWith(calls [][]string, fragment string) []string {
+	for _, call := range calls {
+		for _, arg := range call {
+			if strings.Contains(arg, fragment) {
+				return call
+			}
+		}
+	}
+	return nil
+}
+
+func TestForgeGetPR(t *testing.T) {
+	clearETagCache(t)
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		return []byte(`{"number":7,"title":"fix: things","head":{"ref":"fix/things","sha":" abc123 "},"base":{"ref":"main"}}`), nil
+	})
+	pr, err := NewForge().GetPR(context.Background(), "owner/repo", 7)
+	if err != nil {
+		t.Fatalf("GetPR: %v", err)
+	}
+	want := forge.PR{Number: 7, Title: "fix: things", HeadSHA: "abc123", BaseRef: "main"}
+	if pr != want {
+		t.Fatalf("GetPR = %+v, want %+v", pr, want)
+	}
+	if forgeCallWith(*calls, "repos/owner/repo/pulls/7") == nil {
+		t.Fatalf("expected a repos/owner/repo/pulls/7 read, got %v", *calls)
+	}
+}
+
+func TestForgeGetPR_EmptyHeadSHA(t *testing.T) {
+	clearETagCache(t)
+	withGHRunner(t, func(args []string) ([]byte, error) {
+		return []byte(`{"number":7,"title":"t","head":{"ref":"b","sha":""},"base":{"ref":"main"}}`), nil
+	})
+	if _, err := NewForge().GetPR(context.Background(), "owner/repo", 7); err == nil {
+		t.Fatal("an empty head sha must be rejected — every downstream op anchors to it")
+	}
+}
+
+func TestForgeGetPRDiff(t *testing.T) {
+	diff := "diff --git a/x.go b/x.go\n+not json\n"
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		return []byte(diff), nil
+	})
+	out, err := NewForge().GetPRDiff(context.Background(), "owner/repo", 7)
+	if err != nil {
+		t.Fatalf("GetPRDiff: %v", err)
+	}
+	if string(out) != diff {
+		t.Fatalf("diff body = %q, want raw passthrough %q", out, diff)
+	}
+	call := forgeCallWith(*calls, "repos/owner/repo/pulls/7")
+	if call == nil {
+		t.Fatalf("expected a pulls/7 call, got %v", *calls)
+	}
+	if !hasArg(call, "Accept: application/vnd.github.diff") {
+		t.Fatalf("diff read must override Accept, got %v", call)
+	}
+}
+
+func TestForgeCommitStatuses(t *testing.T) {
+	clearETagCache(t)
+	withGHRunner(t, func(args []string) ([]byte, error) {
+		return []byte(`{"state":"failure","statuses":[
+			{"context":"llm-review-opus","state":"SUCCESS","description":"ok","target_url":"https://x","created_at":"2026-08-10T12:00:00Z"},
+			{"context":"llm-review-cursor","state":"pending","created_at":"not-a-time"}]}`), nil
+	})
+	statuses, err := NewForge().CommitStatuses(context.Background(), "owner/repo", "abc123")
+	if err != nil {
+		t.Fatalf("CommitStatuses: %v", err)
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("statuses = %d, want 2", len(statuses))
+	}
+	first := statuses[0]
+	if first.Context != "llm-review-opus" || first.State != forge.StatusSuccess ||
+		first.Description != "ok" || first.TargetURL != "https://x" {
+		t.Fatalf("first status = %+v", first)
+	}
+	if want := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC); !first.CreatedAt.Equal(want) {
+		t.Fatalf("first CreatedAt = %v, want %v", first.CreatedAt, want)
+	}
+	second := statuses[1]
+	if second.State != forge.StatusPending {
+		t.Fatalf("second state = %q, want pending", second.State)
+	}
+	if !second.CreatedAt.IsZero() {
+		t.Fatalf("an unparseable created_at must map to zero (no usable age), got %v", second.CreatedAt)
+	}
+}
+
+func TestForgeCreateCommitStatus(t *testing.T) {
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		return []byte(`{}`), nil
+	})
+	err := NewForge().CreateCommitStatus(context.Background(), "owner/repo", "abc123", forge.Status{
+		Context:     "llm-review-opus",
+		State:       forge.StatusPending,
+		Description: "review in progress",
+	})
+	if err != nil {
+		t.Fatalf("CreateCommitStatus: %v", err)
+	}
+	call := forgeCallWith(*calls, "repos/owner/repo/statuses/abc123")
+	if call == nil {
+		t.Fatalf("expected a statuses/abc123 post, got %v", *calls)
+	}
+	for _, want := range []string{"state=pending", "context=llm-review-opus", "description=review in progress"} {
+		if !hasArg(call, want) {
+			t.Fatalf("missing field %q in %v", want, call)
+		}
+	}
+	if arg := argWithPrefix(call, "target_url="); arg != "" {
+		t.Fatalf("empty TargetURL must not be posted, got %q", arg)
+	}
+}
+
+func TestForgeCreateCommitStatus_TargetURL(t *testing.T) {
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		return []byte(`{}`), nil
+	})
+	err := NewForge().CreateCommitStatus(context.Background(), "owner/repo", "abc123", forge.Status{
+		Context:   "llm-review-opus",
+		State:     forge.StatusSuccess,
+		TargetURL: "https://example.test/run/1",
+	})
+	if err != nil {
+		t.Fatalf("CreateCommitStatus: %v", err)
+	}
+	call := forgeCallWith(*calls, "repos/owner/repo/statuses/abc123")
+	if !hasArg(call, "target_url=https://example.test/run/1") {
+		t.Fatalf("TargetURL must be posted when set, got %v", call)
+	}
+}
+
+func TestForgeCreateCommitStatus_ErrorPropagates(t *testing.T) {
+	withGHRunner(t, func(args []string) ([]byte, error) {
+		return []byte("HTTP 502"), errors.New("boom")
+	})
+	err := NewForge().CreateCommitStatus(context.Background(), "owner/repo", "abc123", forge.Status{
+		Context: "llm-review-opus",
+		State:   forge.StatusPending,
+	})
+	if err == nil {
+		t.Fatal("a failed status post must surface — a swallowed error here is the silent-no-op bug the bash glue was hardened against")
+	}
+}
+
+func TestForgeCreateCommitStatus_RequiresContextAndState(t *testing.T) {
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		return []byte(`{}`), nil
+	})
+	err := NewForge().CreateCommitStatus(context.Background(), "owner/repo", "abc123", forge.Status{State: forge.StatusPending})
+	if err == nil {
+		t.Fatal("a status without a context must be rejected")
+	}
+	err = NewForge().CreateCommitStatus(context.Background(), "owner/repo", "abc123", forge.Status{Context: "llm-review-opus"})
+	if err == nil {
+		t.Fatal("a status without a state must be rejected")
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("validation failures must not reach the API, got %v", *calls)
+	}
+}
+
+func TestForgeCreateReviewComment(t *testing.T) {
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		return []byte(`{}`), nil
+	})
+	err := NewForge().CreateReviewComment(context.Background(), "owner/repo", 7, "abc123", "a.go", 42, "[P1] boom")
+	if err != nil {
+		t.Fatalf("CreateReviewComment: %v", err)
+	}
+	call := forgeCallWith(*calls, "repos/owner/repo/pulls/7/comments")
+	if call == nil {
+		t.Fatalf("expected a pulls/7/comments post, got %v", *calls)
+	}
+	for _, want := range []string{"body=[P1] boom", "commit_id=abc123", "path=a.go", "line=42", "side=RIGHT"} {
+		if !hasArg(call, want) {
+			t.Fatalf("missing field %q in %v", want, call)
+		}
+	}
+}
+
+func TestForgeCreateReviewComment_ErrorPropagates(t *testing.T) {
+	withGHRunner(t, func(args []string) ([]byte, error) {
+		return []byte("HTTP 422 Validation Failed"), errors.New("boom")
+	})
+	err := NewForge().CreateReviewComment(context.Background(), "owner/repo", 7, "abc123", "a.go", 9999, "[P1] boom")
+	if err == nil {
+		t.Fatal("a rejected inline anchor must surface as an error — it is the caller's CreateComment fallback trigger, and swallowing it drops findings")
+	}
+}
+
+func TestForgeCreateComment(t *testing.T) {
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		return []byte(`{}`), nil
+	})
+	err := NewForge().CreateComment(context.Background(), "owner/repo", 7, "[P1] boom (at `a.go:42`)")
+	if err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+	call := forgeCallWith(*calls, "repos/owner/repo/issues/7/comments")
+	if call == nil {
+		t.Fatalf("expected an issues/7/comments post, got %v", *calls)
+	}
+	if !hasArg(call, "body=[P1] boom (at `a.go:42`)") {
+		t.Fatalf("missing body field in %v", call)
+	}
+}
+
+func TestForgeCreateComment_ErrorPropagates(t *testing.T) {
+	withGHRunner(t, func(args []string) ([]byte, error) {
+		return []byte("HTTP 502"), errors.New("boom")
+	})
+	if err := NewForge().CreateComment(context.Background(), "owner/repo", 7, "b"); err == nil {
+		t.Fatal("a failed fallback comment must not read as posted — it is the last resort before a finding is lost")
+	}
+}
+
+func TestForge_ContextCanceled(t *testing.T) {
+	calls := withGHRunner(t, func(args []string) ([]byte, error) {
+		return []byte(`{}`), nil
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	f := NewForge()
+	if _, err := f.GetPR(ctx, "owner/repo", 7); err == nil {
+		t.Fatal("GetPR must fail on a canceled context")
+	}
+	if _, err := f.GetPRDiff(ctx, "owner/repo", 7); err == nil {
+		t.Fatal("GetPRDiff must fail on a canceled context")
+	}
+	if _, err := f.CommitStatuses(ctx, "owner/repo", "abc123"); err == nil {
+		t.Fatal("CommitStatuses must fail on a canceled context")
+	}
+	if err := f.CreateCommitStatus(ctx, "owner/repo", "abc123", forge.Status{Context: "c", State: forge.StatusPending}); err == nil {
+		t.Fatal("CreateCommitStatus must fail on a canceled context")
+	}
+	if err := f.CreateReviewComment(ctx, "owner/repo", 7, "abc123", "a.go", 1, "b"); err == nil {
+		t.Fatal("CreateReviewComment must fail on a canceled context")
+	}
+	if err := f.CreateComment(ctx, "owner/repo", 7, "b"); err == nil {
+		t.Fatal("CreateComment must fail on a canceled context")
+	}
+	if len(*calls) != 0 {
+		t.Fatalf("a canceled context must not reach the API, got %v", *calls)
+	}
+}


### PR DESCRIPTION
Slice **S2** of #1162 (Go review-producer in the daemon, forge-agnostic, CLIProxy-only).

## What

- **`internal/forge`** (new package): the minimal forge-agnostic client surface the llm-review producer needs — `GetPR`, `GetPRDiff`, `CommitStatuses`, `CreateCommitStatus`, `CreateReviewComment`, `CreateComment`. The op set deliberately mirrors `scripts/llm-review.sh` one-to-one so the producer port (S4) is a transliteration, not a redesign. Status vocabulary and read-side contracts (latest-per-context statuses, zero `CreatedAt` = "no usable age" for the stale-pending self-heal) are documented on the interface so the Forgejo impl (S3) lands against the same semantics — including the verified Forgejo gotcha (per-status read field is `.status`, not `.state`; its impl normalizes here).
- **`internal/github/forge.go`**: the GitHub implementation, riding this package's existing hardened gh transport unchanged — rate-limit classification with backoff, primary-limit fail-fast gate, conditional (ETag) caching on the eligible reads, App-auth injection, bounded subprocess fence. Stateless; repo travels per call.
- Tests through the established `ghAPIRunner` seam: field/endpoint assertions per op, error-propagation on all three write paths (a swallowed status/comment post error is the silent-no-op failure the bash glue was hardened against in #1148/#1152), ctx-cancellation guard, `created_at` parse edge cases.

## Behavior

Purely additive — no existing call sites rewired, no config surface touched. The gate read side (`PRReviewGateVerdict` et al.) is intentionally NOT moved onto this interface: it needs check-runs, which stay outside the forge surface because Forgejo has no equivalent; the producer path never needs them.

## Verification

- `go build ./...`, `go vet ./...` clean; `go test ./...` green (35 packages; the one failure, `worker.TestBuildWorkerCmd_CodexPromptFileIsValidUTF8`, is pre-existing on clean `main` under umask 0002 and unrelated).
- Adversarial review (3 lenses + refutation pass, 13 agents): 10 findings raised, 9 refuted with behavioral-consequence analysis, 1 confirmed (missing error-propagation test for `CreateReviewComment` — mutation-tested: `return nil` passed the suite) and fixed in this commit.
- Known accepted trade-offs (exact parity with the bash producer, no behavioral consequence on the producer path): the diff read returns the transport's combined output (clean in the daemon's non-TTY context), and the combined-status read is non-paginated (same single-page read the bash `status_settled` does; PR heads carry few contexts).

Next: S3 forgejo impl (blocked on the `oklabs-bot` PAT — operator action), S4 producer with CLIProxy-only lens runners, S5 daemon trigger at the unobserved-stream detection (`trackReviewGateHead`/`missingReviewGateElapsed`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New external-forge integration surface with write paths (statuses and comments) whose errors must not be swallowed; reviewers flagged that GitHub `CommitStatuses` may return duplicate contexts if the API includes history, which would violate the documented one-latest-per-context contract until dedup is added.
> 
> **Overview**
> Adds a **forge-agnostic `Client` interface** in `internal/forge` for the upcoming Go llm-review producer: PR metadata and diff, commit statuses (read/write), inline review comments, and plain PR comments. The op set mirrors `scripts/llm-review.sh` so S4 can transliterate rather than redesign; status semantics (latest-per-context, zero `CreatedAt` for stale-pending heal) are documented on the interface.
> 
> **GitHub** is implemented in `internal/github/forge.go` as a stateless `Forge` type on the existing hardened `gh` transport (rate limits, ETag caching on reads, App auth). It rejects empty head SHAs, normalizes status states, maps unparseable `created_at` to zero time, validates status writes, and propagates errors on all write paths. Tests use the `ghAPIRunner` seam for endpoints, fields, cancellation, and error propagation.
> 
> No existing call sites are rewired; check-run–based review gate logic stays off this surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 962bb54dc37714b0e013b9bf245c953a05c00314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change introduces a forge-agnostic client interface and a GitHub implementation for pull-request metadata, diffs, commit statuses, and review comments.

One P1 reliability issue remains: historical commit statuses for the same normalized context are returned together, so a stale status can make review behavior depend on API response ordering instead of the current status.

<h3>Confidence Score: 4/5</h3>

Merge safety is reduced by one non-security P1 reliability failure in commit-status selection.

There is exactly one non-security P1 finding: conflicting historical statuses for a single check context are not reduced to the newest status. The required score is 4.

**Files Needing Attention:** internal/github/forge.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the review comment.
- T-Rex reproduced the contract output to validate the reproduction path of the finding.
- T-Rex executed the focused transport-seam test and captured its source and observed output to validate the behavior described in the finding.
- T-Rex inspected the current implementation lines and the focused regression output to confirm alignment with the finding.

<a href="https://app.greptile.com/trex/runs/18279188/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
internal/github/forge.go:103-117
**Commit-status contexts are not deduplicated**

`CommitStatuses` appends every status from GitHub's combined-status response, although `forge.Client` promises callers one latest status per context. GitHub can return historical entries for the same context, so the review producer can receive a settled status and an older conflicting status and make an order-dependent decision. Preserve only the newest entry for each normalized context before returning the slice.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["feat(forge): forge-agnostic client surfa..."](https://github.com/befeast/maestro/commit/962bb54dc37714b0e013b9bf245c953a05c00314) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51951350)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->