### PR TITLE
feat(forgejo): forge.Client implementation against the verified Forgejo contract (#1162 S3)

### DIFF
--- a/internal/forgejo/forgejo.go
+++ b/internal/forgejo/forgejo.go
@@ -28,6 +28,12 @@ import (
 // forge cannot wedge a producer cycle.
 const requestTimeout = 30 * time.Second
 
+// maxResponseBytes bounds one response body. Exceeding it is an explicit
+// error, never a silent cut: a truncated diff with a nil error would let the
+// producer post a full-diff verdict over a partial diff with no truncation
+// note — the exact evidence-weakening the bash glue's TRUNC_NOTE surfaces.
+const maxResponseBytes = 4 << 20
+
 // Client is the Forgejo forge. Zero value is not usable; construct with New.
 type Client struct {
 	baseURL string
@@ -44,11 +50,22 @@ func New(baseURL, token string) *Client {
 	return &Client{
 		baseURL: strings.TrimRight(baseURL, "/"),
 		token:   token,
-		httpc:   &http.Client{Timeout: requestTimeout},
+		httpc: &http.Client{
+			Timeout: requestTimeout,
+			// Never follow redirects: Go rewrites a redirected POST into a
+			// body-less GET, and Forgejo's write paths have 200-answering GET
+			// twins (list statuses/comments) — a misconfigured base URL behind
+			// an http→https 301 would turn every write into a silent green
+			// no-op. Returning the 3xx as-is makes do() fail loudly instead.
+			CheckRedirect: func(*http.Request, []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
 	}
 }
 
 // WithHTTPClient overrides the underlying HTTP client (tests, custom TLS).
+// The caller then owns the redirect policy New installs by default.
 func (c *Client) WithHTTPClient(httpc *http.Client) *Client {
 	c.httpc = httpc
 	return c
@@ -82,9 +99,14 @@ func (c *Client) do(ctx context.Context, method, path string, payload any) ([]by
 		return nil, fmt.Errorf("%s %s: %w", method, path, err)
 	}
 	defer resp.Body.Close()
-	out, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	// limit+1 so an at-limit body is distinguishable from an over-limit one
+	// (the appauth.go idiom) — oversize fails loudly instead of truncating.
+	out, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("%s %s: read response: %w", method, path, err)
+	}
+	if len(out) > maxResponseBytes {
+		return nil, fmt.Errorf("%s %s: response exceeds %d bytes", method, path, maxResponseBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		excerpt := strings.TrimSpace(string(out))

--- a/internal/forgejo/forgejo.go
+++ b/internal/forgejo/forgejo.go
@@ -1,0 +1,227 @@
+// Package forgejo implements forge.Client against the Forgejo REST API
+// (#1162 S3). The endpoint contract below was verified live against Forgejo
+// 16.0.1; the two gotchas that differ from GitHub are baked in here so callers
+// never see them:
+//
+//   - the combined-status read reports each status's state in a `.status`
+//     field, not `.state` — normalized to forge.StatusState on read;
+//   - there is no per-line inline-comment endpoint — an inline comment is a
+//     one-comment review (POST /pulls/{index}/reviews, event COMMENT, the
+//     line as new_position).
+package forgejo
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/forge"
+)
+
+// requestTimeout bounds one REST round trip when the caller's context carries
+// no earlier deadline, mirroring the gh transport's per-call bound so a hung
+// forge cannot wedge a producer cycle.
+const requestTimeout = 30 * time.Second
+
+// Client is the Forgejo forge. Zero value is not usable; construct with New.
+type Client struct {
+	baseURL string
+	token   string
+	httpc   *http.Client
+}
+
+var _ forge.Client = (*Client)(nil)
+
+// New returns a Forgejo client for one API root, e.g. "https://host/api/v1".
+// token is the PAT sent as `Authorization: token <PAT>`; the caller resolves
+// it (config *_env indirection) — it is never read from the environment here.
+func New(baseURL, token string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		token:   token,
+		httpc:   &http.Client{Timeout: requestTimeout},
+	}
+}
+
+// WithHTTPClient overrides the underlying HTTP client (tests, custom TLS).
+func (c *Client) WithHTTPClient(httpc *http.Client) *Client {
+	c.httpc = httpc
+	return c
+}
+
+// do runs one request and returns the response body. Any non-2xx status is an
+// error carrying a bounded excerpt of the response body — Forgejo's error
+// JSON is short and is exactly what distinguishes "line outside the diff"
+// from "bad token" for the caller's fallback decision.
+func (c *Client) do(ctx context.Context, method, path string, payload any) ([]byte, error) {
+	var body io.Reader
+	if payload != nil {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("encode %s %s: %w", method, path, err)
+		}
+		body = bytes.NewReader(encoded)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("build %s %s: %w", method, path, err)
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "token "+c.token)
+	}
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.httpc.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+	out, err := io.ReadAll(io.LimitReader(resp.Body, 4<<20))
+	if err != nil {
+		return nil, fmt.Errorf("%s %s: read response: %w", method, path, err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		excerpt := strings.TrimSpace(string(out))
+		if len(excerpt) > 512 {
+			excerpt = excerpt[:512]
+		}
+		return nil, fmt.Errorf("%s %s: HTTP %d: %s", method, path, resp.StatusCode, excerpt)
+	}
+	return out, nil
+}
+
+// GetPR returns the PR metadata. An empty head SHA is rejected per the
+// forge.Client contract — every downstream op anchors to it.
+func (c *Client) GetPR(ctx context.Context, repo string, index int) (forge.PR, error) {
+	out, err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/pulls/%d", repo, index), nil)
+	if err != nil {
+		return forge.PR{}, fmt.Errorf("get PR %s#%d: %w", repo, index, err)
+	}
+	var pull struct {
+		Number int    `json:"number"`
+		Title  string `json:"title"`
+		Head   struct {
+			SHA string `json:"sha"`
+		} `json:"head"`
+		Base struct {
+			Ref string `json:"ref"`
+		} `json:"base"`
+	}
+	if err := json.Unmarshal(out, &pull); err != nil {
+		return forge.PR{}, fmt.Errorf("parse PR %s#%d: %w", repo, index, err)
+	}
+	sha := strings.TrimSpace(pull.Head.SHA)
+	if sha == "" {
+		return forge.PR{}, fmt.Errorf("PR %s#%d has an empty head sha", repo, index)
+	}
+	return forge.PR{
+		Number:  pull.Number,
+		Title:   pull.Title,
+		HeadSHA: sha,
+		BaseRef: pull.Base.Ref,
+	}, nil
+}
+
+// GetPRDiff returns the PR's unified diff via the `.diff` media path (the
+// files listing endpoint is NOT equivalent — it paginates and re-encodes).
+func (c *Client) GetPRDiff(ctx context.Context, repo string, index int) ([]byte, error) {
+	out, err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/pulls/%d.diff", repo, index), nil)
+	if err != nil {
+		return nil, fmt.Errorf("get PR %s#%d diff: %w", repo, index, err)
+	}
+	return out, nil
+}
+
+// CommitStatuses returns the statuses on one SHA from the combined-status
+// endpoint (latest per context, so no dedup). Forgejo reports the per-status
+// state in `.status` — NOT `.state`, which unlike GitHub is absent here; that
+// read-side divergence is normalized to forge.StatusState at this boundary.
+func (c *Client) CommitStatuses(ctx context.Context, repo, sha string) ([]forge.Status, error) {
+	out, err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/commits/%s/status", repo, sha), nil)
+	if err != nil {
+		return nil, fmt.Errorf("commit statuses for %s@%s: %w", repo, sha, err)
+	}
+	var combined struct {
+		Statuses []struct {
+			Context     string `json:"context"`
+			Status      string `json:"status"`
+			Description string `json:"description"`
+			TargetURL   string `json:"target_url"`
+			CreatedAt   string `json:"created_at"`
+		} `json:"statuses"`
+	}
+	if err := json.Unmarshal(out, &combined); err != nil {
+		return nil, fmt.Errorf("parse commit statuses for %s@%s: %w", repo, sha, err)
+	}
+	statuses := make([]forge.Status, 0, len(combined.Statuses))
+	for _, st := range combined.Statuses {
+		createdAt, err := time.Parse(time.RFC3339, strings.TrimSpace(st.CreatedAt))
+		if err != nil {
+			createdAt = time.Time{}
+		}
+		statuses = append(statuses, forge.Status{
+			Context:     st.Context,
+			State:       forge.StatusState(strings.ToLower(strings.TrimSpace(st.Status))),
+			Description: st.Description,
+			TargetURL:   st.TargetURL,
+			CreatedAt:   createdAt,
+		})
+	}
+	return statuses, nil
+}
+
+// CreateCommitStatus posts one commit status. The write vocabulary is the
+// shared pending|success|error|failure set. Errors surface unswallowed — the
+// producer's pending-first protocol depends on a failed post being visible.
+func (c *Client) CreateCommitStatus(ctx context.Context, repo, sha string, status forge.Status) error {
+	if status.Context == "" || status.State == "" {
+		return fmt.Errorf("create status on %s@%s: context and state are required", repo, sha)
+	}
+	payload := map[string]string{
+		"state":       string(status.State),
+		"context":     status.Context,
+		"description": status.Description,
+	}
+	if status.TargetURL != "" {
+		payload["target_url"] = status.TargetURL
+	}
+	if _, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/statuses/%s", repo, sha), payload); err != nil {
+		return fmt.Errorf("create status %s=%s on %s@%s: %w", status.Context, status.State, repo, sha, err)
+	}
+	return nil
+}
+
+// CreateReviewComment posts one inline finding as a single-comment COMMENT
+// review — Forgejo has no per-line comment endpoint. new_position is the
+// new-file line in the diff; an anchor Forgejo rejects surfaces as an error
+// so the caller falls back to CreateComment instead of losing the finding.
+func (c *Client) CreateReviewComment(ctx context.Context, repo string, index int, sha, path string, line int, body string) error {
+	payload := map[string]any{
+		"commit_id": sha,
+		"event":     "COMMENT",
+		"comments": []map[string]any{{
+			"path":         path,
+			"new_position": line,
+			"body":         body,
+		}},
+	}
+	if _, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/pulls/%d/reviews", repo, index), payload); err != nil {
+		return fmt.Errorf("create review comment on %s#%d %s:%d: %w", repo, index, path, line, err)
+	}
+	return nil
+}
+
+// CreateComment posts a plain PR comment (PRs share the issue number space).
+func (c *Client) CreateComment(ctx context.Context, repo string, index int, body string) error {
+	payload := map[string]string{"body": body}
+	if _, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/issues/%d/comments", repo, index), payload); err != nil {
+		return fmt.Errorf("create comment on %s#%d: %w", repo, index, err)
+	}
+	return nil
+}

--- a/internal/forgejo/forgejo_test.go
+++ b/internal/forgejo/forgejo_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -77,9 +78,69 @@ func TestGetPR_EmptyHeadSHA(t *testing.T) {
 }
 
 func TestGetPR_HTTPError(t *testing.T) {
-	c, _ := fixtureServer(t, 404, `{"message":"Not Found"}`)
+	// The body deliberately parses as a healthy PR (non-empty head.sha): the
+	// only thing that can fail this test is the non-2xx status check itself,
+	// not the empty-head-sha guard downstream.
+	c, _ := fixtureServer(t, 404, `{"number":3,"title":"t","head":{"sha":"fjsha1"},"base":{"ref":"main"}}`)
 	if _, err := c.GetPR(context.Background(), "owner/repo", 3); err == nil {
 		t.Fatal("a non-2xx response must surface as an error")
+	}
+}
+
+func TestCommitStatuses_HTTPError(t *testing.T) {
+	// A transient 500 must never read as "no statuses on this SHA": the
+	// producer's settled-check would treat the stream as never-run and
+	// re-review, breaking per-head idempotency.
+	c, _ := fixtureServer(t, 500, `{"message":"boom"}`)
+	if _, err := c.CommitStatuses(context.Background(), "owner/repo", "fjsha1"); err == nil {
+		t.Fatal("a non-2xx status read must surface as an error, not an empty list")
+	}
+}
+
+func TestWriteRedirectNotFollowed(t *testing.T) {
+	// Go rewrites a redirected POST into a body-less GET, and Forgejo's write
+	// paths have 200-answering GET twins — following the redirect would turn
+	// the write into a silent green no-op. The client must surface the 3xx.
+	var followed bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			followed = true
+			w.Write([]byte(`[]`))
+			return
+		}
+		w.Header().Set("Location", "/elsewhere")
+		w.WriteHeader(http.StatusMovedPermanently)
+	}))
+	t.Cleanup(srv.Close)
+	c := New(srv.URL, "sekrit")
+	err := c.CreateCommitStatus(context.Background(), "owner/repo", "fjsha1", forge.Status{
+		Context: "llm-review-opus",
+		State:   forge.StatusPending,
+	})
+	if err == nil {
+		t.Fatal("a redirected write must fail loudly, not report success without writing")
+	}
+	if followed {
+		t.Fatal("the client must not re-issue a redirected write as a GET")
+	}
+}
+
+func TestGetPRDiff_OversizeFailsLoudly(t *testing.T) {
+	c, _ := fixtureServer(t, 200, strings.Repeat("x", maxResponseBytes+1))
+	if _, err := c.GetPRDiff(context.Background(), "owner/repo", 3); err == nil {
+		t.Fatal("an over-limit diff must error — a silent cut posts a full-diff verdict over a partial diff")
+	}
+}
+
+func TestGetPRDiff_AtLimitPasses(t *testing.T) {
+	body := strings.Repeat("x", maxResponseBytes)
+	c, _ := fixtureServer(t, 200, body)
+	out, err := c.GetPRDiff(context.Background(), "owner/repo", 3)
+	if err != nil {
+		t.Fatalf("an exactly-at-limit body must pass: %v", err)
+	}
+	if len(out) != maxResponseBytes {
+		t.Fatalf("len = %d, want %d", len(out), maxResponseBytes)
 	}
 }
 

