### PR TITLE
feat(review): Go llm-review producer with CLIProxy and cursor lens runners (#1162 S4)

### DIFF
--- a/internal/review/lens_chat.go
+++ b/internal/review/lens_chat.go
@@ -1,0 +1,119 @@
+package review
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// ChatLens runs a review through an OpenAI-compatible chat-completions
+// endpoint. For the fleet's Anthropic/OpenAI lenses (opus, terra, ...) the
+// endpoint MUST be CLIProxy — the accounting and credential-rotation layer —
+// never a direct provider URL or host login; that invariant is the reason the
+// bash producer's direct `claude -p` opus branch is being retired (#1162).
+// The caller injects the base URL and key from config (*_env indirection).
+type ChatLens struct {
+	// Stream is the status context / stream name, e.g. "llm-review-opus".
+	Stream string
+	// BaseURL is the API root, e.g. "http://127.0.0.1:23020"; the lens posts
+	// to {BaseURL}/v1/chat/completions.
+	BaseURL string
+	// APIKey is sent as a Bearer token.
+	APIKey string
+	// Model is the endpoint's model id, e.g. "claude-opus-5".
+	Model string
+	// Timeout bounds one model run. Zero means 10 minutes.
+	Timeout time.Duration
+	// HTTPClient overrides the transport (tests). Nil means a fresh client;
+	// the run deadline comes from the context either way.
+	HTTPClient *http.Client
+}
+
+const defaultLensTimeout = 10 * time.Minute
+
+func (l *ChatLens) Name() string { return l.Stream }
+
+// Available reports whether the lens is configured. Base URL, key, and model
+// are all required — a missing one becomes the producer's explicit
+// "skipped: credentials not configured" error status, never a silent stream.
+func (l *ChatLens) Available() error {
+	switch {
+	case strings.TrimSpace(l.BaseURL) == "":
+		return fmt.Errorf("chat lens %s: base URL not configured", l.Stream)
+	case strings.TrimSpace(l.APIKey) == "":
+		return fmt.Errorf("chat lens %s: API key not configured", l.Stream)
+	case strings.TrimSpace(l.Model) == "":
+		return fmt.Errorf("chat lens %s: model not configured", l.Stream)
+	}
+	return nil
+}
+
+func (l *ChatLens) timeout() time.Duration {
+	if l.Timeout > 0 {
+		return l.Timeout
+	}
+	return defaultLensTimeout
+}
+
+// Run posts one single-shot chat completion and returns the model's text.
+func (l *ChatLens) Run(ctx context.Context, prompt string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, l.timeout())
+	defer cancel()
+
+	payload, err := json.Marshal(map[string]any{
+		"model": l.Model,
+		"messages": []map[string]string{
+			{"role": "user", "content": prompt},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode request: %w", err)
+	}
+	url := strings.TrimRight(l.BaseURL, "/") + "/v1/chat/completions"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+l.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	httpc := l.HTTPClient
+	if httpc == nil {
+		httpc = &http.Client{}
+	}
+	resp, err := httpc.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("chat completion: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 16<<20))
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		excerpt := strings.TrimSpace(string(body))
+		if len(excerpt) > 512 {
+			excerpt = excerpt[:512]
+		}
+		return "", fmt.Errorf("chat completion: HTTP %d: %s", resp.StatusCode, excerpt)
+	}
+	var parsed struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", fmt.Errorf("parse response: %w", err)
+	}
+	if len(parsed.Choices) == 0 {
+		return "", fmt.Errorf("chat completion: response carries no choices")
+	}
+	return parsed.Choices[0].Message.Content, nil
+}

--- a/internal/review/lens_cursor.go
+++ b/internal/review/lens_cursor.go
@@ -3,10 +3,12 @@ package review
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -82,6 +84,23 @@ func (l *CursorLens) Run(ctx context.Context, prompt string) (string, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	cmd.Env = append(os.Environ(), "CURSOR_API_KEY="+l.APIKey)
+	// Kill the whole process group at the deadline and bound the post-kill
+	// wait (the ghCommandContext pattern): the agent spawns helpers, and a
+	// surviving child holding the inherited output pipe would keep Run
+	// blocked past the deadline — an unbounded producer hang the Timeout
+	// field exists to prevent.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return nil
+		}
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	cmd.WaitDelay = 2 * time.Second
 	if err := cmd.Run(); err != nil {
 		detail := strings.TrimSpace(stderr.String())
 		if len(detail) > 512 {

--- a/internal/review/lens_cursor.go
+++ b/internal/review/lens_cursor.go
@@ -1,0 +1,93 @@
+package review
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// CursorLens runs a review through the cursor-agent CLI. Cursor is the one
+// sanctioned exception to the CLIProxy invariant: CLIProxy does not proxy
+// Cursor, so the agent authenticates with its own key.
+//
+// The subprocess is sandboxed the way the bash glue live-verified (#1161):
+// an EMPTY working directory with the prompt+diff on stdin, so the only
+// thing the agent can read is what we feed it — it cannot roam a checkout.
+// `--mode ask` keeps it read-only (no write/shell tools) and `--trust`
+// suppresses the workspace-trust prompt WITHOUT the command auto-approve
+// that -f/--yolo would grant. stdin also sidesteps ARG_MAX on large diffs.
+// stdout (the review text) is captured separately from stderr so a stray
+// progress/telemetry line can never read as a spurious finding.
+type CursorLens struct {
+	// Stream is the status context / stream name, e.g. "llm-review-cursor".
+	Stream string
+	// Model is the cursor model, e.g. "composer-2.5" (the included-usage
+	// pool default — cost-safe).
+	Model string
+	// APIKey is passed to the subprocess as CURSOR_API_KEY.
+	APIKey string
+	// Binary is the agent executable. Empty means "cursor-agent" on PATH.
+	Binary string
+	// Timeout bounds one run. Zero means 10 minutes.
+	Timeout time.Duration
+}
+
+func (l *CursorLens) Name() string { return l.Stream }
+
+// Available mirrors the bash prepare check: the key is the gating credential
+// (a missing binary is a run failure, not a creds skip).
+func (l *CursorLens) Available() error {
+	if strings.TrimSpace(l.APIKey) == "" {
+		return fmt.Errorf("cursor lens %s: CURSOR_API_KEY not configured", l.Stream)
+	}
+	return nil
+}
+
+func (l *CursorLens) binary() string {
+	if l.Binary != "" {
+		return l.Binary
+	}
+	return "cursor-agent"
+}
+
+func (l *CursorLens) timeout() time.Duration {
+	if l.Timeout > 0 {
+		return l.Timeout
+	}
+	return defaultLensTimeout
+}
+
+// Run executes cursor-agent over the prompt and returns its stdout.
+func (l *CursorLens) Run(ctx context.Context, prompt string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, l.timeout())
+	defer cancel()
+
+	// The empty scratch dir is the read sandbox; remove it with the run.
+	dir, err := os.MkdirTemp("", "llm-review-cursor-")
+	if err != nil {
+		return "", fmt.Errorf("scratch dir: %w", err)
+	}
+	defer os.RemoveAll(dir)
+
+	cmd := exec.CommandContext(ctx, l.binary(),
+		"-p", "--output-format", "text", "--mode", "ask", "--trust",
+		"--model", l.Model)
+	cmd.Dir = dir
+	cmd.Stdin = strings.NewReader(prompt)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = append(os.Environ(), "CURSOR_API_KEY="+l.APIKey)
+	if err := cmd.Run(); err != nil {
+		detail := strings.TrimSpace(stderr.String())
+		if len(detail) > 512 {
+			detail = detail[:512]
+		}
+		return "", fmt.Errorf("cursor-agent: %w: %s", err, detail)
+	}
+	return stdout.String(), nil
+}

--- a/internal/review/lens_test.go
+++ b/internal/review/lens_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestChatLens_Run(t *testing.T) {
@@ -133,6 +134,27 @@ func TestCursorLens_FailureCarriesStderr(t *testing.T) {
 	_, err := l.Run(context.Background(), "p")
 	if err == nil || !strings.Contains(err.Error(), "quota exhausted") {
 		t.Fatalf("err = %v — stderr is the diagnosis and must surface", err)
+	}
+}
+
+func TestCursorLens_TimeoutKillsProcessTree(t *testing.T) {
+	// A child that backgrounds an fd-inheriting helper and then hangs: without
+	// the process-group kill + WaitDelay, Run stays blocked long past the
+	// deadline because the orphan holds the output pipe open.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cursor-agent")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nsleep 60 &\nexec sleep 120\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	l := &CursorLens{Stream: "s", Model: "m", APIKey: "k", Binary: path, Timeout: time.Second}
+	start := time.Now()
+	_, err := l.Run(context.Background(), "p")
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("a run past the deadline must fail")
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("Run blocked %s past a 1s deadline — the orphan held the pipe", elapsed)
 	}
 }
 

--- a/internal/review/lens_test.go
+++ b/internal/review/lens_test.go
@@ -1,0 +1,146 @@
+package review
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestChatLens_Run(t *testing.T) {
+	var seenAuth, seenPath string
+	var seenBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		seenPath = r.URL.Path
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Write([]byte(`{"choices":[{"message":{"content":"NO_FINDINGS"}}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	l := &ChatLens{Stream: "llm-review-opus", BaseURL: srv.URL, APIKey: "k", Model: "claude-opus-5"}
+	out, err := l.Run(context.Background(), "review this")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if out != "NO_FINDINGS" {
+		t.Fatalf("out = %q", out)
+	}
+	if seenPath != "/v1/chat/completions" {
+		t.Fatalf("path = %s", seenPath)
+	}
+	if seenAuth != "Bearer k" {
+		t.Fatalf("auth = %q", seenAuth)
+	}
+	var payload struct {
+		Model    string `json:"model"`
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal(seenBody, &payload); err != nil {
+		t.Fatalf("request body: %v", err)
+	}
+	if payload.Model != "claude-opus-5" || len(payload.Messages) != 1 ||
+		payload.Messages[0].Role != "user" || payload.Messages[0].Content != "review this" {
+		t.Fatalf("payload = %+v", payload)
+	}
+}
+
+func TestChatLens_HTTPErrorSurfaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(502)
+		w.Write([]byte(`{"error":"unknown provider"}`))
+	}))
+	t.Cleanup(srv.Close)
+	l := &ChatLens{Stream: "s", BaseURL: srv.URL, APIKey: "k", Model: "m"}
+	_, err := l.Run(context.Background(), "p")
+	if err == nil || !strings.Contains(err.Error(), "502") {
+		t.Fatalf("err = %v — the proxy's error must surface (a disabled credential answers 502)", err)
+	}
+}
+
+func TestChatLens_NoChoicesIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"choices":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+	l := &ChatLens{Stream: "s", BaseURL: srv.URL, APIKey: "k", Model: "m"}
+	if _, err := l.Run(context.Background(), "p"); err == nil {
+		t.Fatal("an empty choices list must not read as an empty review")
+	}
+}
+
+func TestChatLens_Available(t *testing.T) {
+	if err := (&ChatLens{Stream: "s", BaseURL: "http://x", APIKey: "k", Model: "m"}).Available(); err != nil {
+		t.Fatalf("fully configured lens: %v", err)
+	}
+	for name, l := range map[string]*ChatLens{
+		"no base url": {Stream: "s", APIKey: "k", Model: "m"},
+		"no key":      {Stream: "s", BaseURL: "http://x", Model: "m"},
+		"no model":    {Stream: "s", BaseURL: "http://x", APIKey: "k"},
+	} {
+		if l.Available() == nil {
+			t.Fatalf("%s: must be unavailable", name)
+		}
+	}
+}
+
+// stubCursorAgent writes a fake cursor-agent that asserts its sandbox (empty
+// cwd, key in env, prompt on stdin), emits noise on stderr, and prints the
+// review on stdout.
+func stubCursorAgent(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cursor-agent")
+	script := `#!/bin/sh
+[ -n "$CURSOR_API_KEY" ] || { echo "no key" >&2; exit 3; }
+[ -z "$(ls -A .)" ] || { echo "cwd not empty" >&2; exit 4; }
+input=$(cat)
+[ -n "$input" ] || { echo "no stdin" >&2; exit 5; }
+echo "telemetry noise" >&2
+echo "NO_FINDINGS"
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestCursorLens_Run(t *testing.T) {
+	l := &CursorLens{Stream: "llm-review-cursor", Model: "composer-2.5", APIKey: "k", Binary: stubCursorAgent(t)}
+	out, err := l.Run(context.Background(), "review this")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if strings.TrimSpace(out) != "NO_FINDINGS" {
+		t.Fatalf("out = %q — stderr noise must never reach the parser", out)
+	}
+}
+
+func TestCursorLens_FailureCarriesStderr(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cursor-agent")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\necho \"quota exhausted\" >&2\nexit 2\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	l := &CursorLens{Stream: "s", Model: "m", APIKey: "k", Binary: path}
+	_, err := l.Run(context.Background(), "p")
+	if err == nil || !strings.Contains(err.Error(), "quota exhausted") {
+		t.Fatalf("err = %v — stderr is the diagnosis and must surface", err)
+	}
+}
+
+func TestCursorLens_Available(t *testing.T) {
+	if err := (&CursorLens{Stream: "s", Model: "m", APIKey: "k"}).Available(); err != nil {
+		t.Fatalf("configured lens: %v", err)
+	}
+	if (&CursorLens{Stream: "s", Model: "m"}).Available() == nil {
+		t.Fatal("a missing key must gate the lens (error status, not silence)")
+	}
+}

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -1,0 +1,400 @@
+// Package review is the Go llm-review producer (#1162 S4): it runs the
+// configured model lenses over a PR head diff and publishes, per lens, inline
+// findings plus a commit status `llm-review-<lens>` — the exact two surfaces
+// the daemon's review gate reads (internal/github llmReviewStreamSpec).
+//
+// It is a transliteration of scripts/llm-review.sh with the #1148/#1152
+// hardening preserved:
+//
+//   - pending-first: every lens's status settles (pending or skipped-error)
+//     before any model output or comment lands, so the gate never observes
+//     the half-state "comments exist but a stream has no status";
+//   - per-head idempotency: a lens whose status already settled
+//     (success/failure) on the current head is skipped; a fresh pending means
+//     another run is mid-flight; a stale pending is a crashed run and retries;
+//   - fail-closed: output matching neither findings nor NO_FINDINGS posts an
+//     error status — a refusal or format drift never reads as a clean review;
+//   - no-creds→error: a configured lens without credentials posts an explicit
+//     error status instead of leaving the stream silently unobserved.
+//
+// All forge traffic goes through forge.Client, so GitHub and Forgejo are
+// interchangeable here. Model traffic policy lives in the Lens
+// implementations (CLIProxy-only for API lenses; see lens_chat.go).
+package review
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/forge"
+)
+
+// Lens runs one review model. Implementations: ChatLens (any OpenAI-compatible
+// endpoint — for the fleet that means CLIProxy), CursorLens (cursor-agent).
+type Lens interface {
+	// Name is the stream name and status context, e.g. "llm-review-opus".
+	Name() string
+	// Available reports whether the lens can run: nil when its credentials
+	// are configured, an error describing what is missing otherwise.
+	Available() error
+	// Run executes the model over the prompt and returns its raw text output.
+	Run(ctx context.Context, prompt string) (string, error)
+}
+
+// Producer publishes reviews for one repository through one forge client.
+type Producer struct {
+	Forge forge.Client
+	Repo  string
+	// Lenses are the streams to produce. The caller (daemon trigger, S5) maps
+	// the project's effective review-gate streams here — the two sets MUST
+	// match or the gate degrades on an unproduced stream.
+	Lenses []Lens
+
+	// PendingStaleAfter is the age past which a pending status is treated as
+	// a crashed run and retried. Zero means the bash default, 30 minutes.
+	PendingStaleAfter time.Duration
+	// MaxDiffBytes caps the diff fed to the models. Zero means the bash
+	// default, 400000. The cap is surfaced in the status description when it
+	// truncates — a verdict over a partial diff must be operator-visible.
+	MaxDiffBytes int
+	// Now is the clock (tests). Nil means time.Now.
+	Now func() time.Time
+	// Logf reports progress (journal). Nil means log.Printf.
+	Logf func(format string, args ...any)
+}
+
+const (
+	defaultPendingStaleAfter = 30 * time.Minute
+	defaultMaxDiffBytes      = 400000
+)
+
+// promptTemplate is the shared review prompt, byte-identical to the bash
+// glue's REVIEW_PROMPT_TEMPLATE so verdicts stay comparable across the
+// producers during the cutover. %s is the PR title.
+const promptTemplate = `You are a strict senior code reviewer. Review ONLY the diff below (PR "%s").
+Report genuine defects, not style preferences.
+
+Output format — one line per finding, nothing else:
+[P0] path/to/file.ext:LINE — one-sentence description
+[P1] path/to/file.ext:LINE — one-sentence description
+[P2] path/to/file.ext:LINE — one-sentence description
+[P3] path/to/file.ext:LINE — one-sentence description
+
+Severity contract:
+- P0: guaranteed breakage, data loss, security hole. Blocks merge.
+- P1: real bug or correctness risk on a main path. Blocks merge.
+- P2: minor defect or risky pattern. Advisory only.
+- P3: nitpick. Advisory only.
+
+LINE must be a new-file line number that appears in the diff. If there are no
+findings, output exactly: NO_FINDINGS. Do not output anything else — no
+preamble, no summary, no markdown fences.
+
+DIFF:
+`
+
+func (p *Producer) now() time.Time {
+	if p.Now != nil {
+		return p.Now()
+	}
+	return time.Now()
+}
+
+func (p *Producer) logf(format string, args ...any) {
+	if p.Logf != nil {
+		p.Logf(format, args...)
+		return
+	}
+	log.Printf("[review] "+format, args...)
+}
+
+func (p *Producer) pendingStaleAfter() time.Duration {
+	if p.PendingStaleAfter > 0 {
+		return p.PendingStaleAfter
+	}
+	return defaultPendingStaleAfter
+}
+
+func (p *Producer) maxDiffBytes() int {
+	if p.MaxDiffBytes > 0 {
+		return p.MaxDiffBytes
+	}
+	return defaultMaxDiffBytes
+}
+
+// ProducePR runs every configured lens over the PR's current head. A settled
+// or in-flight lens is a clean skip. The returned error aggregates per-lens
+// failures; idempotent skips never contribute to it.
+func (p *Producer) ProducePR(ctx context.Context, prNumber int) error {
+	pr, err := p.Forge.GetPR(ctx, p.Repo, prNumber)
+	if err != nil {
+		return fmt.Errorf("review %s#%d: %w", p.Repo, prNumber, err)
+	}
+	diff, err := p.Forge.GetPRDiff(ctx, p.Repo, prNumber)
+	if err != nil {
+		return fmt.Errorf("review %s#%d: %w", p.Repo, prNumber, err)
+	}
+	if len(strings.TrimSpace(string(diff))) == 0 {
+		p.logf("%s#%d: empty diff — nothing to review", p.Repo, prNumber)
+		return nil
+	}
+	truncNote := ""
+	if len(diff) > p.maxDiffBytes() {
+		p.logf("%s#%d: diff is %d bytes; truncating to %d", p.Repo, prNumber, len(diff), p.maxDiffBytes())
+		diff = diff[:p.maxDiffBytes()]
+		// Surfaced in the final status description: a verdict over a
+		// truncated diff is weaker evidence and the operator must see that.
+		truncNote = fmt.Sprintf("; warning: diff truncated to %d bytes", p.maxDiffBytes())
+	}
+
+	statuses, err := p.Forge.CommitStatuses(ctx, p.Repo, pr.HeadSHA)
+	if err != nil {
+		return fmt.Errorf("review %s#%d: statuses on %s: %w", p.Repo, prNumber, pr.HeadSHA, err)
+	}
+
+	// Phase 1: settle every lens's status (pending / skipped-error) before
+	// any model runs or any comment is posted.
+	var errs []error
+	var runnable []Lens
+	for _, lens := range p.Lenses {
+		switch p.prepare(ctx, lens, pr.HeadSHA, statuses) {
+		case prepareRun:
+			runnable = append(runnable, lens)
+		case prepareSkip:
+		case prepareCredsMissing:
+			// Error status already posted; the run itself still fails so the
+			// operator sees a degraded producer pass.
+			errs = append(errs, fmt.Errorf("%s: credentials not configured", lens.Name()))
+		case prepareAbort:
+			// Pending post failed: pretending phase 1 happened would hide the
+			// protocol violation. Abort this lens without running the model.
+			errs = append(errs, fmt.Errorf("%s: could not post pending status", lens.Name()))
+		}
+	}
+
+	// Phase 2: run the reviews and flip each pending to its final state.
+	prompt := fmt.Sprintf(promptTemplate, pr.Title)
+	for _, lens := range runnable {
+		if err := p.runLens(ctx, lens, pr, prompt+string(diff), truncNote); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", lens.Name(), err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("review %s#%d: %w", p.Repo, prNumber, errors.Join(errs...))
+	}
+	return nil
+}
+
+type prepareDecision int
+
+const (
+	prepareRun prepareDecision = iota
+	prepareSkip
+	prepareCredsMissing
+	prepareAbort
+)
+
+// prepare is phase 1 for one lens: the settled/stale idempotency decision and
+// the pending-first status publication, mirroring the bash prepare_model.
+func (p *Producer) prepare(ctx context.Context, lens Lens, headSHA string, statuses []forge.Status) prepareDecision {
+	if settled, why := p.statusSettled(lens.Name(), statuses); settled {
+		p.logf("%s needs no run on %s — %s", lens.Name(), headSHA, why)
+		return prepareSkip
+	}
+	if err := lens.Available(); err != nil {
+		p.logf("%s: %v — skipping with error status", lens.Name(), err)
+		// An explicit error status instead of silence: with one stream
+		// settled and the other absent, the gate's aggregate used to sit at
+		// Pending+Observed forever with no escape (#1148 round 1, P1-2).
+		if postErr := p.Forge.CreateCommitStatus(ctx, p.Repo, headSHA, forge.Status{
+			Context:     lens.Name(),
+			State:       forge.StatusError,
+			Description: "skipped: credentials not configured",
+		}); postErr != nil {
+			p.logf("%s: failed to post creds-missing status: %v", lens.Name(), postErr)
+		}
+		return prepareCredsMissing
+	}
+	if err := p.Forge.CreateCommitStatus(ctx, p.Repo, headSHA, forge.Status{
+		Context:     lens.Name(),
+		State:       forge.StatusPending,
+		Description: "review in progress",
+	}); err != nil {
+		p.logf("%s: failed to post pending on %s: %v", lens.Name(), headSHA, err)
+		return prepareAbort
+	}
+	return prepareRun
+}
+
+// statusSettled decides whether this lens needs no run on the head: a settled
+// state (success/failure — the idempotency key) or a fresh pending (another
+// run is mid-flight). Retryable instead: error statuses, stale pendings (the
+// posting run died after phase 1 — the crashed-pending self-heal), and
+// pendings with no usable age (zero CreatedAt: assume crashed, not wedged).
+// The forge's combined status is latest-per-context, so the first match wins.
+func (p *Producer) statusSettled(context string, statuses []forge.Status) (bool, string) {
+	for _, st := range statuses {
+		if st.Context != context {
+			continue
+		}
+		switch st.State {
+		case forge.StatusSuccess, forge.StatusFailure:
+			return true, "already settled (idempotent)"
+		case forge.StatusPending:
+			if st.CreatedAt.IsZero() {
+				return false, ""
+			}
+			if p.now().Sub(st.CreatedAt) < p.pendingStaleAfter() {
+				return true, fmt.Sprintf("pending since %s — another run appears to be in flight", st.CreatedAt.Format(time.RFC3339))
+			}
+			return false, ""
+		default:
+			return false, ""
+		}
+		// Latest-per-context: the first matching entry is the verdict.
+	}
+	return false, ""
+}
+
+// findingLine matches one contract line: severity, path:line anchor, message.
+var findingLine = regexp.MustCompile(`^\[(P[0-3])\] +(\S+?):(\d+) *[—–-]+ *(.*)$`)
+
+// looseFindingLine catches a contract-shaped severity line whose anchor part
+// did not parse (missing line number, spaces in the path). The finding is
+// kept — posted as a plain comment — instead of being dropped or, worse,
+// failing the whole output as unparseable.
+var looseFindingLine = regexp.MustCompile(`^\[(P[0-3])\] +(.*)$`)
+
+var noFindings = regexp.MustCompile(`(?m)^NO_FINDINGS[ \t]*$`)
+
+// Finding is one parsed review finding.
+type Finding struct {
+	Severity string
+	Path     string
+	Line     int
+	Message  string
+}
+
+// Blocking reports whether the finding blocks merge (P0/P1).
+func (f Finding) Blocking() bool { return f.Severity == "P0" || f.Severity == "P1" }
+
+// parseOutput ports the bash parser: strip markdown fences and leading
+// indentation, keep contract lines. ok is false when the output matched
+// neither findings nor NO_FINDINGS — the fail-closed case.
+func parseOutput(output string) (findings []Finding, ok bool) {
+	var cleaned []string
+	for _, line := range strings.Split(output, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "```") {
+			continue
+		}
+		cleaned = append(cleaned, trimmed)
+	}
+	for _, line := range cleaned {
+		if m := findingLine.FindStringSubmatch(line); m != nil {
+			lineNum := 0
+			fmt.Sscanf(m[3], "%d", &lineNum)
+			findings = append(findings, Finding{Severity: m[1], Path: m[2], Line: lineNum, Message: m[4]})
+			continue
+		}
+		if m := looseFindingLine.FindStringSubmatch(line); m != nil {
+			findings = append(findings, Finding{Severity: m[1], Message: m[2]})
+		}
+	}
+	if len(findings) > 0 {
+		return findings, true
+	}
+	if noFindings.MatchString(strings.Join(cleaned, "\n")) {
+		return nil, true
+	}
+	return nil, false
+}
+
+// runLens is phase 2 for one lens: run the model, parse fail-closed, post the
+// findings and flip the pending status to its final state.
+func (p *Producer) runLens(ctx context.Context, lens Lens, pr forge.PR, prompt, truncNote string) error {
+	output, err := lens.Run(ctx, prompt)
+	if err != nil {
+		p.logf("%s run failed: %v", lens.Name(), err)
+		p.postStatus(ctx, lens.Name(), pr.HeadSHA, forge.StatusError, "review run failed")
+		return fmt.Errorf("run: %w", err)
+	}
+	findings, ok := parseOutput(output)
+	if !ok {
+		// Fail closed (#1148 round 1, P1-4): a refusal, an apology, or a
+		// format drift must never read as "clean review".
+		p.logf("%s output matched neither findings nor NO_FINDINGS: %.500s", lens.Name(), output)
+		p.postStatus(ctx, lens.Name(), pr.HeadSHA, forge.StatusError, "review output unparseable")
+		return fmt.Errorf("unparseable output")
+	}
+
+	blocking := 0
+	for _, f := range findings {
+		if f.Blocking() {
+			blocking++
+		}
+		p.postFinding(ctx, lens.Name(), pr, f)
+	}
+	if blocking > 0 {
+		return p.postFinalStatus(ctx, lens.Name(), pr.HeadSHA, forge.StatusFailure,
+			fmt.Sprintf("%d blocking (P0/P1) of %d findings%s", blocking, len(findings), truncNote))
+	}
+	return p.postFinalStatus(ctx, lens.Name(), pr.HeadSHA, forge.StatusSuccess,
+		fmt.Sprintf("%d advisory findings, none blocking%s", len(findings), truncNote))
+}
+
+// postFinding publishes one finding: inline when it carries a usable anchor,
+// falling back to a plain PR comment when the forge rejects the position
+// (line outside the diff, renamed file) — the finding must stay visible
+// either way. The [Px] marker is what the gate's severity parser matches; the
+// trailing stream marker attributes the comment to this stream.
+func (p *Producer) postFinding(ctx context.Context, stream string, pr forge.PR, f Finding) {
+	shortSHA := pr.HeadSHA
+	if len(shortSHA) > 12 {
+		shortSHA = shortSHA[:12]
+	}
+	body := fmt.Sprintf("[%s] %s\n\n<sub>%s @ %s</sub>", f.Severity, f.Message, stream, shortSHA)
+	if f.Path != "" && f.Line > 0 {
+		if err := p.Forge.CreateReviewComment(ctx, p.Repo, pr.Number, pr.HeadSHA, f.Path, f.Line, body); err == nil {
+			return
+		}
+	}
+	fallback := fmt.Sprintf("%s (at `%s:%d`)", body, f.Path, f.Line)
+	if err := p.Forge.CreateComment(ctx, p.Repo, pr.Number, fallback); err != nil {
+		// Comment loss is tolerated (bash parity: `|| true`) — the blocking
+		// signal is the status, and the finding is preserved in the journal.
+		p.logf("%s: failed to post finding comment on #%d: %v", stream, pr.Number, err)
+	}
+}
+
+// postStatus posts a non-final (error) state, logging a failed post — there
+// is nothing better to do with it mid-failure.
+func (p *Producer) postStatus(ctx context.Context, context, sha string, state forge.StatusState, desc string) {
+	if err := p.Forge.CreateCommitStatus(ctx, p.Repo, sha, forge.Status{
+		Context:     context,
+		State:       state,
+		Description: desc,
+	}); err != nil {
+		p.logf("%s: failed to post status %s on %s: %v", context, state, sha, err)
+	}
+}
+
+// postFinalStatus posts the lens's verdict. A failed post is a hard error: a
+// swallowed failure here is what used to let a transient forge error read as
+// a green no-op run.
+func (p *Producer) postFinalStatus(ctx context.Context, context, sha string, state forge.StatusState, desc string) error {
+	if err := p.Forge.CreateCommitStatus(ctx, p.Repo, sha, forge.Status{
+		Context:     context,
+		State:       state,
+		Description: desc,
+	}); err != nil {
+		return fmt.Errorf("post final status %s: %w", state, err)
+	}
+	p.logf("%s: status %s on %s", context, state, sha)
+	return nil
+}

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -261,8 +262,13 @@ func (p *Producer) statusSettled(context string, statuses []forge.Status) (bool,
 	return false, ""
 }
 
-// findingLine matches one contract line: severity, path:line anchor, message.
-var findingLine = regexp.MustCompile(`^\[(P[0-3])\] +(\S+?):(\d+) *[—–-]+ *(.*)$`)
+// findingLine matches one contract line: severity, a path:line anchor token,
+// and the message. The separator is optional — bash's anchor extraction
+// (`[^ ]+:[0-9]+`) never required the dash, so a model that drifts to
+// "[P1] foo.go:12 fix the check" still gets an anchored inline comment; the
+// gate's blocking-findings collectors only read inline comments, so demoting
+// such a finding to a plain comment would drop it from the repair scope.
+var findingLine = regexp.MustCompile(`^\[(P[0-3])\] +(\S+:\d+)(?:(?: *[—–-]+ *| +)(.*))?$`)
 
 // looseFindingLine catches a contract-shaped severity line whose anchor part
 // did not parse (missing line number, spaces in the path). The finding is
@@ -283,13 +289,15 @@ type Finding struct {
 // Blocking reports whether the finding blocks merge (P0/P1).
 func (f Finding) Blocking() bool { return f.Severity == "P0" || f.Severity == "P1" }
 
-// parseOutput ports the bash parser: strip markdown fences and leading
-// indentation, keep contract lines. ok is false when the output matched
-// neither findings nor NO_FINDINGS — the fail-closed case.
+// parseOutput ports the bash parser: strip markdown fences, leading
+// indentation, and CRLF carriage returns (bash's `[[:space:]]` matched \r, so
+// a CRLF-emitting model must not fail closed here), keep contract lines. ok
+// is false when the output matched neither findings nor NO_FINDINGS — the
+// fail-closed case.
 func parseOutput(output string) (findings []Finding, ok bool) {
 	var cleaned []string
 	for _, line := range strings.Split(output, "\n") {
-		trimmed := strings.TrimLeft(line, " \t")
+		trimmed := strings.TrimRight(strings.TrimLeft(line, " \t"), "\r")
 		if strings.HasPrefix(trimmed, "```") {
 			continue
 		}
@@ -297,9 +305,16 @@ func parseOutput(output string) (findings []Finding, ok bool) {
 	}
 	for _, line := range cleaned {
 		if m := findingLine.FindStringSubmatch(line); m != nil {
-			lineNum := 0
-			fmt.Sscanf(m[3], "%d", &lineNum)
-			findings = append(findings, Finding{Severity: m[1], Path: m[2], Line: lineNum, Message: m[4]})
+			// The anchor token splits like bash: path up to the FIRST colon,
+			// line after the LAST — "foo.go:42:13" anchors at (foo.go, 13).
+			token := m[2]
+			path := token[:strings.Index(token, ":")]
+			lineNum, _ := strconv.Atoi(token[strings.LastIndex(token, ":")+1:])
+			msg := m[3]
+			if msg == "" {
+				msg = token
+			}
+			findings = append(findings, Finding{Severity: m[1], Path: path, Line: lineNum, Message: msg})
 			continue
 		}
 		if m := looseFindingLine.FindStringSubmatch(line); m != nil {

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -1,0 +1,415 @@
+package review
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/forge"
+)
+
+// fakeForge records every op in order and answers from canned data.
+type fakeForge struct {
+	pr       forge.PR
+	diff     []byte
+	statuses []forge.Status
+
+	ops            []string
+	posted         []forge.Status
+	inlineErr      error
+	pendingErrFor  map[string]bool
+	finalErrFor    map[string]bool
+	comments       []string
+	inlineComments []string
+}
+
+func (f *fakeForge) GetPR(ctx context.Context, repo string, index int) (forge.PR, error) {
+	f.ops = append(f.ops, "get-pr")
+	return f.pr, nil
+}
+
+func (f *fakeForge) GetPRDiff(ctx context.Context, repo string, index int) ([]byte, error) {
+	f.ops = append(f.ops, "get-diff")
+	return f.diff, nil
+}
+
+func (f *fakeForge) CommitStatuses(ctx context.Context, repo, sha string) ([]forge.Status, error) {
+	f.ops = append(f.ops, "statuses")
+	return f.statuses, nil
+}
+
+func (f *fakeForge) CreateCommitStatus(ctx context.Context, repo, sha string, status forge.Status) error {
+	f.ops = append(f.ops, fmt.Sprintf("status:%s=%s", status.Context, status.State))
+	if status.State == forge.StatusPending && f.pendingErrFor[status.Context] {
+		return errors.New("pending post failed")
+	}
+	if (status.State == forge.StatusSuccess || status.State == forge.StatusFailure) && f.finalErrFor[status.Context] {
+		return errors.New("final post failed")
+	}
+	f.posted = append(f.posted, status)
+	return nil
+}
+
+func (f *fakeForge) CreateReviewComment(ctx context.Context, repo string, index int, sha, path string, line int, body string) error {
+	f.ops = append(f.ops, "inline:"+path)
+	if f.inlineErr != nil {
+		return f.inlineErr
+	}
+	f.inlineComments = append(f.inlineComments, body)
+	return nil
+}
+
+func (f *fakeForge) CreateComment(ctx context.Context, repo string, index int, body string) error {
+	f.ops = append(f.ops, "comment")
+	f.comments = append(f.comments, body)
+	return nil
+}
+
+type fakeLens struct {
+	name         string
+	availableErr error
+	output       string
+	runErr       error
+	runs         int
+	sawPrompt    string
+}
+
+func (l *fakeLens) Name() string     { return l.name }
+func (l *fakeLens) Available() error { return l.availableErr }
+func (l *fakeLens) Run(ctx context.Context, prompt string) (string, error) {
+	l.runs++
+	l.sawPrompt = prompt
+	return l.output, l.runErr
+}
+
+func newFakeForge() *fakeForge {
+	return &fakeForge{
+		pr:   forge.PR{Number: 7, Title: "t", HeadSHA: "abcdef123456789", BaseRef: "main"},
+		diff: []byte("diff --git a/a.go b/a.go\n+x\n"),
+	}
+}
+
+func producer(f *fakeForge, lenses ...Lens) *Producer {
+	return &Producer{
+		Forge:  f,
+		Repo:   "owner/repo",
+		Lenses: lenses,
+		Now:    func() time.Time { return time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC) },
+		Logf:   func(string, ...any) {},
+	}
+}
+
+func lastStatusFor(t *testing.T, f *fakeForge, context string) forge.Status {
+	t.Helper()
+	for i := len(f.posted) - 1; i >= 0; i-- {
+		if f.posted[i].Context == context {
+			return f.posted[i]
+		}
+	}
+	t.Fatalf("no status posted for %s: %v", context, f.posted)
+	return forge.Status{}
+}
+
+func TestProducePR_PendingFirstAcrossLenses(t *testing.T) {
+	f := newFakeForge()
+	a := &fakeLens{name: "llm-review-opus", output: "[P2] a.go:1 — minor"}
+	b := &fakeLens{name: "llm-review-cursor", output: "NO_FINDINGS"}
+	if err := producer(f, a, b).ProducePR(context.Background(), 7); err != nil {
+		t.Fatalf("ProducePR: %v", err)
+	}
+	// Both pendings must land before any comment or final status: the gate
+	// must never observe "comments exist but a stream has no status".
+	var sawFirstFinal bool
+	pendings := 0
+	for _, op := range f.ops {
+		if strings.HasPrefix(op, "status:") && strings.HasSuffix(op, "=pending") {
+			if sawFirstFinal {
+				t.Fatalf("pending posted after phase 2 began: %v", f.ops)
+			}
+			pendings++
+		}
+		if strings.HasPrefix(op, "inline:") || op == "comment" ||
+			(strings.HasPrefix(op, "status:") && !strings.HasSuffix(op, "=pending")) {
+			sawFirstFinal = true
+		}
+	}
+	if pendings != 2 {
+		t.Fatalf("pendings = %d, want 2: %v", pendings, f.ops)
+	}
+	if a.runs != 1 || b.runs != 1 {
+		t.Fatalf("runs = %d/%d, want 1/1", a.runs, b.runs)
+	}
+}
+
+func TestProducePR_SettledSkips(t *testing.T) {
+	for _, state := range []forge.StatusState{forge.StatusSuccess, forge.StatusFailure} {
+		f := newFakeForge()
+		f.statuses = []forge.Status{{Context: "llm-review-opus", State: state}}
+		l := &fakeLens{name: "llm-review-opus", output: "NO_FINDINGS"}
+		if err := producer(f, l).ProducePR(context.Background(), 7); err != nil {
+			t.Fatalf("state %s: %v", state, err)
+		}
+		if l.runs != 0 {
+			t.Fatalf("state %s: a settled lens must not run again (idempotency)", state)
+		}
+		if len(f.posted) != 0 {
+			t.Fatalf("state %s: no statuses expected, got %v", state, f.posted)
+		}
+	}
+}
+
+func TestProducePR_FreshPendingSkips(t *testing.T) {
+	f := newFakeForge()
+	f.statuses = []forge.Status{{
+		Context:   "llm-review-opus",
+		State:     forge.StatusPending,
+		CreatedAt: time.Date(2026, 8, 10, 11, 55, 0, 0, time.UTC), // 5m old
+	}}
+	l := &fakeLens{name: "llm-review-opus", output: "NO_FINDINGS"}
+	if err := producer(f, l).ProducePR(context.Background(), 7); err != nil {
+		t.Fatalf("ProducePR: %v", err)
+	}
+	if l.runs != 0 {
+		t.Fatal("a fresh pending means another run is mid-flight — must skip")
+	}
+}
+
+func TestProducePR_StalePendingRetries(t *testing.T) {
+	f := newFakeForge()
+	f.statuses = []forge.Status{{
+		Context:   "llm-review-opus",
+		State:     forge.StatusPending,
+		CreatedAt: time.Date(2026, 8, 10, 11, 0, 0, 0, time.UTC), // 60m old
+	}}
+	l := &fakeLens{name: "llm-review-opus", output: "NO_FINDINGS"}
+	if err := producer(f, l).ProducePR(context.Background(), 7); err != nil {
+		t.Fatalf("ProducePR: %v", err)
+	}
+	if l.runs != 1 {
+		t.Fatal("a stale pending is a crashed run — must retry")
+	}
+}
+
+func TestProducePR_PendingWithoutAgeRetries(t *testing.T) {
+	f := newFakeForge()
+	f.statuses = []forge.Status{{Context: "llm-review-opus", State: forge.StatusPending}}
+	l := &fakeLens{name: "llm-review-opus", output: "NO_FINDINGS"}
+	if err := producer(f, l).ProducePR(context.Background(), 7); err != nil {
+		t.Fatalf("ProducePR: %v", err)
+	}
+	if l.runs != 1 {
+		t.Fatal("a pending with no usable age must be treated as crashed, not wedge")
+	}
+}
+
+func TestProducePR_ErrorStatusRetries(t *testing.T) {
+	f := newFakeForge()
+	f.statuses = []forge.Status{{Context: "llm-review-opus", State: forge.StatusError}}
+	l := &fakeLens{name: "llm-review-opus", output: "NO_FINDINGS"}
+	if err := producer(f, l).ProducePR(context.Background(), 7); err != nil {
+		t.Fatalf("ProducePR: %v", err)
+	}
+	if l.runs != 1 {
+		t.Fatal("an error status is retryable")
+	}
+}
+
+func TestProducePR_CredsMissingPostsErrorStatus(t *testing.T) {
+	f := newFakeForge()
+	broken := &fakeLens{name: "llm-review-cursor", availableErr: errors.New("no key")}
+	healthy := &fakeLens{name: "llm-review-opus", output: "NO_FINDINGS"}
+	err := producer(f, broken, healthy).ProducePR(context.Background(), 7)
+	if err == nil {
+		t.Fatal("a creds-missing lens must fail the run so the operator sees the degraded pass")
+	}
+	st := lastStatusFor(t, f, "llm-review-cursor")
+	if st.State != forge.StatusError || st.Description != "skipped: credentials not configured" {
+		t.Fatalf("cursor status = %+v", st)
+	}
+	if broken.runs != 0 {
+		t.Fatal("a creds-missing lens must not run")
+	}
+	if healthy.runs != 1 {
+		t.Fatal("the healthy lens must still run — the pair must not wedge on one silent stream")
+	}
+	if st := lastStatusFor(t, f, "llm-review-opus"); st.State != forge.StatusSuccess {
+		t.Fatalf("opus status = %+v", st)
+	}
+}
+
+func TestProducePR_PendingPostFailureAborts(t *testing.T) {
+	f := newFakeForge()
+	f.pendingErrFor = map[string]bool{"llm-review-opus": true}
+	l := &fakeLens{name: "llm-review-opus", output: "NO_FINDINGS"}
+	err := producer(f, l).ProducePR(context.Background(), 7)
+	if err == nil {
+		t.Fatal("a failed pending post must fail the run — a green no-op over it hides the protocol violation")
+	}
+	if l.runs != 0 {
+		t.Fatal("the model must not run when phase 1 did not happen")
+	}
+}
+
+func TestProducePR_UnparseableFailsClosed(t *testing.T) {
+	f := newFakeForge()
+	l := &fakeLens{name: "llm-review-opus", output: "I'm sorry, I cannot review this diff."}
+	err := producer(f, l).ProducePR(context.Background(), 7)
+	if err == nil {
+		t.Fatal("unparseable output must fail the run")
+	}
+	st := lastStatusFor(t, f, "llm-review-opus")
+	if st.State != forge.StatusError || st.Description != "review output unparseable" {
+		t.Fatalf("status = %+v — a refusal must never read as a clean review", st)
+	}
+}
+
+func TestProducePR_RunFailurePostsErrorStatus(t *testing.T) {
+	f := newFakeForge()
+	l := &fakeLens{name: "llm-review-opus", runErr: errors.New("model down")}
+	if err := producer(f, l).ProducePR(context.Background(), 7); err == nil {
+		t.Fatal("a failed run must surface")
+	}
+	st := lastStatusFor(t, f, "llm-review-opus")
+	if st.State != forge.StatusError || st.Description != "review run failed" {
+		t.Fatalf("status = %+v", st)
+	}
+}
+
+func TestProducePR_FindingsPostAndBlock(t *testing.T) {
+	f := newFakeForge()
+	l := &fakeLens{name: "llm-review-opus", output: "[P0] a.go:3 — data loss\n[P2] b.go:9 — nit"}
+	if err := producer(f, l).ProducePR(context.Background(), 7); err != nil {
+		t.Fatalf("ProducePR: %v", err)
+	}
+	if len(f.inlineComments) != 2 {
+		t.Fatalf("inline comments = %d, want 2", len(f.inlineComments))
+	}
+	if !strings.Contains(f.inlineComments[0], "[P0] data loss") ||
+		!strings.Contains(f.inlineComments[0], "<sub>llm-review-opus @ abcdef123456</sub>") {
+		t.Fatalf("first comment = %q — needs the [Px] severity marker and the stream marker", f.inlineComments[0])
+	}
+	st := lastStatusFor(t, f, "llm-review-opus")
+	if st.State != forge.StatusFailure || st.Description != "1 blocking (P0/P1) of 2 findings" {
+		t.Fatalf("status = %+v", st)
+	}
+}
+
+func TestProducePR_AdvisoryOnlySucceeds(t *testing.T) {
+	f := newFakeForge()
+	l := &fakeLens{name: "llm-review-opus", output: "```\n[P3] a.go:1 — nit\n```"}
+	if err := producer(f, l).ProducePR(context.Background(), 7); err != nil {
+		t.Fatalf("ProducePR: %v", err)
+	}
+	st := lastStatusFor(t, f, "llm-review-opus")
+	if st.State != forge.StatusSuccess || st.Description != "1 advisory findings, none blocking" {
+		t.Fatalf("status = %+v", st)
+	}
+}
+
+func TestProducePR_InlineRejectionFallsBack(t *testing.T) {
+	f := newFakeForge()
+	f.inlineErr = errors.New("422 position not in diff")
+	l := &fakeLens{name: "llm-review-opus", output: "[P1] a.go:9999 — boom"}
+	if err := producer(f, l).ProducePR(context.Background(), 7); err != nil {
+		t.Fatalf("ProducePR: %v", err)
+	}
+	if len(f.comments) != 1 || !strings.Contains(f.comments[0], "(at `a.go:9999`)") {
+		t.Fatalf("fallback comments = %v — a rejected anchor must not drop the finding", f.comments)
+	}
+	if st := lastStatusFor(t, f, "llm-review-opus"); st.State != forge.StatusFailure {
+		t.Fatalf("status = %+v — the P1 must still block", st)
+	}
+}
+
+func TestProducePR_AnchorlessFindingFallsBack(t *testing.T) {
+	f := newFakeForge()
+	l := &fakeLens{name: "llm-review-opus", output: "[P1] the whole change is wrong"}
+	if err := producer(f, l).ProducePR(context.Background(), 7); err != nil {
+		t.Fatalf("ProducePR: %v", err)
+	}
+	if len(f.inlineComments) != 0 {
+		t.Fatalf("no inline expected without an anchor, got %v", f.inlineComments)
+	}
+	if len(f.comments) != 1 {
+		t.Fatalf("fallback comments = %v", f.comments)
+	}
+	if st := lastStatusFor(t, f, "llm-review-opus"); st.State != forge.StatusFailure {
+		t.Fatalf("status = %+v — a P1 without an anchor still blocks", st)
+	}
+}
+
+func TestProducePR_TruncationSurfacedInStatus(t *testing.T) {
+	f := newFakeForge()
+	f.diff = []byte("diff --git a/a.go b/a.go\n+" + strings.Repeat("x", 500) + "\n")
+	l := &fakeLens{name: "llm-review-opus", output: "NO_FINDINGS"}
+	p := producer(f, l)
+	p.MaxDiffBytes = 100
+	if err := p.ProducePR(context.Background(), 7); err != nil {
+		t.Fatalf("ProducePR: %v", err)
+	}
+	st := lastStatusFor(t, f, "llm-review-opus")
+	if !strings.Contains(st.Description, "warning: diff truncated to 100 bytes") {
+		t.Fatalf("status = %+v — truncation must be operator-visible", st)
+	}
+	if wantMax := len(fmt.Sprintf(promptTemplate, "t")) + 100; len(l.sawPrompt) != wantMax {
+		t.Fatalf("prompt length = %d, want template+100 = %d", len(l.sawPrompt), wantMax)
+	}
+}
+
+func TestProducePR_EmptyDiffNoOps(t *testing.T) {
+	f := newFakeForge()
+	f.diff = []byte("  \n")
+	l := &fakeLens{name: "llm-review-opus", output: "NO_FINDINGS"}
+	if err := producer(f, l).ProducePR(context.Background(), 7); err != nil {
+		t.Fatalf("ProducePR: %v", err)
+	}
+	if l.runs != 0 || len(f.posted) != 0 {
+		t.Fatal("an empty diff must produce nothing")
+	}
+}
+
+func TestProducePR_FinalStatusPostFailureSurfaces(t *testing.T) {
+	f := newFakeForge()
+	f.finalErrFor = map[string]bool{"llm-review-opus": true}
+	l := &fakeLens{name: "llm-review-opus", output: "NO_FINDINGS"}
+	if err := producer(f, l).ProducePR(context.Background(), 7); err == nil {
+		t.Fatal("a failed final status post must surface — a swallowed one reads as a green no-op run")
+	}
+}
+
+func TestParseOutput(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      string
+		wantN   int
+		wantOK  bool
+		anchor0 string
+	}{
+		{"no findings sentinel", "NO_FINDINGS", 0, true, ""},
+		{"fenced sentinel", "```\nNO_FINDINGS\n```", 0, true, ""},
+		{"indented finding", "  [P1] a.go:3 — boom", 1, true, "a.go:3"},
+		{"hyphen separator", "[P2] b.go:4 - meh", 1, true, "b.go:4"},
+		{"en-dash separator", "[P2] c.go:5 – meh", 1, true, "c.go:5"},
+		{"loose finding keeps severity", "[P0] everything is broken", 1, true, ":0"},
+		{"refusal fails closed", "I cannot help with that.", 0, false, ""},
+		{"empty fails closed", "", 0, false, ""},
+		{"prose with embedded sentinel mid-line stays closed", "maybe NO_FINDINGS later", 0, false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			findings, ok := parseOutput(tc.in)
+			if ok != tc.wantOK || len(findings) != tc.wantN {
+				t.Fatalf("parseOutput(%q) = %d findings, ok=%v; want %d, ok=%v", tc.in, len(findings), ok, tc.wantN, tc.wantOK)
+			}
+			if tc.wantN > 0 {
+				got := fmt.Sprintf("%s:%d", findings[0].Path, findings[0].Line)
+				if got != tc.anchor0 {
+					t.Fatalf("anchor = %s, want %s", got, tc.anchor0)
+				}
+			}
+		})
+	}
+}

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -390,9 +390,13 @@ func TestParseOutput(t *testing.T) {
 	}{
 		{"no findings sentinel", "NO_FINDINGS", 0, true, ""},
 		{"fenced sentinel", "```\nNO_FINDINGS\n```", 0, true, ""},
+		{"crlf sentinel", "NO_FINDINGS\r\n", 0, true, ""},
 		{"indented finding", "  [P1] a.go:3 — boom", 1, true, "a.go:3"},
 		{"hyphen separator", "[P2] b.go:4 - meh", 1, true, "b.go:4"},
 		{"en-dash separator", "[P2] c.go:5 – meh", 1, true, "c.go:5"},
+		{"dash-less anchor stays inline (bash parity)", "[P1] foo.go:12 fix the check", 1, true, "foo.go:12"},
+		{"double-colon token splits first/last (bash parity)", "[P0] foo.go:42:13 — msg", 1, true, "foo.go:13"},
+		{"crlf finding", "[P1] a.go:3 — boom\r\n", 1, true, "a.go:3"},
 		{"loose finding keeps severity", "[P0] everything is broken", 1, true, ":0"},
 		{"refusal fails closed", "I cannot help with that.", 0, false, ""},
 		{"empty fails closed", "", 0, false, ""},


### PR DESCRIPTION
Slice **S4** of #1162, stacked on #1165 (S3) — base is the S3 branch so the diff is S4-only.

## What

`internal/review`: the Go llm-review producer, a deliberate transliteration of `scripts/llm-review.sh` with the #1148/#1152 hardening preserved verbatim:

- **pending-first**: every lens's status settles (pending / skipped-error) before any model output or comment lands — the gate never observes "comments exist but a stream has no status";
- **per-head idempotency**: settled (success/failure) skips; fresh pending = another run mid-flight; stale pending (default 30m) = crashed run, retried; unusable pending age = retried;
- **fail-closed**: output matching neither `[P0]`–`[P3]` findings nor `NO_FINDINGS` posts an error status — a refusal or format drift never reads as a clean review;
- **no-creds→error**: a configured lens without credentials posts `skipped: credentials not configured` instead of leaving the stream silently unobserved (and fails the producer pass so the operator sees it);
- severity contract (P0/P1 block), inline findings with the stream marker `<sub><stream> @ <sha12></sub>`, plain-comment fallback on rejected anchors, operator-visible diff-truncation note; status description strings kept byte-compatible with the bash producer.

All forge traffic goes through `forge.Client` — the producer is GitHub/Forgejo-agnostic by construction.

## Lens runners

- **ChatLens** — single-shot OpenAI-compatible chat completion. For the fleet's Anthropic/OpenAI lenses the endpoint MUST be CLIProxy (accounting + credential rotation); this replaces the bash opus branch's direct host login, the design defect that triggered #1162. Base URL / key / model are injected by the caller — nothing is read from the environment or hardcoded here.
- **CursorLens** — cursor-agent in the #1161 live-verified sandbox: empty cwd, prompt+diff on stdin, `--mode ask --trust` (read-only, no command auto-approve), stdout/stderr split so telemetry never reaches the parser. Cursor remains the sole CLIProxy exception (own key).

## Tests

Protocol matrix over a fake forge + fake lenses (pending-first ordering across lenses, all four settled-state branches, creds-missing degradation with the healthy lens still running, pending-post abort, fail-closed, blocking vs advisory statuses, fallback posting, truncation surfacing, final-status post failure) plus parser table tests (fences, dash variants, anchorless findings, mid-line sentinel stays closed) and lens tests (request shape/auth against httptest; stub cursor-agent asserting its own sandbox).

## Not in this slice

Daemon trigger wiring and bash retirement — S5. Config plumbing for lens credentials (`*_env` indirection) also lands with S5.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches merge-gating review production (status semantics and blocking P0/P1 handling) and spawns external model processes; behavior is heavily tested but not yet integrated into the live daemon path.
> 
> **Overview**
> Adds **`internal/review`**, a Go replacement for `scripts/llm-review.sh` that drives PR LLM reviews through `forge.Client` and publishes per-lens commit statuses (`llm-review-*`) plus inline or fallback PR comments—the same surfaces the review gate consumes.
> 
> **Producer (`Producer.ProducePR`)** preserves the bash hardening: **pending-first** (all lens statuses settle before models run or comments post), **per-head idempotency** (settled success/failure skips; fresh pending defers; stale/zero-age pending retries), **fail-closed** parsing (only `[P0]–[P3]` lines or `NO_FINDINGS`), and **missing creds → error status** instead of a silent stream. Diff cap (default 400k bytes) is noted on final status descriptions when truncation applies.
> 
> **Lens runners:** `ChatLens` posts a single user message to `{BaseURL}/v1/chat/completions` (fleet Anthropic/OpenAI lenses are intended to hit **CLIProxy**, not direct provider URLs). `CursorLens` runs `cursor-agent` in an empty temp cwd with prompt on stdin, `--mode ask --trust`, separated stdout/stderr, and process-group kill on timeout.
> 
> Daemon wiring and bash retirement are explicitly **out of scope** for this slice (S5).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c868824449db93857bbffb584aabc9b16bac907. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds Go-based LLM review production with Chat and Cursor lenses, finding parsing, and forge status publication. The clean-result parser accepts `NO_FINDINGS` when it appears as one line inside refusal text or other commentary, allowing malformed model output to publish a successful review status. Restrict the sentinel to an otherwise-empty normalized response so invalid output fails closed.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until malformed clean-verdict output can no longer publish a successful review result.

The failure was reproduced through the real parser and status-publication path using a response containing commentary before and after `NO_FINDINGS`; the observed result was a successful status with no findings.

**Files Needing Attention:** internal/review/review.go needs the clean-verdict matching logic tightened at the `noFindings` expression and its use in `parseOutput`.

<details open><summary><h3>Security Review</h3></summary>

The review gate can be bypassed by model output that includes a standalone `NO_FINDINGS` line alongside non-review text. Focused execution confirmed that this input is treated as a clean review and publishes a successful forge status, making the fail-open behavior security-relevant.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a finding-comment-proof for a posted P1 finding and included the focused Go test source that uses multiline NO\_FINDINGS with refusal commentary.
- T-Rex produced a second finding-comment-proof for another posted P1 finding.
- The general-contract-validation-proof confirmed that the focused test source and its command output were captured in trex-artifacts, and that the multiline sentinel logic ignores surrounding commentary once it finds a standalone sentinel line, bypassing the fail-closed path.

<a href="https://app.greptile.com/trex/runs/18279507/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Standalone NO_FINDINGS within commentary produces a green review**

   - **Bug**
     - A response containing refusal/commentary before and after a standalone `NO_FINDINGS` line is accepted with zero findings and results in the producer posting a success status.
   - **Cause**
     - `noFindings` uses multiline anchors (`(?m)`), and `parseOutput` tests the entire cleaned multiline response with `MatchString`. Any standalone sentinel line therefore validates otherwise non-contract output.
   - **Fix**
     - Require the cleaned output to contain only the `NO_FINDINGS` sentinel (subject only to explicitly supported fence/whitespace normalization), rather than searching for a sentinel line anywhere in the response.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
internal/review/review.go:279
**Embedded clean sentinel passes the review gate**

The multiline expression accepts `NO_FINDINGS` when it occurs on any individual line. As a result, a lens response containing refusal text or other commentary before or after that line is parsed as a clean result and publishes a successful review status. Require the normalized output to consist solely of the clean sentinel, apart from intentionally supported whitespace and fence normalization, so malformed output fails closed.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(review): parser parity and a bounded..."](https://github.com/befeast/maestro/commit/5c868824449db93857bbffb584aabc9b16bac907) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52145472)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->