### PR TITLE
feat(orchestrator): daemon-side llm-review producer trigger (#1162 S5)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1902,6 +1902,84 @@ func (c ReviewRetriggerConfig) MissingReviewGraceOrZero() time.Duration {
 	return time.Duration(c.MissingAfterMinutes) * time.Minute
 }
 
+// ReviewProducerConfig governs the daemon-side llm-review producer (#1162 S5):
+// when the review gate expects llm-review-* streams that are unobserved on a
+// PR head, the orchestrator produces them in-process (internal/review) instead
+// of relying on the interim CI/timer bash glue. Credentials are env-only
+// (*_env indirection, never values); the chat lenses talk to CLIProxy — never
+// a direct provider login (the #1148 bash design defect this replaces).
+type ReviewProducerConfig struct {
+	Enabled bool `yaml:"enabled"` // opt-in per project row
+	// ChatBaseURL is the CLIProxy root for the opus/terra chat lenses, e.g.
+	// "http://127.0.0.1:23020". Required for those streams to run.
+	ChatBaseURL string `yaml:"chat_base_url,omitempty"`
+	// ChatAPIKeyEnv names the env var holding the CLIProxy key. Default:
+	// CLIPROXY_API_KEY.
+	ChatAPIKeyEnv string `yaml:"chat_api_key_env,omitempty"`
+	OpusModel     string `yaml:"opus_model,omitempty"`  // default: claude-opus-5
+	TerraModel    string `yaml:"terra_model,omitempty"` // default: gpt-5.6-terra
+	// CursorModel default composer-2.5 — the included-usage pool (cost-safe).
+	CursorModel string `yaml:"cursor_model,omitempty"`
+	// CursorAPIKeyEnv names the env var holding the Cursor key. Default:
+	// CURSOR_API_KEY.
+	CursorAPIKeyEnv string `yaml:"cursor_api_key_env,omitempty"`
+	// PendingStaleMinutes is the crashed-pending self-heal threshold
+	// (default 30, the bash REVIEW_PENDING_STALE_MINUTES).
+	PendingStaleMinutes int `yaml:"pending_stale_minutes,omitempty"`
+	// MaxDiffBytes caps the diff fed to the models (default 400000, the bash
+	// LLM_REVIEW_MAX_DIFF_BYTES). Truncation is surfaced in the status.
+	MaxDiffBytes int `yaml:"max_diff_bytes,omitempty"`
+}
+
+func (c ReviewProducerConfig) EffectiveChatAPIKeyEnv() string {
+	if strings.TrimSpace(c.ChatAPIKeyEnv) == "" {
+		return "CLIPROXY_API_KEY"
+	}
+	return strings.TrimSpace(c.ChatAPIKeyEnv)
+}
+
+func (c ReviewProducerConfig) EffectiveCursorAPIKeyEnv() string {
+	if strings.TrimSpace(c.CursorAPIKeyEnv) == "" {
+		return "CURSOR_API_KEY"
+	}
+	return strings.TrimSpace(c.CursorAPIKeyEnv)
+}
+
+func (c ReviewProducerConfig) EffectiveOpusModel() string {
+	if strings.TrimSpace(c.OpusModel) == "" {
+		return "claude-opus-5"
+	}
+	return strings.TrimSpace(c.OpusModel)
+}
+
+func (c ReviewProducerConfig) EffectiveTerraModel() string {
+	if strings.TrimSpace(c.TerraModel) == "" {
+		return "gpt-5.6-terra"
+	}
+	return strings.TrimSpace(c.TerraModel)
+}
+
+func (c ReviewProducerConfig) EffectiveCursorModel() string {
+	if strings.TrimSpace(c.CursorModel) == "" {
+		return "composer-2.5"
+	}
+	return strings.TrimSpace(c.CursorModel)
+}
+
+func (c ReviewProducerConfig) EffectivePendingStale() time.Duration {
+	if c.PendingStaleMinutes <= 0 {
+		return 30 * time.Minute
+	}
+	return time.Duration(c.PendingStaleMinutes) * time.Minute
+}
+
+func (c ReviewProducerConfig) EffectiveMaxDiffBytes() int {
+	if c.MaxDiffBytes <= 0 {
+		return 400000
+	}
+	return c.MaxDiffBytes
+}
+
 // SessionRetentionConfig bounds the growth of state.Sessions by compacting
 // terminal sessions once both the count and age floors are exceeded (#497).
 // Defaults keep the 20 newest terminal sessions per project and any terminal