--- a/internal/forgejo/forgejo_test.go
+++ b/internal/forgejo/forgejo_test.go
@@ -1,0 +1,291 @@
+package forgejo
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/forge"
+)
+
+// recordedRequest captures one request the fixture server saw.
+type recordedRequest struct {
+	Method string
+	Path   string
+	Auth   string
+	Body   []byte
+}
+
+// fixtureServer answers every request with the given status and body and
+// records what it saw. Fixtures mirror the live-verified Forgejo 16.0.1
+// payload shapes.
+func fixtureServer(t *testing.T, status int, body string) (*Client, *[]recordedRequest) {
+	t.Helper()
+	var seen []recordedRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload, _ := io.ReadAll(r.Body)
+		seen = append(seen, recordedRequest{
+			Method: r.Method,
+			Path:   r.URL.Path,
+			Auth:   r.Header.Get("Authorization"),
+			Body:   payload,
+		})
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "sekrit"), &seen
+}
+
+func lastRequest(t *testing.T, seen *[]recordedRequest) recordedRequest {
+	t.Helper()
+	if len(*seen) == 0 {
+		t.Fatal("no request reached the fixture server")
+	}
+	return (*seen)[len(*seen)-1]
+}
+
+func TestGetPR(t *testing.T) {
+	c, seen := fixtureServer(t, 200,
+		`{"number":3,"title":"canary","head":{"ref":"canary","sha":" fjsha1 "},"base":{"ref":"main"}}`)
+	pr, err := c.GetPR(context.Background(), "owner/repo", 3)
+	if err != nil {
+		t.Fatalf("GetPR: %v", err)
+	}
+	want := forge.PR{Number: 3, Title: "canary", HeadSHA: "fjsha1", BaseRef: "main"}
+	if pr != want {
+		t.Fatalf("GetPR = %+v, want %+v", pr, want)
+	}
+	req := lastRequest(t, seen)
+	if req.Method != http.MethodGet || req.Path != "/repos/owner/repo/pulls/3" {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+	if req.Auth != "token sekrit" {
+		t.Fatalf("auth header = %q, want the token scheme", req.Auth)
+	}
+}
+
+func TestGetPR_EmptyHeadSHA(t *testing.T) {
+	c, _ := fixtureServer(t, 200, `{"number":3,"title":"t","head":{"sha":""},"base":{"ref":"main"}}`)
+	if _, err := c.GetPR(context.Background(), "owner/repo", 3); err == nil {
+		t.Fatal("an empty head sha must be rejected — every downstream op anchors to it")
+	}
+}
+
+func TestGetPR_HTTPError(t *testing.T) {
+	c, _ := fixtureServer(t, 404, `{"message":"Not Found"}`)
+	if _, err := c.GetPR(context.Background(), "owner/repo", 3); err == nil {
+		t.Fatal("a non-2xx response must surface as an error")
+	}
+}
+
+func TestGetPRDiff(t *testing.T) {
+	diff := "diff --git a/x.kt b/x.kt\n+not json\n"
+	c, seen := fixtureServer(t, 200, diff)
+	out, err := c.GetPRDiff(context.Background(), "owner/repo", 3)
+	if err != nil {
+		t.Fatalf("GetPRDiff: %v", err)
+	}
+	if string(out) != diff {
+		t.Fatalf("diff = %q, want raw passthrough", out)
+	}
+	req := lastRequest(t, seen)
+	if req.Path != "/repos/owner/repo/pulls/3.diff" {
+		t.Fatalf("path = %s, want the .diff media path", req.Path)
+	}
+}
+
+func TestCommitStatuses_ReadsStatusFieldNotState(t *testing.T) {
+	// The live-verified 16.0.1 gotcha: the per-status state lives in
+	// `.status`. The fixture plants a contradictory `.state` decoy so a
+	// regression to the GitHub field name fails loudly.
+	c, seen := fixtureServer(t, 200, `{"state":"failure","statuses":[
+		{"context":"llm-review-opus","status":"success","state":"failure","description":"ok","target_url":"https://x","created_at":"2026-08-10T12:00:00Z"},
+		{"context":"llm-review-cursor","status":"PENDING","state":"failure","created_at":"not-a-time"}]}`)
+	statuses, err := c.CommitStatuses(context.Background(), "owner/repo", "fjsha1")
+	if err != nil {
+		t.Fatalf("CommitStatuses: %v", err)
+	}
+	if len(statuses) != 2 {
+		t.Fatalf("statuses = %d, want 2", len(statuses))
+	}
+	first := statuses[0]
+	if first.State != forge.StatusSuccess {
+		t.Fatalf("first state = %q — the impl must read Forgejo's .status, never .state", first.State)
+	}
+	if first.Context != "llm-review-opus" || first.Description != "ok" || first.TargetURL != "https://x" {
+		t.Fatalf("first status = %+v", first)
+	}
+	if want := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC); !first.CreatedAt.Equal(want) {
+		t.Fatalf("first CreatedAt = %v, want %v", first.CreatedAt, want)
+	}
+	second := statuses[1]
+	if second.State != forge.StatusPending {
+		t.Fatalf("second state = %q, want pending (normalized lowercase)", second.State)
+	}
+	if !second.CreatedAt.IsZero() {
+		t.Fatalf("an unparseable created_at must map to zero, got %v", second.CreatedAt)
+	}
+	req := lastRequest(t, seen)
+	if req.Path != "/repos/owner/repo/commits/fjsha1/status" {
+		t.Fatalf("path = %s", req.Path)
+	}
+}
+
+func TestCreateCommitStatus(t *testing.T) {
+	c, seen := fixtureServer(t, 201, `{}`)
+	err := c.CreateCommitStatus(context.Background(), "owner/repo", "fjsha1", forge.Status{
+		Context:     "llm-review-opus",
+		State:       forge.StatusPending,
+		Description: "review in progress",
+	})
+	if err != nil {
+		t.Fatalf("CreateCommitStatus: %v", err)
+	}
+	req := lastRequest(t, seen)
+	if req.Method != http.MethodPost || req.Path != "/repos/owner/repo/statuses/fjsha1" {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(req.Body, &payload); err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	want := map[string]string{"state": "pending", "context": "llm-review-opus", "description": "review in progress"}
+	if len(payload) != len(want) {
+		t.Fatalf("payload = %v, want exactly %v (no empty target_url)", payload, want)
+	}
+	for k, v := range want {
+		if payload[k] != v {
+			t.Fatalf("payload[%s] = %q, want %q", k, payload[k], v)
+		}
+	}
+}
+
+func TestCreateCommitStatus_TargetURL(t *testing.T) {
+	c, seen := fixtureServer(t, 201, `{}`)
+	err := c.CreateCommitStatus(context.Background(), "owner/repo", "fjsha1", forge.Status{
+		Context:   "llm-review-opus",
+		State:     forge.StatusSuccess,
+		TargetURL: "https://example.test/run/1",
+	})
+	if err != nil {
+		t.Fatalf("CreateCommitStatus: %v", err)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(lastRequest(t, seen).Body, &payload); err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	if payload["target_url"] != "https://example.test/run/1" {
+		t.Fatalf("target_url = %q", payload["target_url"])
+	}
+}
+
+func TestCreateCommitStatus_ErrorPropagates(t *testing.T) {
+	c, _ := fixtureServer(t, 502, `bad gateway`)
+	err := c.CreateCommitStatus(context.Background(), "owner/repo", "fjsha1", forge.Status{
+		Context: "llm-review-opus",
+		State:   forge.StatusPending,
+	})
+	if err == nil {
+		t.Fatal("a failed status post must surface — the pending-first protocol depends on it")
+	}
+}
+
+func TestCreateCommitStatus_RequiresContextAndState(t *testing.T) {
+	c, seen := fixtureServer(t, 201, `{}`)
+	if err := c.CreateCommitStatus(context.Background(), "owner/repo", "s", forge.Status{State: forge.StatusPending}); err == nil {
+		t.Fatal("a status without a context must be rejected")
+	}
+	if err := c.CreateCommitStatus(context.Background(), "owner/repo", "s", forge.Status{Context: "c"}); err == nil {
+		t.Fatal("a status without a state must be rejected")
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("validation failures must not reach the API, saw %v", *seen)
+	}
+}
+
+func TestCreateReviewComment(t *testing.T) {
+	c, seen := fixtureServer(t, 200, `{}`)
+	err := c.CreateReviewComment(context.Background(), "owner/repo", 3, "fjsha1", "a.kt", 42, "[P1] boom")
+	if err != nil {
+		t.Fatalf("CreateReviewComment: %v", err)
+	}
+	req := lastRequest(t, seen)
+	if req.Method != http.MethodPost || req.Path != "/repos/owner/repo/pulls/3/reviews" {
+		t.Fatalf("request = %s %s — inline comments go through the reviews endpoint only", req.Method, req.Path)
+	}
+	var payload struct {
+		CommitID string `json:"commit_id"`
+		Event    string `json:"event"`
+		Comments []struct {
+			Path        string `json:"path"`
+			NewPosition int    `json:"new_position"`
+			Body        string `json:"body"`
+		} `json:"comments"`
+	}
+	if err := json.Unmarshal(req.Body, &payload); err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	if payload.CommitID != "fjsha1" || payload.Event != "COMMENT" {
+		t.Fatalf("payload = %+v", payload)
+	}
+	if len(payload.Comments) != 1 {
+		t.Fatalf("comments = %d, want exactly 1 (one finding per review)", len(payload.Comments))
+	}
+	cm := payload.Comments[0]
+	if cm.Path != "a.kt" || cm.NewPosition != 42 || cm.Body != "[P1] boom" {
+		t.Fatalf("comment = %+v", cm)
+	}
+}
+
+func TestCreateReviewComment_RejectedAnchorPropagates(t *testing.T) {
+	c, _ := fixtureServer(t, 422, `{"message":"new_position is not in the diff"}`)
+	err := c.CreateReviewComment(context.Background(), "owner/repo", 3, "fjsha1", "a.kt", 9999, "[P1] boom")
+	if err == nil {
+		t.Fatal("a rejected inline anchor must surface as an error — it is the caller's CreateComment fallback trigger")
+	}
+}
+
+func TestCreateComment(t *testing.T) {
+	c, seen := fixtureServer(t, 201, `{}`)
+	if err := c.CreateComment(context.Background(), "owner/repo", 3, "[P1] boom (at `a.kt:9999`)"); err != nil {
+		t.Fatalf("CreateComment: %v", err)
+	}
+	req := lastRequest(t, seen)
+	if req.Method != http.MethodPost || req.Path != "/repos/owner/repo/issues/3/comments" {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(req.Body, &payload); err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	if payload["body"] != "[P1] boom (at `a.kt:9999`)" {
+		t.Fatalf("body = %q", payload["body"])
+	}
+}
+
+func TestCreateComment_ErrorPropagates(t *testing.T) {
+	c, _ := fixtureServer(t, 500, `oops`)
+	if err := c.CreateComment(context.Background(), "owner/repo", 3, "b"); err == nil {
+		t.Fatal("a failed fallback comment must not read as posted")
+	}
+}
+
+func TestContextCanceled(t *testing.T) {
+	c, seen := fixtureServer(t, 200, `{}`)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.GetPR(ctx, "owner/repo", 3); err == nil {
+		t.Fatal("GetPR must fail on a canceled context")
+	}
+	if err := c.CreateComment(ctx, "owner/repo", 3, "b"); err == nil {
+		t.Fatal("CreateComment must fail on a canceled context")
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("a canceled context must not reach the API, saw %v", *seen)
+	}
+}


### PR DESCRIPTION
Slice **S3** of #1162, stacked on #1164 (S2) — base is the S2 branch so the diff is S3-only; retargets to `main` automatically when S2 merges.

## What

`internal/forgejo`: a `net/http` implementation of `forge.Client` against the live-verified Forgejo 16.0.1 contract. The two divergences from GitHub are normalized at this boundary so the S4 producer never sees them:

- the combined-status read reports each status's state in **`.status`, not `.state`** — the fixture test plants a contradictory `.state` decoy so a regression to the GitHub field name fails loudly;
- there is **no per-line inline-comment endpoint** — an inline finding goes through `POST /pulls/{index}/reviews` as a single-comment `COMMENT` review with the line as `new_position`; a rejected anchor surfaces as an error (the caller's fallback trigger to `CreateComment`).

Auth is `Authorization: token <PAT>`; the token is injected by the caller (config `*_env` indirection), never read from the environment here. Non-2xx responses carry a bounded body excerpt — Forgejo's error JSON is what distinguishes "line outside the diff" from "bad token" for the fallback decision. Requests are ctx-propagated and bounded (30s client timeout).

## Tests

httptest fixture suite mirroring the verified payloads: per-op method/path/auth assertions, the `.status` decoy, `created_at` parse + zero-on-unparseable, `target_url` omission when empty, error propagation on all three write paths (pending-first protocol dependency), rejected-anchor propagation, ctx cancellation.

## Not in this slice

Live end-to-end on Forgejo — blocked on ops (#1162 blockers): minting the bot PAT and opening a canary PR. Nothing wires this client into the daemon yet; that is S5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated package with no production wiring yet; risk is mainly correctness of status/comment mapping when the producer adopts it.
> 
> **Overview**
> Adds **`internal/forgejo`**, a new `forge.Client` backed by Forgejo’s REST API (verified against 16.0.1), so the review producer can talk to Forgejo without handling GitHub-specific quirks.
> 
> Forgejo differences are normalized at this layer: combined commit statuses are read from **`.status`** (not `.state`), and inline findings are posted as a single **`COMMENT`** review with **`new_position`** instead of a per-line comment API. Shared transport behavior includes PAT auth, 30s timeouts, no redirect-following on writes, and hard failures when PR diffs exceed **4MB** so partial diffs cannot be treated as complete.
> 
> A broad **httptest** suite locks in paths, payloads, error propagation, and the `.status` vs `.state` regression guard. Nothing in the daemon wires this client yet (later slice).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28acfec722a490390afac8ef0048f5fa1d628367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a Forgejo HTTP implementation for reading pull requests and diffs, managing commit statuses, and posting review comments. HTTP validation confirmed the normal inline-review request shape, but reproduced a request-target error when a SHA contains URL delimiters: the status request no longer addresses that SHA as one path segment.

Merge safety: do not merge until dynamic Forgejo path values are escaped or validated and covered by a regression test.

<h3>Confidence Score: 4/5</h3>

The Forgejo client should not be merged until dynamic URL path components cannot change outbound request targets.

A self-contained HTTP test directly observed the malformed-SHA request target and confirmed the expected inline-review request behavior.

**Files Needing Attention:** internal/forgejo/forgejo.go needs escaped or validated dynamic repository and SHA path components, with regression coverage in internal/forgejo/forgejo_test.go.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding.
- A second P1 finding proof was produced and linked to its corresponding review comment.
- T-Rex uploaded contract-validation artifacts, including the authored harness and pre-/post-run captures.

<a href="https://app.greptile.com/trex/runs/18279365/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **SHA values are interpolated into Forgejo API paths without path-segment escaping**

   - **Bug**
     - At `internal/forgejo/forgejo.go:216`, `CreateCommitStatus` formats `sha` directly into the URL path. The executed httptest harness supplied `head?state=success`; the server observed `/repos/acme/widgets/statuses/head` with query `state=success`. The SHA was therefore not preserved as the single repository/SHA path value required by the client contract. The same direct interpolation pattern also exists in `CommitStatuses` at line 168 and review request routing uses unvalidated repository interpolation at lines 124, 156, 168, 216, 236, and 245.
   - **Cause**
     - Dynamic repository and SHA components are concatenated with `fmt.Sprintf` into a request path before `http.NewRequestWithContext` parses URL delimiters.
   - **Fix**
     - Construct endpoint paths from escaped path segments (for example, `url.PathEscape` for owner, repo, SHA, and file-path segments as applicable, preserving the intended owner/name separator), or build a `url.URL` with an explicitly constructed escaped path. Add regression tests proving `?`, `#`, `/`, and `%` in each dynamic component cannot change the path, query, or fragment. Optionally validate SHA as the expected commit-ID syntax at the Forge.Client boundary.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
internal/forgejo/forgejo.go:216
**Unescaped SHA changes the status endpoint**

`CreateCommitStatus` concatenates `sha` directly into the request URL. A delimiter-bearing value such as `head?state=success` is parsed as `/statuses/head` with `state=success` as the query, so the status is not written to the requested commit and can address a different API operation. Escape dynamic path segments while preserving the `owner/repo` separator, or validate SHAs before building the URL; apply the same protection to the status-read path.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(forgejo): fail loudly on redirects a..."](https://github.com/befeast/maestro/commit/28acfec722a490390afac8ef0048f5fa1d628367) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52145174)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->