### PR TITLE
fix(worker): codex token budget charges uncached spend, not rollout replay (#1156)

### DIFF
--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -165,8 +165,9 @@ func (codexBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*e
 	if cfg.TokenBudget > 0 {
 		// codex exec's public JSONL reports usage only at turn completion. The
 		// native rollout budget is enforced inside the agent loop after every
-		// provider response, including sub-agent work, so it is the enforceable
-		// live proxy for the configured Maestro ceiling. Codex 0.144 changed
+		// provider response, including sub-agent work — but since #1156 only
+		// its OUTPUT component counts (see the prefill note below), so it is
+		// the in-loop backstop, not the full ceiling. Codex 0.144 changed
 		// rollout_budget from a boolean feature to a configured feature object:
 		// `--enable rollout_budget` now replaces that object and discards its
 		// limit. Set the object's enabled field directly and provide the required
@@ -178,12 +179,23 @@ func (codexBackend) BuildCmd(cfg BackendConfig, promptFile, worktree string) (*e
 				reminders = append(reminders, strconv.Itoa(threshold))
 			}
 		}
+		// prefill_token_weight is 0: prefill in an agent loop is almost
+		// entirely replayed (cached) context, and the rollout feature cannot
+		// tell cached from fresh — at weight 1.0 every provider call
+		// re-charged the whole context and a 400k budget died in minutes of
+		// productive work (#1156). Fresh-input spend on the MAIN thread is
+		// enforced by Maestro's live monitor (#952 uncached measure via
+		// cached_input_tokens); sub-agent threads write their own rollout
+		// files the monitor does not read, so their fresh input is bounded
+		// only indirectly through sampled output — a deliberate trade: the
+		// weight-1.0 alternative false-killed every productive worker in
+		// minutes, the sub-agent input-heavy tail is the smaller risk.
 		args = append(args,
 			"-c", "features.rollout_budget.enabled=true",
 			"-c", fmt.Sprintf("features.rollout_budget.limit_tokens=%d", cfg.TokenBudget),
 			"-c", fmt.Sprintf("features.rollout_budget.reminder_at_remaining_tokens=[%s]", strings.Join(reminders, ",")),
 			"-c", "features.rollout_budget.sampling_token_weight=1.0",
-			"-c", "features.rollout_budget.prefill_token_weight=1.0",
+			"-c", "features.rollout_budget.prefill_token_weight=0.0",
 		)
 	}
 	args = append(args, "-")

--- a/internal/worker/token_budget.go
+++ b/internal/worker/token_budget.go
@@ -213,7 +213,7 @@ func (m *liveTokenMonitor) observe(line string) (int, bool) {
 			}
 		}
 		if fr.Type == "turn.completed" && fr.Usage != nil {
-			if total := fr.Usage.InputTokens + fr.Usage.OutputTokens; total > m.totalTokens {
+			if total := codexBudgetUsage(fr.Usage); total > m.totalTokens {
 				m.totalTokens = total
 			}
 		}
@@ -287,9 +287,10 @@ func readCodexLiveUsage(threadID string) (int, bool) {
 				Type string `json:"type"`
 				Info *struct {
 					Total *struct {
-						InputTokens  int `json:"input_tokens"`
-						OutputTokens int `json:"output_tokens"`
-						TotalTokens  int `json:"total_tokens"`
+						InputTokens       int `json:"input_tokens"`
+						CachedInputTokens int `json:"cached_input_tokens"`
+						OutputTokens      int `json:"output_tokens"`
+						TotalTokens       int `json:"total_tokens"`
 					} `json:"total_token_usage"`
 				} `json:"info"`
 			} `json:"payload"`
@@ -297,9 +298,18 @@ func readCodexLiveUsage(threadID string) (int, bool) {
 		if json.Unmarshal([]byte(line), &event) != nil || event.Type != "event_msg" || event.Payload == nil || event.Payload.Type != "token_count" || event.Payload.Info == nil || event.Payload.Info.Total == nil {
 			continue
 		}
-		total := event.Payload.Info.Total.TotalTokens
+		// #1156: total_token_usage counts cached (replayed) input 1:1, so it
+		// grows by the whole context on every turn — 441k "observed" in four
+		// minutes of productive work. The budget charges only uncached spend,
+		// the same #952 semantics the claude measure uses.
+		usage := event.Payload.Info.Total
+		total := usage.TotalTokens
 		if total <= 0 {
-			total = event.Payload.Info.Total.InputTokens + event.Payload.Info.Total.OutputTokens
+			total = usage.InputTokens + usage.OutputTokens
+		}
+		total -= usage.CachedInputTokens
+		if total < 0 {
+			total = 0
 		}
 		if total > maxTokens {
 			maxTokens = total
@@ -339,4 +349,19 @@ func piBudgetUsage(usage *piUsageBlock) int {
 		return 0
 	}
 	return usage.Input + usage.Output + usage.CacheWrite
+}
+
+// codexBudgetUsage is claudeBudgetUsage's codex sibling (#1156): cached input
+// is replayed context and must not re-charge the ceiling on every turn. Codex
+// reports the cached subset explicitly, so the ceiling counts uncached input
+// plus output (reasoning is already inside output_tokens).
+func codexBudgetUsage(usage *codexUsageBlock) int {
+	if usage == nil {
+		return 0
+	}
+	uncachedInput := usage.InputTokens - usage.CachedInputTokens
+	if uncachedInput < 0 {
+		uncachedInput = 0
+	}
+	return uncachedInput + usage.OutputTokens
 }

--- a/internal/worker/token_budget_test.go
+++ b/internal/worker/token_budget_test.go
@@ -162,7 +162,11 @@ func TestLiveTokenMonitor_BackendEvents(t *testing.T) {
 	}
 }
 
-func TestLiveTokenMonitor_CodexReadsCumulativeRolloutUsage(t *testing.T) {
+func TestLiveTokenMonitor_CodexRolloutExcludesCachedInput(t *testing.T) {
+	// The #1156 incident shape: total_token_usage grows by the whole replayed
+	// context each turn (441k "observed" in 4 minutes of productive work).
+	// The budget must charge only uncached spend — cache-heavy growth stays
+	// under the ceiling, genuine spend still kills.
 	home := t.TempDir()
 	t.Setenv("CODEX_HOME", home)
 	threadID := "019abcde-1234-7000-8000-000000000906"
@@ -170,16 +174,46 @@ func TestLiveTokenMonitor_CodexReadsCumulativeRolloutUsage(t *testing.T) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	rollout := `{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":83000,"cached_input_tokens":70000,"output_tokens":2000,"reasoning_output_tokens":1000,"total_tokens":85000}}}}` + "\n"
-	if err := os.WriteFile(dir+"/rollout-test-"+threadID+".jsonl", []byte(rollout), 0o644); err != nil {
+	path := dir + "/rollout-test-" + threadID + ".jsonl"
+	rollout := `{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":83000,"cached_input_tokens":70000,"output_tokens":2000,"reasoning_output_tokens":1000,"total_tokens":85000}}}}` + "\n" +
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":420000,"cached_input_tokens":405000,"output_tokens":21000,"reasoning_output_tokens":4000,"total_tokens":441000}}}}` + "\n"
+	if err := os.WriteFile(path, []byte(rollout), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
 	monitor := newLiveTokenMonitor("codex", 80_000)
 	monitor.observe(`{"type":"thread.started","thread_id":"` + threadID + `"}`)
 	observed, exceeded := monitor.observe(`{"type":"item.started","item":{"type":"command_execution"}}`)
-	if !exceeded || observed != 85_000 {
-		t.Fatalf("observe = %d,%t, want 85000,true", observed, exceeded)
+	// 441k total is 405k cache replay: uncached = 36k, well under the 80k cap.
+	if exceeded || observed != 36_000 {
+		t.Fatalf("observe = %d,%t, want 36000,false — cache replay must not kill the worker", observed, exceeded)
+	}
+
+	// Genuine spend past the cap still kills: 100k uncached input.
+	more := `{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":520000,"cached_input_tokens":405000,"output_tokens":30000,"reasoning_output_tokens":4000,"total_tokens":550000}}}}` + "\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(more); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	observed, exceeded = monitor.observe(`{"type":"item.started","item":{"type":"command_execution"}}`)
+	if !exceeded || observed != 145_000 {
+		t.Fatalf("observe = %d,%t, want 145000,true — genuine spend must still enforce", observed, exceeded)
+	}
+}
+
+func TestLiveTokenMonitor_CodexTurnCompletedExcludesCachedInput(t *testing.T) {
+	monitor := newLiveTokenMonitor("codex", 80_000)
+	observed, exceeded := monitor.observe(`{"type":"turn.completed","usage":{"input_tokens":420000,"cached_input_tokens":400000,"output_tokens":15000}}`)
+	if exceeded || observed != 35_000 {
+		t.Fatalf("observe = %d,%t, want 35000,false", observed, exceeded)
+	}
+	observed, exceeded = monitor.observe(`{"type":"turn.completed","usage":{"input_tokens":600000,"cached_input_tokens":480000,"output_tokens":25000}}`)
+	if !exceeded || observed != 145_000 {
+		t.Fatalf("observe = %d,%t, want 145000,true", observed, exceeded)
 	}
 }
 
@@ -211,7 +245,11 @@ func TestBuildWorkerCmd_TokenBudgetFailClosedAndCodexProxy(t *testing.T) {
 			t.Fatal(err)
 		}
 		joined := strings.Join(cmd.Args, " ")
-		for _, want := range []string{"--json", "features.rollout_budget.enabled=true", "features.rollout_budget.limit_tokens=80000", "features.rollout_budget.reminder_at_remaining_tokens=[16000,8000]", "sampling_token_weight=1.0", "prefill_token_weight=1.0"} {
+		// prefill weight 0: the native budget cannot tell cached from fresh
+		// prefill, and weight 1.0 re-charged the whole context every call
+		// (#1156). Fresh input is enforced by the live monitor's uncached
+		// measure instead.
+		for _, want := range []string{"--json", "features.rollout_budget.enabled=true", "features.rollout_budget.limit_tokens=80000", "features.rollout_budget.reminder_at_remaining_tokens=[16000,8000]", "sampling_token_weight=1.0", "prefill_token_weight=0.0"} {
 			if !strings.Contains(joined, want) {
 				t.Errorf("codex args missing %q: %s", want, joined)
 			}


### PR DESCRIPTION
Fixes #1156.

Two layers counted cache replay 1:1 for codex-family backends (441k "observed" in 3m57s of productive gen-1 work — 5 worker kills across 2 days on tx10 #44/#47):

- **Live monitor**: `readCodexLiveUsage` took `total_token_usage.total_tokens` verbatim and `turn.completed` summed raw input+output — both include cached input, so the measure grew by the whole replayed context every turn. Both paths now subtract `cached_input_tokens`: the exact #952 uncached semantics the claude measure uses (`codexBudgetUsage` mirrors `claudeBudgetUsage`). Bonus: a resumed thread no longer inherits an instant kill from its replayed history.
- **Native rollout budget**: we configured `prefill_token_weight=1.0`; prefill in an agent loop is almost entirely replayed context and the feature cannot tell cached from fresh, so codex itself re-charged the context every provider call. Prefill weight is 0 now; the native budget remains the in-loop backstop on sampled output.

**Documented trade-off** (adversarial review finding, accepted deliberately): sub-agent threads write their own rollout files the live monitor does not read, so their *fresh input* is now bounded only indirectly via sampled output. The alternative (weight 1.0) false-killed every productive worker in minutes — a live P0 blocking the fleet resume; the input-heavy sub-agent tail is the smaller risk. Follow-up issue tracks proper sub-agent rollout coverage.

Also noted: the measure name `codex_rollout_tokens` now means "uncached rollout tokens" — kept for marker continuity; magnitude-interpreting consumers don't exist today.

Regression tests replay the incident shape: 441k total with 405k cached stays under an 80k cap; genuine uncached spend past the cap still kills; `turn.completed` path covered separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live worker kill semantics and Codex rollout argv for fleet workers; fixes a P0 false-kill but leaves a documented gap for sub-agent fresh-input enforcement.
> 
> **Overview**
> Fixes **false Codex worker kills** when cached context replay inflated observed token usage (#1156).
> 
> **Live monitor** now charges **uncached input plus output** for Codex: rollout file reads subtract `cached_input_tokens` from `total_token_usage`, and `turn.completed` uses new `codexBudgetUsage` (same idea as Claude’s uncached measure). Cache-heavy totals like 441k with 405k cached no longer trip an 80k cap; real uncached spend still enforces the ceiling.
> 
> **Native Codex rollout budget** sets `prefill_token_weight=0.0` instead of `1.0`, because prefill in the agent loop is mostly replayed context Codex cannot distinguish from fresh input—weight 1.0 re-charged the full context every provider call. The in-loop budget is now mainly a **sampled-output backstop**; main-thread fresh input is covered by the live monitor.
> 
> **Trade-off (documented):** sub-agent rollout files are not read by the monitor, so sub-agent fresh input is only indirectly bounded via sampled output; accepted vs. weight 1.0 killing productive workers in minutes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20a744c86c1857843975e778296799859692beb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change updates Codex worker-budget accounting to exclude replayed cached context while continuing to charge uncached input and generated output.

An independent execution replayed cache-heavy rollout telemetry and terminal `turn.completed` usage. On the updated code, cached context did not prematurely stop the worker, while additional uncached usage still stopped it. The same execution confirmed that Codex command construction retains the native sampled-output backstop with prefill weighting disabled.

The potential premature cache-accounting regression was disproved by the exercised rollout and terminal-usage paths.

<h3>Confidence Score: 5/5</h3>

The reviewed worker-budget behavior is safe to merge: cache replay no longer consumes the budget repeatedly, and real uncached usage remains enforceable.

Independent execution covered the rollout-file parser, terminal usage parser, and Codex command configuration, including comparison with the parent behavior that prematurely counted cached context.

**Files Needing Attention:** No additional files need attention. The exercised changes are in internal/worker/token_budget.go and internal/worker/backend.go, with regression coverage in internal/worker/token_budget_test.go.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran an independent Go test across the parent and updated revisions, replaying cache-heavy rollout JSONL and Codex command construction to exercise the same validation path on both revisions.
- On the parent revision, cache-heavy rollout usage measured 441000 and terminal usage 435000, both exceeding the 80000 limit, with native prefill weight of 1.0.
- On the updated revision, cache-heavy rollout dropped to 36000 with uncached spend at 145000 and a stop; turn.completed followed the same 35000/145000 pattern, and the command kept sampling\_token\_weight and prefill\_token\_weight redacted.
- The validation confirms that replayed cache context is excluded while genuine spend and the native output backstop remain enforced.

<a href="https://app.greptile.com/trex/runs/18307692/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(worker): codex token budget charges ..."](https://github.com/befeast/maestro/commit/20a744c86c1857843975e778296799859692beb6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52210987)</sub>

<!-- /greptile_comment -->