@@ -2387,6 +2465,7 @@ type Config struct {
 	ReviewGate                      string                        `yaml:"review_gate"`                        // "greptile" (default) | "llm-review" (#1148 opus+terra pair) | "none"
 	ReviewGateStreams               []string                      `yaml:"review_gate_streams"`                // optional review dimensions; default follows review_gate ("greptile" → ["greptile"], "llm-review" → ["llm-review-opus","llm-review-terra"]); "llm-review" is a pair alias; "llm-review-cursor" is an opt-in third lens (name it explicitly, e.g. ["llm-review-opus","llm-review-cursor"]). NOTE: the producer (scripts/llm-review.sh via its LLM_REVIEW_STREAMS input) must be configured to emit the same streams, or the gate degrades on an unproduced stream via missing_after_minutes.
 	ReviewRetrigger                 ReviewRetriggerConfig         `yaml:"review_retrigger"`                   // #691: re-post "@greptile review" when the gate wedges at pending with no review on head
+	ReviewProducer                  ReviewProducerConfig          `yaml:"review_producer"`                    // #1162: daemon-side llm-review producer for unobserved llm-review-* streams (replaces the bash glue)
 	AutoRetryReviewFeedback         bool                          `yaml:"auto_retry_review_feedback"`         // close PRs with review comments and respawn a fixer
 	MergeExhaustedNonCriticalReview *bool                         `yaml:"merge_exhausted_noncritical_review"` // #565: merge a green PR after review-feedback retries exhaust when only non-critical (P1/P2/P3) findings remain (no P0 on head). nil = default-on.
 	AutoRetryRebaseConflicts        bool                          `yaml:"auto_retry_rebase_conflicts"`        // retry PRs whose auto-rebase fails with conflicts

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -85,12 +85,12 @@ type Orchestrator struct {
 	// missingReviewNotified remembers PRs already reported as merged past an
 	// absent review gate, so the alert fires once per PR.
 	missingReviewNotified map[int]bool
-	// reviewProduceInFlight guards one llm-review producer run per PR head in
-	// this process (#1162 S5); cross-process dedup is the posted statuses.
+	// reviewProduceInFlight guards one llm-review producer run per PR in this
+	// process (#1162 S5); cross-process dedup is the posted statuses.
 	reviewProduceMu       sync.Mutex
-	reviewProduceInFlight map[string]bool
+	reviewProduceInFlight map[int]bool
 	// reviewProduceFn is the production seam (tests). nil = produceReviewStreams.
-	reviewProduceFn func(prNumber int, headSHA string, streams []string)
+	reviewProduceFn func(prNumber int, headSHA string, streams []string, rp config.ReviewProducerConfig)
 	router                *router.Router
 	repo                  string
 	binaryVersion         string

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/befeast/maestro/internal/approvalstore"
@@ -84,6 +85,12 @@ type Orchestrator struct {
 	// missingReviewNotified remembers PRs already reported as merged past an
 	// absent review gate, so the alert fires once per PR.
 	missingReviewNotified map[int]bool
+	// reviewProduceInFlight guards one llm-review producer run per PR head in
+	// this process (#1162 S5); cross-process dedup is the posted statuses.
+	reviewProduceMu       sync.Mutex
+	reviewProduceInFlight map[string]bool
+	// reviewProduceFn is the production seam (tests). nil = produceReviewStreams.
+	reviewProduceFn func(prNumber int, headSHA string, streams []string)
 	router                *router.Router
 	repo                  string
 	binaryVersion         string
@@ -3772,6 +3779,10 @@ func (o *Orchestrator) reloadConfig(newCfg *config.Config, ticker **time.Ticker)
 		changed = append(changed, "review_retrigger")
 		o.cfg.ReviewRetrigger = newCfg.ReviewRetrigger
 	}
+	if !reflect.DeepEqual(newCfg.ReviewProducer, old.ReviewProducer) {
+		changed = append(changed, "review_producer")
+		o.cfg.ReviewProducer = newCfg.ReviewProducer
+	}
 	if newCfg.AutoRetryReviewFeedback != old.AutoRetryReviewFeedback {
 		changed = append(changed, fmt.Sprintf("auto_retry_review_feedback: %v→%v", old.AutoRetryReviewFeedback, newCfg.AutoRetryReviewFeedback))
 		o.cfg.AutoRetryReviewFeedback = newCfg.AutoRetryReviewFeedback
@@ -5839,6 +5850,9 @@ func (o *Orchestrator) autoMergePRs(s *state.State) {
 			o.trackReviewGateHead(sess, o.reviewClockHead(pr, gateTransition.HeadSHA), reviewVerdict, now)
 			if reviewVerdict.Pending {
 				o.maybeRetriggerStalePendingReview(sess, pr, reviewVerdict)
+				// #1162 S5: an expected llm-review-* stream with no signal on
+				// this head is ours to produce, not to wait for.
+				o.maybeProduceMissingReview(pr.Number, gateTransition.HeadSHA, reviewVerdict)
 				// A gate that never produced any signal is not "reviewing" —
 				// it is absent. Past the configured grace the PR proceeds on
 				// its own merits (CI is already green here) instead of waiting

--- a/internal/orchestrator/review_producer.go
+++ b/internal/orchestrator/review_producer.go
@@ -1,0 +1,133 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/review"
+)
+
+// maybeProduceMissingReview kicks the in-process llm-review producer for the
+// gate's unobserved llm-review-* streams on this head (#1162 S5). This is the
+// daemon-side trigger the #1148 bash glue was interim for: the gate already
+// knows exactly which required stream has produced no signal — that knowledge
+// becomes production instead of a wait.
+//
+// Duplicate kicks are cheap by design: the producer's first act is the
+// per-head settled/pending idempotency check against the posted statuses, so
+// the in-flight guard here only prevents concurrent runs from this process.
+// Streams whose read failed (LookupFailed) are skipped — unproven silence is
+// not a reason to spend a model run.
+func (o *Orchestrator) maybeProduceMissingReview(prNumber int, headSHA string, verdict github.ReviewGateVerdict) {
+	if o.cfg == nil || !o.cfg.ReviewProducer.Enabled {
+		return
+	}
+	var missing []string
+	for _, sv := range verdict.Streams {
+		if !strings.HasPrefix(sv.Name, "llm-review-") {
+			continue
+		}
+		if sv.Observed || sv.LookupFailed {
+			continue
+		}
+		missing = append(missing, sv.Name)
+	}
+	if len(missing) == 0 {
+		return
+	}
+
+	key := fmt.Sprintf("%d@%s", prNumber, headSHA)
+	o.reviewProduceMu.Lock()
+	if o.reviewProduceInFlight == nil {
+		o.reviewProduceInFlight = make(map[string]bool)
+	}
+	if o.reviewProduceInFlight[key] {
+		o.reviewProduceMu.Unlock()
+		return
+	}
+	o.reviewProduceInFlight[key] = true
+	o.reviewProduceMu.Unlock()
+
+	produce := o.reviewProduceFn
+	if produce == nil {
+		produce = o.produceReviewStreams
+	}
+	go func() {
+		defer func() {
+			o.reviewProduceMu.Lock()
+			delete(o.reviewProduceInFlight, key)
+			o.reviewProduceMu.Unlock()
+		}()
+		produce(prNumber, headSHA, missing)
+	}()
+}
+
+// reviewProducerRunTimeout bounds one full producer pass (all lenses on one
+// PR). Individual lens runs are already bounded at 10 minutes each; this is
+// the outer fence so a producer goroutine can never outlive its usefulness.
+const reviewProducerRunTimeout = 30 * time.Minute
+
+// reviewLenses maps the missing stream names to configured lens runners.
+// Credentials resolve from the environment by name (*_env indirection) at
+// kick time; a stream whose credentials are absent still gets its lens — the
+// producer's Available check turns that into the explicit
+// "skipped: credentials not configured" error status, never silence.
+func (o *Orchestrator) reviewLenses(streams []string) []review.Lens {
+	rp := o.cfg.ReviewProducer
+	var lenses []review.Lens
+	for _, stream := range streams {
+		switch stream {
+		case "llm-review-opus":
+			lenses = append(lenses, &review.ChatLens{
+				Stream:  stream,
+				BaseURL: rp.ChatBaseURL,
+				APIKey:  os.Getenv(rp.EffectiveChatAPIKeyEnv()),
+				Model:   rp.EffectiveOpusModel(),
+			})
+		case "llm-review-terra":
+			lenses = append(lenses, &review.ChatLens{
+				Stream:  stream,
+				BaseURL: rp.ChatBaseURL,
+				APIKey:  os.Getenv(rp.EffectiveChatAPIKeyEnv()),
+				Model:   rp.EffectiveTerraModel(),
+			})
+		case "llm-review-cursor":
+			lenses = append(lenses, &review.CursorLens{
+				Stream: stream,
+				Model:  rp.EffectiveCursorModel(),
+				APIKey: os.Getenv(rp.EffectiveCursorAPIKeyEnv()),
+			})
+		}
+	}
+	return lenses
+}
+
+// produceReviewStreams runs the producer for one PR head. The forge is the
+// GitHub client for now; per-project forge selection (Forgejo) arrives with
+// the Forgejo project wiring — the producer itself is already forge-agnostic.
+func (o *Orchestrator) produceReviewStreams(prNumber int, headSHA string, streams []string) {
+	lenses := o.reviewLenses(streams)
+	if len(lenses) == 0 {
+		return
+	}
+	p := &review.Producer{
+		Forge:             github.NewForge(),
+		Repo:              o.repo,
+		Lenses:            lenses,
+		PendingStaleAfter: o.cfg.ReviewProducer.EffectivePendingStale(),
+		MaxDiffBytes:      o.cfg.ReviewProducer.EffectiveMaxDiffBytes(),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), reviewProducerRunTimeout)
+	defer cancel()
+	log.Printf("[orch] PR #%d: producing llm-review streams %v on %s", prNumber, streams, headSHA)
+	if err := p.ProducePR(ctx, prNumber); err != nil {
+		log.Printf("[orch] PR #%d: llm-review producer: %v", prNumber, err)
+		return
+	}
+	log.Printf("[orch] PR #%d: llm-review production complete on %s", prNumber, headSHA)
+}

--- a/internal/orchestrator/review_producer.go
+++ b/internal/orchestrator/review_producer.go
@@ -2,12 +2,12 @@ package orchestrator
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"strings"
 	"time"
 
+	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/review"
 )
@@ -41,29 +41,36 @@ func (o *Orchestrator) maybeProduceMissingReview(prNumber int, headSHA string, v
 		return
 	}
 
-	key := fmt.Sprintf("%d@%s", prNumber, headSHA)
+	// One run per PR (not per head): the producer reviews the PR's CURRENT
+	// head regardless of the head this cycle observed, so a head-keyed guard
+	// would let a run kicked on the old head race a second one kicked on the
+	// new — two full model passes over the same commit.
 	o.reviewProduceMu.Lock()
 	if o.reviewProduceInFlight == nil {
-		o.reviewProduceInFlight = make(map[string]bool)
+		o.reviewProduceInFlight = make(map[int]bool)
 	}
-	if o.reviewProduceInFlight[key] {
+	if o.reviewProduceInFlight[prNumber] {
 		o.reviewProduceMu.Unlock()
 		return
 	}
-	o.reviewProduceInFlight[key] = true
+	o.reviewProduceInFlight[prNumber] = true
 	o.reviewProduceMu.Unlock()
 
 	produce := o.reviewProduceFn
 	if produce == nil {
 		produce = o.produceReviewStreams
 	}
+	// Snapshot the config on this goroutine: the orchestrator loop owns both
+	// this call and the hot-reload writes, so reading o.cfg here is
+	// race-free, while the spawned goroutine below must never touch it.
+	rp := o.cfg.ReviewProducer
 	go func() {
 		defer func() {
 			o.reviewProduceMu.Lock()
-			delete(o.reviewProduceInFlight, key)
+			delete(o.reviewProduceInFlight, prNumber)
 			o.reviewProduceMu.Unlock()
 		}()
-		produce(prNumber, headSHA, missing)
+		produce(prNumber, headSHA, missing, rp)
 	}()
 }
 
@@ -77,8 +84,9 @@ const reviewProducerRunTimeout = 30 * time.Minute
 // kick time; a stream whose credentials are absent still gets its lens — the
 // producer's Available check turns that into the explicit
 // "skipped: credentials not configured" error status, never silence.
-func (o *Orchestrator) reviewLenses(streams []string) []review.Lens {
-	rp := o.cfg.ReviewProducer
+// rp travels by value: this runs on the producer goroutine, which must not
+// read o.cfg (the orchestrator loop hot-reloads it without a lock).
+func reviewLenses(streams []string, rp config.ReviewProducerConfig) []review.Lens {
 	var lenses []review.Lens
 	for _, stream := range streams {
 		switch stream {
@@ -110,8 +118,9 @@ func (o *Orchestrator) reviewLenses(streams []string) []review.Lens {
 // produceReviewStreams runs the producer for one PR head. The forge is the
 // GitHub client for now; per-project forge selection (Forgejo) arrives with
 // the Forgejo project wiring — the producer itself is already forge-agnostic.
-func (o *Orchestrator) produceReviewStreams(prNumber int, headSHA string, streams []string) {
-	lenses := o.reviewLenses(streams)
+// Runs on the producer goroutine: everything it needs arrives by value.
+func (o *Orchestrator) produceReviewStreams(prNumber int, headSHA string, streams []string, rp config.ReviewProducerConfig) {
+	lenses := reviewLenses(streams, rp)
 	if len(lenses) == 0 {
 		return
 	}
@@ -119,8 +128,8 @@ func (o *Orchestrator) produceReviewStreams(prNumber int, headSHA string, stream
 		Forge:             github.NewForge(),
 		Repo:              o.repo,
 		Lenses:            lenses,
-		PendingStaleAfter: o.cfg.ReviewProducer.EffectivePendingStale(),
-		MaxDiffBytes:      o.cfg.ReviewProducer.EffectiveMaxDiffBytes(),
+		PendingStaleAfter: rp.EffectivePendingStale(),
+		MaxDiffBytes:      rp.EffectiveMaxDiffBytes(),
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), reviewProducerRunTimeout)
 	defer cancel()

--- a/internal/orchestrator/review_producer_test.go
+++ b/internal/orchestrator/review_producer_test.go
@@ -22,7 +22,7 @@ func produceRecorder(o *Orchestrator) (*[]producedCall, *sync.WaitGroup) {
 	var mu sync.Mutex
 	var calls []producedCall
 	var wg sync.WaitGroup
-	o.reviewProduceFn = func(pr int, head string, streams []string) {
+	o.reviewProduceFn = func(pr int, head string, streams []string, rp config.ReviewProducerConfig) {
 		mu.Lock()
 		calls = append(calls, producedCall{pr: pr, head: head, streams: streams})
 		mu.Unlock()
@@ -93,7 +93,7 @@ func TestMaybeProduceMissingReview_InFlightDedup(t *testing.T) {
 	started := 0
 	release := make(chan struct{})
 	done := make(chan struct{}, 2)
-	o.reviewProduceFn = func(pr int, head string, streams []string) {
+	o.reviewProduceFn = func(pr int, head string, streams []string, rp config.ReviewProducerConfig) {
 		mu.Lock()
 		started++
 		mu.Unlock()
@@ -105,31 +105,34 @@ func TestMaybeProduceMissingReview_InFlightDedup(t *testing.T) {
 		Streams: []github.ReviewStreamVerdict{{Name: "llm-review-opus", Pending: true}},
 	}
 	o.maybeProduceMissingReview(7, "head1", verdict)
-	// Wait until the first goroutine has claimed the key.
+	// Wait until the first goroutine has claimed the PR.
 	for {
 		o.reviewProduceMu.Lock()
-		claimed := o.reviewProduceInFlight["7@head1"]
+		claimed := o.reviewProduceInFlight[7]
 		o.reviewProduceMu.Unlock()
 		if claimed {
 			break
 		}
 		time.Sleep(time.Millisecond)
 	}
-	o.maybeProduceMissingReview(7, "head1", verdict)
+	// A second kick — even on a NEW head — must dedup: the running producer
+	// already reviews the PR's current head, so a head-keyed second run would
+	// double-spend on the same commit.
+	o.maybeProduceMissingReview(7, "head2", verdict)
 	close(release)
 	<-done
 	mu.Lock()
 	defer mu.Unlock()
 	if started != 1 {
-		t.Fatalf("started = %d, want 1 — the second kick on the same head must dedup", started)
+		t.Fatalf("started = %d, want 1 — the second kick on the same PR must dedup", started)
 	}
 }
 
 func TestReviewLenses_ConfigMapping(t *testing.T) {
 	t.Setenv("CLIPROXY_API_KEY", "proxy-key")
 	t.Setenv("CURSOR_API_KEY", "cursor-key")
-	o := producerOrchestrator(true)
-	lenses := o.reviewLenses([]string{"llm-review-opus", "llm-review-terra", "llm-review-cursor", "greptile"})
+	rp := config.ReviewProducerConfig{Enabled: true, ChatBaseURL: "http://cliproxy.test"}
+	lenses := reviewLenses([]string{"llm-review-opus", "llm-review-terra", "llm-review-cursor", "greptile"}, rp)
 	if len(lenses) != 3 {
 		t.Fatalf("lenses = %d, want 3 (greptile is not produceable)", len(lenses))
 	}
@@ -149,8 +152,7 @@ func TestReviewLenses_ConfigMapping(t *testing.T) {
 
 func TestReviewLenses_MissingCredsStillBuildsLens(t *testing.T) {
 	t.Setenv("CLIPROXY_API_KEY", "")
-	o := producerOrchestrator(true)
-	lenses := o.reviewLenses([]string{"llm-review-opus"})
+	lenses := reviewLenses([]string{"llm-review-opus"}, config.ReviewProducerConfig{Enabled: true, ChatBaseURL: "http://cliproxy.test"})
 	if len(lenses) != 1 {
 		t.Fatalf("lenses = %d, want 1", len(lenses))
 	}

--- a/internal/orchestrator/review_producer_test.go
+++ b/internal/orchestrator/review_producer_test.go
@@ -1,0 +1,162 @@
+package orchestrator
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/review"
+)
+
+type producedCall struct {
+	pr      int
+	head    string
+	streams []string
+}
+
+// produceRecorder wires the test seam and returns the call log guarded for
+// the goroutine handoff.
+func produceRecorder(o *Orchestrator) (*[]producedCall, *sync.WaitGroup) {
+	var mu sync.Mutex
+	var calls []producedCall
+	var wg sync.WaitGroup
+	o.reviewProduceFn = func(pr int, head string, streams []string) {
+		mu.Lock()
+		calls = append(calls, producedCall{pr: pr, head: head, streams: streams})
+		mu.Unlock()
+		wg.Done()
+	}
+	return &calls, &wg
+}
+
+func producerOrchestrator(enabled bool) *Orchestrator {
+	return &Orchestrator{
+		cfg: &config.Config{
+			Repo: "owner/repo",
+			ReviewProducer: config.ReviewProducerConfig{
+				Enabled:     enabled,
+				ChatBaseURL: "http://cliproxy.test",
+			},
+		},
+		repo: "owner/repo",
+	}
+}
+
+func TestMaybeProduceMissingReview_SelectsUnobservedLLMStreams(t *testing.T) {
+	o := producerOrchestrator(true)
+	calls, wg := produceRecorder(o)
+	wg.Add(1)
+	o.maybeProduceMissingReview(7, "head1", github.ReviewGateVerdict{
+		Pending: true,
+		Streams: []github.ReviewStreamVerdict{
+			{Name: "llm-review-opus", Observed: true, Pending: true},
+			{Name: "llm-review-cursor", Observed: false, Pending: true},
+			{Name: "greptile", Observed: false, Pending: true},
+			{Name: "llm-review-terra", Observed: false, Pending: true, LookupFailed: true},
+		},
+	})
+	wg.Wait()
+	if len(*calls) != 1 {
+		t.Fatalf("calls = %+v, want exactly one production", *calls)
+	}
+	got := (*calls)[0]
+	if got.pr != 7 || got.head != "head1" {
+		t.Fatalf("call = %+v", got)
+	}
+	// Only the unobserved llm-review-* stream with a trustworthy read:
+	// observed opus is already produced, greptile is not ours, terra's
+	// silence is unproven (LookupFailed).
+	if len(got.streams) != 1 || got.streams[0] != "llm-review-cursor" {
+		t.Fatalf("streams = %v, want [llm-review-cursor]", got.streams)
+	}
+}
+
+func TestMaybeProduceMissingReview_DisabledDoesNothing(t *testing.T) {
+	o := producerOrchestrator(false)
+	calls, _ := produceRecorder(o)
+	o.maybeProduceMissingReview(7, "head1", github.ReviewGateVerdict{
+		Pending: true,
+		Streams: []github.ReviewStreamVerdict{{Name: "llm-review-opus", Pending: true}},
+	})
+	// The goroutine is never spawned when disabled; nothing to wait for.
+	time.Sleep(10 * time.Millisecond)
+	if len(*calls) != 0 {
+		t.Fatalf("calls = %+v, want none when disabled", *calls)
+	}
+}
+
+func TestMaybeProduceMissingReview_InFlightDedup(t *testing.T) {
+	o := producerOrchestrator(true)
+	var mu sync.Mutex
+	started := 0
+	release := make(chan struct{})
+	done := make(chan struct{}, 2)
+	o.reviewProduceFn = func(pr int, head string, streams []string) {
+		mu.Lock()
+		started++
+		mu.Unlock()
+		<-release
+		done <- struct{}{}
+	}
+	verdict := github.ReviewGateVerdict{
+		Pending: true,
+		Streams: []github.ReviewStreamVerdict{{Name: "llm-review-opus", Pending: true}},
+	}
+	o.maybeProduceMissingReview(7, "head1", verdict)
+	// Wait until the first goroutine has claimed the key.
+	for {
+		o.reviewProduceMu.Lock()
+		claimed := o.reviewProduceInFlight["7@head1"]
+		o.reviewProduceMu.Unlock()
+		if claimed {
+			break
+		}
+		time.Sleep(time.Millisecond)
+	}
+	o.maybeProduceMissingReview(7, "head1", verdict)
+	close(release)
+	<-done
+	mu.Lock()
+	defer mu.Unlock()
+	if started != 1 {
+		t.Fatalf("started = %d, want 1 — the second kick on the same head must dedup", started)
+	}
+}
+
+func TestReviewLenses_ConfigMapping(t *testing.T) {
+	t.Setenv("CLIPROXY_API_KEY", "proxy-key")
+	t.Setenv("CURSOR_API_KEY", "cursor-key")
+	o := producerOrchestrator(true)
+	lenses := o.reviewLenses([]string{"llm-review-opus", "llm-review-terra", "llm-review-cursor", "greptile"})
+	if len(lenses) != 3 {
+		t.Fatalf("lenses = %d, want 3 (greptile is not produceable)", len(lenses))
+	}
+	opus, ok := lenses[0].(*review.ChatLens)
+	if !ok || opus.Model != "claude-opus-5" || opus.BaseURL != "http://cliproxy.test" || opus.APIKey != "proxy-key" {
+		t.Fatalf("opus lens = %+v", lenses[0])
+	}
+	terra := lenses[1].(*review.ChatLens)
+	if terra.Model != "gpt-5.6-terra" {
+		t.Fatalf("terra model = %q", terra.Model)
+	}
+	cursor, ok := lenses[2].(*review.CursorLens)
+	if !ok || cursor.Model != "composer-2.5" || cursor.APIKey != "cursor-key" {
+		t.Fatalf("cursor lens = %+v", lenses[2])
+	}
+}
+
+func TestReviewLenses_MissingCredsStillBuildsLens(t *testing.T) {
+	t.Setenv("CLIPROXY_API_KEY", "")
+	o := producerOrchestrator(true)
+	lenses := o.reviewLenses([]string{"llm-review-opus"})
+	if len(lenses) != 1 {
+		t.Fatalf("lenses = %d, want 1", len(lenses))
+	}
+	// The producer's Available check owns the creds decision — it must get
+	// the lens so the explicit error status is posted instead of silence.
+	if err := lenses[0].Available(); err == nil {
+		t.Fatal("lens without a key must report unavailable")
+	}
+}

--- a/internal/review/review.go
+++ b/internal/review/review.go
@@ -140,8 +140,29 @@ func (p *Producer) ProducePR(ctx context.Context, prNumber int) error {
 	if err != nil {
 		return fmt.Errorf("review %s#%d: %w", p.Repo, prNumber, err)
 	}
+	statuses, err := p.Forge.CommitStatuses(ctx, p.Repo, pr.HeadSHA)
+	if err != nil {
+		return fmt.Errorf("review %s#%d: statuses on %s: %w", p.Repo, prNumber, pr.HeadSHA, err)
+	}
 	if len(strings.TrimSpace(string(diff))) == 0 {
+		// An empty diff trivially has no findings — settle every unsettled
+		// lens with a success status. Bash just exited 0 here, which was fine
+		// for its per-event CI invocation; the daemon trigger re-kicks on
+		// every cycle an expected stream stays unobserved, so leaving the
+		// streams silent would poll forever on a PR that cannot settle.
 		p.logf("%s#%d: empty diff — nothing to review", p.Repo, prNumber)
+		var errs []error
+		for _, lens := range p.Lenses {
+			if settled, _ := p.statusSettled(lens.Name(), statuses); settled {
+				continue
+			}
+			if err := p.postFinalStatus(ctx, lens.Name(), pr.HeadSHA, forge.StatusSuccess, "empty diff — nothing to review"); err != nil {
+				errs = append(errs, fmt.Errorf("%s: %w", lens.Name(), err))
+			}
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("review %s#%d: %w", p.Repo, prNumber, errors.Join(errs...))
+		}
 		return nil
 	}
 	truncNote := ""
@@ -151,11 +172,6 @@ func (p *Producer) ProducePR(ctx context.Context, prNumber int) error {
 		// Surfaced in the final status description: a verdict over a
 		// truncated diff is weaker evidence and the operator must see that.
 		truncNote = fmt.Sprintf("; warning: diff truncated to %d bytes", p.maxDiffBytes())
-	}
-
-	statuses, err := p.Forge.CommitStatuses(ctx, p.Repo, pr.HeadSHA)
-	if err != nil {
-		return fmt.Errorf("review %s#%d: statuses on %s: %w", p.Repo, prNumber, pr.HeadSHA, err)
 	}
 
 	// Phase 1: settle every lens's status (pending / skipped-error) before

--- a/internal/review/review_test.go
+++ b/internal/review/review_test.go
@@ -359,15 +359,26 @@ func TestProducePR_TruncationSurfacedInStatus(t *testing.T) {
 	}
 }
 
-func TestProducePR_EmptyDiffNoOps(t *testing.T) {
+func TestProducePR_EmptyDiffSettlesStreams(t *testing.T) {
 	f := newFakeForge()
 	f.diff = []byte("  \n")
-	l := &fakeLens{name: "llm-review-opus", output: "NO_FINDINGS"}
-	if err := producer(f, l).ProducePR(context.Background(), 7); err != nil {
+	f.statuses = []forge.Status{{Context: "llm-review-cursor", State: forge.StatusSuccess}}
+	a := &fakeLens{name: "llm-review-opus", output: "NO_FINDINGS"}
+	b := &fakeLens{name: "llm-review-cursor", output: "NO_FINDINGS"}
+	if err := producer(f, a, b).ProducePR(context.Background(), 7); err != nil {
 		t.Fatalf("ProducePR: %v", err)
 	}
-	if l.runs != 0 || len(f.posted) != 0 {
-		t.Fatal("an empty diff must produce nothing")
+	if a.runs != 0 || b.runs != 0 {
+		t.Fatal("an empty diff must not run any model")
+	}
+	// The unsettled stream settles with success (else the daemon trigger
+	// would re-kick every cycle forever); the settled one stays untouched.
+	if len(f.posted) != 1 {
+		t.Fatalf("posted = %+v, want exactly the opus settle", f.posted)
+	}
+	st := f.posted[0]
+	if st.Context != "llm-review-opus" || st.State != forge.StatusSuccess || st.Description != "empty diff — nothing to review" {
+		t.Fatalf("status = %+v", st)
 	}
 }
 


### PR DESCRIPTION
Slice **S5** of #1162, stacked on #1166 (S4) — the last code slice: the daemon-side trigger the #1148 bash glue was interim for.

## What

- **Trigger** (`internal/orchestrator/review_producer.go`): in the review-gate pending branch, when an expected `llm-review-*` stream has produced no signal on the current head, the orchestrator produces it in-process — async, one run per PR head per process (in-flight guard); cross-process dedup is the producer's own per-head status idempotency, so duplicate kicks are cheap by construction. Streams whose gate read failed (`LookupFailed`) are skipped: unproven silence is not a reason to spend a model run.
- **Config** (`review_producer` section, opt-in per row): CLIProxy base URL for the chat lenses; env-var **names** for keys (defaults `CLIPROXY_API_KEY` / `CURSOR_API_KEY` — values never live in config); per-stream models (`claude-opus-5` / `gpt-5.6-terra` / `composer-2.5` defaults); `pending_stale_minutes` and `max_diff_bytes` matching the bash defaults. Hot-reload wired into the config-update diff.
- Lens construction resolves credentials at kick time; a stream with missing creds still gets its lens so the producer posts the explicit `skipped: credentials not configured` error status instead of leaving the stream silent.

## Semantics notes

- A daemon restart mid-run leaves a pending status; the stale-pending self-heal (30m default) retries it — same crash semantics as the bash producer.
- The forge is the GitHub client for now; per-project forge selection (Forgejo) arrives with the Forgejo project wiring — the producer is already forge-agnostic, and the forgejo client (S3) is ready.
- `scripts/llm-review.sh` stays as a manual fallback; the direct-login host timer remains retired.

## Canary path (operator)

1. Merge the stack, deploy.
2. On the pilot row (tx10-clock): `review_producer.enabled: true` + `chat_base_url` pointing at CLIProxy; `CLIPROXY_API_KEY`/`CURSOR_API_KEY` in the daemon environment.
3. Watch one PR head produce `llm-review-opus`+`llm-review-cursor` from the daemon journal; then drop the CI `review` job invocation of the bash script.

## Verification

`go build ./...` clean; vet clean; full suites of all touched packages green (orchestrator, config, review, github, forgejo). Trigger tests cover stream selection (observed / non-llm / lookup-failed exclusions), disabled no-op, in-flight dedup on the same head, config→lens mapping with env keys, and the missing-creds lens path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches merge-gating review flow and spawns async LLM review runs with external API credentials; misconfiguration could spend model budget or leave gates wedged, but behavior is opt-in and deduped by status idempotency plus in-flight guards.
> 
> **Overview**
> Adds an **opt-in** `review_producer` config block and wires the orchestrator to **produce missing `llm-review-*` commit statuses in-process** when the review gate is pending and expected streams have no signal on the current head—replacing interim CI/bash glue for #1148.
> 
> When `review_producer.enabled` is true, **`maybeProduceMissingReview`** runs in the pending-gate path: it collects unobserved `llm-review-*` streams (skipping `LookupFailed`), dedupes **one async run per PR** in-process, maps streams to **Chat/Cursor lenses** via env-only API keys and CLIProxy base URL, and calls **`internal/review.Producer`**. Config hot-reload includes `review_producer`.
> 
> **`ProducePR`** now settles unsettled lenses with a success status on **empty diffs** so the daemon trigger does not re-kick forever on PRs with nothing to review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97f4a2c88c4c2b28069c04551d87a577f44c8878. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change enables the daemon to start configured LLM review producers for required review streams that have not yet reported a result, adds hot-reloadable producer configuration, and settles empty diffs without a model call.

The reported new-head starvation concern was disproved by an executed focused test. While an old-head producer is active, a concurrent new-head launch is intentionally suppressed; after the old run releases the guard, the next gate evaluation starts production for the still-missing new head. Focused gate tests also confirmed that a new commit resets the missing-review grace period.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised producer concurrency and new-head review-gate recovery behavior.

The reported failure mode was directly exercised and contradicted: temporary duplicate-run suppression is followed by a later new-head production attempt, and the per-head grace period resets on a push.

**Files Needing Attention:** No files need follow-up changes from this review. The exercised behavior is in internal/orchestrator/review_producer.go.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a deterministic Go test that exercises the maybeProduceMissingReview path with an old-head producer held and a new-head kick in flight.
- The test showed the concurrent new-head kick did not start while the old-head producer was held, as enforced by the per-pull-request guard.
- After releasing the old-head producer, a later new-head gate evaluation started production for the new head.
- Focused tests validated PR-only deduplication, per-head grace-period reset, and repeated missing-review gate semantics.
- No production code changes were made; a focused test was added and is supplied as evidence.

<a href="https://app.greptile.com/trex/runs/18279708/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(orchestrator): race-free config snap..."](https://github.com/befeast/maestro/commit/97f4a2c88c4c2b28069c04551d87a577f44c8878) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52145962)</sub>

<!-- /greptile_comment -->