### PR TITLE
fix(review-gate): explicit [Px] marker takes precedence over severity needles (#1168)

### DIFF
--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2849,13 +2849,35 @@ func isCriticalSeverity(body string) bool {
 	return hasSeverityMarker(body, "p0")
 }
 
+// leadingSeverityMarker matches an explicit bracketed severity opening the
+// comment body — the format every llm-review producer emits (#1148).
+var leadingSeverityMarker = regexp.MustCompile(`^\s*\[(p[0-3])\]`)
+
+// explicitSeverityLevel returns the level ("p0"..."p3") of the body's leading
+// [Px] marker, or "" when the body does not open with one.
+func explicitSeverityLevel(lower string) string {
+	m := leadingSeverityMarker.FindStringSubmatch(lower)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
 // hasSeverityMarker reports whether the comment body carries the given
 // severity level ("p0"/"p1"/...) in any of the recognized encodings:
 // Greptile badge markup (alt="P0", shields "badge/P0", ".../P0"), or the
 // plain-text forms "[P0]" and "severity: P0" that a simple glue script can
 // emit without any HTML (#1148).
+//
+// An explicit leading [Px] marker is authoritative (#1168): the substring
+// needles below exist for badge markup and prose, and without precedence the
+// "/p1" needle promoted any advisory whose MESSAGE merely quoted "P0/P1"
+// (e.g. a [P3] citing the severity contract) into a merge-blocking finding.
 func hasSeverityMarker(body, level string) bool {
 	lower := strings.ToLower(body)
+	if explicit := explicitSeverityLevel(lower); explicit != "" {
+		return explicit == level
+	}
 	if strings.Contains(lower, "alt=\""+level+"\"") {
 		return true
 	}

--- a/internal/github/severity_marker_test.go
+++ b/internal/github/severity_marker_test.go
@@ -1,0 +1,67 @@
+package github
+
+import "testing"
+
+// #1168: an explicit leading [Px] marker is authoritative — the substring
+// needles must not promote an advisory whose message merely quotes "P0/P1".
+func TestHasSeverityMarker_ExplicitMarkerPrecedence(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		high bool
+		crit bool
+	}{
+		{
+			name: "advisory quoting the severity contract stays advisory",
+			body: "[P3] consider documenting which findings are P0/P1 blockers\n\n<sub>llm-review-opus @ abcdef123456</sub>",
+			high: false,
+			crit: false,
+		},
+		{
+			name: "P1 with a P0 quote in the message is high but not critical",
+			body: "[P1] this mirrors the P0 class from the contract",
+			high: true,
+			crit: false,
+		},
+		{
+			name: "plain P0 finding",
+			body: "[P0] data loss on restart",
+			high: true,
+			crit: true,
+		},
+		{
+			name: "indented marker still explicit",
+			body: "  [p2] lowercase and indented",
+			high: false,
+			crit: false,
+		},
+		{
+			name: "greptile badge without leading marker keeps needle behavior",
+			body: `<img alt="P1" src="https://img.shields.io/badge/P1-red"> nil deref`,
+			high: true,
+			crit: false,
+		},
+		{
+			name: "prose severity label without leading marker keeps needle behavior",
+			body: "severity: P0 — guaranteed breakage",
+			high: true,
+			crit: true,
+		},
+		{
+			name: "mid-body bracket marker is not a leading marker",
+			body: "see the [P0] note above; this is informational",
+			high: true, // needle behavior preserved: no LEADING marker present
+			crit: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isHighSeverity(tc.body); got != tc.high {
+				t.Fatalf("isHighSeverity(%q) = %v, want %v", tc.body, got, tc.high)
+			}
+			if got := isCriticalSeverity(tc.body); got != tc.crit {
+				t.Fatalf("isCriticalSeverity(%q) = %v, want %v", tc.body, got, tc.crit)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1168.

`hasSeverityMarker`'s `"/"+level` needle fired on any body containing "P0/P1" — a `[P3]` advisory quoting the severity contract became a merge-blocking finding (confirmed mechanically during the #1162 S4 review; pre-existing, identical under the bash producer).

An explicit leading `[Px]` marker — the format every llm-review producer emits — is now authoritative for severity attribution. Bodies without a leading marker (Greptile badge markup, prose `severity: P0`) keep the needle behavior byte-for-byte, including the deliberate mid-body-bracket case.

Table test covers: the quoting-advisory case, P1-quoting-P0, indented/lowercase markers, badge and prose regression guards, and the mid-body non-leading bracket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how review comments classify P0/P1 for merge gates and repair scope; the fix reduces false blocking but alters behavior on edge cases (mid-body `[Px]` still uses needles).
> 
> **Overview**
> **Fixes false merge-blocking** when llm-review comments open with an explicit `[Px]` marker but the message only *mentions* other severities (e.g. a `[P3]` advisory that quotes “P0/P1 blockers”).
> 
> `hasSeverityMarker` now treats a **leading** `[P0]`–`[P3]` marker (optional whitespace, case-insensitive) as **authoritative**: if present, only that level is used and substring needles (`/p1`, `badge/p0`, mid-body `[P0]`, etc.) are ignored. Comments **without** a leading marker keep the previous needle behavior for Greptile badges and `severity: P0` prose.
> 
> Adds table tests for the quoting-advisory case, P1-with-P0-quote, indented markers, badge/prose regressions, and mid-body brackets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a93e192d0263c17981326dba08283e8827749cdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes a leading explicit `[P0]`–`[P3]` marker authoritative when classifying review comments, preventing quoted severity terms later in an advisory comment from turning it into a merge-blocking finding.

The focused Go regression test was run against the parent revision and the updated code. The parent revision incorrectly treated a leading `[P3]` comment quoting `P0/P1` as high severity, while the updated code passed that case along with explicit P0/P1, legacy badge, and `severity:` fallback cases. No defects remain to address.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge based on focused before-and-after validation of the affected severity-classification behavior.

No unresolved defects were found. The focused test reproduced the previous false classification on the parent revision and passed all explicit-marker and legacy-fallback cases after the change.

**Files Needing Attention:** No files need further attention; `internal/github/github.go` and `internal/github/severity_marker_test.go` were covered by the focused validation.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the focused severity-marker Go regression test against both the parent revision and the updated code.
- The parent revision produced an incorrect classification for a leading \[P3\] comment quoting P0/P1.
- The updated code passed every focused case, including explicit markers and legacy badge and prose formats.
- Used the verification script to run the before-and-after Go test runs and compare results.
- HEAD passed every focused case, indicating the intended behavior is implemented on the tip of the branch.

<a href="https://app.greptile.com/trex/runs/18281619/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(review-gate): explicit \[Px\] marker t..."](https://github.com/befeast/maestro/commit/a93e192d0263c17981326dba08283e8827749cdf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52149484)</sub>

<!-- /greptile_comment -->