### PR TITLE
feat(config): per-project forge block with fail-loud validation (#1172 M1)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/url"
 	"os"
 	pathpkg "path"
 	"path/filepath"
@@ -489,6 +490,59 @@ type VersioningConfig struct {
 type GitHubProjectsConfig struct {
 	Enabled       bool `yaml:"enabled"`
 	ProjectNumber int  `yaml:"project_number"` // GitHub Project number (auto-detect from repo)
+}
+
+// Forge kinds enumerate the supported code forges (#1172). parse() rejects any
+// other value so a typo cannot silently fall back to the GitHub default.
+const (
+	ForgeKindGitHub  = "github"
+	ForgeKindForgejo = "forgejo"
+)
+
+// ForgeConfig selects which code forge hosts the project repo (#1172 M1).
+// Absent block or empty kind means GitHub (the historical default); kind
+// "forgejo" routes the transport to a Forgejo instance (M2+) and requires
+// base_url. The token is env-only (*_env indirection, never the value) and the
+// config package never reads the environment itself — consumers resolve the
+// named variable at use time, same as the review_producer *_env pattern.
+type ForgeConfig struct {
+	Kind     string `yaml:"kind,omitempty"`      // "github" (default) | "forgejo"
+	BaseURL  string `yaml:"base_url,omitempty"`  // forgejo only: instance root, e.g. https://git.oklabs.uk (no /api/v1)
+	TokenEnv string `yaml:"token_env,omitempty"` // forgejo only: NAME of the env var holding the PAT (never the value)
+}
+
+// EffectiveKind returns the configured forge kind, defaulting to GitHub when
+// the block is absent or kind is empty (every legacy row).
+func (f ForgeConfig) EffectiveKind() string {
+	if f.Kind == "" {
+		return ForgeKindGitHub
+	}
+	return f.Kind
+}
+
+// IsForgejo reports whether the project routes its transport to Forgejo.
+func (f ForgeConfig) IsForgejo() bool {
+	return f.EffectiveKind() == ForgeKindForgejo
+}
+
+// EffectiveTokenEnv returns the NAME of the env var holding the Forgejo PAT,
+// defaulting to FORGEJO_TOKEN. It never reads the environment — the consumer
+// (M2 transport) resolves the variable at use time.
+func (f ForgeConfig) EffectiveTokenEnv() string {
+	if strings.TrimSpace(f.TokenEnv) == "" {
+		return "FORGEJO_TOKEN"
+	}
+	return strings.TrimSpace(f.TokenEnv)
+}
+
+// APIRoot returns the Forgejo API root derived from the instance base_url
+// (the shape internal/forgejo.New expects, e.g. https://host/api/v1), or the
+// empty string for the GitHub kind.
+func (f ForgeConfig) APIRoot() string {
+	if !f.IsForgejo() {
+		return ""
+	}
+	return strings.TrimRight(f.BaseURL, "/") + "/api/v1"
 }
 
 // GitHubAppConfig holds credentials for authenticating as a GitHub App
@@ -2259,6 +2313,76 @@ func windowsDriveAbsPath(p string) bool {
 	return len(p) >= 3 && ((p[0] >= 'a' && p[0] <= 'z') || (p[0] >= 'A' && p[0] <= 'Z')) && p[1] == ':' && p[2] == '/'
 }
 
+// validateForge enforces the forge block contract (#1172 M1), fail-loud: an
+// exact-match kind enum, forgejo-only fields rejected on the GitHub default, a
+// clean instance-root base_url for forgejo (scheme http/https, host, no query
+// or fragment, no /api/v1 suffix — the API root is derived), an env-var-NAME
+// token_env, and no GitHub Projects integration on forgejo rows (the queue is
+// labels; there is no Forgejo equivalent). An absent block validates trivially
+// so every legacy config is unaffected.
+func validateForge(cfg *Config) error {
+	f := cfg.Forge
+	switch f.Kind {
+	case "", ForgeKindGitHub, ForgeKindForgejo:
+		// supported (exact match, no case folding)
+	default:
+		return fmt.Errorf("config: forge.kind %q is not supported (want %q, %q, or empty for the GitHub default)", f.Kind, ForgeKindGitHub, ForgeKindForgejo)
+	}
+	if !f.IsForgejo() {
+		if f.BaseURL != "" {
+			return fmt.Errorf("config: forge.base_url is only valid with forge.kind %q", ForgeKindForgejo)
+		}
+		if f.TokenEnv != "" {
+			return fmt.Errorf("config: forge.token_env is only valid with forge.kind %q", ForgeKindForgejo)
+		}
+		return nil
+	}
+	if strings.TrimSpace(f.BaseURL) == "" {
+		return fmt.Errorf("config: forge.base_url is required when forge.kind is %q", ForgeKindForgejo)
+	}
+	u, err := url.Parse(f.BaseURL)
+	if err != nil {
+		return fmt.Errorf("config: forge.base_url %q is not a valid URL: %v", f.BaseURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("config: forge.base_url %q must use an http or https scheme", f.BaseURL)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("config: forge.base_url %q must include a host", f.BaseURL)
+	}
+	if u.User != nil {
+		return fmt.Errorf("config: forge.base_url %q must not contain userinfo — credentials belong in forge.token_env (an env var NAME), never in base_url", f.BaseURL)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("config: forge.base_url %q must not contain a query or fragment", f.BaseURL)
+	}
+	// Reject '.'/'..' path segments outright: a dot-segment like
+	// /api/v1/x/.. would defeat the /api/v1 suffix guard below once a client
+	// normalizes the path. Segment-wise check, not path.Clean, so a bare
+	// trailing slash is not a false positive.
+	for _, seg := range strings.Split(u.Path, "/") {
+		if seg == "." || seg == ".." {
+			return fmt.Errorf("config: forge.base_url %q must not contain '.' or '..' path segments", f.BaseURL)
+		}
+	}
+	if strings.HasSuffix(strings.TrimRight(u.Path, "/"), "/api/v1") {
+		return fmt.Errorf("config: forge.base_url %q must be the Forgejo instance root (e.g. https://forge.example.com) — /api/v1 is appended automatically", f.BaseURL)
+	}
+	if f.TokenEnv != "" {
+		env := strings.TrimSpace(f.TokenEnv)
+		if env == "" {
+			return fmt.Errorf("config: forge.token_env must be non-empty when set (omit it for the FORGEJO_TOKEN default)")
+		}
+		if containsControlOrSpace(env) || strings.Contains(env, "=") {
+			return fmt.Errorf("config: forge.token_env %q must be an env var NAME (no whitespace or '=' characters), never a token value", f.TokenEnv)
+		}
+	}
+	if cfg.GitHubProjects.Enabled {
+		return fmt.Errorf("config: github_projects.enabled is not supported with forge.kind %q — the GitHub Projects integration has no Forgejo equivalent (the queue is labels); set github_projects.enabled: false or drop the block", ForgeKindForgejo)
+	}
+	return nil
+}
+
 // RemoteRunnerConfig is the deliberately small, project-scoped SSH adapter
 // used by the remote-worker spike (#1058). The control plane still owns issue
 // selection, durable state, the local tmux/process lease, and a lightweight
@@ -2472,7 +2596,8 @@ type Config struct {
 	Telegram                        TelegramConfig                `yaml:"telegram"`
 	Notify                          NotifyConfig                  `yaml:"notify"` // #1018: ntfy push transport + alert-class routing
 	Versioning                      VersioningConfig              `yaml:"versioning"`
-	SelfDeploy                      SelfDeployConfig              `yaml:"self_deploy"` // #698: opt-in post-merge self-deploy of the maestro binary (default OFF)
+	SelfDeploy                      SelfDeployConfig              `yaml:"self_deploy"`     // #698: opt-in post-merge self-deploy of the maestro binary (default OFF)
+	Forge                           ForgeConfig                   `yaml:"forge,omitempty"` // #1172: code forge selection (absent/github = historical default; forgejo requires base_url)
 	GitHubProjects                  GitHubProjectsConfig          `yaml:"github_projects"`
 	GitHubApp                       GitHubAppConfig               `yaml:"github_app"`                 // #823: GitHub App auth (app_id + private_key_path + installation_id)
 	GitHubMirror                    GitHubMirrorConfig            `yaml:"github_mirror"`              // #826: mirror-first vs api-direct supervisor/orchestrator reads
@@ -2699,6 +2824,12 @@ func parse(data []byte) (*Config, error) {
 		return nil, err
 	}
 	if err := validateManagementHome(cfg.ManagementHome); err != nil {
+		return nil, err
+	}
+	// #1172 M1: forge selection. An absent block (every legacy row) is the
+	// GitHub default and validates trivially; a present block is checked
+	// fail-loud so a typo can never silently route to the wrong forge.
+	if err := validateForge(cfg); err != nil {
 		return nil, err
 	}
 	if err := validateWorkerRuntime(cfg.WorkerRuntime); err != nil {

--- a/internal/config/forge_test.go
+++ b/internal/config/forge_test.go
@@ -1,0 +1,207 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Backward compat (#1172 M1): every existing row has no forge block, so an
+// absent block must parse unchanged and resolve to the GitHub default.
+func TestParse_AbsentForgeBlockDefaultsToGitHub(t *testing.T) {
+	cfg, err := Parse([]byte("repo: owner/repo\n"))
+	if err != nil {
+		t.Fatalf("legacy config without forge block must parse: %v", err)
+	}
+	if got := cfg.Forge.EffectiveKind(); got != ForgeKindGitHub {
+		t.Fatalf("EffectiveKind() = %q, want %q", got, ForgeKindGitHub)
+	}
+	if cfg.Forge.IsForgejo() {
+		t.Fatalf("IsForgejo() should be false without a forge block")
+	}
+	if got := cfg.Forge.APIRoot(); got != "" {
+		t.Fatalf("APIRoot() = %q, want empty for the GitHub default", got)
+	}
+}
+
+func TestParse_ForgeExplicitGitHubKindAccepted(t *testing.T) {
+	cfg, err := Parse([]byte("repo: o/r\nforge:\n  kind: github\n"))
+	if err != nil {
+		t.Fatalf("explicit github kind should parse: %v", err)
+	}
+	if cfg.Forge.IsForgejo() || cfg.Forge.EffectiveKind() != ForgeKindGitHub {
+		t.Fatalf("explicit github kind should resolve to the GitHub default, got %+v", cfg.Forge)
+	}
+}
+
+func TestParse_ForgejoValidBlockAccepted(t *testing.T) {
+	yamlDoc := "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com/\n"
+	cfg, err := Parse([]byte(yamlDoc))
+	if err != nil {
+		t.Fatalf("valid forgejo block should parse: %v", err)
+	}
+	if !cfg.Forge.IsForgejo() {
+		t.Fatalf("IsForgejo() should be true, got %+v", cfg.Forge)
+	}
+	if got, want := cfg.Forge.APIRoot(), "https://forge.example.com/api/v1"; got != want {
+		t.Fatalf("APIRoot() = %q, want %q (trailing slash trimmed, /api/v1 appended)", got, want)
+	}
+	if got := cfg.Forge.EffectiveTokenEnv(); got != "FORGEJO_TOKEN" {
+		t.Fatalf("EffectiveTokenEnv() default = %q, want FORGEJO_TOKEN", got)
+	}
+}
+
+func TestParse_ForgejoTokenEnvOverride(t *testing.T) {
+	yamlDoc := "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n  token_env: MY_FORGE_PAT\n"
+	cfg, err := Parse([]byte(yamlDoc))
+	if err != nil {
+		t.Fatalf("forgejo block with token_env should parse: %v", err)
+	}
+	if got := cfg.Forge.EffectiveTokenEnv(); got != "MY_FORGE_PAT" {
+		t.Fatalf("EffectiveTokenEnv() = %q, want the MY_FORGE_PAT override", got)
+	}
+}
+
+func TestParse_ForgeValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		yaml    string
+		wantSub string
+	}{
+		{
+			name:    "unknown kind names allowed set",
+			yaml:    "repo: o/r\nforge:\n  kind: gitlab\n",
+			wantSub: `forge.kind "gitlab" is not supported (want "github", "forgejo"`,
+		},
+		{
+			name:    "case-folded kind rejected (exact match only)",
+			yaml:    "repo: o/r\nforge:\n  kind: Forgejo\n",
+			wantSub: `forge.kind "Forgejo" is not supported`,
+		},
+		{
+			name:    "forgejo without base_url",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n",
+			wantSub: "forge.base_url is required",
+		},
+		{
+			name:    "base_url ending in /api/v1",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com/api/v1\n",
+			wantSub: "/api/v1 is appended automatically",
+		},
+		{
+			name:    "base_url ending in /api/v1/ (trailing slash)",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com/api/v1/\n",
+			wantSub: "/api/v1 is appended automatically",
+		},
+		{
+			name:    "base_url with query",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com/?x=1\n",
+			wantSub: "must not contain a query or fragment",
+		},
+		{
+			name:    "base_url with fragment",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: 'https://forge.example.com/#frag'\n",
+			wantSub: "must not contain a query or fragment",
+		},
+		{
+			name:    "base_url with bad scheme",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: ssh://forge.example.com\n",
+			wantSub: "must use an http or https scheme",
+		},
+		{
+			name:    "base_url without host",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https:///path\n",
+			wantSub: "must include a host",
+		},
+		{
+			name:    "base_url with userinfo credentials",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://user:secret@forge.example.com\n",
+			wantSub: "must not contain userinfo",
+		},
+		{
+			name:    "base_url with dot-dot segment defeating the api/v1 guard",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com/api/v1/x/..\n",
+			wantSub: "'.' or '..' path segments",
+		},
+		{
+			name:    "base_url with dot segment",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com/./api\n",
+			wantSub: "'.' or '..' path segments",
+		},
+		{
+			name:    "github kind with base_url",
+			yaml:    "repo: o/r\nforge:\n  kind: github\n  base_url: https://forge.example.com\n",
+			wantSub: `forge.base_url is only valid with forge.kind "forgejo"`,
+		},
+		{
+			name:    "empty kind with base_url",
+			yaml:    "repo: o/r\nforge:\n  base_url: https://forge.example.com\n",
+			wantSub: `forge.base_url is only valid with forge.kind "forgejo"`,
+		},
+		{
+			name:    "github kind with token_env",
+			yaml:    "repo: o/r\nforge:\n  kind: github\n  token_env: FORGEJO_TOKEN\n",
+			wantSub: `forge.token_env is only valid with forge.kind "forgejo"`,
+		},
+		{
+			name:    "token_env with space",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n  token_env: 'MY TOKEN'\n",
+			wantSub: "must be an env var NAME",
+		},
+		{
+			name:    "token_env with equals",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n  token_env: 'FORGEJO_TOKEN=abc'\n",
+			wantSub: "must be an env var NAME",
+		},
+		{
+			name:    "forgejo with github_projects enabled",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\ngithub_projects:\n  enabled: true\n",
+			wantSub: "no Forgejo equivalent",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.yaml))
+			if err == nil {
+				t.Fatalf("expected validation error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error %q should contain %q", err.Error(), tc.wantSub)
+			}
+		})
+	}
+}
+
+// The GitHub Projects rejection is a forgejo-only rule: a config with NO forge
+// block and an enabled github_projects integration is every existing GitHub
+// row with a Projects board — it must keep parsing unchanged. A leak of that
+// check out of the forgejo branch would brick all of them at once.
+func TestParse_GitHubProjectsEnabledWithoutForgeBlockAccepted(t *testing.T) {
+	yamlDoc := "repo: o/r\ngithub_projects:\n  enabled: true\n  project_number: 5\n"
+	cfg, err := Parse([]byte(yamlDoc))
+	if err != nil {
+		t.Fatalf("github_projects on a forge-less (GitHub default) row must parse: %v", err)
+	}
+	if !cfg.GitHubProjects.Enabled || cfg.GitHubProjects.ProjectNumber != 5 {
+		t.Fatalf("github_projects not parsed verbatim: %+v", cfg.GitHubProjects)
+	}
+}
+
+func TestParse_ForgejoWithDisabledGitHubProjectsAccepted(t *testing.T) {
+	yamlDoc := "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\ngithub_projects:\n  enabled: false\n"
+	if _, err := Parse([]byte(yamlDoc)); err != nil {
+		t.Fatalf("forgejo with explicitly disabled github_projects should parse: %v", err)
+	}
+}
+
+// The strict write path must accept the new forge block by name (KnownFields),
+// while still rejecting a misspelled child key inside it.
+func TestParseStrict_AcceptsForgeBlock(t *testing.T) {
+	yamlDoc := "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n  token_env: FORGEJO_TOKEN\n"
+	if _, err := ParseStrict([]byte(yamlDoc)); err != nil {
+		t.Fatalf("strict decode of a valid forge block should pass: %v", err)
+	}
+	bad := "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n  token_envv: typo\n"
+	if _, err := ParseStrict([]byte(bad)); err == nil || !strings.Contains(err.Error(), "token_envv") {
+		t.Fatalf("strict decode should name the misspelled forge child key, got: %v", err)
+	}
+}

--- a/internal/daemon/flow.go
+++ b/internal/daemon/flow.go
@@ -330,7 +330,7 @@ func (d *Daemon) runReloadPump(ctx context.Context, flow *projectFlow, watchCh <
 				continue
 			}
 			// Identity / restart-required fields (repo, state_dir, session_prefix,
-			// local_path) cannot be hot-applied: the orchestrator, supervisor,
+			// local_path, forge) cannot be hot-applied: the orchestrator, supervisor,
 			// watchdog, and the
 			// supervisor's GitHub client were all built from the flow's STARTUP
 			// identity. Storing a changed identity in the holder would make
@@ -340,7 +340,7 @@ func (d *Daemon) runReloadPump(ctx context.Context, flow *projectFlow, watchCh <
 			// the diff-loop handles as a fresh flow); hot-reloadable edits still
 			// apply (#768, Codex).
 			if identityChanged(flow.cfg, newCfg) {
-				log.Printf("[%s] config reload: restart-required field (repo/state_dir/session_prefix/local_path) changed — restart required, live reload skipped", flow.name)
+				log.Printf("[%s] config reload: restart-required field (repo/state_dir/session_prefix/local_path/forge) changed — restart required, live reload skipped", flow.name)
 				continue
 			}
 			newCfg.RuntimeSuperviseIntervalSeconds = runtimeIntervalSeconds(d.opts.SuperviseInterval)
@@ -387,12 +387,35 @@ func (d *Daemon) runReloadPump(ctx context.Context, flow *projectFlow, watchCh <
 // session_prefix names worker sessions. LocalPath is also part of the delivery
 // approval digest and selects the supervisor/executor checkout. Applying it to
 // only one reader would make every newly minted delivery approval fail closed
-// with a config mismatch. A change here therefore needs one atomic flow restart.
+// with a config mismatch. The forge block (#1172) is likewise identity: the
+// transport client is built once at startup, so flipping a live row between
+// forges (or re-pointing base_url/token_env) must not apply live. A change
+// here therefore needs one atomic flow restart.
 func identityChanged(a, b *config.Config) bool {
 	if a == nil || b == nil {
 		return a != b
 	}
-	return a.Repo != b.Repo || a.StateDir != b.StateDir || a.SessionPrefix != b.SessionPrefix || a.LocalPath != b.LocalPath
+	return a.Repo != b.Repo || a.StateDir != b.StateDir || a.SessionPrefix != b.SessionPrefix || a.LocalPath != b.LocalPath ||
+		effectiveForgeIdentity(a.Forge) != effectiveForgeIdentity(b.Forge)
+}
+
+// forgeIdentity is the comparable EFFECTIVE transport identity of a forge
+// block. identityChanged compares this instead of the raw struct so that an
+// operator spelling out a default on a live row (kind: github, or token_env:
+// FORGEJO_TOKEN) is not mistaken for a restart-required change — that would
+// freeze hot reload for every unrelated edit on the row.
+type forgeIdentity struct {
+	kind     string
+	apiRoot  string
+	tokenEnv string
+}
+
+func effectiveForgeIdentity(f config.ForgeConfig) forgeIdentity {
+	return forgeIdentity{
+		kind:     f.EffectiveKind(),
+		apiRoot:  f.APIRoot(),
+		tokenEnv: f.EffectiveTokenEnv(),
+	}
 }
 
 // runOrchestrator is the production run loop for one flow. It mirrors the

--- a/internal/daemon/project_identity_reload_test.go
+++ b/internal/daemon/project_identity_reload_test.go
@@ -55,6 +55,62 @@ func TestIdentityChangedIgnoresProjectMetadata(t *testing.T) {
 	}
 }
 
+// Flipping a live row between forges (#1172) rebinds the transport the flow was
+// built on at startup, so an EFFECTIVE forge-identity change is an identity
+// change. Spelling out a default (kind: github, token_env: FORGEJO_TOKEN) is
+// NOT a change — comparing the raw struct there would freeze hot reload for
+// every unrelated edit on the row.
+func TestIdentityChangedFlagsForgeChange(t *testing.T) {
+	base := &config.Config{
+		Repo:          "owner/svc",
+		StateDir:      "/state/svc",
+		SessionPrefix: "svc",
+	}
+
+	// Absent block vs an explicitly spelled-out GitHub default: no change.
+	explicitGitHub := *base
+	explicitGitHub.Forge = config.ForgeConfig{Kind: "github"}
+	if identityChanged(base, &explicitGitHub) {
+		t.Fatalf("spelling out kind: github (== the default) must stay hot-reloadable")
+	}
+
+	// A real kind flip to forgejo requires a restart.
+	moved := *base
+	moved.Forge = config.ForgeConfig{Kind: "forgejo", BaseURL: "https://forge.example.com"}
+	if !identityChanged(base, &moved) {
+		t.Fatalf("flipping a row from the GitHub default to forgejo must require a restart")
+	}
+
+	// Identical populated forge blocks on both sides are not a change.
+	a := *base
+	a.Forge = config.ForgeConfig{Kind: "forgejo", BaseURL: "https://forge.example.com", TokenEnv: "FORGEJO_TOKEN"}
+	b := a
+	if identityChanged(&a, &b) {
+		t.Fatalf("equal forge blocks must not be flagged as an identity change")
+	}
+
+	// Spelling out the token_env default vs leaving it empty: no change.
+	implicitToken := a
+	implicitToken.Forge.TokenEnv = ""
+	if identityChanged(&a, &implicitToken) {
+		t.Fatalf("token_env: FORGEJO_TOKEN (== the default) vs empty must stay hot-reloadable")
+	}
+
+	// Re-pointing base_url rebinds the transport target.
+	rehomed := a
+	rehomed.Forge.BaseURL = "https://other.example.com"
+	if !identityChanged(&a, &rehomed) {
+		t.Fatalf("a forge.base_url change must require a restart")
+	}
+
+	// Re-pointing token_env to a NON-default name rebinds credentials.
+	c := b
+	c.Forge.TokenEnv = "OTHER_TOKEN"
+	if !identityChanged(&b, &c) {
+		t.Fatalf("a forge.token_env change to a non-default name must require a restart")
+	}
+}
+
 // A real store-watch metadata edit must reach the live Fleet API without
 // restarting the flow. This covers the full store -> watcher -> holder/dashboard
 // path, not only the identityChanged predicate.

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -7,6 +7,18 @@
 repo: YOUR_ORG/YOUR_REPO
 local_path: /path/to/local/repo
 worktree_base: /path/to/worktrees/repo
+
+# Code forge selection (#1172). Omit the block (or use kind: github) for the
+# GitHub default. kind: forgejo routes the project's transport to a Forgejo
+# instance and requires base_url — the instance ROOT (no /api/v1; the API root
+# is derived automatically). token_env is the NAME of the env var holding the
+# Forgejo PAT (default: FORGEJO_TOKEN) — never the token value itself.
+# Note: github_projects must stay disabled on forgejo rows — the GitHub
+# Projects integration has no Forgejo equivalent (the queue is labels).
+# forge:
+#   kind: forgejo
+#   base_url: https://forge.example.com
+#   token_env: FORGEJO_TOKEN
 max_parallel: 5
 max_runtime_minutes: 120           # hard timeout per worker (default: 120)
 worker_runtime:


### PR DESCRIPTION
## Summary

M1 of the Forgejo migration (#1172): the per-project `forge:` config block that later slices (M2 transport switch) key off. Config layer only — no transport or consumer changes.

- New `ForgeConfig` (`kind: github|forgejo`, `base_url`, `token_env`) on the project row; an absent block means GitHub, so every existing store row parses identically (regression-tested).
- Fail-loud validation in `config.parse` (runs on both the daemon load path and the `config-store` write path via `ParseStrict`):
  - `kind` is an exact-match enum;
  - forgejo requires `base_url` = instance root (http/https, no userinfo, no query/fragment, no dot-segments; a `/api/v1` suffix is rejected with a hint — `APIRoot()` appends it automatically);
  - `token_env` holds an env var NAME (default `FORGEJO_TOKEN`), never a value; forgejo-only fields on a github row are errors;
  - `github_projects.enabled: true` on a forgejo row is an error (M6 folded in: Forgejo has no Projects API — the queue is labels).
- Accessors follow the `Effective*` style (`EffectiveKind` / `IsForgejo` / `EffectiveTokenEnv` / `APIRoot`); the config package never reads the environment — consumers resolve the env var at use time (M2), same as the `review_producer.*_env` pattern.
- Hot-reload identity guard: changing the effective forge identity (kind / API root / token env) on a live row is restart-required, like `repo`/`local_path`; cosmetic edits equal to defaults (e.g. explicit `kind: github`) do not trip it.
- `maestro.yaml.example` documents the block. No configstore/CLI changes needed: export/edit are `yaml.Node` passthrough, and the strict unknown-key check picks the new field up automatically.

## Review

Adversarially reviewed pre-PR: no P0–P2 findings; the four P3 findings are already fixed in this commit (userinfo-in-URL rejection, dot-segment bypass of the `/api/v1` guard, effective-vs-raw identity comparison, backward-compat regression test for `github_projects.enabled` without a forge block).

## Testing

`go build ./...` and `go vet ./...` clean; `internal/config` (18-subtest validation table, 8 test functions) and `internal/daemon` green. Full suite green except 3 pre-existing `internal/worker` failures reproduced on clean main (host umask 0002 makes `t.TempDir()` group-writable) — unrelated.

Part of #1172 (M1; M6 folded in).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Config validation runs on every project load and strict config-store writes; misconfiguration fails loud, but forge identity now gates hot reload and forgejo rows cannot use GitHub Projects.
> 
> **Overview**
> Adds the **M1 config-only** slice of #1172: a per-project `forge:` block so later transport work can key off forge selection without changing behavior today.
> 
> Projects can set **`kind: github`** (default when the block is absent) or **`forgejo`** with instance-root **`base_url`** and optional **`token_env`** (env var **name**, default `FORGEJO_TOKEN`). Helpers derive effective kind, Forgejo API root (`/api/v1` appended), and token env without reading the environment. **`parse` / `ParseStrict`** reject unknown kinds, misplaced forgejo-only fields on GitHub rows, bad URLs (credentials, query/fragment, `/api/v1` suffix, dot segments), and **`github_projects.enabled: true`** on forgejo rows.
> 
> The daemon treats **effective forge identity** (kind, API root, token env) as restart-required on hot reload—like `repo`/`local_path`—while cosmetic defaults (explicit `kind: github`) do not block unrelated edits. **`maestro.yaml.example`** documents the block; tests cover validation and backward compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9512f3e5a98615c77bdd88b94fd16c517424705. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds per-project Forgejo configuration, validates Forge settings, derives Forgejo API roots, and requires a daemon restart when forge transport identity changes.

The reported concern about subpath instance URLs was disproved. The exact configuration `https://forge.example.com/admin` was accepted, derived `https://forge.example.com/admin/api/v1`, and successfully reached a server serving only `/admin/api/v1/version`. Forgejo deployments may use a configured public subpath, so retaining that subpath when deriving the API root is correct.

No actionable defects remain.

<h3>Confidence Score: 5/5</h3>

The configuration behavior is safe to merge: valid Forgejo reverse-proxy subpaths are preserved when deriving API endpoints.

The only reported failure mode was exercised through the public parser and an HTTP request to the derived endpoint. The observed successful request contradicts the claim that Forgejo instance URLs must be host-root-only.

**Files Needing Attention:** No files need follow-up changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A focused Go runtime probe parsed the exact configuration and derived the API root https://forge.example.com/admin/api/v1, then requested /admin/api/v1/version from a server configured to accept only that subpath, returning 200 OK.
- Forge configuration parsing and validation tests for the subpath and API root derivation passed.
- The exact runtime output reported candidate\_accepted=true, candidate\_api\_root=https://forge.example.com/admin/api/v1, requested\_path=/admin/api/v1/version, and http\_status=200 OK.
- Code contracts enforce preserving subpath segments when forming /api/v1 and reject only an explicit /api/v1 suffix, not legitimate subpaths.
- Authoritative Forgejo documentation confirms subpath deployments use ROOT\_URL with the subpath and expose API URLs beneath it.

<a href="https://app.greptile.com/trex/runs/18328930/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(config): per-project forge block wi..."](https://github.com/befeast/maestro/commit/b9512f3e5a98615c77bdd88b94fd16c517424705) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52254108)</sub>

<!-- /greptile_comment -->