### PR TITLE
feat(github): forge transport switch + Forgejo core reads (#1172 M2)

### DIFF
--- a/cmd/maestro/delivery_approval_test.go
+++ b/cmd/maestro/delivery_approval_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"github.com/befeast/maestro/internal/approvalstore"
 	"github.com/befeast/maestro/internal/approver"
 	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/state"
 )
 
@@ -128,6 +130,26 @@ func TestExecuteApprovedDeliveryCLIUsesConfiguredDBAndMirrorsResult(t *testing.T
 	}
 	if _, err := os.Stat(approvalstore.DefaultDBPath()); !os.IsNotExist(err) {
 		t.Fatalf("default approvals DB was touched despite custom path: err=%v", err)
+	}
+}
+
+// Delivery freshness is GitHub-anchored end to end (RevisionContains proves
+// ancestry against https://github.com/<repo>.git — the MIRROR of a forgejo
+// row). The factory must fail loud on forgejo rows so no delivery ever
+// validates Forgejo merge SHAs against a possibly-stale GitHub mirror
+// (#1172 M2; forge-aware delivery lands in M3/M4).
+func TestDeliveryFreshnessCheckerFactoryFailsLoudOnForgejo(t *testing.T) {
+	cfg := &config.Config{
+		Repo:  "o/r",
+		Forge: config.ForgeConfig{Kind: config.ForgeKindForgejo, BaseURL: "https://forge.example.com"},
+	}
+	checker := deliveryFreshnessCheckerFactory(cfg)
+	if checker == nil {
+		t.Fatal("factory must return a fail-loud checker on forgejo rows, not nil")
+	}
+	err := checker.CheckDeliveryFreshness(context.Background(), &state.DeliveryPayload{})
+	if !errors.Is(err, github.ErrForgejoNotSupported) {
+		t.Fatalf("forgejo delivery freshness = %v; want errors.Is ErrForgejoNotSupported", err)
 	}
 }
 

--- a/cmd/maestro/digest.go
+++ b/cmd/maestro/digest.go
@@ -128,7 +128,7 @@ func loadDigestProjects(fleetPath string, configs multiFlag, storePath, storePro
 			log.Printf("warn: load state for %s: %v (sections from state will be empty)", cfg.Repo, err)
 			st = nil
 		}
-		p := digest.ProjectFromConfig(entry.name, cfg, st, github.New(cfg.Repo))
+		p := digest.ProjectFromConfig(entry.name, cfg, st, github.New(cfg.Repo, cfg.Forge))
 		projects = append(projects, p)
 		if notifierCfg == nil && strings.TrimSpace(cfg.Telegram.Target) != "" {
 			notifierCfg = cfg

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -854,7 +854,7 @@ func runCmd(args []string) {
 		// Start HTTP server if configured
 		if cfg.Server.Port > 0 {
 			srv := server.New(cfg, refreshCh)
-			srv.SetActionDeps(github.New(cfg.Repo), nil)
+			srv.SetActionDeps(github.New(cfg.Repo, cfg.Forge), nil)
 			if err := srv.SetApprovalStore(approvalsMode, *approvalsDB); err != nil {
 				log.Fatalf("run: open approvals store: %v", err)
 			}
@@ -917,7 +917,7 @@ func runCmd(args []string) {
 			// Start HTTP server if configured
 			if c.Server.Port > 0 {
 				srv := server.New(c, refreshCh)
-				srv.SetActionDeps(github.New(c.Repo), nil)
+				srv.SetActionDeps(github.New(c.Repo, c.Forge), nil)
 				if err := srv.SetApprovalStore(approvalsMode, *approvalsDB); err != nil {
 					log.Fatalf("[%s] run: open approvals store: %v", c.SessionPrefix, err)
 				}
@@ -993,7 +993,7 @@ func superviseCmd(args []string) {
 	if *dryRun {
 		cfg.Supervisor.DryRun = true
 	}
-	gh := github.New(cfg.Repo)
+	gh := github.New(cfg.Repo, cfg.Forge)
 	// The cycle is context-aware (#1119): a cancelled ctx stops it at the next
 	// phase boundary. SIGINT/SIGTERM cancel it for the looping command below;
 	// --once inherits the same ctx and cancels it on return.
@@ -1187,7 +1187,7 @@ func superviseApprovalCmd(action string, args []string, defaultConfigPath string
 	// Execute the now-approved approval. Synchronous and blocking; the
 	// caller (operator) sees the result on stdout and via exit code.
 	ex := &approver.Executor{
-		GH:        github.New(cfg.Repo),
+		GH:        github.New(cfg.Repo, cfg.Forge),
 		Worktrees: approver.WorktreeRemoverFunc(worker.RemoveWorktree),
 		Cfg:       cfg,
 		Sessions:  approver.SessionLookupFunc(st.SessionAt),
@@ -1389,7 +1389,7 @@ var deliveryFreshnessCheckerFactory = func(cfg *config.Config) approver.Delivery
 	if cfg == nil {
 		return nil
 	}
-	return approver.NewGitHubDeliveryFreshnessChecker(github.New(cfg.Repo), cfg.Repo, cfg.LocalPath)
+	return approver.NewGitHubDeliveryFreshnessChecker(github.New(cfg.Repo, cfg.Forge), cfg.Repo, cfg.LocalPath)
 }
 
 var deliveryCheckoutPreparerFactory = func(*config.Config) approver.CheckoutPreparer { return nil }
@@ -1743,7 +1743,7 @@ func serveCmd(args []string) {
 	refreshCh := make(chan struct{}, 1)
 	log.Printf("serving dashboard — repo=%s addr=%s:%d read_only=%v", cfg.Repo, cfg.Server.Host, cfg.Server.Port, cfg.Server.ReadOnly)
 	srv := server.New(cfg, refreshCh)
-	srv.SetActionDeps(github.New(cfg.Repo), nil)
+	srv.SetActionDeps(github.New(cfg.Repo, cfg.Forge), nil)
 	if err := srv.Start(ctx); err != nil {
 		log.Fatalf("serve: %v", err)
 	}
@@ -1952,7 +1952,7 @@ func showProjectStatus(cfg *config.Config, jsonOutput bool) {
 	})
 
 	// Fetch CI status for pr_open sessions
-	gh := github.New(cfg.Repo)
+	gh := github.New(cfg.Repo, cfg.Forge)
 	ciStatuses := make(map[string]string) // session name → CI display string
 	for _, name := range names {
 		sess := s.Sessions[name]
@@ -2575,7 +2575,7 @@ func spawnCmd(args []string) {
 	}
 
 	// Fetch issue details via gh CLI
-	gh := github.New(cfg.Repo)
+	gh := github.New(cfg.Repo, cfg.Forge)
 	issues, err := gh.ListOpenIssues(nil)
 	if err != nil {
 		log.Fatalf("fetch issues: %v", err)
@@ -3093,7 +3093,7 @@ func versionBumpCmd(args []string) {
 	}
 
 	cfg := loadConfig(*configPath)
-	gh := github.New(cfg.Repo)
+	gh := github.New(cfg.Repo, cfg.Forge)
 
 	if *sinceLastTag {
 		result, err := versioning.RunSinceLastTag(cfg, gh)

--- a/cmd/maestro/main.go
+++ b/cmd/maestro/main.go
@@ -1389,6 +1389,17 @@ var deliveryFreshnessCheckerFactory = func(cfg *config.Config) approver.Delivery
 	if cfg == nil {
 		return nil
 	}
+	if cfg.Forge.IsForgejo() {
+		// Delivery freshness is GitHub-anchored end to end: RevisionContains
+		// proves merge ancestry against https://github.com/<repo>.git, which on
+		// a forgejo row is the MIRROR, not the original — a stale mirror could
+		// flip the verdict with no error (#1172 M2). Fail loud instead: the
+		// executor treats any checker error as unverified and runs no side
+		// effect. Forge-aware delivery lands with the M3/M4 slices.
+		return approver.DeliveryFreshnessFunc(func(context.Context, *state.DeliveryPayload) error {
+			return fmt.Errorf("delivery freshness is GitHub-anchored: %w", github.ErrForgejoNotSupported)
+		})
+	}
 	return approver.NewGitHubDeliveryFreshnessChecker(github.New(cfg.Repo, cfg.Forge), cfg.Repo, cfg.LocalPath)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2380,6 +2380,13 @@ func validateForge(cfg *Config) error {
 	if cfg.GitHubProjects.Enabled {
 		return fmt.Errorf("config: github_projects.enabled is not supported with forge.kind %q — the GitHub Projects integration has no Forgejo equivalent (the queue is labels); set github_projects.enabled: false or drop the block", ForgeKindForgejo)
 	}
+	if cfg.GitHubMirror.MirrorFirst() {
+		// The mirror store is fed by GITHUB webhooks and keyed by bare
+		// owner/name — the same key the repo has on both forges of a mirrored
+		// pair. Serving it to a forgejo row would silently answer supervisor/
+		// orchestrator reads from the GitHub MIRROR's state (#1172 M2).
+		return fmt.Errorf("config: github_mirror.source %q is not supported with forge.kind %q — the mirror store is fed by GitHub webhooks, so mirror-first reads would serve the GitHub mirror's state instead of the Forgejo original; set github_mirror.source: %q or drop the block", GitHubSourceMirrorFirst, ForgeKindForgejo, GitHubSourceAPI)
+	}
 	return nil
 }
 

--- a/internal/config/forge_test.go
+++ b/internal/config/forge_test.go
@@ -157,6 +157,14 @@ func TestParse_ForgeValidation(t *testing.T) {
 			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\ngithub_projects:\n  enabled: true\n",
 			wantSub: "no Forgejo equivalent",
 		},
+		{
+			// #1172 M2: the mirror store is fed by GitHub webhooks and keyed by
+			// bare owner/name — on a mirrored repo, mirror-first reads on a
+			// forgejo row would silently serve the GitHub mirror's state.
+			name:    "forgejo with mirror-first github_mirror",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\ngithub_mirror:\n  source: mirror-first\n",
+			wantSub: "fed by GitHub webhooks",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -190,6 +198,17 @@ func TestParse_ForgejoWithDisabledGitHubProjectsAccepted(t *testing.T) {
 	yamlDoc := "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\ngithub_projects:\n  enabled: false\n"
 	if _, err := Parse([]byte(yamlDoc)); err != nil {
 		t.Fatalf("forgejo with explicitly disabled github_projects should parse: %v", err)
+	}
+}
+
+// The mirror-first rejection is scoped to the SOURCE selector: a forgejo row
+// with an explicit api-direct source (or a bare github_mirror block tuning
+// reconcile cadence) must keep parsing — only mirror-served reads are the
+// cross-forge hazard.
+func TestParse_ForgejoWithAPIDirectMirrorAccepted(t *testing.T) {
+	yamlDoc := "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\ngithub_mirror:\n  source: api\n"
+	if _, err := Parse([]byte(yamlDoc)); err != nil {
+		t.Fatalf("forgejo with api-direct github_mirror should parse: %v", err)
 	}
 }
 

--- a/internal/daemon/mirror_source.go
+++ b/internal/daemon/mirror_source.go
@@ -32,6 +32,16 @@ func (d *Daemon) newReadSource(repo string, getCfg func() *config.Config) *mirro
 		horizon = cfg.GitHubMirror.StaleHorizon()
 		fc = cfg.Forge
 	}
+	// The mirror store is fed by GITHUB webhooks and keyed by bare owner/name —
+	// the same key a mirrored repo has on BOTH forges. A forgejo row must never
+	// read it: the mirror would silently serve the GitHub mirror's issue/PR
+	// state instead of the Forgejo original (#1172 M2). Config validation
+	// already rejects mirror-first on forgejo rows; this belt covers the
+	// api-direct-but-mirror-open case and returns nil so the flow reads its
+	// own forge directly.
+	if fc.IsForgejo() {
+		return nil
+	}
 	return mirrorstore.NewSource(github.New(repo, fc), d.mirror, repo, mirrorstore.SourceOptions{
 		Horizon: horizon,
 		APIDirect: func() bool {
@@ -64,6 +74,14 @@ func (d *Daemon) runMirrorReconcile(ctx context.Context, name, repo string, getC
 	var fc config.ForgeConfig
 	if cfg := getCfg(); cfg != nil {
 		fc = cfg.Forge
+	}
+	// Never reconcile a forgejo row into the mirror store: the store is
+	// GitHub-webhook-defined, and a forgejo-mode client's ported reads would
+	// interleave Forgejo-reconciled rows with GitHub webhook rows under the
+	// same owner/name key (#1172 M2). Forgejo rows simply have no mirror.
+	if fc.IsForgejo() {
+		log.Printf("[%s] mirror reconcile skipped — repo=%s is a forgejo row; the mirror store is GitHub-webhook-fed", name, repo)
+		return
 	}
 	rec := mirrorstore.NewReconciler(d.mirror, github.New(repo, fc), repo)
 	interval := reconcileInterval(getCfg)

--- a/internal/daemon/mirror_source.go
+++ b/internal/daemon/mirror_source.go
@@ -27,10 +27,12 @@ func (d *Daemon) newReadSource(repo string, getCfg func() *config.Config) *mirro
 		return nil
 	}
 	horizon := d.mirrorHorizon
+	var fc config.ForgeConfig
 	if cfg := getCfg(); cfg != nil {
 		horizon = cfg.GitHubMirror.StaleHorizon()
+		fc = cfg.Forge
 	}
-	return mirrorstore.NewSource(github.New(repo), d.mirror, repo, mirrorstore.SourceOptions{
+	return mirrorstore.NewSource(github.New(repo, fc), d.mirror, repo, mirrorstore.SourceOptions{
 		Horizon: horizon,
 		APIDirect: func() bool {
 			cfg := getCfg()
@@ -59,7 +61,11 @@ func (d *Daemon) runMirrorReconcile(ctx context.Context, name, repo string, getC
 	if d.mirror == nil {
 		return
 	}
-	rec := mirrorstore.NewReconciler(d.mirror, github.New(repo), repo)
+	var fc config.ForgeConfig
+	if cfg := getCfg(); cfg != nil {
+		fc = cfg.Forge
+	}
+	rec := mirrorstore.NewReconciler(d.mirror, github.New(repo, fc), repo)
 	interval := reconcileInterval(getCfg)
 	log.Printf("[%s] mirror reconcile loop started — repo=%s cadence=%s", name, repo, interval)
 	timer := time.NewTimer(interval)

--- a/internal/daemon/mirror_source_test.go
+++ b/internal/daemon/mirror_source_test.go
@@ -64,6 +64,59 @@ func TestNewReadSourceServesWarmMirror(t *testing.T) {
 	}
 }
 
+// TestNewReadSourceNilOnForgejoRow: the mirror store is GitHub-webhook-fed and
+// keyed by bare owner/name, so a forgejo row must never read it — even with a
+// mirror open and a (config-validation-rejected, but belt-and-braces)
+// mirror-first source, the flow reads its own forge directly (#1172 M2).
+func TestNewReadSourceNilOnForgejoRow(t *testing.T) {
+	mirror, err := mirrorstore.Open(filepath.Join(t.TempDir(), "maestro.db"))
+	if err != nil {
+		t.Fatalf("open mirror: %v", err)
+	}
+	defer mirror.Close()
+
+	d := &Daemon{mirror: mirror, mirrorHorizon: mirrorstore.DefaultStaleHorizon}
+	getCfg := func() *config.Config {
+		return &config.Config{
+			Repo:         "o/r",
+			Forge:        config.ForgeConfig{Kind: config.ForgeKindForgejo, BaseURL: "https://forge.example.com"},
+			GitHubMirror: config.GitHubMirrorConfig{Source: config.GitHubSourceMirrorFirst},
+		}
+	}
+	if src := d.newReadSource("o/r", getCfg); src != nil {
+		t.Fatal("newReadSource must be nil on a forgejo row — the mirror holds the GitHub mirror's state")
+	}
+}
+
+// TestRunMirrorReconcileSkipsForgejoRow: reconciling a forgejo row would write
+// Forgejo-read rows into the GitHub-webhook-fed store under the same owner/name
+// key — the loop must exit before its first pass (#1172 M2).
+func TestRunMirrorReconcileSkipsForgejoRow(t *testing.T) {
+	mirror, err := mirrorstore.Open(filepath.Join(t.TempDir(), "maestro.db"))
+	if err != nil {
+		t.Fatalf("open mirror: %v", err)
+	}
+	defer mirror.Close()
+
+	d := &Daemon{mirror: mirror}
+	getCfg := func() *config.Config {
+		return &config.Config{
+			Repo:  "o/r",
+			Forge: config.ForgeConfig{Kind: config.ForgeKindForgejo, BaseURL: "https://forge.example.com"},
+		}
+	}
+	done := make(chan struct{})
+	go func() {
+		d.runMirrorReconcile(context.Background(), "flow", "o/r", getCfg)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runMirrorReconcile should return immediately on a forgejo row")
+	}
+}
+
 // TestReconcileIntervalReadsConfig: the reconcile cadence comes from the flow's
 // live config, defaulting when it is momentarily unavailable (#827).
 func TestReconcileIntervalReadsConfig(t *testing.T) {

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -86,7 +86,8 @@ func runSupervise(ctx context.Context, name string, getCfg func() *config.Config
 	// falling back to the API on a miss/stale. A nil reader (mirror disabled)
 	// falls back to a plain client, byte-identical to pre-#826 behavior.
 	if reader == nil {
-		reader = github.New(getCfg().Repo)
+		cfg := getCfg()
+		reader = github.New(cfg.Repo, cfg.Forge)
 	}
 	// Capture and log each cycle's SupervisorDecision. The daemon still acts
 	// (label/comment/approve), but without this the structural "why did the

--- a/internal/forgejo/forgejo.go
+++ b/internal/forgejo/forgejo.go
@@ -76,17 +76,24 @@ func (c *Client) WithHTTPClient(httpc *http.Client) *Client {
 // JSON is short and is exactly what distinguishes "line outside the diff"
 // from "bad token" for the caller's fallback decision.
 func (c *Client) do(ctx context.Context, method, path string, payload any) ([]byte, error) {
+	out, _, err := c.doHeader(ctx, method, path, payload)
+	return out, err
+}
+
+// doHeader is do plus the response headers, for callers that consume list
+// metadata (the pager cross-checks x-total-count against what it accumulated).
+func (c *Client) doHeader(ctx context.Context, method, path string, payload any) ([]byte, http.Header, error) {
 	var body io.Reader
 	if payload != nil {
 		encoded, err := json.Marshal(payload)
 		if err != nil {
-			return nil, fmt.Errorf("encode %s %s: %w", method, path, err)
+			return nil, nil, fmt.Errorf("encode %s %s: %w", method, path, err)
 		}
 		body = bytes.NewReader(encoded)
 	}
 	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
 	if err != nil {
-		return nil, fmt.Errorf("build %s %s: %w", method, path, err)
+		return nil, nil, fmt.Errorf("build %s %s: %w", method, path, err)
 	}
 	if c.token != "" {
 		req.Header.Set("Authorization", "token "+c.token)
@@ -96,26 +103,26 @@ func (c *Client) do(ctx context.Context, method, path string, payload any) ([]by
 	}
 	resp, err := c.httpc.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("%s %s: %w", method, path, err)
+		return nil, nil, fmt.Errorf("%s %s: %w", method, path, err)
 	}
 	defer resp.Body.Close()
 	// limit+1 so an at-limit body is distinguishable from an over-limit one
 	// (the appauth.go idiom) — oversize fails loudly instead of truncating.
 	out, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes+1))
 	if err != nil {
-		return nil, fmt.Errorf("%s %s: read response: %w", method, path, err)
+		return nil, nil, fmt.Errorf("%s %s: read response: %w", method, path, err)
 	}
 	if len(out) > maxResponseBytes {
-		return nil, fmt.Errorf("%s %s: response exceeds %d bytes", method, path, maxResponseBytes)
+		return nil, nil, fmt.Errorf("%s %s: response exceeds %d bytes", method, path, maxResponseBytes)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		excerpt := strings.TrimSpace(string(out))
 		if len(excerpt) > 512 {
 			excerpt = excerpt[:512]
 		}
-		return nil, fmt.Errorf("%s %s: HTTP %d: %s", method, path, resp.StatusCode, excerpt)
+		return nil, nil, fmt.Errorf("%s %s: HTTP %d: %s", method, path, resp.StatusCode, excerpt)
 	}
-	return out, nil
+	return out, resp.Header, nil
 }
 
 // GetPR returns the PR metadata. An empty head SHA is rejected per the

--- a/internal/forgejo/reads.go
+++ b/internal/forgejo/reads.go
@@ -315,6 +315,52 @@ func (c *Client) GetPull(ctx context.Context, repo string, index int) (Pull, err
 	return wp.pull(), nil
 }
 
+// PullCommit is one commit on a pull request: the sha plus the full commit
+// message verbatim (the wire message carries a trailing newline; headline
+// extraction is the caller's job, mirroring the gh layer's parsePRCommits).
+type PullCommit struct {
+	SHA     string
+	Message string
+}
+
+// ListPullCommits returns the commits on one pull request in server order.
+// Unlike the comments/labels endpoints this one IS paginated (page/limit
+// accepted, x-total-count + Link observed live), so it goes through the pager.
+func (c *Client) ListPullCommits(ctx context.Context, repo string, index int, allPages bool) ([]PullCommit, error) {
+	type wireCommit struct {
+		SHA    string `json:"sha"`
+		Commit struct {
+			Message string `json:"message"`
+		} `json:"commit"`
+	}
+	wires, err := listPages[wireCommit](ctx, c, fmt.Sprintf("/repos/%s/pulls/%d/commits", repo, index), allPages)
+	if err != nil {
+		return nil, fmt.Errorf("list pull commits %s#%d: %w", repo, index, err)
+	}
+	commits := make([]PullCommit, 0, len(wires))
+	for _, w := range wires {
+		commits = append(commits, PullCommit{SHA: w.SHA, Message: w.Commit.Message})
+	}
+	return commits, nil
+}
+
+// ListPullFiles returns the repo-relative paths changed by one pull request.
+// Paginated like the commits list.
+func (c *Client) ListPullFiles(ctx context.Context, repo string, index int, allPages bool) ([]string, error) {
+	type wireFile struct {
+		Filename string `json:"filename"`
+	}
+	wires, err := listPages[wireFile](ctx, c, fmt.Sprintf("/repos/%s/pulls/%d/files", repo, index), allPages)
+	if err != nil {
+		return nil, fmt.Errorf("list pull files %s#%d: %w", repo, index, err)
+	}
+	files := make([]string, 0, len(wires))
+	for _, w := range wires {
+		files = append(files, w.Filename)
+	}
+	return files, nil
+}
+
 // DefaultBranch returns the repository's default branch. Empty is an error —
 // every caller anchors base-branch logic to it.
 func (c *Client) DefaultBranch(ctx context.Context, repo string) (string, error) {

--- a/internal/forgejo/reads.go
+++ b/internal/forgejo/reads.go
@@ -1,0 +1,361 @@
+// Core read methods for the #1172 transport switch (M2). These back the
+// internal/github funnel dispatch on forgejo-mode rows; the forge.Client six
+// in forgejo.go stay untouched as the producer surface.
+//
+// Contract notes baked in here (all live-verified against Forgejo 16.0.1 on
+// 2026-08-11):
+//
+//   - the server clamps list pages at 50 items (settings/api
+//     max_response_items), so the pagination loop uses 50 as its own page
+//     size — asking for more silently returns 50 and would break the
+//     "short page means done" stop condition;
+//   - an unknown label name in the `labels` filter is silently DISCARDED and
+//     the UNFILTERED list comes back, so ListIssues re-filters client-side;
+//   - issues and pulls share one index space: issue-shaped payloads carry a
+//     `pull_request` key on BOTH kinds, null on real issues — callers must
+//     test the pointer, never key presence;
+//   - the pulls list default order is index-desc, NOT updated-desc; newest-
+//     updated-first requires an explicit sort=recentupdate;
+//   - issue comments and issue labels have NO page/limit params and return
+//     everything in one response — they must not go through the pager.
+package forgejo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// pageSize is the live-verified server clamp (GET /api/v1/settings/api →
+// max_response_items: 50). Requesting more still returns at most 50, so the
+// pager must use the clamp itself or every page would look "short" and the
+// loop would stop after page one.
+const pageSize = 50
+
+// maxListPages bounds the pagination loop: 100 pages × 50 items = 5000
+// entries, far beyond homelab scale. Hitting the cap is an explicit error —
+// never a silent truncation that downstream logic would read as "the full
+// set".
+const maxListPages = 100
+
+// Label is one issue/PR label. Only the name matters to callers.
+type Label struct {
+	Name string `json:"name"`
+}
+
+// PullMeta is the pull-request marker on issue-shaped payloads. The key is
+// present on real issues too, with value null — so only the pointer test
+// (Issue.PullRequest != nil) identifies a pull.
+type PullMeta struct {
+	Merged   bool    `json:"merged"`
+	MergedAt *string `json:"merged_at"`
+	Draft    bool    `json:"draft"`
+}
+
+// Issue mirrors the live-verified Forgejo issue payload. State is
+// "open"|"closed" verbatim (lowercase).
+type Issue struct {
+	Number int     `json:"number"`
+	Title  string  `json:"title"`
+	Body   string  `json:"body"`
+	State  string  `json:"state"`
+	Labels []Label `json:"labels"`
+	// PullRequest is non-nil when the entry is actually a pull request.
+	// Issues and pulls share one index space, so GetIssue on a pull index
+	// returns an issue-shaped payload with this set — issue paths must keep
+	// the != nil belt.
+	PullRequest *PullMeta `json:"pull_request"`
+}
+
+// IssueComment is one issue/PR comment, flattened to what the gh layer maps
+// into its own IssueComment (id/body/user.login/created_at).
+type IssueComment struct {
+	ID        int64
+	Body      string
+	Author    string
+	CreatedAt string
+}
+
+// Pull is the widened pull view for the transport switch (forge.PR stays
+// minimal for the producer surface). State is "open"|"closed" verbatim
+// (lowercase — a merged pull is state=closed with MergedAt set). Mergeable is
+// a plain bool on the wire (no tri-state observed), kept as *bool so an
+// absent field is distinguishable from false. MergedAt is nil when unmerged,
+// RFC3339 when merged; MergeCommitSHA is "" when unmerged, 40-hex when
+// merged.
+type Pull struct {
+	Number         int
+	Title          string
+	Body           string
+	State          string
+	Draft          bool
+	Mergeable      *bool
+	MergedAt       *string
+	MergeCommitSHA string
+	HeadRef        string
+	HeadSHA        string
+	BaseRef        string
+}
+
+// wirePull is the nested wire shape of GET /repos/{repo}/pulls[/{index}].
+type wirePull struct {
+	Number         int     `json:"number"`
+	Title          string  `json:"title"`
+	Body           string  `json:"body"`
+	State          string  `json:"state"`
+	Draft          bool    `json:"draft"`
+	Mergeable      *bool   `json:"mergeable"`
+	MergedAt       *string `json:"merged_at"`
+	MergeCommitSHA string  `json:"merge_commit_sha"`
+	Head           struct {
+		Ref string `json:"ref"`
+		SHA string `json:"sha"`
+	} `json:"head"`
+	Base struct {
+		Ref string `json:"ref"`
+	} `json:"base"`
+}
+
+func (wp wirePull) pull() Pull {
+	return Pull{
+		Number:         wp.Number,
+		Title:          wp.Title,
+		Body:           wp.Body,
+		State:          wp.State,
+		Draft:          wp.Draft,
+		Mergeable:      wp.Mergeable,
+		MergedAt:       wp.MergedAt,
+		MergeCommitSHA: wp.MergeCommitSHA,
+		HeadRef:        wp.Head.Ref,
+		HeadSHA:        wp.Head.SHA,
+		BaseRef:        wp.Base.Ref,
+	}
+}
+
+// listPages fetches a JSON-array list endpoint page by page. path carries the
+// caller's query already encoded (or none); the pager appends page/limit.
+// allPages=false bounds the read to the first page (50 entries). More than
+// maxListPages full pages is an explicit error — silent truncation would let
+// e.g. a merged-PR scan miss the PR it was looking for and re-dispatch work.
+func listPages[T any](ctx context.Context, c *Client, path string, allPages bool) ([]T, error) {
+	sep := "?"
+	if strings.Contains(path, "?") {
+		sep = "&"
+	}
+	var all []T
+	for page := 1; ; page++ {
+		if page > maxListPages {
+			return nil, fmt.Errorf("GET %s: more than %d pages (%d entries so far); refusing to truncate silently", path, maxListPages, len(all))
+		}
+		paged := fmt.Sprintf("%s%slimit=%d&page=%d", path, sep, pageSize, page)
+		out, err := c.do(ctx, http.MethodGet, paged, nil)
+		if err != nil {
+			return nil, err
+		}
+		var items []T
+		if err := json.Unmarshal(out, &items); err != nil {
+			return nil, fmt.Errorf("parse GET %s: %w", paged, err)
+		}
+		all = append(all, items...)
+		if !allPages || len(items) < pageSize {
+			return all, nil
+		}
+	}
+}
+
+// hasLabel reports whether labels contains name (case-folded — label filters
+// are name-based and the belt must not drop a hit over casing).
+func hasLabel(labels []Label, name string) bool {
+	for _, l := range labels {
+		if strings.EqualFold(l.Name, name) {
+			return true
+		}
+	}
+	return false
+}
+
+// ListIssues lists issues — never pulls — in one state ("open", "closed",
+// "all"; empty means server default "open"), optionally filtered to a single
+// label (the gh layer ORs multiple labels client-side by N calls; that
+// contract is kept here). Two client-side belts on top of the server filter:
+//
+//   - pull entries are dropped even though type=issues already excludes them
+//     (shared index space, zero tolerance for a pull leaking into issue
+//     dispatch);
+//   - the label is re-checked by name, because the server silently DISCARDS
+//     an unknown label name and returns the unfiltered list — trusting it
+//     would turn a typo'd label into "dispatch everything".
+func (c *Client) ListIssues(ctx context.Context, repo, state, label string, allPages bool) ([]Issue, error) {
+	q := url.Values{}
+	q.Set("type", "issues")
+	if state != "" {
+		q.Set("state", state)
+	}
+	if label != "" {
+		q.Set("labels", label)
+	}
+	path := fmt.Sprintf("/repos/%s/issues?%s", repo, q.Encode())
+	issues, err := listPages[Issue](ctx, c, path, allPages)
+	if err != nil {
+		return nil, fmt.Errorf("list issues %s: %w", repo, err)
+	}
+	kept := make([]Issue, 0, len(issues))
+	for _, is := range issues {
+		if is.PullRequest != nil {
+			continue
+		}
+		if label != "" && !hasLabel(is.Labels, label) {
+			continue
+		}
+		kept = append(kept, is)
+	}
+	return kept, nil
+}
+
+// GetIssue returns one issue by index, verbatim — including a populated
+// PullRequest when the index belongs to a pull (shared number space); the
+// caller owns the != nil belt.
+func (c *Client) GetIssue(ctx context.Context, repo string, index int) (Issue, error) {
+	out, err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/issues/%d", repo, index), nil)
+	if err != nil {
+		return Issue{}, fmt.Errorf("get issue %s#%d: %w", repo, index, err)
+	}
+	var is Issue
+	if err := json.Unmarshal(out, &is); err != nil {
+		return Issue{}, fmt.Errorf("parse issue %s#%d: %w", repo, index, err)
+	}
+	return is, nil
+}
+
+// ListIssueComments returns all comments on one issue/PR. The endpoint has NO
+// page/limit params (swagger: only since/before) and returns everything in
+// one response — do not route it through the pager.
+func (c *Client) ListIssueComments(ctx context.Context, repo string, index int) ([]IssueComment, error) {
+	out, err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/issues/%d/comments", repo, index), nil)
+	if err != nil {
+		return nil, fmt.Errorf("list comments %s#%d: %w", repo, index, err)
+	}
+	var wire []struct {
+		ID   int64  `json:"id"`
+		Body string `json:"body"`
+		User struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		CreatedAt string `json:"created_at"`
+	}
+	if err := json.Unmarshal(out, &wire); err != nil {
+		return nil, fmt.Errorf("parse comments %s#%d: %w", repo, index, err)
+	}
+	comments := make([]IssueComment, 0, len(wire))
+	for _, wc := range wire {
+		comments = append(comments, IssueComment{
+			ID:        wc.ID,
+			Body:      wc.Body,
+			Author:    wc.User.Login,
+			CreatedAt: wc.CreatedAt,
+		})
+	}
+	return comments, nil
+}
+
+// IssueLabels returns the label names on one issue/PR. Like comments, the
+// endpoint has no page/limit params and returns everything in one response.
+func (c *Client) IssueLabels(ctx context.Context, repo string, index int) ([]string, error) {
+	out, err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/issues/%d/labels", repo, index), nil)
+	if err != nil {
+		return nil, fmt.Errorf("list labels %s#%d: %w", repo, index, err)
+	}
+	var labels []Label
+	if err := json.Unmarshal(out, &labels); err != nil {
+		return nil, fmt.Errorf("parse labels %s#%d: %w", repo, index, err)
+	}
+	names := make([]string, 0, len(labels))
+	for _, l := range labels {
+		names = append(names, l.Name)
+	}
+	return names, nil
+}
+
+// ListPulls lists pull requests in one state ("open", "closed", "all"; empty
+// means server default "open"), newest-updated-first. The sort is explicit:
+// the server's default order is index-desc, NOT updated-desc, and the gh
+// layer's closed-PR scans depend on updated-desc semantics.
+func (c *Client) ListPulls(ctx context.Context, repo, state string, allPages bool) ([]Pull, error) {
+	q := url.Values{}
+	q.Set("sort", "recentupdate")
+	if state != "" {
+		q.Set("state", state)
+	}
+	path := fmt.Sprintf("/repos/%s/pulls?%s", repo, q.Encode())
+	wires, err := listPages[wirePull](ctx, c, path, allPages)
+	if err != nil {
+		return nil, fmt.Errorf("list pulls %s: %w", repo, err)
+	}
+	pulls := make([]Pull, 0, len(wires))
+	for _, wp := range wires {
+		pulls = append(pulls, wp.pull())
+	}
+	return pulls, nil
+}
+
+// GetPull returns one pull request by index, widened for the transport
+// switch. forge.Client's GetPR stays as-is for the producer surface.
+func (c *Client) GetPull(ctx context.Context, repo string, index int) (Pull, error) {
+	out, err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/pulls/%d", repo, index), nil)
+	if err != nil {
+		return Pull{}, fmt.Errorf("get pull %s#%d: %w", repo, index, err)
+	}
+	var wp wirePull
+	if err := json.Unmarshal(out, &wp); err != nil {
+		return Pull{}, fmt.Errorf("parse pull %s#%d: %w", repo, index, err)
+	}
+	return wp.pull(), nil
+}
+
+// DefaultBranch returns the repository's default branch. Empty is an error —
+// every caller anchors base-branch logic to it.
+func (c *Client) DefaultBranch(ctx context.Context, repo string) (string, error) {
+	out, err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s", repo), nil)
+	if err != nil {
+		return "", fmt.Errorf("get repo %s: %w", repo, err)
+	}
+	var meta struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := json.Unmarshal(out, &meta); err != nil {
+		return "", fmt.Errorf("parse repo %s: %w", repo, err)
+	}
+	branch := strings.TrimSpace(meta.DefaultBranch)
+	if branch == "" {
+		return "", fmt.Errorf("repo %s reports no default branch", repo)
+	}
+	return branch, nil
+}
+
+// BranchHeadSHA returns the head commit SHA of one branch. The branch name is
+// path-escaped so slash-containing feature branches route correctly
+// (/branches/{name} answers 200 for both escaped and raw slashes live, but
+// escaping is the documented, unambiguous form). The head SHA lives in
+// commit.id (Branch.commit is a PayloadCommit, not the top-level sha shape).
+func (c *Client) BranchHeadSHA(ctx context.Context, repo, branch string) (string, error) {
+	out, err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/branches/%s", repo, url.PathEscape(branch)), nil)
+	if err != nil {
+		return "", fmt.Errorf("get branch %s@%s: %w", repo, branch, err)
+	}
+	var br struct {
+		Commit struct {
+			ID string `json:"id"`
+		} `json:"commit"`
+	}
+	if err := json.Unmarshal(out, &br); err != nil {
+		return "", fmt.Errorf("parse branch %s@%s: %w", repo, branch, err)
+	}
+	sha := strings.TrimSpace(br.Commit.ID)
+	if sha == "" {
+		return "", fmt.Errorf("branch %s@%s has an empty head sha", repo, branch)
+	}
+	return sha, nil
+}

--- a/internal/forgejo/reads.go
+++ b/internal/forgejo/reads.go
@@ -42,6 +42,15 @@ const pageSize = 50
 // set".
 const maxListPages = 100
 
+// boundedWindow is the item budget of a bounded (allPages=false) read: 100,
+// matching the gh transport's single-page per_page=100 calls. The server
+// clamps pages at 50 (pageSize), so a first-page-only bounded read would see
+// HALF the window the gh path sees — a consumer scanning the bounded open-PR
+// list (e.g. HasOpenPRForIssue on supervisor dispatch) would miss a linked PR
+// sitting at position 51 and re-dispatch the issue. The pager keeps fetching
+// clamped pages until the window is filled or the set ends.
+const boundedWindow = 100
+
 // Label is one issue/PR label. Only the name matters to callers.
 type Label struct {
 	Name string `json:"name"`
@@ -141,9 +150,12 @@ func (wp wirePull) pull() Pull {
 
 // listPages fetches a JSON-array list endpoint page by page. path carries the
 // caller's query already encoded (or none); the pager appends page/limit.
-// allPages=false bounds the read to the first page (50 entries). More than
-// maxListPages full pages is an explicit error — silent truncation would let
-// e.g. a merged-PR scan miss the PR it was looking for and re-dispatch work.
+// allPages=false bounds the read to a boundedWindow (100) item window —
+// clamped pages are fetched until the window fills or a short page ends the
+// set — so bounded reads see the same window as the gh transport's
+// single-page per_page=100 calls. More than maxListPages full pages is an
+// explicit error — silent truncation would let e.g. a merged-PR scan miss the
+// PR it was looking for and re-dispatch work.
 //
 // The x-total-count header (live-verified present and filter-consistent on
 // every paged endpoint here) is a truncation belt: pageSize hardcodes THIS
@@ -152,10 +164,14 @@ func (wp wirePull) pull() Pull {
 // and an authoritative read (e.g. the #827 reconcile open-issue set) would
 // silently truncate — downstream would stamp still-open issues closed. A
 // short final page that leaves the accumulated count below the server's own
-// total is therefore an explicit error. The total is re-read on every page so
-// a set that legitimately shrinks mid-scan does not false-alarm, and reaching
-// the total on a full page ends the loop without demanding one empty page
-// (which at exactly maxListPages×pageSize entries would trip the cap error).
+// total is therefore an explicit error. Reaching the bounded window with more
+// entries outstanding on the server is NOT truncation — it is the window's
+// contract — so the bounded stop returns before the belt is consulted; the
+// belt still fires when a short page strands a bounded read below BOTH the
+// window and the server total. The total is re-read on every page so a set
+// that legitimately shrinks mid-scan does not false-alarm, and reaching the
+// total on a full page ends the loop without demanding one empty page (which
+// at exactly maxListPages×pageSize entries would trip the cap error).
 func listPages[T any](ctx context.Context, c *Client, path string, allPages bool) ([]T, error) {
 	sep := "?"
 	if strings.Contains(path, "?") {
@@ -182,8 +198,11 @@ func listPages[T any](ctx context.Context, c *Client, path string, allPages bool
 			return nil, fmt.Errorf("parse GET %s: %w", paged, err)
 		}
 		all = append(all, items...)
-		if !allPages {
-			return all, nil
+		if !allPages && len(all) >= boundedWindow {
+			// Intentional bounded stop: the window is full, anything beyond it
+			// is out of contract (gh parity), so the truncation belt below
+			// must not see this as a short set.
+			return all[:boundedWindow], nil
 		}
 		if len(items) < pageSize {
 			if total >= 0 && len(all) < total {

--- a/internal/forgejo/reads.go
+++ b/internal/forgejo/reads.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -82,10 +83,13 @@ type IssueComment struct {
 // Pull is the widened pull view for the transport switch (forge.PR stays
 // minimal for the producer surface). State is "open"|"closed" verbatim
 // (lowercase — a merged pull is state=closed with MergedAt set). Mergeable is
-// a plain bool on the wire (no tri-state observed), kept as *bool so an
-// absent field is distinguishable from false. MergedAt is nil when unmerged,
-// RFC3339 when merged; MergeCommitSHA is "" when unmerged, 40-hex when
-// merged.
+// a plain bool on the wire (no tri-state), kept as *bool so an absent field
+// is distinguishable from false, and carried VERBATIM: the server forces it
+// false on draft/WIP pulls and during the async conflict re-check
+// (live-verified, 41/41 draft pulls report false), so the gh layer — not this
+// transport — owns mapping that contamination out (fjPullToREST). MergedAt is
+// nil when unmerged, RFC3339 when merged; MergeCommitSHA is "" when unmerged,
+// 40-hex when merged.
 type Pull struct {
 	Number         int
 	Title          string
@@ -140,27 +144,54 @@ func (wp wirePull) pull() Pull {
 // allPages=false bounds the read to the first page (50 entries). More than
 // maxListPages full pages is an explicit error — silent truncation would let
 // e.g. a merged-PR scan miss the PR it was looking for and re-dispatch work.
+//
+// The x-total-count header (live-verified present and filter-consistent on
+// every paged endpoint here) is a truncation belt: pageSize hardcodes THIS
+// instance's max_response_items clamp, and on a server clamped LOWER every
+// page would come back short, the short-page stop would fire after page one,
+// and an authoritative read (e.g. the #827 reconcile open-issue set) would
+// silently truncate — downstream would stamp still-open issues closed. A
+// short final page that leaves the accumulated count below the server's own
+// total is therefore an explicit error. The total is re-read on every page so
+// a set that legitimately shrinks mid-scan does not false-alarm, and reaching
+// the total on a full page ends the loop without demanding one empty page
+// (which at exactly maxListPages×pageSize entries would trip the cap error).
 func listPages[T any](ctx context.Context, c *Client, path string, allPages bool) ([]T, error) {
 	sep := "?"
 	if strings.Contains(path, "?") {
 		sep = "&"
 	}
 	var all []T
+	total := -1 // -1: header absent, belt disabled
 	for page := 1; ; page++ {
 		if page > maxListPages {
 			return nil, fmt.Errorf("GET %s: more than %d pages (%d entries so far); refusing to truncate silently", path, maxListPages, len(all))
 		}
 		paged := fmt.Sprintf("%s%slimit=%d&page=%d", path, sep, pageSize, page)
-		out, err := c.do(ctx, http.MethodGet, paged, nil)
+		out, header, err := c.doHeader(ctx, http.MethodGet, paged, nil)
 		if err != nil {
 			return nil, err
+		}
+		if raw := strings.TrimSpace(header.Get("X-Total-Count")); raw != "" {
+			if parsed, parseErr := strconv.Atoi(raw); parseErr == nil && parsed >= 0 {
+				total = parsed
+			}
 		}
 		var items []T
 		if err := json.Unmarshal(out, &items); err != nil {
 			return nil, fmt.Errorf("parse GET %s: %w", paged, err)
 		}
 		all = append(all, items...)
-		if !allPages || len(items) < pageSize {
+		if !allPages {
+			return all, nil
+		}
+		if len(items) < pageSize {
+			if total >= 0 && len(all) < total {
+				return nil, fmt.Errorf("GET %s: page %d came back short at %d items with only %d of %d total entries accumulated (server page clamp below %d?); refusing to truncate silently", path, page, len(items), len(all), total, pageSize)
+			}
+			return all, nil
+		}
+		if total >= 0 && len(all) >= total {
 			return all, nil
 		}
 	}

--- a/internal/forgejo/reads_test.go
+++ b/internal/forgejo/reads_test.go
@@ -246,19 +246,81 @@ func TestListIssues_TotalReachedOnFullFinalPagePasses(t *testing.T) {
 	}
 }
 
-func TestListIssues_FirstPageOnlyWhenAllPagesFalse(t *testing.T) {
-	c, seen := newReadsClient(t, func(*http.Request) (int, string) {
-		return 200, issuesPage(t, 1, pageSize)
+// A bounded read must see the same 100-item window as the gh transport's
+// per_page=100 single-page calls: with 120 entries on the server it assembles
+// two clamped pages, stops at exactly boundedWindow, and the truncation belt
+// must NOT fire even though x-total-count says more entries exist — stopping
+// at the window is the contract, not truncation.
+func TestListIssues_BoundedWindowStopsAtHundred(t *testing.T) {
+	c, seen := newReadsClientWithTotal(t, func(r *http.Request) (int, int, string) {
+		switch r.URL.Query().Get("page") {
+		case "1":
+			return 120, 200, issuesPage(t, 1, pageSize)
+		case "2":
+			return 120, 200, issuesPage(t, 1+pageSize, pageSize)
+		default:
+			return 0, 500, `{"message":"page beyond the bounded window"}`
+		}
 	})
 	issues, err := c.ListIssues(context.Background(), "owner/repo", "open", "", false)
 	if err != nil {
 		t.Fatalf("ListIssues: %v", err)
 	}
-	if len(issues) != pageSize {
-		t.Fatalf("issues = %d, want %d", len(issues), pageSize)
+	if len(issues) != boundedWindow {
+		t.Fatalf("issues = %d, want the %d-item bounded window", len(issues), boundedWindow)
+	}
+	if issues[0].Number != 1 || issues[boundedWindow-1].Number != boundedWindow {
+		t.Fatalf("window broken: first=%d last=%d", issues[0].Number, issues[boundedWindow-1].Number)
+	}
+	if len(*seen) != 2 {
+		t.Fatalf("requests = %d, want 2 (two clamped pages fill the window)", len(*seen))
+	}
+}
+
+// A bounded read over a set smaller than the window returns the whole set —
+// the short final page ends the loop, and the total-matching count keeps the
+// truncation belt quiet.
+func TestListIssues_BoundedReturnsAllWhenSetSmallerThanWindow(t *testing.T) {
+	c, seen := newReadsClientWithTotal(t, func(r *http.Request) (int, int, string) {
+		switch r.URL.Query().Get("page") {
+		case "1":
+			return 80, 200, issuesPage(t, 1, pageSize)
+		case "2":
+			return 80, 200, issuesPage(t, 1+pageSize, 80-pageSize)
+		default:
+			return 0, 500, `{"message":"unexpected page"}`
+		}
+	})
+	issues, err := c.ListIssues(context.Background(), "owner/repo", "open", "", false)
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 80 {
+		t.Fatalf("issues = %d, want all 80 (set smaller than the window)", len(issues))
+	}
+	if len(*seen) != 2 {
+		t.Fatalf("requests = %d, want 2", len(*seen))
+	}
+}
+
+// Genuine truncation must still fail loud in bounded mode: a server clamped
+// below pageSize answers a short first page, leaving the read below BOTH the
+// window and the server's own total — returning that silently would hand a
+// consumer (HasOpenPRForIssue et al.) a fraction of the window it believes it
+// scanned.
+func TestListIssues_BoundedLowerServerClampFailsLoud(t *testing.T) {
+	c, seen := newReadsClientWithTotal(t, func(*http.Request) (int, int, string) {
+		return 120, 200, issuesPage(t, 1, 25) // clamp 25 < pageSize, 120 total
+	})
+	_, err := c.ListIssues(context.Background(), "owner/repo", "open", "", false)
+	if err == nil {
+		t.Fatal("a short page below both window and total must error, not truncate silently")
+	}
+	if !strings.Contains(err.Error(), "refusing to truncate") {
+		t.Fatalf("error should name the truncation, got: %v", err)
 	}
 	if len(*seen) != 1 {
-		t.Fatalf("requests = %d, want 1 — allPages=false is a bounded read", len(*seen))
+		t.Fatalf("requests = %d, want 1", len(*seen))
 	}
 }
 
@@ -655,20 +717,32 @@ func TestListPullFiles(t *testing.T) {
 	}
 }
 
-func TestListPullFiles_FirstPageOnlyWhenAllPagesFalse(t *testing.T) {
-	c, seen := newReadsClient(t, func(r *http.Request) (int, string) {
-		items := make([]string, 0, pageSize)
-		for i := 0; i < pageSize; i++ {
-			items = append(items, fmt.Sprintf(`{"filename":"f%d.go"}`, i))
+// The bounded window applies to every paged list read: two full clamped pages
+// fill it, a third is never requested.
+func TestListPullFiles_BoundedWindowWhenAllPagesFalse(t *testing.T) {
+	filesPage := func(from, n int) string {
+		items := make([]string, 0, n)
+		for i := 0; i < n; i++ {
+			items = append(items, fmt.Sprintf(`{"filename":"f%d.go"}`, from+i))
 		}
-		return 200, "[" + strings.Join(items, ",") + "]"
+		return "[" + strings.Join(items, ",") + "]"
+	}
+	c, seen := newReadsClient(t, func(r *http.Request) (int, string) {
+		switch r.URL.Query().Get("page") {
+		case "1":
+			return 200, filesPage(0, pageSize)
+		case "2":
+			return 200, filesPage(pageSize, pageSize)
+		default:
+			return 500, `{"message":"page beyond the bounded window"}`
+		}
 	})
 	files, err := c.ListPullFiles(context.Background(), "owner/repo", 1, false)
 	if err != nil {
 		t.Fatalf("ListPullFiles: %v", err)
 	}
-	if len(files) != pageSize || len(*seen) != 1 {
-		t.Fatalf("files = %d requests = %d, want one full page and no follow-up", len(files), len(*seen))
+	if len(files) != boundedWindow || len(*seen) != 2 {
+		t.Fatalf("files = %d requests = %d, want the %d-item window from exactly 2 pages", len(files), len(*seen), boundedWindow)
 	}
 }
 

--- a/internal/forgejo/reads_test.go
+++ b/internal/forgejo/reads_test.go
@@ -1,0 +1,499 @@
+package forgejo
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// readReq captures one request the reads fixture server saw. Path is the
+// ESCAPED path (RawPath when set) so percent-encoding assertions — the
+// slash-in-branch-name case — see what actually went on the wire.
+type readReq struct {
+	Method string
+	Path   string
+	Query  url.Values
+}
+
+// newReadsClient builds a client against a fixture server whose responses are
+// computed per request — pagination tests need page-dependent bodies.
+func newReadsClient(t *testing.T, fn func(r *http.Request) (int, string)) (*Client, *[]readReq) {
+	t.Helper()
+	var seen []readReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, readReq{
+			Method: r.Method,
+			Path:   r.URL.EscapedPath(),
+			Query:  r.URL.Query(),
+		})
+		status, body := fn(r)
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "sekrit"), &seen
+}
+
+// staticReads is newReadsClient with one fixed response.
+func staticReads(t *testing.T, status int, body string) (*Client, *[]readReq) {
+	t.Helper()
+	return newReadsClient(t, func(*http.Request) (int, string) { return status, body })
+}
+
+// issuesPage builds a JSON array of n issues numbered from `from`, each
+// carrying the given label names and the contract's ever-present
+// "pull_request": null key of a real issue.
+func issuesPage(t *testing.T, from, n int, labels ...string) string {
+	t.Helper()
+	items := make([]map[string]any, 0, n)
+	for i := 0; i < n; i++ {
+		ls := make([]map[string]any, 0, len(labels))
+		for _, name := range labels {
+			ls = append(ls, map[string]any{"id": 1, "name": name, "color": "00aabb"})
+		}
+		items = append(items, map[string]any{
+			"number":       from + i,
+			"title":        fmt.Sprintf("issue %d", from+i),
+			"body":         "b",
+			"state":        "open",
+			"labels":       ls,
+			"pull_request": nil,
+		})
+	}
+	out, err := json.Marshal(items)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	return string(out)
+}
+
+func TestListIssues(t *testing.T) {
+	c, seen := staticReads(t, 200, issuesPage(t, 7, 2, "maestro-ready"))
+	issues, err := c.ListIssues(context.Background(), "owner/repo", "open", "maestro-ready", true)
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 2 || issues[0].Number != 7 || issues[1].Number != 8 {
+		t.Fatalf("issues = %+v", issues)
+	}
+	if issues[0].Title != "issue 7" || issues[0].Body != "b" || issues[0].State != "open" {
+		t.Fatalf("first issue = %+v", issues[0])
+	}
+	if len(issues[0].Labels) != 1 || issues[0].Labels[0].Name != "maestro-ready" {
+		t.Fatalf("labels = %+v", issues[0].Labels)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %d, want 1 (a short page ends the loop)", len(*seen))
+	}
+	req := (*seen)[0]
+	if req.Method != http.MethodGet || req.Path != "/repos/owner/repo/issues" {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+	for key, want := range map[string]string{
+		"type":   "issues",
+		"state":  "open",
+		"labels": "maestro-ready",
+		"limit":  strconv.Itoa(pageSize),
+		"page":   "1",
+	} {
+		if got := req.Query.Get(key); got != want {
+			t.Fatalf("query %s = %q, want %q (full query: %v)", key, got, want, req.Query)
+		}
+	}
+}
+
+func TestListIssues_Pagination(t *testing.T) {
+	// Page 1 full (== the server clamp), page 2 short → exactly two requests,
+	// results concatenated in order.
+	c, seen := newReadsClient(t, func(r *http.Request) (int, string) {
+		switch r.URL.Query().Get("page") {
+		case "1":
+			return 200, issuesPage(t, 1, pageSize, "maestro-ready")
+		case "2":
+			return 200, issuesPage(t, 1+pageSize, 3, "maestro-ready")
+		default:
+			return 500, `{"message":"unexpected page"}`
+		}
+	})
+	issues, err := c.ListIssues(context.Background(), "owner/repo", "open", "maestro-ready", true)
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != pageSize+3 {
+		t.Fatalf("issues = %d, want %d", len(issues), pageSize+3)
+	}
+	if issues[0].Number != 1 || issues[pageSize+2].Number != pageSize+3 {
+		t.Fatalf("order broken: first=%d last=%d", issues[0].Number, issues[pageSize+2].Number)
+	}
+	if len(*seen) != 2 {
+		t.Fatalf("requests = %d, want 2", len(*seen))
+	}
+	if (*seen)[0].Query.Get("page") != "1" || (*seen)[1].Query.Get("page") != "2" {
+		t.Fatalf("pages requested: %v then %v", (*seen)[0].Query, (*seen)[1].Query)
+	}
+}
+
+func TestListIssues_PageCapIsExplicitError(t *testing.T) {
+	// Every page comes back full → the pager must stop at maxListPages with a
+	// loud error, never return a silently truncated set.
+	c, seen := newReadsClient(t, func(*http.Request) (int, string) {
+		return 200, issuesPage(t, 1, pageSize)
+	})
+	_, err := c.ListIssues(context.Background(), "owner/repo", "open", "", true)
+	if err == nil {
+		t.Fatal("an over-cap listing must error — silent truncation reads as \"the full set\"")
+	}
+	if !strings.Contains(err.Error(), "refusing to truncate") {
+		t.Fatalf("error should name the cap, got: %v", err)
+	}
+	if len(*seen) != maxListPages {
+		t.Fatalf("requests = %d, want exactly %d", len(*seen), maxListPages)
+	}
+}
+
+func TestListIssues_FirstPageOnlyWhenAllPagesFalse(t *testing.T) {
+	c, seen := newReadsClient(t, func(*http.Request) (int, string) {
+		return 200, issuesPage(t, 1, pageSize)
+	})
+	issues, err := c.ListIssues(context.Background(), "owner/repo", "open", "", false)
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != pageSize {
+		t.Fatalf("issues = %d, want %d", len(issues), pageSize)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %d, want 1 — allPages=false is a bounded read", len(*seen))
+	}
+}
+
+func TestListIssues_RefiltersUnknownLabelClientSide(t *testing.T) {
+	// P1 footgun (live-verified): a label name the repo does not have is
+	// silently DISCARDED by the server, which then returns the UNFILTERED
+	// list. The client-side belt must drop everything that does not carry the
+	// requested label by name.
+	unfiltered := `[` +
+		strings.TrimSuffix(strings.TrimPrefix(issuesPage(t, 1, 1, "Maestro-Ready"), "["), "]") + `,` +
+		strings.TrimSuffix(strings.TrimPrefix(issuesPage(t, 2, 1, "enhancement"), "["), "]") + `,` +
+		strings.TrimSuffix(strings.TrimPrefix(issuesPage(t, 3, 1), "["), "]") + `]`
+	c, _ := staticReads(t, 200, unfiltered)
+	issues, err := c.ListIssues(context.Background(), "owner/repo", "open", "maestro-ready", true)
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Number != 1 {
+		t.Fatalf("issues = %+v, want only #1 (case-folded label match)", issues)
+	}
+}
+
+func TestListIssues_DropsPullEntries(t *testing.T) {
+	// Real issues carry "pull_request": null; pulls carry a populated object.
+	// Only the pointer test tells them apart — key presence never does.
+	c, _ := staticReads(t, 200, `[
+		{"number":1,"title":"real issue","state":"open","labels":[],"pull_request":null},
+		{"number":2,"title":"a pull","state":"open","labels":[],
+		 "pull_request":{"merged":false,"merged_at":null,"draft":false,"html_url":"https://x/pulls/2"}}]`)
+	issues, err := c.ListIssues(context.Background(), "owner/repo", "open", "", true)
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Number != 1 {
+		t.Fatalf("issues = %+v, want the pull entry dropped", issues)
+	}
+}
+
+func TestListIssues_HTTPError(t *testing.T) {
+	c, _ := staticReads(t, 500, `{"message":"boom"}`)
+	if _, err := c.ListIssues(context.Background(), "owner/repo", "open", "", true); err == nil {
+		t.Fatal("a non-2xx listing must surface as an error, not an empty set")
+	}
+}
+
+func TestGetIssue(t *testing.T) {
+	c, seen := staticReads(t, 200,
+		`{"number":7,"title":"t","body":"full body","state":"closed",
+		  "labels":[{"id":1,"name":"maestro-ready","color":"00aabb"}],"pull_request":null}`)
+	is, err := c.GetIssue(context.Background(), "owner/repo", 7)
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if is.Number != 7 || is.Body != "full body" || is.State != "closed" {
+		t.Fatalf("issue = %+v", is)
+	}
+	if is.PullRequest != nil {
+		t.Fatalf("a real issue's null pull_request must decode to nil, got %+v", is.PullRequest)
+	}
+	if len(is.Labels) != 1 || is.Labels[0].Name != "maestro-ready" {
+		t.Fatalf("labels = %+v", is.Labels)
+	}
+	req := (*seen)[0]
+	if req.Method != http.MethodGet || req.Path != "/repos/owner/repo/issues/7" {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+}
+
+func TestGetIssue_PullIndexCarriesMarker(t *testing.T) {
+	// Shared number space: GET /issues/{n} on a pull index answers 200 with
+	// an issue shape whose pull_request is populated. The marker must survive
+	// so callers can keep their != nil belt.
+	c, _ := staticReads(t, 200,
+		`{"number":1,"title":"pr","state":"closed","labels":[],
+		  "pull_request":{"merged":true,"merged_at":"2026-07-31T21:55:11Z","draft":false}}`)
+	is, err := c.GetIssue(context.Background(), "owner/repo", 1)
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if is.PullRequest == nil {
+		t.Fatal("a pull index must surface a non-nil PullRequest marker")
+	}
+	if !is.PullRequest.Merged || is.PullRequest.MergedAt == nil {
+		t.Fatalf("marker = %+v", is.PullRequest)
+	}
+}
+
+func TestGetIssue_HTTPError(t *testing.T) {
+	c, _ := staticReads(t, 404, `{"message":"not found"}`)
+	if _, err := c.GetIssue(context.Background(), "owner/repo", 999); err == nil {
+		t.Fatal("a 404 must surface as an error")
+	}
+}
+
+func TestListIssueComments(t *testing.T) {
+	c, seen := staticReads(t, 200, `[
+		{"id":101,"body":"first","user":{"login":"alice"},"created_at":"2026-08-01T10:00:00Z","updated_at":"2026-08-01T10:00:00Z"},
+		{"id":102,"body":"second","user":{"login":"bob"},"created_at":"2026-08-02T10:00:00Z","updated_at":"2026-08-02T10:00:00Z"}]`)
+	comments, err := c.ListIssueComments(context.Background(), "owner/repo", 7)
+	if err != nil {
+		t.Fatalf("ListIssueComments: %v", err)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("comments = %d, want 2", len(comments))
+	}
+	want := IssueComment{ID: 101, Body: "first", Author: "alice", CreatedAt: "2026-08-01T10:00:00Z"}
+	if comments[0] != want {
+		t.Fatalf("comments[0] = %+v, want %+v", comments[0], want)
+	}
+	req := (*seen)[0]
+	if req.Path != "/repos/owner/repo/issues/7/comments" {
+		t.Fatalf("path = %s", req.Path)
+	}
+	// The endpoint has no page/limit params — sending them would be dead
+	// weight at best and a behavior change on a future server at worst.
+	if req.Query.Get("page") != "" || req.Query.Get("limit") != "" {
+		t.Fatalf("comments must not be paginated, query = %v", req.Query)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %d, want 1 (single-response endpoint)", len(*seen))
+	}
+}
+
+func TestIssueLabels(t *testing.T) {
+	c, seen := staticReads(t, 200,
+		`[{"id":1,"name":"maestro-ready","color":"00aabb"},{"id":2,"name":"enhancement","color":"84b6eb"}]`)
+	names, err := c.IssueLabels(context.Background(), "owner/repo", 36)
+	if err != nil {
+		t.Fatalf("IssueLabels: %v", err)
+	}
+	if len(names) != 2 || names[0] != "maestro-ready" || names[1] != "enhancement" {
+		t.Fatalf("names = %v", names)
+	}
+	req := (*seen)[0]
+	if req.Path != "/repos/owner/repo/issues/36/labels" {
+		t.Fatalf("path = %s", req.Path)
+	}
+	if req.Query.Get("page") != "" || req.Query.Get("limit") != "" {
+		t.Fatalf("labels must not be paginated, query = %v", req.Query)
+	}
+}
+
+func TestListPulls(t *testing.T) {
+	// Server order must be preserved verbatim: sort=recentupdate delivers
+	// updated-desc and the client must not re-sort.
+	c, seen := staticReads(t, 200, `[
+		{"number":33,"title":"newer","body":"b","state":"open","draft":true,"mergeable":true,
+		 "merged_at":null,"merge_commit_sha":null,
+		 "head":{"ref":"feat/a","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},"base":{"ref":"main"}},
+		{"number":34,"title":"older","body":"","state":"open","draft":false,"mergeable":true,
+		 "merged_at":null,"merge_commit_sha":null,
+		 "head":{"ref":"feat/b","sha":"dfc9446cb6a16c60075286299cd07d2cb655769a"},"base":{"ref":"main"}}]`)
+	pulls, err := c.ListPulls(context.Background(), "owner/repo", "all", true)
+	if err != nil {
+		t.Fatalf("ListPulls: %v", err)
+	}
+	if len(pulls) != 2 || pulls[0].Number != 33 || pulls[1].Number != 34 {
+		t.Fatalf("pulls = %+v, want server order preserved", pulls)
+	}
+	first := pulls[0]
+	if first.Title != "newer" || !first.Draft || first.HeadRef != "feat/a" || first.BaseRef != "main" {
+		t.Fatalf("first pull = %+v", first)
+	}
+	if first.HeadSHA != "59e99c49c27d3e2f73bae1657f07cd2f9a15f926" {
+		t.Fatalf("head sha = %q", first.HeadSHA)
+	}
+	if first.MergedAt != nil || first.MergeCommitSHA != "" {
+		t.Fatalf("unmerged pull must carry nil MergedAt and empty MergeCommitSHA, got %+v", first)
+	}
+	req := (*seen)[0]
+	if req.Method != http.MethodGet || req.Path != "/repos/owner/repo/pulls" {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+	for key, want := range map[string]string{
+		"sort":  "recentupdate", // default server order is index-desc, NOT updated-desc
+		"state": "all",
+		"limit": strconv.Itoa(pageSize),
+		"page":  "1",
+	} {
+		if got := req.Query.Get(key); got != want {
+			t.Fatalf("query %s = %q, want %q (full query: %v)", key, got, want, req.Query)
+		}
+	}
+}
+
+func TestListPulls_HTTPError(t *testing.T) {
+	c, _ := staticReads(t, 502, `bad gateway`)
+	if _, err := c.ListPulls(context.Background(), "owner/repo", "open", true); err == nil {
+		t.Fatal("a non-2xx listing must surface as an error")
+	}
+}
+
+func TestGetPull_Merged(t *testing.T) {
+	// The live-verified merged shape: state stays lowercase "closed",
+	// merged_at is RFC3339, merge_commit_sha is 40-hex.
+	c, seen := staticReads(t, 200,
+		`{"number":2,"title":"gate","body":"pr body","state":"closed","draft":false,
+		  "mergeable":true,"merged":true,"merged_at":"2026-07-31T21:55:11Z",
+		  "merge_commit_sha":"dfc9446cb6a16c60075286299cd07d2cb655769a",
+		  "head":{"ref":"canary/llm-review-e2e","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},
+		  "base":{"ref":"main"}}`)
+	p, err := c.GetPull(context.Background(), "owner/repo", 2)
+	if err != nil {
+		t.Fatalf("GetPull: %v", err)
+	}
+	if p.Number != 2 || p.Title != "gate" || p.Body != "pr body" {
+		t.Fatalf("pull = %+v", p)
+	}
+	if p.State != "closed" {
+		t.Fatalf("state = %q, want lowercase verbatim (the gh layer upper-cases)", p.State)
+	}
+	if p.Mergeable == nil || !*p.Mergeable {
+		t.Fatalf("mergeable = %v", p.Mergeable)
+	}
+	if p.MergedAt == nil || *p.MergedAt != "2026-07-31T21:55:11Z" {
+		t.Fatalf("merged_at = %v", p.MergedAt)
+	}
+	if len(p.MergeCommitSHA) != 40 {
+		t.Fatalf("merge_commit_sha = %q, want 40-hex (PRMergeInfo asserts on it)", p.MergeCommitSHA)
+	}
+	if p.HeadRef != "canary/llm-review-e2e" || p.BaseRef != "main" {
+		t.Fatalf("refs = %q / %q — slashes must survive verbatim", p.HeadRef, p.BaseRef)
+	}
+	req := (*seen)[0]
+	if req.Path != "/repos/owner/repo/pulls/2" {
+		t.Fatalf("path = %s", req.Path)
+	}
+}
+
+func TestGetPull_Unmerged(t *testing.T) {
+	c, _ := staticReads(t, 200,
+		`{"number":1,"title":"open pr","body":null,"state":"open","draft":false,
+		  "mergeable":true,"merged":false,"merged_at":null,"merge_commit_sha":null,
+		  "head":{"ref":"feat/x","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},"base":{"ref":"main"}}`)
+	p, err := c.GetPull(context.Background(), "owner/repo", 1)
+	if err != nil {
+		t.Fatalf("GetPull: %v", err)
+	}
+	if p.MergedAt != nil {
+		t.Fatalf("merged_at = %v, want nil on an unmerged pull", p.MergedAt)
+	}
+	if p.MergeCommitSHA != "" {
+		t.Fatalf("merge_commit_sha = %q, want empty on an unmerged pull", p.MergeCommitSHA)
+	}
+	if p.Body != "" {
+		t.Fatalf("a null body must decode to empty, got %q", p.Body)
+	}
+}
+
+func TestGetPull_HTTPError(t *testing.T) {
+	// A real-issue index answers 404 on /pulls/{n} (shared number space).
+	c, _ := staticReads(t, 404, `{"message":"not found"}`)
+	if _, err := c.GetPull(context.Background(), "owner/repo", 36); err == nil {
+		t.Fatal("a 404 must surface as an error")
+	}
+}
+
+func TestDefaultBranch(t *testing.T) {
+	c, seen := staticReads(t, 200, `{"name":"apertune","default_branch":"main"}`)
+	branch, err := c.DefaultBranch(context.Background(), "owner/repo")
+	if err != nil {
+		t.Fatalf("DefaultBranch: %v", err)
+	}
+	if branch != "main" {
+		t.Fatalf("branch = %q", branch)
+	}
+	req := (*seen)[0]
+	if req.Method != http.MethodGet || req.Path != "/repos/owner/repo" {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+}
+
+func TestDefaultBranch_EmptyIsError(t *testing.T) {
+	c, _ := staticReads(t, 200, `{"name":"empty-repo"}`)
+	if _, err := c.DefaultBranch(context.Background(), "owner/repo"); err == nil {
+		t.Fatal("a missing default branch must error — base-branch logic anchors to it")
+	}
+}
+
+func TestBranchHeadSHA(t *testing.T) {
+	// The head SHA lives in commit.id (Branch.commit is a PayloadCommit); a
+	// top-level "sha" decoy guards against regressing to the commits-list
+	// shape.
+	c, seen := staticReads(t, 200,
+		`{"name":"canary/llm-review-e2e","sha":"decoy",
+		  "commit":{"id":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926","message":"m"}}`)
+	sha, err := c.BranchHeadSHA(context.Background(), "owner/repo", "canary/llm-review-e2e")
+	if err != nil {
+		t.Fatalf("BranchHeadSHA: %v", err)
+	}
+	if sha != "59e99c49c27d3e2f73bae1657f07cd2f9a15f926" {
+		t.Fatalf("sha = %q", sha)
+	}
+	req := (*seen)[0]
+	if req.Path != "/repos/owner/repo/branches/canary%2Fllm-review-e2e" {
+		t.Fatalf("path = %s, want the slash percent-escaped", req.Path)
+	}
+}
+
+func TestBranchHeadSHA_EmptySHAIsError(t *testing.T) {
+	c, _ := staticReads(t, 200, `{"name":"b","commit":{"id":"  "}}`)
+	if _, err := c.BranchHeadSHA(context.Background(), "owner/repo", "b"); err == nil {
+		t.Fatal("an empty head sha must be rejected")
+	}
+}
+
+func TestBranchHeadSHA_HTTPError(t *testing.T) {
+	c, _ := staticReads(t, 404, `{"message":"branch does not exist"}`)
+	if _, err := c.BranchHeadSHA(context.Background(), "owner/repo", "gone"); err == nil {
+		t.Fatal("a missing branch must surface as an error")
+	}
+}
+
+func TestReads_ContextCanceled(t *testing.T) {
+	c, seen := staticReads(t, 200, `[]`)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.ListIssues(ctx, "owner/repo", "open", "", true); err == nil {
+		t.Fatal("ListIssues must fail on a canceled context")
+	}
+	if _, err := c.GetPull(ctx, "owner/repo", 1); err == nil {
+		t.Fatal("GetPull must fail on a canceled context")
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("a canceled context must not reach the API, saw %v", *seen)
+	}
+}

--- a/internal/forgejo/reads_test.go
+++ b/internal/forgejo/reads_test.go
@@ -157,6 +157,95 @@ func TestListIssues_PageCapIsExplicitError(t *testing.T) {
 	}
 }
 
+// newReadsClientWithTotal is newReadsClient plus an x-total-count response
+// header, for the pager's truncation belt.
+func newReadsClientWithTotal(t *testing.T, fn func(r *http.Request) (total int, status int, body string)) (*Client, *[]readReq) {
+	t.Helper()
+	var seen []readReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = append(seen, readReq{
+			Method: r.Method,
+			Path:   r.URL.EscapedPath(),
+			Query:  r.URL.Query(),
+		})
+		total, status, body := fn(r)
+		w.Header().Set("X-Total-Count", strconv.Itoa(total))
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "sekrit"), &seen
+}
+
+// pageSize hardcodes THIS instance's max_response_items clamp. On a server
+// clamped LOWER, every page comes back short, so without the x-total-count
+// belt the short-page stop would end the loop after page one and silently
+// truncate an authoritative read (#827 reconcile would stamp still-open
+// issues closed).
+func TestListIssues_LowerServerClampFailsLoud(t *testing.T) {
+	c, seen := newReadsClientWithTotal(t, func(*http.Request) (int, int, string) {
+		return 120, 200, issuesPage(t, 1, 25) // clamp 25 < pageSize, 120 total
+	})
+	_, err := c.ListIssues(context.Background(), "owner/repo", "open", "", true)
+	if err == nil {
+		t.Fatal("a short page with more entries outstanding must error, not truncate silently")
+	}
+	if !strings.Contains(err.Error(), "refusing to truncate") {
+		t.Fatalf("error should name the truncation, got: %v", err)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %d, want 1 (the mismatch is detectable on the first short page)", len(*seen))
+	}
+}
+
+// A short final page whose accumulated count MATCHES the server total is the
+// normal end of a listing — the belt must not false-alarm; and a total that
+// shrank mid-scan (an issue closed between pages) must also pass, which is
+// why the pager re-reads the header on every page.
+func TestListIssues_TotalMatchingShortPagePasses(t *testing.T) {
+	c, _ := newReadsClientWithTotal(t, func(r *http.Request) (int, int, string) {
+		switch r.URL.Query().Get("page") {
+		case "1":
+			return pageSize + 3, 200, issuesPage(t, 1, pageSize)
+		case "2":
+			return pageSize + 3, 200, issuesPage(t, 1+pageSize, 3)
+		default:
+			return 0, 500, `{"message":"unexpected page"}`
+		}
+	})
+	issues, err := c.ListIssues(context.Background(), "owner/repo", "open", "", true)
+	if err != nil {
+		t.Fatalf("ListIssues: %v", err)
+	}
+	if len(issues) != pageSize+3 {
+		t.Fatalf("issues = %d, want %d", len(issues), pageSize+3)
+	}
+}
+
+// Exactly maxListPages×pageSize entries: the last allowed page comes back
+// full, but the total says the set is complete — the pager must return it
+// instead of demanding one empty page beyond the cap and erroring.
+func TestListIssues_TotalReachedOnFullFinalPagePasses(t *testing.T) {
+	const exact = maxListPages * pageSize
+	c, seen := newReadsClientWithTotal(t, func(r *http.Request) (int, int, string) {
+		page, _ := strconv.Atoi(r.URL.Query().Get("page"))
+		if page < 1 || page > maxListPages {
+			return 0, 500, `{"message":"page out of range"}`
+		}
+		return exact, 200, issuesPage(t, (page-1)*pageSize+1, pageSize)
+	})
+	issues, err := c.ListIssues(context.Background(), "owner/repo", "open", "", true)
+	if err != nil {
+		t.Fatalf("ListIssues at exactly the cap boundary: %v", err)
+	}
+	if len(issues) != exact {
+		t.Fatalf("issues = %d, want %d", len(issues), exact)
+	}
+	if len(*seen) != maxListPages {
+		t.Fatalf("requests = %d, want exactly %d (no empty page beyond the cap)", len(*seen), maxListPages)
+	}
+}
+
 func TestListIssues_FirstPageOnlyWhenAllPagesFalse(t *testing.T) {
 	c, seen := newReadsClient(t, func(*http.Request) (int, string) {
 		return 200, issuesPage(t, 1, pageSize)

--- a/internal/forgejo/reads_test.go
+++ b/internal/forgejo/reads_test.go
@@ -483,6 +483,113 @@ func TestBranchHeadSHA_HTTPError(t *testing.T) {
 	}
 }
 
+func TestListPullCommits(t *testing.T) {
+	// commit.message carries a trailing "\n" on the wire (live-verified);
+	// it must survive verbatim — headline extraction is the gh layer's job.
+	c, seen := staticReads(t, 200,
+		`[{"sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926","commit":{"message":"feat: first\n\nbody\n"}},
+		  {"sha":"dfc9446cb6a16c60075286299cd07d2cb655769a","commit":{"message":"fix: second\n"}}]`)
+	commits, err := c.ListPullCommits(context.Background(), "owner/repo", 1, true)
+	if err != nil {
+		t.Fatalf("ListPullCommits: %v", err)
+	}
+	if len(commits) != 2 {
+		t.Fatalf("commits = %+v", commits)
+	}
+	if commits[0].SHA != "59e99c49c27d3e2f73bae1657f07cd2f9a15f926" || commits[0].Message != "feat: first\n\nbody\n" {
+		t.Fatalf("first commit = %+v, want the message verbatim incl. trailing newline", commits[0])
+	}
+	req := (*seen)[0]
+	if req.Path != "/repos/owner/repo/pulls/1/commits" {
+		t.Fatalf("path = %s", req.Path)
+	}
+	if req.Query.Get("limit") != strconv.Itoa(pageSize) || req.Query.Get("page") != "1" {
+		t.Fatalf("commits list must be paginated, query = %v", req.Query)
+	}
+}
+
+func TestListPullCommits_Pagination(t *testing.T) {
+	commit := `{"sha":"%040d","commit":{"message":"c %d\n"}}`
+	page := func(from, n int) string {
+		items := make([]string, 0, n)
+		for i := 0; i < n; i++ {
+			items = append(items, fmt.Sprintf(commit, from+i, from+i))
+		}
+		return "[" + strings.Join(items, ",") + "]"
+	}
+	c, seen := newReadsClient(t, func(r *http.Request) (int, string) {
+		switch r.URL.Query().Get("page") {
+		case "1":
+			return 200, page(1, pageSize)
+		case "2":
+			return 200, page(1+pageSize, 2)
+		default:
+			return 200, "[]"
+		}
+	})
+	commits, err := c.ListPullCommits(context.Background(), "owner/repo", 1, true)
+	if err != nil {
+		t.Fatalf("ListPullCommits: %v", err)
+	}
+	if len(commits) != pageSize+2 {
+		t.Fatalf("commits = %d, want %d", len(commits), pageSize+2)
+	}
+	if len(*seen) != 2 {
+		t.Fatalf("requests = %d, want 2", len(*seen))
+	}
+}
+
+func TestListPullCommits_HTTPError(t *testing.T) {
+	c, _ := staticReads(t, 500, `{"message":"boom"}`)
+	if _, err := c.ListPullCommits(context.Background(), "owner/repo", 1, true); err == nil {
+		t.Fatal("a 500 must surface as an error")
+	}
+}
+
+func TestListPullFiles(t *testing.T) {
+	c, seen := staticReads(t, 200,
+		`[{"filename":"cmd/main.go","status":"modified","additions":1,"deletions":0},
+		  {"filename":"web/app.css","status":"added","additions":9,"deletions":0}]`)
+	files, err := c.ListPullFiles(context.Background(), "owner/repo", 1, true)
+	if err != nil {
+		t.Fatalf("ListPullFiles: %v", err)
+	}
+	if len(files) != 2 || files[0] != "cmd/main.go" || files[1] != "web/app.css" {
+		t.Fatalf("files = %v", files)
+	}
+	req := (*seen)[0]
+	if req.Path != "/repos/owner/repo/pulls/1/files" {
+		t.Fatalf("path = %s", req.Path)
+	}
+	if req.Query.Get("limit") != strconv.Itoa(pageSize) || req.Query.Get("page") != "1" {
+		t.Fatalf("files list must be paginated, query = %v", req.Query)
+	}
+}
+
+func TestListPullFiles_FirstPageOnlyWhenAllPagesFalse(t *testing.T) {
+	c, seen := newReadsClient(t, func(r *http.Request) (int, string) {
+		items := make([]string, 0, pageSize)
+		for i := 0; i < pageSize; i++ {
+			items = append(items, fmt.Sprintf(`{"filename":"f%d.go"}`, i))
+		}
+		return 200, "[" + strings.Join(items, ",") + "]"
+	})
+	files, err := c.ListPullFiles(context.Background(), "owner/repo", 1, false)
+	if err != nil {
+		t.Fatalf("ListPullFiles: %v", err)
+	}
+	if len(files) != pageSize || len(*seen) != 1 {
+		t.Fatalf("files = %d requests = %d, want one full page and no follow-up", len(files), len(*seen))
+	}
+}
+
+func TestListPullFiles_HTTPError(t *testing.T) {
+	c, _ := staticReads(t, 404, `{"message":"not found"}`)
+	if _, err := c.ListPullFiles(context.Background(), "owner/repo", 9, true); err == nil {
+		t.Fatal("a 404 must surface as an error")
+	}
+}
+
 func TestReads_ContextCanceled(t *testing.T) {
 	c, seen := staticReads(t, 200, `[]`)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/github/forgejo_failloud_test.go
+++ b/internal/github/forgejo_failloud_test.go
@@ -33,11 +33,12 @@ func stubGHNeverCalled(t *testing.T) *atomic.Int64 {
 	return &calls
 }
 
-// TestForgejoModeFailsLoud pins the M2 stage-C invariant: on a forgejo-mode
-// client EVERY unported receiver method fails with ErrForgejoNotSupported and
-// the gh CLI is never touched. One sample method per receiver-choke shape and
-// per file (github.go, github_projects.go, review_threads.go,
-// visual_evidence.go).
+// TestForgejoModeFailsLoud pins the M2 invariant: on a forgejo-mode client
+// EVERY still-unported receiver method fails with ErrForgejoNotSupported and
+// the gh CLI is never touched — one sample per receiver-choke shape, plus one
+// per explicit early guard (the methods that would otherwise half-work now
+// that the core-read funnels are ported). visual_evidence.go no longer
+// contributes a sample: both of its methods are ported.
 func TestForgejoModeFailsLoud(t *testing.T) {
 	t.Setenv("TEST_FORGEJO_TOKEN", "x")
 	calls := stubGHNeverCalled(t)
@@ -58,12 +59,18 @@ func TestForgejoModeFailsLoud(t *testing.T) {
 		name string
 		call func() error
 	}{
-		// github.go — c.ghAPI funnel (getRESTPull under PRCIStatus/PRMergeStatus).
+		// github.go — explicit early guards (their first transport touch is a
+		// ported read, or they swallow downstream errors by design; without
+		// the guard they would half-work — see the M2 spec's NOT-ported list).
 		{"PRCIStatus", func() error { _, err := c.PRCIStatus(1); return err }},
 		{"PRMergeStatus", func() error { _, _, err := c.PRMergeStatus(1); return err }},
-		{"GetIssue", func() error { _, err := c.GetIssue(1); return err }},
+		{"PRChecksOutput", func() error { _, err := c.PRChecksOutput(1); return err }},
+		{"CIFailureSummary", func() error { _, err := c.CIFailureSummary(1); return err }},
+		{"CollectPRReviewFeedback", func() error { _, err := c.CollectPRReviewFeedback(1, nil); return err }},
+		// github.go — c.ghAPI funnel.
+		{"RateLimit", func() error { _, err := c.RateLimit(); return err }},
 		// github.go — c.ghAPIWithArgs funnel.
-		{"ListAllOpenPRs", func() error { _, err := c.ListAllOpenPRs(); return err }},
+		{"checkRunsForSHA", func() error { _, err := c.checkRunsForSHA("59e99c49c27d3e2f73bae1657f07cd2f9a15f926"); return err }},
 		// github.go — c.ghExec funnel (writes).
 		{"CreatePR", func() error { _, err := c.CreatePR("t", "b", "main", "head"); return err }},
 		{"CreateRelease", func() error { return c.CreateRelease("v0.0.1", "t") }},
@@ -71,8 +78,6 @@ func TestForgejoModeFailsLoud(t *testing.T) {
 		{"DiscoverProject", func() error { _, err := c.DiscoverProject(1); return err }},
 		// review_threads.go — GraphQL through c.ghExec.
 		{"PRUnresolvedReviewThreadsOnHead", func() error { _, _, err := c.PRUnresolvedReviewThreadsOnHead(1); return err }},
-		// visual_evidence.go — c.ghAPIWithArgs funnel.
-		{"PRChangedFiles", func() error { _, err := c.PRChangedFiles(1); return err }},
 	}
 	for _, s := range samples {
 		err := s.call()
@@ -91,8 +96,11 @@ func TestForgejoModeFailsLoud(t *testing.T) {
 
 // TestForgejoModeEmptyTokenSurfacesForgeErr pins the construction contract: an
 // empty (or whitespace) token env leaves fj nil and every call surfaces the
-// token fault loudly — naming the env var to export — while staying
-// errors.Is-matchable against the sentinel.
+// token fault loudly, naming the env var to export. PORTED methods surface it
+// as a plain error WITHOUT the sentinel — the operation is supported, the
+// configuration is broken, and a caller branching on ErrForgejoNotSupported
+// to mean "feature absent on this forge" must not confuse the two. Unported
+// methods keep wrapping the sentinel (with the token fault in the message).
 func TestForgejoModeEmptyTokenSurfacesForgeErr(t *testing.T) {
 	t.Setenv("TEST_FORGEJO_TOKEN", "   ")
 	calls := stubGHNeverCalled(t)
@@ -110,12 +118,16 @@ func TestForgejoModeEmptyTokenSurfacesForgeErr(t *testing.T) {
 	}
 
 	samples := []struct {
-		name string
-		call func() error
+		name         string
+		call         func() error
+		wantSentinel bool
 	}{
-		{"GetIssue", func() error { _, err := c.GetIssue(1); return err }},
-		{"ListOpenPRs", func() error { _, err := c.ListOpenPRs(); return err }},
-		{"CreatePR", func() error { _, err := c.CreatePR("t", "b", "main", "head"); return err }},
+		// Ported reads: the token fault, no sentinel.
+		{"GetIssue", func() error { _, err := c.GetIssue(1); return err }, false},
+		{"ListOpenPRs", func() error { _, err := c.ListOpenPRs(); return err }, false},
+		{"BranchHeadSHA", func() error { _, err := c.BranchHeadSHA("main"); return err }, false},
+		// Unported write: sentinel, with the token fault in the message.
+		{"CreatePR", func() error { _, err := c.CreatePR("t", "b", "main", "head"); return err }, true},
 	}
 	for _, s := range samples {
 		err := s.call()
@@ -126,8 +138,8 @@ func TestForgejoModeEmptyTokenSurfacesForgeErr(t *testing.T) {
 		if !strings.Contains(err.Error(), "TEST_FORGEJO_TOKEN") {
 			t.Errorf("%s: err = %v, want the empty token env named", s.name, err)
 		}
-		if !errors.Is(err, ErrForgejoNotSupported) {
-			t.Errorf("%s: err = %v, not errors.Is-matchable against ErrForgejoNotSupported", s.name, err)
+		if got := errors.Is(err, ErrForgejoNotSupported); got != s.wantSentinel {
+			t.Errorf("%s: errors.Is(err, ErrForgejoNotSupported) = %v, want %v (err = %v)", s.name, got, s.wantSentinel, err)
 		}
 	}
 	if n := calls.Load(); n != 0 {

--- a/internal/github/forgejo_failloud_test.go
+++ b/internal/github/forgejo_failloud_test.go
@@ -1,0 +1,148 @@
+package github
+
+import (
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// stubGHNeverCalled arms the gh transport so that ANY leak from a forgejo-mode
+// client to the gh CLI is caught two ways: the ghAPIRunner seam counts (and
+// fails) an invocation, and ghExecutable points at a nonexistent binary so a
+// path bypassing the seam (ghExec / ghOutputContext shapes) cannot silently
+// reach the real gh — the repo is mirrored on github.com, so a leaked call
+// would read the GitHub mirror instead of the Forgejo original (#1172 P0).
+func stubGHNeverCalled(t *testing.T) *atomic.Int64 {
+	t.Helper()
+	var calls atomic.Int64
+	origRunner := ghAPIRunner
+	origExecutable := ghExecutable
+	ghAPIRunner = func(args ...string) ([]byte, error) {
+		calls.Add(1)
+		t.Errorf("ghAPIRunner invoked in forgejo mode: gh %v", args)
+		return nil, errors.New("gh must not be called in forgejo mode")
+	}
+	ghExecutable = "/nonexistent/forgejo-mode-must-not-exec-gh"
+	t.Cleanup(func() {
+		ghAPIRunner = origRunner
+		ghExecutable = origExecutable
+	})
+	return &calls
+}
+
+// TestForgejoModeFailsLoud pins the M2 stage-C invariant: on a forgejo-mode
+// client EVERY unported receiver method fails with ErrForgejoNotSupported and
+// the gh CLI is never touched. One sample method per receiver-choke shape and
+// per file (github.go, github_projects.go, review_threads.go,
+// visual_evidence.go).
+func TestForgejoModeFailsLoud(t *testing.T) {
+	t.Setenv("TEST_FORGEJO_TOKEN", "x")
+	calls := stubGHNeverCalled(t)
+
+	c := New("BeFeast/apertune", config.ForgeConfig{
+		Kind:     "forgejo",
+		BaseURL:  "http://forgejo.test",
+		TokenEnv: "TEST_FORGEJO_TOKEN",
+	})
+	if c.fj == nil {
+		t.Fatalf("fj = nil, want constructed forgejo client when token env is set")
+	}
+	if c.forgeErr != nil {
+		t.Fatalf("forgeErr = %v, want nil when token env is set", c.forgeErr)
+	}
+
+	samples := []struct {
+		name string
+		call func() error
+	}{
+		// github.go — c.ghAPI funnel (getRESTPull under PRCIStatus/PRMergeStatus).
+		{"PRCIStatus", func() error { _, err := c.PRCIStatus(1); return err }},
+		{"PRMergeStatus", func() error { _, _, err := c.PRMergeStatus(1); return err }},
+		{"GetIssue", func() error { _, err := c.GetIssue(1); return err }},
+		// github.go — c.ghAPIWithArgs funnel.
+		{"ListAllOpenPRs", func() error { _, err := c.ListAllOpenPRs(); return err }},
+		// github.go — c.ghExec funnel (writes).
+		{"CreatePR", func() error { _, err := c.CreatePR("t", "b", "main", "head"); return err }},
+		{"CreateRelease", func() error { return c.CreateRelease("v0.0.1", "t") }},
+		// github_projects.go — c.ghOutputContext funnel (GraphQL Projects).
+		{"DiscoverProject", func() error { _, err := c.DiscoverProject(1); return err }},
+		// review_threads.go — GraphQL through c.ghExec.
+		{"PRUnresolvedReviewThreadsOnHead", func() error { _, _, err := c.PRUnresolvedReviewThreadsOnHead(1); return err }},
+		// visual_evidence.go — c.ghAPIWithArgs funnel.
+		{"PRChangedFiles", func() error { _, err := c.PRChangedFiles(1); return err }},
+	}
+	for _, s := range samples {
+		err := s.call()
+		if err == nil {
+			t.Errorf("%s: err = nil, want ErrForgejoNotSupported", s.name)
+			continue
+		}
+		if !errors.Is(err, ErrForgejoNotSupported) {
+			t.Errorf("%s: err = %v, not errors.Is-matchable against ErrForgejoNotSupported", s.name, err)
+		}
+	}
+	if n := calls.Load(); n != 0 {
+		t.Fatalf("gh runner invoked %d time(s) in forgejo mode, want 0", n)
+	}
+}
+
+// TestForgejoModeEmptyTokenSurfacesForgeErr pins the construction contract: an
+// empty (or whitespace) token env leaves fj nil and every call surfaces the
+// token fault loudly — naming the env var to export — while staying
+// errors.Is-matchable against the sentinel.
+func TestForgejoModeEmptyTokenSurfacesForgeErr(t *testing.T) {
+	t.Setenv("TEST_FORGEJO_TOKEN", "   ")
+	calls := stubGHNeverCalled(t)
+
+	c := New("BeFeast/apertune", config.ForgeConfig{
+		Kind:     "forgejo",
+		BaseURL:  "http://forgejo.test",
+		TokenEnv: "TEST_FORGEJO_TOKEN",
+	})
+	if c.fj != nil {
+		t.Fatalf("fj != nil, want nil when token env is empty")
+	}
+	if c.forgeErr == nil {
+		t.Fatalf("forgeErr = nil, want token-env error")
+	}
+
+	samples := []struct {
+		name string
+		call func() error
+	}{
+		{"GetIssue", func() error { _, err := c.GetIssue(1); return err }},
+		{"ListOpenPRs", func() error { _, err := c.ListOpenPRs(); return err }},
+		{"CreatePR", func() error { _, err := c.CreatePR("t", "b", "main", "head"); return err }},
+	}
+	for _, s := range samples {
+		err := s.call()
+		if err == nil {
+			t.Errorf("%s: err = nil, want token-env failure", s.name)
+			continue
+		}
+		if !strings.Contains(err.Error(), "TEST_FORGEJO_TOKEN") {
+			t.Errorf("%s: err = %v, want the empty token env named", s.name, err)
+		}
+		if !errors.Is(err, ErrForgejoNotSupported) {
+			t.Errorf("%s: err = %v, not errors.Is-matchable against ErrForgejoNotSupported", s.name, err)
+		}
+	}
+	if n := calls.Load(); n != 0 {
+		t.Fatalf("gh runner invoked %d time(s) in forgejo mode, want 0", n)
+	}
+}
+
+// TestGitHubModeZeroForgeConfig pins that a zero config.ForgeConfig builds the
+// historical GitHub-mode client: no forgejo routing, no forge error.
+func TestGitHubModeZeroForgeConfig(t *testing.T) {
+	c := New("owner/repo", config.ForgeConfig{})
+	if c.isForgejo() {
+		t.Fatalf("isForgejo() = true for zero ForgeConfig, want false")
+	}
+	if c.forgeErr != nil || c.fj != nil {
+		t.Fatalf("zero ForgeConfig client carries forge state: fj=%v forgeErr=%v", c.fj, c.forgeErr)
+	}
+}

--- a/internal/github/forgejo_port.go
+++ b/internal/github/forgejo_port.go
@@ -1,0 +1,313 @@
+// Forgejo-side implementations of the ported core-read funnels (#1172 M2).
+//
+// Dispatch happens at the FUNNELS: each fj* method here maps Forgejo wire
+// types (internal/forgejo) into the existing internal structs — restIssue,
+// restPull, IssueComment — so restIssue.issue() / restPull.pr() and every
+// derived method (PRDetails, PRHeadSHA, PRMergeInfo, IsPRMerged, PRMergeable,
+// MergedPRNumberForIssue, HasOpenPRForIssue, ...) run unchanged on both
+// forges.
+//
+// Mapping contract (live-verified against Forgejo 16.0.1, 2026-08-11):
+//
+//   - state is "open"|"closed" lowercase verbatim on issues AND pulls — same
+//     as GitHub REST, so restPull.pr()'s upper-casing and
+//     restIssueStateClosed() work unchanged; a merged pull is state=closed
+//     with merged_at set;
+//   - merged_at is null when unmerged / RFC3339 when merged, and
+//     merge_commit_sha is null-or-40-hex under the same rule, so
+//     PRMergeInfo's 40-hex assert holds;
+//   - mergeable is a plain bool on the wire (true observed even on merged
+//     pulls — NOT GitHub's tri-state), carried as *bool so
+//     mergeableFromRESTPull takes the bool branch when present;
+//   - mergeable_state has NO Forgejo equivalent: restPull.MergeableState is
+//     always "" here, which is why PRMergeStatus keeps an explicit
+//     NOT-ported guard (an empty raw state reads as "don't know, proceed");
+//   - draft is a plain bool.
+//
+// Methods that stay UNPORTED keep failing loud with ErrForgejoNotSupported
+// through the receiver chokes; the handful that would otherwise half-work
+// after this port (their first transport touch is now a ported read, or they
+// swallow downstream errors by design) carry explicit early guards in
+// github.go — see the "NOT ported in M2" list in the M2 spec.
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/befeast/maestro/internal/forgejo"
+)
+
+// fjTransport returns the Forgejo REST client, or the construction-time
+// fault. An empty token env surfaces here on EVERY ported call — naming the
+// env var to export — as a plain loud error, deliberately NOT wrapped in
+// ErrForgejoNotSupported: the operation IS supported, the configuration is
+// broken, and a caller branching on the sentinel to mean "feature absent on
+// this forge" must not confuse the two.
+func (c *Client) fjTransport() (*forgejo.Client, error) {
+	if c.forgeErr != nil {
+		return nil, fmt.Errorf("repo %s: %w", c.Repo, c.forgeErr)
+	}
+	if c.fj == nil {
+		return nil, fmt.Errorf("repo %s: forgejo transport not initialized", c.Repo)
+	}
+	return c.fj, nil
+}
+
+// fjIssueToREST maps a Forgejo issue into the gh-wire restIssue, preserving
+// the pull_request marker (issues and pulls share one index space on both
+// forges, so the parseRESTIssues belt semantics carry over).
+func fjIssueToREST(is forgejo.Issue) restIssue {
+	body := is.Body
+	ri := restIssue{
+		Number: is.Number,
+		Title:  is.Title,
+		Body:   &body,
+		State:  is.State,
+	}
+	for _, l := range is.Labels {
+		ri.Labels = append(ri.Labels, struct {
+			Name string `json:"name"`
+		}{Name: l.Name})
+	}
+	if is.PullRequest != nil {
+		ri.PullRequest = &struct{}{}
+	}
+	return ri
+}
+
+// fjPullToREST maps a Forgejo pull into the gh-wire restPull. MergeableState
+// is always "" — Forgejo has no equivalent field (see the package comment).
+func fjPullToREST(p forgejo.Pull) restPull {
+	body := p.Body
+	rp := restPull{
+		Number:         p.Number,
+		Title:          p.Title,
+		Body:           &body,
+		State:          p.State,
+		Draft:          p.Draft,
+		Mergeable:      p.Mergeable,
+		MergeableState: "",
+		MergedAt:       p.MergedAt,
+		MergeCommitSHA: p.MergeCommitSHA,
+	}
+	rp.Head.Ref = p.HeadRef
+	rp.Head.SHA = p.HeadSHA
+	rp.Base.Ref = p.BaseRef
+	return rp
+}
+
+// fjListOpenIssuesByLabel backs listOpenIssuesByLabel (allPages=false, the
+// cheap working-set read) and listAllOpenIssuesByLabel (allPages=true, the
+// authoritative reconcile read). forgejo.ListIssues already drops pull
+// entries and re-filters the label client-side (the server silently discards
+// unknown label names); the marker belt here mirrors parseRESTIssues so both
+// transports enforce it at the same layer.
+func (c *Client) fjListOpenIssuesByLabel(label string, allPages bool) ([]Issue, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return nil, err
+	}
+	fjIssues, err := fj.ListIssues(context.Background(), c.Repo, "open", label, allPages)
+	if err != nil {
+		return nil, fmt.Errorf("list open issues: %w", err)
+	}
+	issues := make([]Issue, 0, len(fjIssues))
+	for _, is := range fjIssues {
+		ri := fjIssueToREST(is)
+		if ri.PullRequest != nil {
+			continue
+		}
+		issues = append(issues, ri.issue())
+	}
+	return issues, nil
+}
+
+func (c *Client) fjGetIssue(number int) (Issue, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return Issue{}, err
+	}
+	is, err := fj.GetIssue(context.Background(), c.Repo, number)
+	if err != nil {
+		return Issue{}, fmt.Errorf("get issue %d: %w", number, err)
+	}
+	// Verbatim like parseRESTIssue: a pull index returns its issue shape
+	// (shared number space); callers keep their own pull_request belt.
+	return fjIssueToREST(is).issue(), nil
+}
+
+func (c *Client) fjIsIssueClosed(number int) (bool, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return false, err
+	}
+	is, err := fj.GetIssue(context.Background(), c.Repo, number)
+	if err != nil {
+		return false, fmt.Errorf("get issue %d: %w", number, err)
+	}
+	return restIssueStateClosed(is.State), nil
+}
+
+// fjListPulls backs ListOpenPRs/listClosedPRs (allPages=false — first page,
+// like the gh single-page reads; Forgejo's server clamp makes that 50 entries
+// vs gh's 100, fine at homelab scale) and ListAllOpenPRs (allPages=true).
+// forgejo.ListPulls always sends sort=recentupdate, giving the same
+// newest-updated-first order as the gh path's sort=updated&direction=desc —
+// listClosedPRs/MergedPRNumberForIssue semantics depend on it.
+func (c *Client) fjListPulls(state string, allPages bool) ([]PR, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return nil, err
+	}
+	pulls, err := fj.ListPulls(context.Background(), c.Repo, state, allPages)
+	if err != nil {
+		return nil, fmt.Errorf("list %s PRs: %w", state, err)
+	}
+	prs := make([]PR, 0, len(pulls))
+	for _, p := range pulls {
+		prs = append(prs, fjPullToREST(p).pr())
+	}
+	return prs, nil
+}
+
+func (c *Client) fjGetRESTPull(prNumber int) (restPull, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return restPull{}, err
+	}
+	p, err := fj.GetPull(context.Background(), c.Repo, prNumber)
+	if err != nil {
+		return restPull{}, err
+	}
+	return fjPullToREST(p), nil
+}
+
+// fjLatestMergedPRGenerations pages the FULL closed set and filters on
+// Base.Ref client-side inside latestMergedPRGenerations — the shared helper
+// the gh path uses, so tie-at-same-second and 40-hex semantics stay
+// identical. The opaque error strings mirror the gh path on purpose: these
+// messages flow into delivery-executor state.
+func (c *Client) fjLatestMergedPRGenerations(ctx context.Context) ([]PRMergeInfo, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return nil, err
+	}
+	deliveryBase, err := c.RepositoryDefaultBranch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	pulls, err := fj.ListPulls(ctx, c.Repo, "closed", true)
+	if err != nil {
+		return nil, errors.New("list merged delivery generations failed")
+	}
+	rest := make([]restPull, 0, len(pulls))
+	for _, p := range pulls {
+		rest = append(rest, fjPullToREST(p))
+	}
+	return latestMergedPRGenerations(rest, deliveryBase)
+}
+
+// fjRepositoryDefaultBranch keeps the gh path's validation (a branch name
+// with query/fragment metacharacters must not reach URL construction) and
+// its opaque read-failure message; only the transport fault (empty token
+// env) surfaces verbatim, because that one names the fix.
+func (c *Client) fjRepositoryDefaultBranch(ctx context.Context) (string, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return "", err
+	}
+	branch, err := fj.DefaultBranch(ctx, c.Repo)
+	if err != nil {
+		return "", errors.New("read repository delivery branch failed")
+	}
+	if strings.ContainsAny(branch, "\r\n?&#") {
+		return "", errors.New("repository delivery branch is invalid")
+	}
+	return branch, nil
+}
+
+func (c *Client) fjBranchHeadSHA(branch string) (string, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return "", err
+	}
+	return fj.BranchHeadSHA(context.Background(), c.Repo, branch)
+}
+
+func (c *Client) fjListIssueComments(issueNumber int) ([]IssueComment, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return nil, err
+	}
+	fjComments, err := fj.ListIssueComments(context.Background(), c.Repo, issueNumber)
+	if err != nil {
+		return nil, fmt.Errorf("list issue comments for #%d: %w", issueNumber, err)
+	}
+	comments := make([]IssueComment, 0, len(fjComments))
+	for _, fc := range fjComments {
+		comments = append(comments, IssueComment{
+			ID:        fc.ID,
+			Body:      fc.Body,
+			Author:    fc.Author,
+			CreatedAt: fc.CreatedAt,
+		})
+	}
+	return comments, nil
+}
+
+func (c *Client) fjPRLabels(prNumber int) ([]string, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return nil, err
+	}
+	names, err := fj.IssueLabels(context.Background(), c.Repo, prNumber)
+	if err != nil {
+		return nil, fmt.Errorf("list PR %d labels: %w", prNumber, err)
+	}
+	return names, nil
+}
+
+// fjPRCommits applies the same headline extraction as parsePRCommits: trim,
+// skip empty, first line only (Forgejo messages carry a trailing newline on
+// the wire).
+func (c *Client) fjPRCommits(prNumber int) ([]string, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return nil, err
+	}
+	commits, err := fj.ListPullCommits(context.Background(), c.Repo, prNumber, true)
+	if err != nil {
+		return nil, fmt.Errorf("list PR %d commits: %w", prNumber, err)
+	}
+	msgs := make([]string, 0, len(commits))
+	for _, commit := range commits {
+		message := strings.TrimSpace(commit.Message)
+		if message == "" {
+			continue
+		}
+		msgs = append(msgs, strings.SplitN(message, "\n", 2)[0])
+	}
+	return msgs, nil
+}
+
+// fjPRChangedFiles mirrors parsePRChangedFiles: trimmed, empties dropped.
+func (c *Client) fjPRChangedFiles(prNumber int) ([]string, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return nil, err
+	}
+	names, err := fj.ListPullFiles(context.Background(), c.Repo, prNumber, true)
+	if err != nil {
+		return nil, fmt.Errorf("list PR %d files: %w", prNumber, err)
+	}
+	files := make([]string, 0, len(names))
+	for _, entry := range names {
+		if name := strings.TrimSpace(entry); name != "" {
+			files = append(files, name)
+		}
+	}
+	return files, nil
+}

--- a/internal/github/forgejo_port.go
+++ b/internal/github/forgejo_port.go
@@ -58,6 +58,39 @@ func (c *Client) fjTransport() (*forgejo.Client, error) {
 	return c.fj, nil
 }
 
+// forgejoCallContext is the context for fj* adapter calls made from ctx-less
+// legacy Client methods. It derives from a context canceled the moment the gh
+// transport's shutdown fail-fast fires (BeginShutdown, #797), giving the
+// forgejo path the same drain semantics the gh path already has: once
+// shutdown begins, an in-flight or newly issued Forgejo HTTP request fails
+// promptly instead of riding out the transport's 30s timeout. Full caller-ctx
+// propagation through the ~80 ctx-less Client method signatures is deferred
+// to the signature modernization; methods that already take a ctx
+// (RepositoryDefaultBranch, LatestMergedPRGenerations) pass the caller's ctx
+// straight through and do not use this.
+//
+// The caller must defer cancel() — it releases the shutdown watcher.
+func forgejoCallContext() (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	shutdown := ghShutdownChan()
+	select {
+	case <-shutdown:
+		// Shutdown already begun: hand out an already-canceled context so the
+		// transport fails fast without even dialing.
+		cancel()
+		return ctx, cancel
+	default:
+	}
+	go func() {
+		select {
+		case <-shutdown:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	return ctx, cancel
+}
+
 // fjIssueToREST maps a Forgejo issue into the gh-wire restIssue, preserving
 // the pull_request marker (issues and pulls share one index space on both
 // forges, so the parseRESTIssues belt semantics carry over).
@@ -129,7 +162,9 @@ func (c *Client) fjListOpenIssuesByLabel(label string, allPages bool) ([]Issue, 
 	if err != nil {
 		return nil, err
 	}
-	fjIssues, err := fj.ListIssues(context.Background(), c.Repo, "open", label, allPages)
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	fjIssues, err := fj.ListIssues(ctx, c.Repo, "open", label, allPages)
 	if err != nil {
 		return nil, fmt.Errorf("list open issues: %w", err)
 	}
@@ -149,7 +184,9 @@ func (c *Client) fjGetIssue(number int) (Issue, error) {
 	if err != nil {
 		return Issue{}, err
 	}
-	is, err := fj.GetIssue(context.Background(), c.Repo, number)
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	is, err := fj.GetIssue(ctx, c.Repo, number)
 	if err != nil {
 		return Issue{}, fmt.Errorf("get issue %d: %w", number, err)
 	}
@@ -163,16 +200,19 @@ func (c *Client) fjIsIssueClosed(number int) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	is, err := fj.GetIssue(context.Background(), c.Repo, number)
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	is, err := fj.GetIssue(ctx, c.Repo, number)
 	if err != nil {
 		return false, fmt.Errorf("get issue %d: %w", number, err)
 	}
 	return restIssueStateClosed(is.State), nil
 }
 
-// fjListPulls backs ListOpenPRs/listClosedPRs (allPages=false — first page,
-// like the gh single-page reads; Forgejo's server clamp makes that 50 entries
-// vs gh's 100, fine at homelab scale) and ListAllOpenPRs (allPages=true).
+// fjListPulls backs ListOpenPRs/listClosedPRs (allPages=false — a bounded
+// 100-item window assembled from clamped 50-item pages, matching the gh
+// single-page per_page=100 reads item for item) and ListAllOpenPRs
+// (allPages=true).
 // forgejo.ListPulls always sends sort=recentupdate, giving the same
 // newest-updated-first order as the gh path's sort=updated&direction=desc —
 // listClosedPRs/MergedPRNumberForIssue semantics depend on it.
@@ -181,7 +221,9 @@ func (c *Client) fjListPulls(state string, allPages bool) ([]PR, error) {
 	if err != nil {
 		return nil, err
 	}
-	pulls, err := fj.ListPulls(context.Background(), c.Repo, state, allPages)
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	pulls, err := fj.ListPulls(ctx, c.Repo, state, allPages)
 	if err != nil {
 		return nil, fmt.Errorf("list %s PRs: %w", state, err)
 	}
@@ -197,7 +239,9 @@ func (c *Client) fjGetRESTPull(prNumber int) (restPull, error) {
 	if err != nil {
 		return restPull{}, err
 	}
-	p, err := fj.GetPull(context.Background(), c.Repo, prNumber)
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	p, err := fj.GetPull(ctx, c.Repo, prNumber)
 	if err != nil {
 		return restPull{}, err
 	}
@@ -253,7 +297,9 @@ func (c *Client) fjBranchHeadSHA(branch string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fj.BranchHeadSHA(context.Background(), c.Repo, branch)
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	return fj.BranchHeadSHA(ctx, c.Repo, branch)
 }
 
 func (c *Client) fjListIssueComments(issueNumber int) ([]IssueComment, error) {
@@ -261,7 +307,9 @@ func (c *Client) fjListIssueComments(issueNumber int) ([]IssueComment, error) {
 	if err != nil {
 		return nil, err
 	}
-	fjComments, err := fj.ListIssueComments(context.Background(), c.Repo, issueNumber)
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	fjComments, err := fj.ListIssueComments(ctx, c.Repo, issueNumber)
 	if err != nil {
 		return nil, fmt.Errorf("list issue comments for #%d: %w", issueNumber, err)
 	}
@@ -282,7 +330,9 @@ func (c *Client) fjPRLabels(prNumber int) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	names, err := fj.IssueLabels(context.Background(), c.Repo, prNumber)
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	names, err := fj.IssueLabels(ctx, c.Repo, prNumber)
 	if err != nil {
 		return nil, fmt.Errorf("list PR %d labels: %w", prNumber, err)
 	}
@@ -297,7 +347,9 @@ func (c *Client) fjPRCommits(prNumber int) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	commits, err := fj.ListPullCommits(context.Background(), c.Repo, prNumber, true)
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	commits, err := fj.ListPullCommits(ctx, c.Repo, prNumber, true)
 	if err != nil {
 		return nil, fmt.Errorf("list PR %d commits: %w", prNumber, err)
 	}
@@ -318,7 +370,9 @@ func (c *Client) fjPRChangedFiles(prNumber int) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	names, err := fj.ListPullFiles(context.Background(), c.Repo, prNumber, true)
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	names, err := fj.ListPullFiles(ctx, c.Repo, prNumber, true)
 	if err != nil {
 		return nil, fmt.Errorf("list PR %d files: %w", prNumber, err)
 	}

--- a/internal/github/forgejo_port.go
+++ b/internal/github/forgejo_port.go
@@ -18,7 +18,9 @@
 //     PRMergeInfo's 40-hex assert holds;
 //   - mergeable is a plain bool on the wire (true observed even on merged
 //     pulls — NOT GitHub's tri-state), carried as *bool so
-//     mergeableFromRESTPull takes the bool branch when present;
+//     mergeableFromRESTPull takes the bool branch when present; it is the
+//     server's Mergeable() predicate, forced false on drafts and during the
+//     async conflict re-check — see fjPullToREST for the parity mapping;
 //   - mergeable_state has NO Forgejo equivalent: restPull.MergeableState is
 //     always "" here, which is why PRMergeStatus keeps an explicit
 //     NOT-ported guard (an empty raw state reads as "don't know, proceed");
@@ -80,15 +82,32 @@ func fjIssueToREST(is forgejo.Issue) restIssue {
 
 // fjPullToREST maps a Forgejo pull into the gh-wire restPull. MergeableState
 // is always "" — Forgejo has no equivalent field (see the package comment).
+//
+// Mergeable parity (live-verified on a Forgejo 16.0 instance, 41/41 draft
+// pulls): Forgejo's wire mergeable is the server-side Mergeable() predicate,
+// which is false while the async conflict re-check runs AND on every
+// draft/WIP pull regardless of conflicts. GitHub's bool answers only "can a
+// merge commit be created" (null while computing, true on clean drafts), so a
+// draft's false carries zero conflict information here — mapping it through
+// would turn EVERY draft PR into "CONFLICTING" and e.g. openPRNeedsRepair
+// would authorize repair on it each cycle. Drop the draft-contaminated false
+// to nil so mergeableFromRESTPull answers "UNKNOWN", exactly GitHub's
+// not-computed state. The non-draft checking-window false (seconds after a
+// push, indistinguishable from a real conflict on the wire) remains an
+// accepted transient until the M4 merge-semantics slice.
 func fjPullToREST(p forgejo.Pull) restPull {
 	body := p.Body
+	mergeable := p.Mergeable
+	if p.Draft && mergeable != nil && !*mergeable {
+		mergeable = nil
+	}
 	rp := restPull{
 		Number:         p.Number,
 		Title:          p.Title,
 		Body:           &body,
 		State:          p.State,
 		Draft:          p.Draft,
-		Mergeable:      p.Mergeable,
+		Mergeable:      mergeable,
 		MergeableState: "",
 		MergedAt:       p.MergedAt,
 		MergeCommitSHA: p.MergeCommitSHA,

--- a/internal/github/forgejo_port_test.go
+++ b/internal/github/forgejo_port_test.go
@@ -383,6 +383,34 @@ func TestForgejoPortGetRESTPullDerivedUnmerged(t *testing.T) {
 	}
 }
 
+// Forgejo's wire mergeable is the server-side Mergeable() predicate, forced
+// false on EVERY draft/WIP pull regardless of conflicts (live-verified: 41/41
+// draft pulls on a Forgejo 16.0 instance report false). GitHub's bool stays
+// true on a clean draft, so mapping the draft false through would flip every
+// draft PR to "CONFLICTING" and openPRNeedsRepair would authorize repair on it
+// each cycle. The port drops the contaminated false to nil → "UNKNOWN".
+func TestForgejoPortDraftMergeableFalseIsUnknown(t *testing.T) {
+	pullPath := "/repos/" + fjTestRepo + "/pulls/3"
+	c, _, ghCalls := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		pullPath: `{"number":3,"title":"draft pr","body":"wip","state":"open","draft":true,
+			"mergeable":false,"merged":false,"merged_at":null,"merge_commit_sha":null,
+			"head":{"ref":"feat/wip","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},
+			"base":{"ref":"main"}}`,
+	}))
+
+	mergeable, err := c.PRMergeable(3)
+	if err != nil || mergeable != "UNKNOWN" {
+		t.Fatalf("PRMergeable on a draft = %q, %v; want UNKNOWN (draft false carries no conflict information)", mergeable, err)
+	}
+	pr, err := c.PRDetails(3)
+	if err != nil || !pr.IsDraft {
+		t.Fatalf("PRDetails = %+v, %v; draft flag must survive the mapping", pr, err)
+	}
+	if n := ghCalls.Load(); n != 0 {
+		t.Fatalf("gh runner invoked %d time(s), want 0", n)
+	}
+}
+
 func TestForgejoPortLatestMergedPRGenerationsBaseFilter(t *testing.T) {
 	repoPath := "/repos/" + fjTestRepo
 	pullsPath := "/repos/" + fjTestRepo + "/pulls"

--- a/internal/github/forgejo_port_test.go
+++ b/internal/github/forgejo_port_test.go
@@ -8,6 +8,7 @@ package github
 // mirrored on github.com, so a leaked read would consult the GitHub mirror.
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,6 +18,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/befeast/maestro/internal/config"
 )
@@ -186,13 +188,19 @@ func TestForgejoPortListAllOpenIssuesPaginates(t *testing.T) {
 	if len(*seen) != 2 {
 		t.Fatalf("requests = %d, want 2 (page 2 is short and ends the loop)", len(*seen))
 	}
-	// The single-page variant must NOT paginate.
+	// The bounded variant assembles the gh-parity 100-item window from
+	// clamped pages: page 1 is full so page 2 is fetched, the short page ends
+	// the read below the window, and nothing beyond is requested.
 	*seen = nil
-	if _, err := c.ListOpenIssues(nil); err != nil {
+	bounded, err := c.ListOpenIssues(nil)
+	if err != nil {
 		t.Fatalf("ListOpenIssues: %v", err)
 	}
-	if len(*seen) != 1 {
-		t.Fatalf("single-page read made %d requests, want 1", len(*seen))
+	if len(bounded) != 53 {
+		t.Fatalf("bounded issues = %d, want all 53 (set smaller than the 100-item window)", len(bounded))
+	}
+	if len(*seen) != 2 {
+		t.Fatalf("bounded read made %d requests, want 2 (full page then short page)", len(*seen))
 	}
 }
 
@@ -728,5 +736,78 @@ func TestGitHubModeCoreReadsUnchanged(t *testing.T) {
 		if !strings.Contains(endpoints[i], want) {
 			t.Fatalf("gh call %d = %q, want it to contain %q", i, endpoints[i], want)
 		}
+	}
+}
+
+// --- shutdown-aware call contexts (#797 parity for ctx-less fj adapters) -----
+
+// forgejoCallContext must mirror the gh path's drain semantics: alive before
+// BeginShutdown, canceled by it mid-flight, and born canceled after it.
+func TestForgejoCallContextFollowsShutdown(t *testing.T) {
+	resetShutdownForTest()
+	t.Cleanup(resetShutdownForTest)
+
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	select {
+	case <-ctx.Done():
+		t.Fatal("call context done before shutdown began")
+	default:
+	}
+
+	BeginShutdown()
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("BeginShutdown did not cancel an already-issued forgejo call context")
+	}
+
+	post, postCancel := forgejoCallContext()
+	defer postCancel()
+	select {
+	case <-post.Done():
+	default:
+		t.Fatal("a call context minted after BeginShutdown must start canceled")
+	}
+}
+
+// A ctx-less legacy method (GetIssue) whose Forgejo read is in flight against
+// a hanging server must return promptly with a context error once shutdown
+// begins — not ride out the transport's 30s timeout (the pre-fix behavior:
+// context.Background() made daemon drain wait on every hung read).
+func TestForgejoPortShutdownCancelsInFlightRead(t *testing.T) {
+	resetShutdownForTest()
+	t.Cleanup(resetShutdownForTest)
+
+	reached := make(chan struct{})
+	c, _, _ := newForgejoPortClient(t, func(r *http.Request) (int, string) {
+		close(reached)
+		<-r.Context().Done() // hang until the canceled client tears the request down
+		return 500, `{"message":"too late"}`
+	})
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := c.GetIssue(41)
+		errCh <- err
+	}()
+
+	select {
+	case <-reached:
+	case <-time.After(5 * time.Second):
+		t.Fatal("fixture server never saw the read")
+	}
+	BeginShutdown()
+
+	select {
+	case err := <-errCh:
+		if err == nil {
+			t.Fatal("read must fail once shutdown cancels its context")
+		}
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled through the adapter chain", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("read still in flight 5s after BeginShutdown — forgejo calls are not shutdown-aware")
 	}
 }

--- a/internal/github/forgejo_port_test.go
+++ b/internal/github/forgejo_port_test.go
@@ -1,0 +1,704 @@
+package github
+
+// End-to-end forgejo-mode tests for the ported core-read funnels (#1172 M2).
+// Each test constructs the REAL stack — config.ForgeConfig → github.New →
+// internal/forgejo.Client → httptest server — with contract-verified Forgejo
+// JSON fixtures (live-verified against Forgejo 16.0.1 on 2026-08-11), and
+// arms the gh transport so any leak to the gh CLI fails the test: the repo is
+// mirrored on github.com, so a leaked read would consult the GitHub mirror.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+const fjTestRepo = "BeFeast/apertune"
+
+// fjSeenReq is one request the fixture server observed. Path is the ESCAPED
+// path so percent-encoding assertions (slash-in-branch-name) see the wire.
+type fjSeenReq struct {
+	Method string
+	Path   string
+	Query  url.Values
+	Auth   string
+}
+
+// newForgejoPortClient builds a forgejo-mode github.Client whose transport
+// points at an httptest fixture server, plus the request log. The gh seam is
+// armed via stubGHNeverCalled so every test doubles as a no-gh-leak check.
+// The M1 config contract puts the API under BaseURL + "/api/v1", so handler
+// paths in fn arrive WITHOUT that prefix (it is stripped here after being
+// asserted).
+func newForgejoPortClient(t *testing.T, fn func(r *http.Request) (int, string)) (*Client, *[]fjSeenReq, *atomic.Int64) {
+	t.Helper()
+	ghCalls := stubGHNeverCalled(t)
+	var seen []fjSeenReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.EscapedPath(), "/api/v1/") {
+			t.Errorf("request outside the API root: %s", r.URL.EscapedPath())
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		seen = append(seen, fjSeenReq{
+			Method: r.Method,
+			Path:   strings.TrimPrefix(r.URL.EscapedPath(), "/api/v1"),
+			Query:  r.URL.Query(),
+			Auth:   r.Header.Get("Authorization"),
+		})
+		status, body := fn(r)
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("TEST_FORGEJO_TOKEN", "test-token")
+	c := New(fjTestRepo, config.ForgeConfig{
+		Kind:     "forgejo",
+		BaseURL:  srv.URL,
+		TokenEnv: "TEST_FORGEJO_TOKEN",
+	})
+	if c.fj == nil || c.forgeErr != nil {
+		t.Fatalf("client not in forgejo transport state: fj=%v forgeErr=%v", c.fj, c.forgeErr)
+	}
+	return c, &seen, ghCalls
+}
+
+// fjRoute serves fixed bodies keyed by the request path relative to the API
+// root ("/repos/..."). Unrouted paths fail the test.
+func fjRoute(t *testing.T, routes map[string]string) func(r *http.Request) (int, string) {
+	t.Helper()
+	return func(r *http.Request) (int, string) {
+		path := strings.TrimPrefix(r.URL.EscapedPath(), "/api/v1")
+		if body, ok := routes[path]; ok {
+			return 200, body
+		}
+		t.Errorf("unrouted fixture path: %s", path)
+		return 404, `{"message":"no fixture"}`
+	}
+}
+
+// --- issues ------------------------------------------------------------------
+
+func TestForgejoPortListOpenIssues(t *testing.T) {
+	issuesPath := "/repos/" + fjTestRepo + "/issues"
+	c, seen, ghCalls := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		// Contract shape: real issues carry "pull_request": null (the KEY is
+		// always present); pull entries carry a populated object. The entry
+		// without the requested label simulates the P1 footgun — an unknown/
+		// mismatched label name makes the server return the UNFILTERED list.
+		issuesPath: `[
+			{"number":36,"title":"ready one","body":"b36","state":"open",
+			 "labels":[{"id":1,"name":"maestro-ready","color":"00aabb"}],"pull_request":null},
+			{"number":34,"title":"a pull in the shared index space","body":"","state":"open",
+			 "labels":[{"id":1,"name":"maestro-ready","color":"00aabb"}],
+			 "pull_request":{"merged":false,"merged_at":null,"draft":true,"html_url":"x"}},
+			{"number":17,"title":"unlabeled leak","body":"","state":"open",
+			 "labels":[{"id":2,"name":"enhancement","color":"cc0000"}],"pull_request":null},
+			{"number":13,"title":"ready two","body":null,"state":"open",
+			 "labels":[{"id":1,"name":"maestro-ready","color":"00aabb"}],"pull_request":null}
+		]`,
+	}))
+
+	issues, err := c.ListOpenIssues([]string{"maestro-ready"})
+	if err != nil {
+		t.Fatalf("ListOpenIssues: %v", err)
+	}
+	if len(issues) != 2 || issues[0].Number != 36 || issues[1].Number != 13 {
+		t.Fatalf("issues = %+v, want the pull entry AND the unlabeled leak dropped, order preserved", issues)
+	}
+	if issues[0].Title != "ready one" || issues[0].Body != "b36" || issues[0].State != "open" {
+		t.Fatalf("issue 36 mapped wrong: %+v", issues[0])
+	}
+	if issues[1].Body != "" {
+		t.Fatalf("null body must map to empty, got %q", issues[1].Body)
+	}
+	if len(issues[0].Labels) != 1 || issues[0].Labels[0].Name != "maestro-ready" {
+		t.Fatalf("labels = %+v", issues[0].Labels)
+	}
+
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %d, want 1", len(*seen))
+	}
+	req := (*seen)[0]
+	if req.Method != http.MethodGet || req.Path != issuesPath {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+	for key, want := range map[string]string{
+		"type":   "issues",
+		"state":  "open",
+		"labels": "maestro-ready",
+	} {
+		if got := req.Query.Get(key); got != want {
+			t.Fatalf("query %s = %q, want %q (full: %v)", key, got, want, req.Query)
+		}
+	}
+	if req.Auth != "token test-token" {
+		t.Fatalf("Authorization = %q, want the Forgejo token scheme", req.Auth)
+	}
+	if n := ghCalls.Load(); n != 0 {
+		t.Fatalf("gh runner invoked %d time(s), want 0", n)
+	}
+}
+
+func TestForgejoPortListAllOpenIssuesPaginates(t *testing.T) {
+	page := func(from, n int) string {
+		items := make([]map[string]any, 0, n)
+		for i := 0; i < n; i++ {
+			items = append(items, map[string]any{
+				"number": from + i, "title": fmt.Sprintf("i%d", from+i), "body": "b",
+				"state": "open", "labels": []any{}, "pull_request": nil,
+			})
+		}
+		out, err := json.Marshal(items)
+		if err != nil {
+			t.Fatalf("marshal fixture: %v", err)
+		}
+		return string(out)
+	}
+	c, seen, _ := newForgejoPortClient(t, func(r *http.Request) (int, string) {
+		switch r.URL.Query().Get("page") {
+		case "1":
+			return 200, page(1, 50) // the live-verified server clamp
+		case "2":
+			return 200, page(51, 3)
+		default:
+			t.Errorf("unexpected page %q", r.URL.Query().Get("page"))
+			return 200, "[]"
+		}
+	})
+
+	issues, err := c.ListAllOpenIssues(nil)
+	if err != nil {
+		t.Fatalf("ListAllOpenIssues: %v", err)
+	}
+	if len(issues) != 53 {
+		t.Fatalf("issues = %d, want 53 across two pages", len(issues))
+	}
+	if len(*seen) != 2 {
+		t.Fatalf("requests = %d, want 2 (page 2 is short and ends the loop)", len(*seen))
+	}
+	// The single-page variant must NOT paginate.
+	*seen = nil
+	if _, err := c.ListOpenIssues(nil); err != nil {
+		t.Fatalf("ListOpenIssues: %v", err)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("single-page read made %d requests, want 1", len(*seen))
+	}
+}
+
+func TestForgejoPortGetIssueAndDerived(t *testing.T) {
+	issuePath := "/repos/" + fjTestRepo + "/issues/7"
+	c, _, ghCalls := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		issuePath: `{"number":7,"title":"closed one","body":"the body","state":"closed",
+			"labels":[{"id":3,"name":"bug","color":"ee0000"}],"pull_request":null}`,
+	}))
+
+	issue, err := c.GetIssue(7)
+	if err != nil {
+		t.Fatalf("GetIssue: %v", err)
+	}
+	if issue.Number != 7 || issue.Title != "closed one" || issue.Body != "the body" || issue.State != "closed" {
+		t.Fatalf("issue = %+v", issue)
+	}
+	if len(issue.Labels) != 1 || issue.Labels[0].Name != "bug" {
+		t.Fatalf("labels = %+v", issue.Labels)
+	}
+
+	body, err := c.IssueBody(7)
+	if err != nil || body != "the body" {
+		t.Fatalf("IssueBody = %q, %v", body, err)
+	}
+	closed, err := c.IsIssueClosed(7)
+	if err != nil || !closed {
+		t.Fatalf("IsIssueClosed = %v, %v; want true", closed, err)
+	}
+	if n := ghCalls.Load(); n != 0 {
+		t.Fatalf("gh runner invoked %d time(s), want 0", n)
+	}
+}
+
+// --- pulls ---------------------------------------------------------------------
+
+func TestForgejoPortListOpenPRsMapping(t *testing.T) {
+	pullsPath := "/repos/" + fjTestRepo + "/pulls"
+	c, seen, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		pullsPath: `[
+			{"number":5,"title":"draft pr","body":"wip","state":"open","draft":true,
+			 "mergeable":true,"merged":false,"merged_at":null,"merge_commit_sha":null,
+			 "head":{"ref":"feat/one","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},
+			 "base":{"ref":"main"}},
+			{"number":4,"title":"ready pr","body":null,"state":"open","draft":false,
+			 "mergeable":true,"merged":false,"merged_at":null,"merge_commit_sha":null,
+			 "head":{"ref":"feat/two","sha":"dfc9446cb6a16c60075286299cd07d2cb655769a"},
+			 "base":{"ref":"main"}}
+		]`,
+	}))
+
+	prs, err := c.ListOpenPRs()
+	if err != nil {
+		t.Fatalf("ListOpenPRs: %v", err)
+	}
+	if len(prs) != 2 {
+		t.Fatalf("prs = %+v", prs)
+	}
+	// restPull.pr() upper-cases the wire's lowercase state.
+	if prs[0].State != "OPEN" {
+		t.Fatalf("state = %q, want OPEN (pr() upper-cases the lowercase wire state)", prs[0].State)
+	}
+	if !prs[0].IsDraft || prs[1].IsDraft {
+		t.Fatalf("draft mapping wrong: %+v", prs)
+	}
+	if prs[0].MergedAt != "" {
+		t.Fatalf("unmerged MergedAt = %q, want empty", prs[0].MergedAt)
+	}
+	if prs[0].HeadRefName != "feat/one" || prs[1].Body != "" {
+		t.Fatalf("mapping wrong: %+v", prs)
+	}
+
+	req := (*seen)[0]
+	if req.Query.Get("state") != "open" || req.Query.Get("sort") != "recentupdate" {
+		t.Fatalf("query = %v, want state=open plus the explicit recentupdate sort", req.Query)
+	}
+}
+
+func TestForgejoPortMergedPRNumberForIssue(t *testing.T) {
+	pullsPath := "/repos/" + fjTestRepo + "/pulls"
+	c, seen, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		// Newest-updated-first server order: an unmerged closed PR, then the
+		// merged one that closes #12.
+		pullsPath: `[
+			{"number":9,"title":"abandoned","body":"Closes #12","state":"closed","draft":false,
+			 "mergeable":true,"merged":false,"merged_at":null,"merge_commit_sha":null,
+			 "head":{"ref":"feat/old","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},
+			 "base":{"ref":"main"}},
+			{"number":8,"title":"landed","body":"Closes #12","state":"closed","draft":false,
+			 "mergeable":true,"merged":true,"merged_at":"2026-07-31T21:55:11Z",
+			 "merge_commit_sha":"dfc9446cb6a16c60075286299cd07d2cb655769a",
+			 "head":{"ref":"feat/landed","sha":"aaaa446cb6a16c60075286299cd07d2cb655769a"},
+			 "base":{"ref":"main"}}
+		]`,
+	}))
+
+	n, err := c.MergedPRNumberForIssue(12)
+	if err != nil {
+		t.Fatalf("MergedPRNumberForIssue: %v", err)
+	}
+	if n != 8 {
+		t.Fatalf("merged PR = %d, want 8 (the unmerged closed PR must not count)", n)
+	}
+	req := (*seen)[0]
+	if req.Query.Get("state") != "closed" || req.Query.Get("sort") != "recentupdate" {
+		t.Fatalf("query = %v, want state=closed plus recentupdate", req.Query)
+	}
+}
+
+func TestForgejoPortGetRESTPullDerivedMerged(t *testing.T) {
+	pullPath := "/repos/" + fjTestRepo + "/pulls/1"
+	const mergeSHA = "dfc9446cb6a16c60075286299cd07d2cb655769a"
+	const headSHA = "59e99c49c27d3e2f73bae1657f07cd2f9a15f926"
+	c, _, ghCalls := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		// The live merged-PR shape: state closed (lowercase), mergeable STILL
+		// true (Forgejo's bool is not GitHub's tri-state), slash ref verbatim.
+		pullPath: `{"number":1,"title":"merged pr","body":"done","state":"closed","draft":false,
+			"mergeable":true,"merged":true,"merged_at":"2026-07-31T21:55:11Z",
+			"merge_commit_sha":"` + mergeSHA + `",
+			"head":{"ref":"canary/llm-review-e2e","sha":"` + headSHA + `"},
+			"base":{"ref":"main"}}`,
+	}))
+
+	pr, err := c.PRDetails(1)
+	if err != nil {
+		t.Fatalf("PRDetails: %v", err)
+	}
+	if pr.State != "CLOSED" || pr.HeadRefName != "canary/llm-review-e2e" || pr.MergedAt != "2026-07-31T21:55:11Z" {
+		t.Fatalf("PRDetails = %+v", pr)
+	}
+
+	sha, err := c.PRHeadSHA(1)
+	if err != nil || sha != headSHA {
+		t.Fatalf("PRHeadSHA = %q, %v", sha, err)
+	}
+
+	merged, err := c.IsPRMerged(1)
+	if err != nil || !merged {
+		t.Fatalf("IsPRMerged = %v, %v; want true", merged, err)
+	}
+
+	mergeable, err := c.PRMergeable(1)
+	if err != nil || mergeable != "MERGEABLE" {
+		t.Fatalf("PRMergeable = %q, %v (the wire bool feeds mergeableFromRESTPull)", mergeable, err)
+	}
+
+	info, err := c.PRMergeInfo(1)
+	if err != nil {
+		t.Fatalf("PRMergeInfo: %v", err)
+	}
+	if info.SHA != mergeSHA || info.HeadSHA != headSHA {
+		t.Fatalf("PRMergeInfo = %+v", info)
+	}
+	if info.MergedAt.UTC().Format("2006-01-02T15:04:05Z") != "2026-07-31T21:55:11Z" {
+		t.Fatalf("MergedAt = %v", info.MergedAt)
+	}
+	if got, err := c.PRMergeCommitSHA(1); err != nil || got != mergeSHA {
+		t.Fatalf("PRMergeCommitSHA = %q, %v", got, err)
+	}
+	if n := ghCalls.Load(); n != 0 {
+		t.Fatalf("gh runner invoked %d time(s), want 0", n)
+	}
+}
+
+func TestForgejoPortGetRESTPullDerivedUnmerged(t *testing.T) {
+	pullPath := "/repos/" + fjTestRepo + "/pulls/2"
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		pullPath: `{"number":2,"title":"open pr","body":null,"state":"open","draft":false,
+			"mergeable":false,"merged":false,"merged_at":null,"merge_commit_sha":null,
+			"head":{"ref":"feat/x","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},
+			"base":{"ref":"main"}}`,
+	}))
+
+	merged, err := c.IsPRMerged(2)
+	if err != nil || merged {
+		t.Fatalf("IsPRMerged = %v, %v; want false", merged, err)
+	}
+	if _, err := c.PRMergeInfo(2); err == nil || !strings.Contains(err.Error(), "not merged") {
+		t.Fatalf("PRMergeInfo on an unmerged PR = %v, want the not-merged error", err)
+	}
+	mergeable, err := c.PRMergeable(2)
+	if err != nil || mergeable != "CONFLICTING" {
+		t.Fatalf("PRMergeable = %q, %v; want CONFLICTING from mergeable=false", mergeable, err)
+	}
+	pr, err := c.PRDetails(2)
+	if err != nil || pr.MergedAt != "" || pr.Body != "" {
+		t.Fatalf("PRDetails = %+v, %v (null body and null merged_at must map to empty)", pr, err)
+	}
+}
+
+func TestForgejoPortLatestMergedPRGenerationsBaseFilter(t *testing.T) {
+	repoPath := "/repos/" + fjTestRepo
+	pullsPath := "/repos/" + fjTestRepo + "/pulls"
+	c, seen, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		repoPath: `{"name":"apertune","default_branch":"main"}`,
+		pullsPath: `[
+			{"number":30,"title":"tie a","body":"","state":"closed","draft":false,
+			 "mergeable":true,"merged":true,"merged_at":"2026-08-02T10:00:00Z",
+			 "merge_commit_sha":"aaaa446cb6a16c60075286299cd07d2cb655769a",
+			 "head":{"ref":"feat/a","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},"base":{"ref":"main"}},
+			{"number":31,"title":"tie b","body":"","state":"closed","draft":false,
+			 "mergeable":true,"merged":true,"merged_at":"2026-08-02T10:00:00Z",
+			 "merge_commit_sha":"bbbb446cb6a16c60075286299cd07d2cb655769a",
+			 "head":{"ref":"feat/b","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},"base":{"ref":"main"}},
+			{"number":32,"title":"newer but wrong base","body":"","state":"closed","draft":false,
+			 "mergeable":true,"merged":true,"merged_at":"2026-08-03T10:00:00Z",
+			 "merge_commit_sha":"cccc446cb6a16c60075286299cd07d2cb655769a",
+			 "head":{"ref":"feat/c","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},"base":{"ref":"release/v1"}},
+			{"number":33,"title":"older","body":"","state":"closed","draft":false,
+			 "mergeable":true,"merged":true,"merged_at":"2026-08-01T10:00:00Z",
+			 "merge_commit_sha":"dddd446cb6a16c60075286299cd07d2cb655769a",
+			 "head":{"ref":"feat/d","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},"base":{"ref":"main"}},
+			{"number":34,"title":"closed unmerged","body":"","state":"closed","draft":false,
+			 "mergeable":true,"merged":false,"merged_at":null,"merge_commit_sha":null,
+			 "head":{"ref":"feat/e","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},"base":{"ref":"main"}}
+		]`,
+	}))
+
+	infos, err := c.LatestMergedPRGenerations(t.Context())
+	if err != nil {
+		t.Fatalf("LatestMergedPRGenerations: %v", err)
+	}
+	if len(infos) != 2 {
+		t.Fatalf("generations = %+v, want exactly the two main-based PRs tied at the latest second", infos)
+	}
+	got := map[string]bool{infos[0].SHA: true, infos[1].SHA: true}
+	if !got["aaaa446cb6a16c60075286299cd07d2cb655769a"] || !got["bbbb446cb6a16c60075286299cd07d2cb655769a"] {
+		t.Fatalf("wrong tie set: %+v (release/v1 must be filtered client-side on Base.Ref)", infos)
+	}
+	// Two reads: repo (default branch) then the closed-pulls page.
+	if len(*seen) != 2 || (*seen)[0].Path != repoPath || (*seen)[1].Path != pullsPath {
+		t.Fatalf("requests = %+v", *seen)
+	}
+}
+
+// --- sub-resources ------------------------------------------------------------
+
+func TestForgejoPortListIssueComments(t *testing.T) {
+	commentsPath := "/repos/" + fjTestRepo + "/issues/42/comments"
+	c, seen, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		commentsPath: `[
+			{"id":101,"body":"first","user":{"login":"oleg"},"created_at":"2026-08-01T10:00:00Z","updated_at":"2026-08-01T10:00:00Z"},
+			{"id":102,"body":"@maestro groom","user":{"login":"smoke-bot"},"created_at":"2026-08-02T11:30:00Z","updated_at":"2026-08-02T11:30:00Z"}
+		]`,
+	}))
+
+	comments, err := c.ListIssueComments(42)
+	if err != nil {
+		t.Fatalf("ListIssueComments: %v", err)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("comments = %+v", comments)
+	}
+	want := IssueComment{ID: 102, Body: "@maestro groom", Author: "smoke-bot", CreatedAt: "2026-08-02T11:30:00Z"}
+	if comments[1] != want {
+		t.Fatalf("comment = %+v, want %+v", comments[1], want)
+	}
+	// The endpoint has NO page/limit params on Forgejo — one bare request.
+	req := (*seen)[0]
+	if len(*seen) != 1 || req.Query.Get("limit") != "" || req.Query.Get("page") != "" {
+		t.Fatalf("requests = %+v, want one unpaged read", *seen)
+	}
+}
+
+func TestForgejoPortPRLabels(t *testing.T) {
+	labelsPath := "/repos/" + fjTestRepo + "/issues/36/labels"
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		labelsPath: `[{"id":1,"name":"maestro-ready","color":"00aabb"},{"id":2,"name":"enhancement","color":"cc0000"}]`,
+	}))
+	names, err := c.PRLabels(36)
+	if err != nil {
+		t.Fatalf("PRLabels: %v", err)
+	}
+	if len(names) != 2 || names[0] != "maestro-ready" || names[1] != "enhancement" {
+		t.Fatalf("labels = %v", names)
+	}
+}
+
+func TestForgejoPortPRCommitsHeadlines(t *testing.T) {
+	commitsPath := "/repos/" + fjTestRepo + "/pulls/1/commits"
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		// Wire messages carry a trailing "\n" (live-verified); one entry is
+		// multi-line, one is whitespace-only and must be dropped.
+		commitsPath: `[
+			{"sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926","commit":{"message":"feat: headline\n\nlong body\n"}},
+			{"sha":"dfc9446cb6a16c60075286299cd07d2cb655769a","commit":{"message":"  \n"}},
+			{"sha":"aaaa446cb6a16c60075286299cd07d2cb655769a","commit":{"message":"fix: second\n"}}
+		]`,
+	}))
+	msgs, err := c.PRCommits(1)
+	if err != nil {
+		t.Fatalf("PRCommits: %v", err)
+	}
+	if len(msgs) != 2 || msgs[0] != "feat: headline" || msgs[1] != "fix: second" {
+		t.Fatalf("headlines = %v (headline extraction must match parsePRCommits)", msgs)
+	}
+}
+
+func TestForgejoPortPRChangedFiles(t *testing.T) {
+	filesPath := "/repos/" + fjTestRepo + "/pulls/1/files"
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		filesPath: `[{"filename":"web/app.css","status":"modified","additions":3,"deletions":1},
+			{"filename":"  ","status":"modified"},
+			{"filename":"cmd/main.go","status":"added","additions":9,"deletions":0}]`,
+	}))
+	files, err := c.PRChangedFiles(1)
+	if err != nil {
+		t.Fatalf("PRChangedFiles: %v", err)
+	}
+	if len(files) != 2 || files[0] != "web/app.css" || files[1] != "cmd/main.go" {
+		t.Fatalf("files = %v", files)
+	}
+}
+
+func TestForgejoPortPRVisualEvidenceAttached(t *testing.T) {
+	pullPath := "/repos/" + fjTestRepo + "/pulls/3"
+	commentsPath := "/repos/" + fjTestRepo + "/issues/3/comments"
+	pullNoImage := `{"number":3,"title":"ui","body":"plain text","state":"open","draft":false,
+		"mergeable":true,"merged":false,"merged_at":null,"merge_commit_sha":null,
+		"head":{"ref":"feat/ui","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},"base":{"ref":"main"}}`
+
+	t.Run("image in body short-circuits", func(t *testing.T) {
+		c, seen, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+			pullPath: strings.Replace(pullNoImage, "plain text", "![shot](https://h/x.png)", 1),
+		}))
+		ok, err := c.PRVisualEvidenceAttached(3)
+		if err != nil || !ok {
+			t.Fatalf("PRVisualEvidenceAttached = %v, %v; want true from the body", ok, err)
+		}
+		if len(*seen) != 1 {
+			t.Fatalf("requests = %+v, want the comments read skipped", *seen)
+		}
+	})
+	t.Run("image in a comment", func(t *testing.T) {
+		c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+			pullPath:     pullNoImage,
+			commentsPath: `[{"id":1,"body":"<img src=\"https://h/s.png\">","user":{"login":"worker"},"created_at":"2026-08-01T10:00:00Z"}]`,
+		}))
+		ok, err := c.PRVisualEvidenceAttached(3)
+		if err != nil || !ok {
+			t.Fatalf("PRVisualEvidenceAttached = %v, %v; want true from the comment", ok, err)
+		}
+	})
+	t.Run("no image anywhere", func(t *testing.T) {
+		c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+			pullPath:     pullNoImage,
+			commentsPath: `[{"id":1,"body":"looks good","user":{"login":"worker"},"created_at":"2026-08-01T10:00:00Z"}]`,
+		}))
+		ok, err := c.PRVisualEvidenceAttached(3)
+		if err != nil || ok {
+			t.Fatalf("PRVisualEvidenceAttached = %v, %v; want false", ok, err)
+		}
+	})
+}
+
+// --- repo / branch -------------------------------------------------------------
+
+func TestForgejoPortRepositoryDefaultBranch(t *testing.T) {
+	repoPath := "/repos/" + fjTestRepo
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		repoPath: `{"name":"apertune","default_branch":"main"}`,
+	}))
+	branch, err := c.RepositoryDefaultBranch(t.Context())
+	if err != nil || branch != "main" {
+		t.Fatalf("RepositoryDefaultBranch = %q, %v", branch, err)
+	}
+}
+
+func TestForgejoPortRepositoryDefaultBranchRejectsMetachars(t *testing.T) {
+	repoPath := "/repos/" + fjTestRepo
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		repoPath: `{"name":"apertune","default_branch":"main?x=1"}`,
+	}))
+	if _, err := c.RepositoryDefaultBranch(t.Context()); err == nil {
+		t.Fatal("a metacharacter branch must be rejected — gh-path validation parity")
+	}
+}
+
+func TestForgejoPortBranchHeadSHAEscapesSlash(t *testing.T) {
+	c, seen, _ := newForgejoPortClient(t, func(r *http.Request) (int, string) {
+		return 200, `{"name":"canary/llm-review-e2e","sha":"decoy",
+			"commit":{"id":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926","message":"m"}}`
+	})
+	sha, err := c.BranchHeadSHA("canary/llm-review-e2e")
+	if err != nil {
+		t.Fatalf("BranchHeadSHA: %v", err)
+	}
+	if sha != "59e99c49c27d3e2f73bae1657f07cd2f9a15f926" {
+		t.Fatalf("sha = %q (must come from commit.id, not the top-level decoy)", sha)
+	}
+	req := (*seen)[0]
+	if req.Path != "/repos/"+fjTestRepo+"/branches/canary%2Fllm-review-e2e" {
+		t.Fatalf("path = %s, want the slash percent-escaped", req.Path)
+	}
+}
+
+// --- fail-loud edges -------------------------------------------------------------
+
+func TestForgejoPortHTTPErrorSurfaces(t *testing.T) {
+	c, _, _ := newForgejoPortClient(t, func(*http.Request) (int, string) {
+		return 500, `{"message":"boom"}`
+	})
+	_, err := c.GetIssue(1)
+	if err == nil {
+		t.Fatal("a 500 must surface as an error")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("err = %v, want the HTTP status visible", err)
+	}
+	if errors.Is(err, ErrForgejoNotSupported) {
+		t.Fatalf("err = %v: a transport failure on a PORTED read must not claim not-supported", err)
+	}
+}
+
+// TestForgejoPortGuardsMakeNoRequests pins the explicit NOT-ported guards: the
+// methods that would half-work now that their underlying funnels are ported
+// must fail with the sentinel BEFORE any Forgejo request — a half-executed
+// read would waste quota and, worse, look like partial support.
+func TestForgejoPortGuardsMakeNoRequests(t *testing.T) {
+	c, seen, ghCalls := newForgejoPortClient(t, func(*http.Request) (int, string) {
+		return 200, `{}`
+	})
+	guards := []struct {
+		name string
+		call func() error
+	}{
+		{"PRMergeStatus", func() error { _, _, err := c.PRMergeStatus(1); return err }},
+		{"PRCheckRollup", func() error { _, err := c.PRCheckRollup(1); return err }},
+		{"PRCIStatus", func() error { _, err := c.PRCIStatus(1); return err }},
+		{"PRChecksOutput", func() error { _, err := c.PRChecksOutput(1); return err }},
+		{"CIFailureSummary", func() error { _, err := c.CIFailureSummary(1); return err }},
+		{"CollectPRReviewFeedback", func() error { _, err := c.CollectPRReviewFeedback(1, nil); return err }},
+	}
+	for _, g := range guards {
+		err := g.call()
+		if err == nil {
+			t.Errorf("%s: err = nil, want ErrForgejoNotSupported", g.name)
+			continue
+		}
+		if !errors.Is(err, ErrForgejoNotSupported) {
+			t.Errorf("%s: err = %v, not errors.Is-matchable against the sentinel", g.name, err)
+		}
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("guarded methods reached the Forgejo API: %+v", *seen)
+	}
+	if n := ghCalls.Load(); n != 0 {
+		t.Fatalf("gh runner invoked %d time(s), want 0", n)
+	}
+}
+
+// --- github-mode regression -------------------------------------------------------
+
+// TestGitHubModeCoreReadsUnchanged pins that a zero-ForgeConfig client keeps
+// issuing the exact historical gh reads for the funnels this port touched —
+// same endpoints, same pagination flags — and parses them as before.
+func TestGitHubModeCoreReadsUnchanged(t *testing.T) {
+	resetPrimaryLimitForTest()
+	var endpoints []string
+	orig := ghAPIRunner
+	ghAPIRunner = func(args ...string) ([]byte, error) {
+		joined := strings.Join(args, " ")
+		endpoints = append(endpoints, joined)
+		switch {
+		case strings.Contains(joined, "/issues/9/comments"):
+			return []byte(`[{"id":1,"body":"c","user":{"login":"u"},"created_at":"2026-08-01T10:00:00Z"}]`), nil
+		case strings.Contains(joined, "/issues/7"):
+			return []byte(`{"number":7,"title":"t","body":"b","state":"open","labels":[]}`), nil
+		case strings.Contains(joined, "/pulls?state=open"):
+			return []byte(`[{"number":4,"title":"pr","body":"","state":"open","draft":false,
+				"head":{"ref":"feat/x","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},
+				"base":{"ref":"main"},"merged_at":null}]`), nil
+		}
+		return nil, fmt.Errorf("unexpected gh call: %s", joined)
+	}
+	t.Cleanup(func() {
+		ghAPIRunner = orig
+		resetPrimaryLimitForTest()
+	})
+
+	c := New("owner/repo", config.ForgeConfig{})
+
+	issue, err := c.GetIssue(7)
+	if err != nil || issue.Number != 7 {
+		t.Fatalf("GetIssue = %+v, %v", issue, err)
+	}
+	prs, err := c.ListOpenPRs()
+	if err != nil || len(prs) != 1 || prs[0].State != "OPEN" {
+		t.Fatalf("ListOpenPRs = %+v, %v", prs, err)
+	}
+	comments, err := c.ListIssueComments(9)
+	if err != nil || len(comments) != 1 || comments[0].Author != "u" {
+		t.Fatalf("ListIssueComments = %+v, %v", comments, err)
+	}
+
+	wantSubstrings := []string{
+		"repos/owner/repo/issues/7",
+		"repos/owner/repo/pulls?state=open&per_page=100",
+		"repos/owner/repo/issues/9/comments?per_page=100 --paginate",
+	}
+	if len(endpoints) != len(wantSubstrings) {
+		t.Fatalf("gh calls = %v", endpoints)
+	}
+	for i, want := range wantSubstrings {
+		if !strings.Contains(endpoints[i], want) {
+			t.Fatalf("gh call %d = %q, want it to contain %q", i, endpoints[i], want)
+		}
+	}
+}

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -21,6 +21,9 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/forgejo"
 )
 
 type greptileCheckRun struct {
@@ -130,6 +133,21 @@ type PR struct {
 
 type Client struct {
 	Repo string
+
+	// forgeKind routes the transport (#1172): "github" (the zero value's
+	// effective meaning and the historical default) keeps every method on the
+	// gh CLI path; "forgejo" routes ported methods to fj and makes EVERY
+	// unported method fail loud with ErrForgejoNotSupported. It must never be
+	// possible for a forgejo-mode client to fall through to gh: the repo is
+	// mirrored on github.com, so a silent fallback would read/write the GitHub
+	// mirror instead of the Forgejo original.
+	forgeKind string
+	// fj is the Forgejo REST client; non-nil only in forgejo mode with a
+	// resolvable token.
+	fj *forgejo.Client
+	// forgeErr records a construction-time fault (empty token env) surfaced on
+	// every call instead of at construction, keeping New infallible.
+	forgeErr error
 }
 
 type RateLimitBucket struct {
@@ -218,8 +236,100 @@ func (rp restPull) pr() PR {
 	}
 }
 
-func New(repo string) *Client {
-	return &Client{Repo: repo}
+// New builds the client for one repo on one forge (#1172). A zero
+// config.ForgeConfig (or kind "github") yields the historical GitHub client,
+// byte-identical in behavior. Kind "forgejo" resolves the PAT from the
+// configured token env NOW (config never reads the environment itself); an
+// empty token becomes forgeErr — surfaced loudly on every call — rather than a
+// construction failure, so all existing call sites stay infallible.
+func New(repo string, fc config.ForgeConfig) *Client {
+	c := &Client{Repo: repo, forgeKind: fc.EffectiveKind()}
+	if fc.IsForgejo() {
+		token := strings.TrimSpace(os.Getenv(fc.EffectiveTokenEnv()))
+		if token == "" {
+			c.forgeErr = fmt.Errorf("forge token env %s is empty; export it in the daemon environment", fc.EffectiveTokenEnv())
+		} else {
+			c.fj = forgejo.New(fc.APIRoot(), token)
+		}
+	}
+	return c
+}
+
+// ErrForgejoNotSupported marks a Client method that has no Forgejo transport
+// yet. Every forgejo-mode error for an unported method is errors.Is-matchable
+// against it, so callers can distinguish "this operation does not exist on
+// this forge yet" from a transport failure.
+var ErrForgejoNotSupported = errors.New("not supported on forgejo yet (#1172)")
+
+// isForgejo reports whether this client routes to Forgejo. The zero Client
+// (and every github/empty-kind construction) answers false.
+func (c *Client) isForgejo() bool {
+	return c.forgeKind == config.ForgeKindForgejo
+}
+
+// forgejoUnsupported builds the fail-loud error for an unported method on a
+// forgejo-mode client. It always wraps ErrForgejoNotSupported; when the client
+// also failed to resolve its token at construction, that more actionable fault
+// is surfaced in the same message.
+func (c *Client) forgejoUnsupported(what string) error {
+	if c.forgeErr != nil {
+		return fmt.Errorf("%s: repo %s: %v: %w", what, c.Repo, c.forgeErr, ErrForgejoNotSupported)
+	}
+	return fmt.Errorf("%s: repo %s: %w", what, c.Repo, ErrForgejoNotSupported)
+}
+
+// ---------------------------------------------------------------------------
+// Receiver chokes (#1172). The repo is MIRRORED: it exists on github.com AND
+// on the Forgejo instance, so any receiver method that reaches the gh CLI on a
+// forgejo-mode client silently reads/writes the GitHub mirror instead of the
+// Forgejo original. Every receiver-method body in this package MUST therefore
+// call these chokes instead of the package-level gh functions; the package
+// functions remain only for the chokes themselves, package-level (non-Client)
+// code, and the forge.go Forge adapter (github-only by construction). Enforced
+// by TestForgejoModeFailsLoud and the grep check in the M2 spec.
+// ---------------------------------------------------------------------------
+
+// ghAPI is the receiver-bound choke over the package ghAPI.
+func (c *Client) ghAPI(endpoint string) ([]byte, error) {
+	if c.isForgejo() {
+		return nil, c.forgejoUnsupported("gh api " + endpoint)
+	}
+	return ghAPI(endpoint)
+}
+
+// ghAPIWithArgs is the receiver-bound choke over the package ghAPIWithArgs.
+func (c *Client) ghAPIWithArgs(endpoint string, args ...string) ([]byte, error) {
+	if c.isForgejo() {
+		return nil, c.forgejoUnsupported(strings.TrimSpace("gh api " + endpoint + " " + strings.Join(args, " ")))
+	}
+	return ghAPIWithArgs(endpoint, args...)
+}
+
+// ghAPIWithArgsContext is the receiver-bound choke over the package
+// ghAPIWithArgsContext.
+func (c *Client) ghAPIWithArgsContext(ctx context.Context, endpoint string, args ...string) ([]byte, error) {
+	if c.isForgejo() {
+		return nil, c.forgejoUnsupported(strings.TrimSpace("gh api " + endpoint + " " + strings.Join(args, " ")))
+	}
+	return ghAPIWithArgsContext(ctx, endpoint, args...)
+}
+
+// ghExec is the receiver-bound choke for the ghCommand(...).CombinedOutput()
+// call shape (gh subcommands: pr/issue/release/api graphql).
+func (c *Client) ghExec(args ...string) ([]byte, error) {
+	if c.isForgejo() {
+		return nil, c.forgejoUnsupported("gh " + strings.Join(args, " "))
+	}
+	return ghCommand(args...).CombinedOutput()
+}
+
+// ghOutputContext is the receiver-bound choke for the
+// ghCommandContext(ctx, ...).Output() call shape (the GraphQL Projects reads).
+func (c *Client) ghOutputContext(ctx context.Context, args ...string) ([]byte, error) {
+	if c.isForgejo() {
+		return nil, c.forgejoUnsupported("gh " + strings.Join(args, " "))
+	}
+	return ghCommandContext(ctx, args...).Output()
 }
 
 func ghAPI(endpoint string) ([]byte, error) {
@@ -1370,7 +1480,7 @@ func parseRateLimitStatus(out []byte) (RateLimitStatus, error) {
 }
 
 func (c *Client) RateLimit() (RateLimitStatus, error) {
-	out, err := ghAPI("rate_limit")
+	out, err := c.ghAPI("rate_limit")
 	if err != nil {
 		return RateLimitStatus{}, err
 	}
@@ -1815,7 +1925,7 @@ func (c *Client) listOpenIssuesByLabel(label string) ([]Issue, error) {
 		endpoint += "&labels=" + url.QueryEscape(label)
 	}
 
-	out, err := ghAPI(endpoint)
+	out, err := c.ghAPI(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("list open issues: %w", err)
 	}
@@ -1867,7 +1977,7 @@ func (c *Client) listAllOpenIssuesByLabel(label string) ([]Issue, error) {
 		endpoint += "&labels=" + url.QueryEscape(label)
 	}
 
-	out, err := ghAPIWithArgs(endpoint, "--paginate")
+	out, err := c.ghAPIWithArgs(endpoint, "--paginate")
 	if err != nil {
 		return nil, fmt.Errorf("list all open issues: %w", err)
 	}
@@ -1885,7 +1995,7 @@ func (c *Client) listAllOpenIssuesByLabel(label string) ([]Issue, error) {
 
 // GetIssue fetches a single issue by number
 func (c *Client) GetIssue(number int) (Issue, error) {
-	out, err := ghAPI(fmt.Sprintf("repos/%s/issues/%d", c.Repo, number))
+	out, err := c.ghAPI(fmt.Sprintf("repos/%s/issues/%d", c.Repo, number))
 	if err != nil {
 		return Issue{}, fmt.Errorf("get issue %d: %w", number, err)
 	}
@@ -1910,7 +2020,7 @@ func (c *Client) IssueBody(number int) (string, error) {
 
 // IsIssueClosed returns true if the issue is closed
 func (c *Client) IsIssueClosed(number int) (bool, error) {
-	out, err := ghAPI(fmt.Sprintf("repos/%s/issues/%d", c.Repo, number))
+	out, err := c.ghAPI(fmt.Sprintf("repos/%s/issues/%d", c.Repo, number))
 	if err != nil {
 		return false, fmt.Errorf("get issue %d: %w", number, err)
 	}
@@ -1925,7 +2035,7 @@ func (c *Client) IsIssueClosed(number int) (bool, error) {
 
 // ListOpenPRs returns all open PRs
 func (c *Client) ListOpenPRs() ([]PR, error) {
-	out, err := ghAPI(fmt.Sprintf("repos/%s/pulls?state=open&per_page=100", c.Repo))
+	out, err := c.ghAPI(fmt.Sprintf("repos/%s/pulls?state=open&per_page=100", c.Repo))
 	if err != nil {
 		return nil, fmt.Errorf("list open PRs: %w", err)
 	}
@@ -1941,7 +2051,7 @@ func (c *Client) ListOpenPRs() ([]PR, error) {
 // for why the reconciliation loop (#827) needs the full open set rather than
 // page one before it uses absence as a close signal.
 func (c *Client) ListAllOpenPRs() ([]PR, error) {
-	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls?state=open&per_page=100", c.Repo), "--paginate")
+	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls?state=open&per_page=100", c.Repo), "--paginate")
 	if err != nil {
 		return nil, fmt.Errorf("list all open PRs: %w", err)
 	}
@@ -1958,7 +2068,7 @@ func (c *Client) ListAllOpenPRs() ([]PR, error) {
 }
 
 func (c *Client) listClosedPRs() ([]PR, error) {
-	out, err := ghAPI(fmt.Sprintf("repos/%s/pulls?state=closed&per_page=100&sort=updated&direction=desc", c.Repo))
+	out, err := c.ghAPI(fmt.Sprintf("repos/%s/pulls?state=closed&per_page=100&sort=updated&direction=desc", c.Repo))
 	if err != nil {
 		return nil, fmt.Errorf("list closed PRs: %w", err)
 	}
@@ -1977,7 +2087,7 @@ func (c *Client) ListClosedPRs() ([]PR, error) {
 }
 
 func (c *Client) getRESTPull(prNumber int) (restPull, error) {
-	out, err := ghAPI(fmt.Sprintf("repos/%s/pulls/%d", c.Repo, prNumber))
+	out, err := c.ghAPI(fmt.Sprintf("repos/%s/pulls/%d", c.Repo, prNumber))
 	if err != nil {
 		return restPull{}, err
 	}
@@ -2055,7 +2165,7 @@ func (c *Client) LatestMergedPRGenerations(ctx context.Context) ([]PRMergeInfo, 
 	if err != nil {
 		return nil, err
 	}
-	out, err := ghAPIWithArgsContext(ctx, fmt.Sprintf("repos/%s/pulls?state=closed&base=%s&per_page=100&sort=updated&direction=desc", c.Repo, url.QueryEscape(deliveryBase)), "--paginate")
+	out, err := c.ghAPIWithArgsContext(ctx, fmt.Sprintf("repos/%s/pulls?state=closed&base=%s&per_page=100&sort=updated&direction=desc", c.Repo, url.QueryEscape(deliveryBase)), "--paginate")
 	if err != nil {
 		return nil, errors.New("list merged delivery generations failed")
 	}
@@ -2074,7 +2184,7 @@ func (c *Client) LatestMergedPRGenerations(ctx context.Context) ([]PRMergeInfo, 
 // Repositories using trunk/master are supported, and a newer merge into an
 // unrelated release/feature branch cannot supersede a default-branch delivery.
 func (c *Client) RepositoryDefaultBranch(ctx context.Context) (string, error) {
-	out, err := ghAPIWithArgsContext(ctx, fmt.Sprintf("repos/%s", c.Repo))
+	out, err := c.ghAPIWithArgsContext(ctx, fmt.Sprintf("repos/%s", c.Repo))
 	if err != nil {
 		return "", errors.New("read repository delivery branch failed")
 	}
@@ -2142,7 +2252,7 @@ func (c *Client) BranchHeadSHA(branch string) (string, error) {
 	if branch == "" {
 		return "", fmt.Errorf("empty branch")
 	}
-	out, err := ghAPI(fmt.Sprintf("repos/%s/commits/%s", c.Repo, url.PathEscape(branch)))
+	out, err := c.ghAPI(fmt.Sprintf("repos/%s/commits/%s", c.Repo, url.PathEscape(branch)))
 	if err != nil {
 		return "", err
 	}
@@ -2160,7 +2270,7 @@ func (c *Client) BranchHeadSHA(branch string) (string, error) {
 }
 
 func (c *Client) checkRunsForSHA(sha string) ([]greptileCheckRun, error) {
-	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/commits/%s/check-runs?per_page=100", c.Repo, sha), "--paginate")
+	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/commits/%s/check-runs?per_page=100", c.Repo, sha), "--paginate")
 	if err != nil {
 		return nil, err
 	}
@@ -2172,7 +2282,7 @@ func (c *Client) checkRunsForSHA(sha string) ([]greptileCheckRun, error) {
 }
 
 func (c *Client) combinedStatusForSHA(sha string) (combinedStatusResponse, error) {
-	out, err := ghAPI(fmt.Sprintf("repos/%s/commits/%s/status", c.Repo, sha))
+	out, err := c.ghAPI(fmt.Sprintf("repos/%s/commits/%s/status", c.Repo, sha))
 	if err != nil {
 		return combinedStatusResponse{}, err
 	}
@@ -2193,7 +2303,7 @@ func (c *Client) CreatePR(title, body, base, head string) (int, error) {
 		"--base", base,
 		"--head", head,
 	}
-	out, err := ghCommand(args...).CombinedOutput()
+	out, err := c.ghExec(args...)
 	if err != nil {
 		return 0, fmt.Errorf("gh pr create: %w\n%s", err, out)
 	}
@@ -2212,11 +2322,11 @@ func (c *Client) CreatePR(title, body, base, head string) (int, error) {
 
 // UpdatePRBody replaces a pull request body.
 func (c *Client) UpdatePRBody(prNumber int, body string) error {
-	out, err := ghCommand(
+	out, err := c.ghExec(
 		"pr", "edit", strconv.Itoa(prNumber),
 		"--repo", c.Repo,
 		"--body", body,
-	).CombinedOutput()
+	)
 	if err != nil {
 		return fmt.Errorf("gh pr edit %d --body: %w\n%s", prNumber, err, out)
 	}
@@ -2512,7 +2622,7 @@ func (c *Client) prGreptileReviewStreamVerdict(prNumber int) (ReviewStreamVerdic
 
 commentFallback:
 	// --- 3. Fallback: check PR comments (legacy Greptile comment-mode) ---
-	commentsOut, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
+	commentsOut, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
 	if err != nil {
 		return ReviewStreamVerdict{}, fmt.Errorf("list issue comments for PR %d: %w", prNumber, err)
 	}
@@ -2608,7 +2718,7 @@ func (c *Client) commentScopedToHead(comment issueComment, sha string) (scoped b
 // review comment-fallback path calls it, which runs when no review check run
 // exists at all.
 func (c *Client) commitCommittedAt(sha string) (time.Time, error) {
-	out, err := ghAPI(fmt.Sprintf("repos/%s/commits/%s", c.Repo, sha))
+	out, err := c.ghAPI(fmt.Sprintf("repos/%s/commits/%s", c.Repo, sha))
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -2982,7 +3092,7 @@ func (c *Client) PRHighSeverityReviewOnHead(prNumber int) (sha string, findings 
 func (c *Client) greptileReviewComments(prNumber int) ([]greptileReviewComment, error) {
 	// Routed through the shared wrapper (#797) so this per-cycle read gets the
 	// rate-limit backoff, the conditional-request cache, and usage accounting.
-	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
+	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
 	if err != nil {
 		return nil, err
 	}
@@ -2996,17 +3106,17 @@ func (c *Client) greptileReviewComments(prNumber int) ([]greptileReviewComment, 
 // ClosePR closes a PR without merging and leaves a comment explaining why.
 func (c *Client) ClosePR(prNumber int, comment string) error {
 	if comment != "" {
-		out, err := ghCommand("pr", "comment",
+		out, err := c.ghExec("pr", "comment",
 			fmt.Sprint(prNumber),
 			"--repo", c.Repo,
-			"--body", comment).CombinedOutput()
+			"--body", comment)
 		if err != nil {
 			return fmt.Errorf("gh pr comment %d: %w\n%s", prNumber, err, out)
 		}
 	}
-	out, err := ghCommand("pr", "close",
+	out, err := c.ghExec("pr", "close",
 		fmt.Sprint(prNumber),
-		"--repo", c.Repo).CombinedOutput()
+		"--repo", c.Repo)
 	if err != nil {
 		return fmt.Errorf("gh pr close %d: %w\n%s", prNumber, err, out)
 	}
@@ -3097,7 +3207,7 @@ type checkAnnotation struct {
 }
 
 func (c *Client) checkRunAnnotations(id int64) ([]checkAnnotation, error) {
-	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/check-runs/%d/annotations?per_page=100", c.Repo, id), "--paginate")
+	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/check-runs/%d/annotations?per_page=100", c.Repo, id), "--paginate")
 	if err != nil {
 		return nil, err
 	}
@@ -3249,12 +3359,12 @@ func (c *Client) MergePRAtHead(prNumber int, expectedHeadSHA string) error {
 	if expectedHeadSHA == "" {
 		return fmt.Errorf("merge PR %d: expected head SHA is required", prNumber)
 	}
-	out, err := ghCommand("pr", "merge",
+	out, err := c.ghExec("pr", "merge",
 		fmt.Sprint(prNumber),
 		"--repo", c.Repo,
 		"--squash",
 		"--delete-branch",
-		"--match-head-commit", expectedHeadSHA).CombinedOutput()
+		"--match-head-commit", expectedHeadSHA)
 	if err != nil {
 		return fmt.Errorf("gh pr merge %d at head %s: %w\n%s", prNumber, expectedHeadSHA, err, out)
 	}
@@ -3265,9 +3375,9 @@ func (c *Client) MergePRAtHead(prNumber int, expectedHeadSHA string) error {
 // `gh pr ready`). `gh pr merge` on a draft fails with "still a draft", so
 // the orchestrator readies a green draft PR before merging it (#697).
 func (c *Client) MarkPRReady(prNumber int) error {
-	out, err := ghCommand("pr", "ready",
+	out, err := c.ghExec("pr", "ready",
 		fmt.Sprint(prNumber),
-		"--repo", c.Repo).CombinedOutput()
+		"--repo", c.Repo)
 	if err != nil {
 		return fmt.Errorf("gh pr ready %d: %w\n%s", prNumber, err, out)
 	}
@@ -3285,9 +3395,9 @@ func (c *Client) MarkPRReady(prNumber int) error {
 // same pass; they should let the next supervisor cycle re-validate and
 // re-mint against the new state (#547).
 func (c *Client) UpdateBranch(prNumber int) error {
-	out, err := ghCommand("pr", "update-branch",
+	out, err := c.ghExec("pr", "update-branch",
 		fmt.Sprint(prNumber),
-		"--repo", c.Repo).CombinedOutput()
+		"--repo", c.Repo)
 	if err != nil {
 		return fmt.Errorf("gh pr update-branch %d: %w\n%s", prNumber, err, out)
 	}
@@ -3297,17 +3407,17 @@ func (c *Client) UpdateBranch(prNumber int) error {
 // CloseIssue closes a GitHub issue and leaves a comment explaining why
 func (c *Client) CloseIssue(number int, comment string) error {
 	if comment != "" {
-		out, err := ghCommand("issue", "comment",
+		out, err := c.ghExec("issue", "comment",
 			fmt.Sprint(number),
 			"--repo", c.Repo,
-			"--body", comment).CombinedOutput()
+			"--body", comment)
 		if err != nil {
 			return fmt.Errorf("gh issue comment %d: %w\n%s", number, err, out)
 		}
 	}
-	out, err := ghCommand("issue", "close",
+	out, err := c.ghExec("issue", "close",
 		fmt.Sprint(number),
-		"--repo", c.Repo).CombinedOutput()
+		"--repo", c.Repo)
 	if err != nil {
 		return fmt.Errorf("gh issue close %d: %w\n%s", number, err, out)
 	}
@@ -3316,11 +3426,11 @@ func (c *Client) CloseIssue(number int, comment string) error {
 
 // AddIssueLabel adds a label to an issue.
 func (c *Client) AddIssueLabel(issueNumber int, label string) error {
-	out, err := ghCommand("issue", "edit",
+	out, err := c.ghExec("issue", "edit",
 		strconv.Itoa(issueNumber),
 		"--repo", c.Repo,
 		"--add-label", label,
-	).CombinedOutput()
+	)
 	if err != nil {
 		return fmt.Errorf("gh issue edit --add-label: %w\n%s", err, out)
 	}
@@ -3342,7 +3452,7 @@ func (c *Client) EnsureLabel(name, color, description string) error {
 	if description = strings.TrimSpace(description); description != "" {
 		args = append(args, "--description", description)
 	}
-	out, err := ghCommand(args...).CombinedOutput()
+	out, err := c.ghExec(args...)
 	if err != nil {
 		return fmt.Errorf("gh label create %q: %w\n%s", name, err, out)
 	}
@@ -3351,11 +3461,11 @@ func (c *Client) EnsureLabel(name, color, description string) error {
 
 // RemoveIssueLabel removes a label from an issue.
 func (c *Client) RemoveIssueLabel(issueNumber int, label string) error {
-	out, err := ghCommand("issue", "edit",
+	out, err := c.ghExec("issue", "edit",
 		strconv.Itoa(issueNumber),
 		"--repo", c.Repo,
 		"--remove-label", label,
-	).CombinedOutput()
+	)
 	if err != nil {
 		return fmt.Errorf("gh issue edit --remove-label: %w\n%s", err, out)
 	}
@@ -3364,11 +3474,11 @@ func (c *Client) RemoveIssueLabel(issueNumber int, label string) error {
 
 // CommentIssue leaves a comment on an issue.
 func (c *Client) CommentIssue(issueNumber int, body string) error {
-	out, err := ghCommand("issue", "comment",
+	out, err := c.ghExec("issue", "comment",
 		strconv.Itoa(issueNumber),
 		"--repo", c.Repo,
 		"--body", body,
-	).CombinedOutput()
+	)
 	if err != nil {
 		return fmt.Errorf("gh issue comment: %w\n%s", err, out)
 	}
@@ -3381,7 +3491,7 @@ func (c *Client) CommentIssue(issueNumber int, body string) error {
 // without a webhook dependency. GitHub treats PRs as issues, so this also
 // works for PR numbers, but the supervisor only calls it for issues.
 func (c *Client) ListIssueComments(issueNumber int) ([]IssueComment, error) {
-	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, issueNumber), "--paginate")
+	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, issueNumber), "--paginate")
 	if err != nil {
 		return nil, fmt.Errorf("list issue comments for #%d: %w", issueNumber, err)
 	}
@@ -3410,11 +3520,11 @@ func (c *Client) ListIssueComments(issueNumber int) ([]IssueComment, error) {
 
 // CommentPR leaves a comment on a pull request.
 func (c *Client) CommentPR(prNumber int, body string) error {
-	out, err := ghCommand("pr", "comment",
+	out, err := c.ghExec("pr", "comment",
 		strconv.Itoa(prNumber),
 		"--repo", c.Repo,
 		"--body", body,
-	).CombinedOutput()
+	)
 	if err != nil {
 		return fmt.Errorf("gh pr comment: %w\n%s", err, out)
 	}
@@ -3423,7 +3533,7 @@ func (c *Client) CommentPR(prNumber int, body string) error {
 
 // PRLabels returns the labels on a PR.
 func (c *Client) PRLabels(prNumber int) ([]string, error) {
-	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/labels?per_page=100", c.Repo, prNumber), "--paginate")
+	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/labels?per_page=100", c.Repo, prNumber), "--paginate")
 	if err != nil {
 		return nil, fmt.Errorf("list PR %d labels: %w", prNumber, err)
 	}
@@ -3436,7 +3546,7 @@ func (c *Client) PRLabels(prNumber int) ([]string, error) {
 
 // PRCommits returns commit messages for a PR.
 func (c *Client) PRCommits(prNumber int) ([]string, error) {
-	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d/commits?per_page=100", c.Repo, prNumber), "--paginate")
+	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d/commits?per_page=100", c.Repo, prNumber), "--paginate")
 	if err != nil {
 		return nil, fmt.Errorf("list PR %d commits: %w", prNumber, err)
 	}
@@ -3449,11 +3559,11 @@ func (c *Client) PRCommits(prNumber int) ([]string, error) {
 
 // CreateRelease creates a GitHub release for the given tag.
 func (c *Client) CreateRelease(tag, title string) error {
-	out, err := ghCommand("release", "create",
+	out, err := c.ghExec("release", "create",
 		tag,
 		"--repo", c.Repo,
 		"--title", title,
-		"--generate-notes").CombinedOutput()
+		"--generate-notes")
 	if err != nil {
 		return fmt.Errorf("gh release create %s: %w\n%s", tag, err, out)
 	}
@@ -3776,7 +3886,7 @@ func (c *Client) CreateIssue(title, body string, labels []string) (int, error) {
 		args = append(args, "--label", l)
 	}
 
-	out, err := ghCommand(args...).CombinedOutput()
+	out, err := c.ghExec(args...)
 	if err != nil {
 		return 0, fmt.Errorf("gh issue create: %w\n%s", err, out)
 	}
@@ -3796,11 +3906,11 @@ func (c *Client) CreateIssue(title, body string, labels []string) (int, error) {
 
 // EditIssueBody updates the body of a GitHub issue.
 func (c *Client) EditIssueBody(number int, body string) error {
-	out, err := ghCommand("issue", "edit",
+	out, err := c.ghExec("issue", "edit",
 		strconv.Itoa(number),
 		"--repo", c.Repo,
 		"--body", body,
-	).CombinedOutput()
+	)
 	if err != nil {
 		return fmt.Errorf("gh issue edit %d --body: %w\n%s", number, err, out)
 	}
@@ -4443,7 +4553,7 @@ func (c *Client) CollectPRReviewFeedback(prNumber int, streams []string) (string
 
 	// 1. Fetch issue-level comments (Greptile summary with confidence score),
 	// via the shared wrapper (#797) for backoff + conditional caching.
-	issueCommentsOut, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
+	issueCommentsOut, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
 	if err == nil {
 		var comments []struct {
 			Body string `json:"body"`

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1920,6 +1920,9 @@ func (c *Client) ListOpenIssues(labels []string) ([]Issue, error) {
 }
 
 func (c *Client) listOpenIssuesByLabel(label string) ([]Issue, error) {
+	if c.isForgejo() {
+		return c.fjListOpenIssuesByLabel(label, false)
+	}
 	endpoint := fmt.Sprintf("repos/%s/issues?state=open&per_page=100", c.Repo)
 	if label != "" {
 		endpoint += "&labels=" + url.QueryEscape(label)
@@ -1972,6 +1975,9 @@ func (c *Client) ListAllOpenIssues(labels []string) ([]Issue, error) {
 }
 
 func (c *Client) listAllOpenIssuesByLabel(label string) ([]Issue, error) {
+	if c.isForgejo() {
+		return c.fjListOpenIssuesByLabel(label, true)
+	}
 	endpoint := fmt.Sprintf("repos/%s/issues?state=open&per_page=100", c.Repo)
 	if label != "" {
 		endpoint += "&labels=" + url.QueryEscape(label)
@@ -1995,6 +2001,9 @@ func (c *Client) listAllOpenIssuesByLabel(label string) ([]Issue, error) {
 
 // GetIssue fetches a single issue by number
 func (c *Client) GetIssue(number int) (Issue, error) {
+	if c.isForgejo() {
+		return c.fjGetIssue(number)
+	}
 	out, err := c.ghAPI(fmt.Sprintf("repos/%s/issues/%d", c.Repo, number))
 	if err != nil {
 		return Issue{}, fmt.Errorf("get issue %d: %w", number, err)
@@ -2020,6 +2029,9 @@ func (c *Client) IssueBody(number int) (string, error) {
 
 // IsIssueClosed returns true if the issue is closed
 func (c *Client) IsIssueClosed(number int) (bool, error) {
+	if c.isForgejo() {
+		return c.fjIsIssueClosed(number)
+	}
 	out, err := c.ghAPI(fmt.Sprintf("repos/%s/issues/%d", c.Repo, number))
 	if err != nil {
 		return false, fmt.Errorf("get issue %d: %w", number, err)
@@ -2035,6 +2047,9 @@ func (c *Client) IsIssueClosed(number int) (bool, error) {
 
 // ListOpenPRs returns all open PRs
 func (c *Client) ListOpenPRs() ([]PR, error) {
+	if c.isForgejo() {
+		return c.fjListPulls("open", false)
+	}
 	out, err := c.ghAPI(fmt.Sprintf("repos/%s/pulls?state=open&per_page=100", c.Repo))
 	if err != nil {
 		return nil, fmt.Errorf("list open PRs: %w", err)
@@ -2051,6 +2066,9 @@ func (c *Client) ListOpenPRs() ([]PR, error) {
 // for why the reconciliation loop (#827) needs the full open set rather than
 // page one before it uses absence as a close signal.
 func (c *Client) ListAllOpenPRs() ([]PR, error) {
+	if c.isForgejo() {
+		return c.fjListPulls("open", true)
+	}
 	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls?state=open&per_page=100", c.Repo), "--paginate")
 	if err != nil {
 		return nil, fmt.Errorf("list all open PRs: %w", err)
@@ -2068,6 +2086,11 @@ func (c *Client) ListAllOpenPRs() ([]PR, error) {
 }
 
 func (c *Client) listClosedPRs() ([]PR, error) {
+	if c.isForgejo() {
+		// forgejo.ListPulls sorts recentupdate — same newest-updated-first
+		// contract as this endpoint's sort=updated&direction=desc.
+		return c.fjListPulls("closed", false)
+	}
 	out, err := c.ghAPI(fmt.Sprintf("repos/%s/pulls?state=closed&per_page=100&sort=updated&direction=desc", c.Repo))
 	if err != nil {
 		return nil, fmt.Errorf("list closed PRs: %w", err)
@@ -2087,6 +2110,9 @@ func (c *Client) ListClosedPRs() ([]PR, error) {
 }
 
 func (c *Client) getRESTPull(prNumber int) (restPull, error) {
+	if c.isForgejo() {
+		return c.fjGetRESTPull(prNumber)
+	}
 	out, err := c.ghAPI(fmt.Sprintf("repos/%s/pulls/%d", c.Repo, prNumber))
 	if err != nil {
 		return restPull{}, err
@@ -2161,6 +2187,9 @@ func (c *Client) PRMergeInfo(prNumber int) (PRMergeInfo, error) {
 // delivery executor resolves a tie with canonical-remote commit ancestry and
 // otherwise fails closed.
 func (c *Client) LatestMergedPRGenerations(ctx context.Context) ([]PRMergeInfo, error) {
+	if c.isForgejo() {
+		return c.fjLatestMergedPRGenerations(ctx)
+	}
 	deliveryBase, err := c.RepositoryDefaultBranch(ctx)
 	if err != nil {
 		return nil, err
@@ -2184,6 +2213,9 @@ func (c *Client) LatestMergedPRGenerations(ctx context.Context) ([]PRMergeInfo, 
 // Repositories using trunk/master are supported, and a newer merge into an
 // unrelated release/feature branch cannot supersede a default-branch delivery.
 func (c *Client) RepositoryDefaultBranch(ctx context.Context) (string, error) {
+	if c.isForgejo() {
+		return c.fjRepositoryDefaultBranch(ctx)
+	}
 	out, err := c.ghAPIWithArgsContext(ctx, fmt.Sprintf("repos/%s", c.Repo))
 	if err != nil {
 		return "", errors.New("read repository delivery branch failed")
@@ -2251,6 +2283,9 @@ func (c *Client) BranchHeadSHA(branch string) (string, error) {
 	branch = strings.TrimSpace(branch)
 	if branch == "" {
 		return "", fmt.Errorf("empty branch")
+	}
+	if c.isForgejo() {
+		return c.fjBranchHeadSHA(branch)
 	}
 	out, err := c.ghAPI(fmt.Sprintf("repos/%s/commits/%s", c.Repo, url.PathEscape(branch)))
 	if err != nil {
@@ -2425,6 +2460,13 @@ type PRCheckSignal struct {
 // the source that did answer, but Complete=false and Fingerprint is absent so a
 // partial poll cannot fabricate material progress.
 func (c *Client) PRCheckRollup(prNumber int) (PRCheckRollup, error) {
+	if c.isForgejo() {
+		// NOT ported in M2 (status rollup is M4), guarded explicitly: the
+		// head-SHA read below is ported and would succeed, and the joint
+		// check-runs/status failure after it formats with %v — which would
+		// strip errors.Is matchability from the sentinel.
+		return PRCheckRollup{Verdict: "unknown"}, c.forgejoUnsupported("PRCheckRollup (check-runs/status rollup; M4)")
+	}
 	sha, err := c.pullHeadSHA(prNumber)
 	if err != nil {
 		return PRCheckRollup{Verdict: "unknown"}, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
@@ -2535,6 +2577,15 @@ func (c *Client) PRMergeable(prNumber int) (string, error) {
 // mergeStateStatus is lower-cased and trimmed; "" means GitHub has not
 // computed it yet (caller should treat that as "don't know, proceed").
 func (c *Client) PRMergeStatus(prNumber int) (mergeable string, mergeStateStatus string, err error) {
+	if c.isForgejo() {
+		// NOT ported in M2, guarded explicitly: getRESTPull IS ported, so
+		// without this the method would "work" — returning the mergeable
+		// verdict plus a permanently-empty mergeable_state, which callers
+		// read as "GitHub has not computed it yet, proceed". Forgejo has no
+		// mergeable_state equivalent; the behind-vs-conflict semantics land
+		// in M4. PRMergeable (the bool verdict alone) IS ported.
+		return "", "", c.forgejoUnsupported("PRMergeStatus (no mergeable_state equivalent on forgejo; M4)")
+	}
 	pr, err := c.getRESTPull(prNumber)
 	if err != nil {
 		return "", "", fmt.Errorf("get pull %d: %w", prNumber, err)
@@ -3126,6 +3177,12 @@ func (c *Client) ClosePR(prNumber int, comment string) error {
 // PRChecksOutput returns a REST-derived check overview for a PR, useful for
 // capturing CI failure details to pass to retry workers.
 func (c *Client) PRChecksOutput(prNumber int) (string, error) {
+	if c.isForgejo() {
+		// NOT ported in M2, guarded explicitly: same %v-formatting hazard as
+		// PRCheckRollup — the ported head-SHA read would succeed and the
+		// joint failure below would lose the sentinel.
+		return "", c.forgejoUnsupported("PRChecksOutput (check-runs/status rollup; M4)")
+	}
 	sha, err := c.pullHeadSHA(prNumber)
 	if err != nil {
 		return "", fmt.Errorf("get pull %d head sha: %w", prNumber, err)
@@ -3491,6 +3548,9 @@ func (c *Client) CommentIssue(issueNumber int, body string) error {
 // without a webhook dependency. GitHub treats PRs as issues, so this also
 // works for PR numbers, but the supervisor only calls it for issues.
 func (c *Client) ListIssueComments(issueNumber int) ([]IssueComment, error) {
+	if c.isForgejo() {
+		return c.fjListIssueComments(issueNumber)
+	}
 	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, issueNumber), "--paginate")
 	if err != nil {
 		return nil, fmt.Errorf("list issue comments for #%d: %w", issueNumber, err)
@@ -3533,6 +3593,9 @@ func (c *Client) CommentPR(prNumber int, body string) error {
 
 // PRLabels returns the labels on a PR.
 func (c *Client) PRLabels(prNumber int) ([]string, error) {
+	if c.isForgejo() {
+		return c.fjPRLabels(prNumber)
+	}
 	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/labels?per_page=100", c.Repo, prNumber), "--paginate")
 	if err != nil {
 		return nil, fmt.Errorf("list PR %d labels: %w", prNumber, err)
@@ -3546,6 +3609,9 @@ func (c *Client) PRLabels(prNumber int) ([]string, error) {
 
 // PRCommits returns commit messages for a PR.
 func (c *Client) PRCommits(prNumber int) ([]string, error) {
+	if c.isForgejo() {
+		return c.fjPRCommits(prNumber)
+	}
 	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d/commits?per_page=100", c.Repo, prNumber), "--paginate")
 	if err != nil {
 		return nil, fmt.Errorf("list PR %d commits: %w", prNumber, err)
@@ -4481,6 +4547,13 @@ func FormatReviewFeedback(comments []ReviewComment) string {
 
 // CIFailureSummary gets the CI check run failure summary for a PR.
 func (c *Client) CIFailureSummary(prNumber int) (string, error) {
+	if c.isForgejo() {
+		// NOT ported in M2, guarded explicitly: every downstream error here
+		// is deliberately swallowed (the summary degrades to the overview),
+		// so without a guard forgejo mode would return an error STRING as a
+		// nil-error "summary" and feed it into a retry-worker prompt.
+		return "", c.forgejoUnsupported("CIFailureSummary (check-runs; M4)")
+	}
 	// 1. Get check overview
 	overview, err := c.PRChecksOutput(prNumber)
 	if err != nil {
@@ -4549,6 +4622,13 @@ func (c *Client) CIFailureSummary(prNumber int) (string, error) {
 // into a worker prompt, or empty string if no actionable review feedback
 // exists.
 func (c *Client) CollectPRReviewFeedback(prNumber int, streams []string) (string, error) {
+	if c.isForgejo() {
+		// NOT ported in M2 (review-gate family is M4), guarded explicitly:
+		// both reads below swallow errors by design ("no feedback" degrades
+		// to empty), so forgejo mode would silently report "no review
+		// feedback" with a nil error instead of failing loud.
+		return "", c.forgejoUnsupported("CollectPRReviewFeedback (review-gate family; M4)")
+	}
 	var sections []string
 
 	// 1. Fetch issue-level comments (Greptile summary with confidence score),

--- a/internal/github/github_projects.go
+++ b/internal/github/github_projects.go
@@ -85,7 +85,7 @@ func (c *Client) DiscoverProject(projectNumber int) (*ProjectField, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
-	out, err := ghCommandContext(ctx, "api", "graphql", "-f", "query="+query).Output()
+	out, err := c.ghOutputContext(ctx, "api", "graphql", "-f", "query="+query)
 	if err != nil {
 		return nil, fmt.Errorf("discover project %d: %w", projectNumber, err)
 	}
@@ -288,7 +288,7 @@ func (c *Client) fetchProjectItemsPage(projectID, cursor string) ([]byte, error)
 
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
-	out, err := ghCommandContext(ctx, "api", "graphql", "-f", "query="+query).Output()
+	out, err := c.ghOutputContext(ctx, "api", "graphql", "-f", "query="+query)
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return nil, fmt.Errorf("graphql project items: %w\nstderr: %s", err, exitErr.Stderr)
@@ -406,7 +406,7 @@ func (c *Client) ListProjectItemStatusCounts(pf *ProjectField) ([]ProjectBoardCo
 
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
-	out, err := ghCommandContext(ctx, "api", "graphql", "-f", "query="+query).Output()
+	out, err := c.ghOutputContext(ctx, "api", "graphql", "-f", "query="+query)
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return nil, 0, fmt.Errorf("graphql project status counts: %w\nstderr: %s", err, exitErr.Stderr)
@@ -534,7 +534,7 @@ func (c *Client) TrySyncIssueStatusOneOf(pf *ProjectField, issueNumber int, cand
 func (c *Client) getIssueNodeID(issueNumber int) (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
-	out, err := ghCommandContext(ctx, "api", fmt.Sprintf("repos/%s/issues/%d", c.Repo, issueNumber)).Output()
+	out, err := c.ghOutputContext(ctx, "api", fmt.Sprintf("repos/%s/issues/%d", c.Repo, issueNumber))
 	if err != nil {
 		return "", fmt.Errorf("gh api issue %d: %w", issueNumber, err)
 	}
@@ -568,7 +568,7 @@ func (c *Client) addToProject(projectID, contentID string) (string, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
-	out, err := ghCommandContext(ctx, "api", "graphql", "-f", "query="+query).Output()
+	out, err := c.ghOutputContext(ctx, "api", "graphql", "-f", "query="+query)
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return "", fmt.Errorf("graphql addProjectV2ItemById: %w\nstderr: %s\nstdout: %s", err, exitErr.Stderr, out)
@@ -618,7 +618,7 @@ func (c *Client) setProjectItemStatus(projectID, itemID, fieldID, optionID strin
 
 	ctx, cancel := context.WithTimeout(context.Background(), ghTimeout)
 	defer cancel()
-	out, err := ghCommandContext(ctx, "api", "graphql", "-f", "query="+query).Output()
+	out, err := c.ghOutputContext(ctx, "api", "graphql", "-f", "query="+query)
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			return fmt.Errorf("graphql updateProjectV2ItemFieldValue: %w\nstderr: %s\nstdout: %s", err, exitErr.Stderr, out)

--- a/internal/github/github_projects_test.go
+++ b/internal/github/github_projects_test.go
@@ -5,10 +5,12 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/befeast/maestro/internal/config"
 )
 
 func TestDiscoverProject_RequiresOrg(t *testing.T) {
-	c := New("owner/repo")
+	c := New("owner/repo", config.ForgeConfig{})
 	// DiscoverProject makes real API calls; just verify it doesn't panic
 	_ = c
 }
@@ -66,13 +68,13 @@ func TestParseDiscoverProjectResponse_UserOwner(t *testing.T) {
 }
 
 func TestSyncIssueStatus_NilProjectField(t *testing.T) {
-	c := New("owner/repo")
+	c := New("owner/repo", config.ForgeConfig{})
 	// A nil ProjectField should be a no-op (not panic)
 	c.SyncIssueStatus(nil, 1, "Todo")
 }
 
 func TestListNonDoneProjectItems_NilProjectField(t *testing.T) {
-	c := New("owner/repo")
+	c := New("owner/repo", config.ForgeConfig{})
 	_, err := c.ListNonDoneProjectItems(nil)
 	if err == nil {
 		t.Error("expected error for nil ProjectField")
@@ -356,12 +358,12 @@ func TestResolveProjectStatusOption(t *testing.T) {
 }
 
 func TestSyncIssueStatusOneOf_NilProjectField(t *testing.T) {
-	c := New("owner/repo")
+	c := New("owner/repo", config.ForgeConfig{})
 	c.SyncIssueStatusOneOf(nil, 1, "In Review", "Review", "In Progress")
 }
 
 func TestTrySyncIssueStatusOneOf_NilProjectField(t *testing.T) {
-	c := New("owner/repo")
+	c := New("owner/repo", config.ForgeConfig{})
 	if c.TrySyncIssueStatusOneOf(nil, 1, "In Review") {
 		t.Fatal("TrySyncIssueStatusOneOf should report false for nil project field")
 	}
@@ -495,7 +497,7 @@ func TestParseProjectItemStatusCountsResponse_SurfacesGraphQLErrors(t *testing.T
 }
 
 func TestListProjectItemStatusCounts_NilProjectField(t *testing.T) {
-	c := New("owner/repo")
+	c := New("owner/repo", config.ForgeConfig{})
 	if _, _, err := c.ListProjectItemStatusCounts(nil); err == nil {
 		t.Fatal("expected error for nil ProjectField")
 	}

--- a/internal/github/review_threads.go
+++ b/internal/github/review_threads.go
@@ -94,7 +94,7 @@ func (c *Client) PRUnresolvedReviewThreadsOnHead(prNumber int) (string, []Review
   }
 }`, strconv.Quote(owner), strconv.Quote(name), prNumber, after)
 
-		out, err := ghCommand("api", "graphql", "-f", "query="+query).CombinedOutput()
+		out, err := c.ghExec("api", "graphql", "-f", "query="+query)
 		if err != nil {
 			return "", nil, fmt.Errorf("read review threads for PR %d: %w\n%s", prNumber, err, out)
 		}

--- a/internal/github/visual_evidence.go
+++ b/internal/github/visual_evidence.go
@@ -14,7 +14,7 @@ import (
 
 // PRChangedFiles returns the repo-relative paths changed by a PR.
 func (c *Client) PRChangedFiles(prNumber int) ([]string, error) {
-	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d/files?per_page=100", c.Repo, prNumber), "--paginate")
+	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d/files?per_page=100", c.Repo, prNumber), "--paginate")
 	if err != nil {
 		return nil, fmt.Errorf("list PR %d files: %w", prNumber, err)
 	}
@@ -53,7 +53,7 @@ func (c *Client) PRVisualEvidenceAttached(prNumber int) (bool, error) {
 		return true, nil
 	}
 
-	out, err := ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
+	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
 	if err != nil {
 		return false, fmt.Errorf("list PR %d comments: %w", prNumber, err)
 	}

--- a/internal/github/visual_evidence.go
+++ b/internal/github/visual_evidence.go
@@ -14,6 +14,9 @@ import (
 
 // PRChangedFiles returns the repo-relative paths changed by a PR.
 func (c *Client) PRChangedFiles(prNumber int) ([]string, error) {
+	if c.isForgejo() {
+		return c.fjPRChangedFiles(prNumber)
+	}
 	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d/files?per_page=100", c.Repo, prNumber), "--paginate")
 	if err != nil {
 		return nil, fmt.Errorf("list PR %d files: %w", prNumber, err)
@@ -53,13 +56,13 @@ func (c *Client) PRVisualEvidenceAttached(prNumber int) (bool, error) {
 		return true, nil
 	}
 
-	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
+	// ListIssueComments issues the byte-identical gh read this method used to
+	// make inline (same endpoint, same --paginate) and dispatches to the
+	// Forgejo comments read on forgejo rows — both getRESTPull above and this
+	// call route per forge, so the method itself is transport-agnostic.
+	comments, err := c.ListIssueComments(prNumber)
 	if err != nil {
 		return false, fmt.Errorf("list PR %d comments: %w", prNumber, err)
-	}
-	comments, err := parseIssueComments(out)
-	if err != nil {
-		return false, fmt.Errorf("parse PR %d comments: %w", prNumber, err)
 	}
 	for _, comment := range comments {
 		if ContainsEmbeddedImage(comment.Body) {

--- a/internal/mission/mission_test.go
+++ b/internal/mission/mission_test.go
@@ -194,7 +194,7 @@ func TestProcessMissions_DecomposeAndTrack(t *testing.T) {
 		},
 	}
 
-	gh := github.New("owner/repo")
+	gh := github.New("owner/repo", config.ForgeConfig{})
 	proc := NewProcessor(cfg, gh)
 
 	childCounter := 100
@@ -259,7 +259,7 @@ func TestProcessMissions_SkipAlreadyTracked(t *testing.T) {
 		},
 	}
 
-	gh := github.New("owner/repo")
+	gh := github.New("owner/repo", config.ForgeConfig{})
 	proc := NewProcessor(cfg, gh)
 
 	createCalled := false
@@ -304,7 +304,7 @@ func TestProcessMissions_MaxChildrenCap(t *testing.T) {
 		},
 	}
 
-	gh := github.New("owner/repo")
+	gh := github.New("owner/repo", config.ForgeConfig{})
 	proc := NewProcessor(cfg, gh)
 
 	childCounter := 200
@@ -354,7 +354,7 @@ func TestProcessMissions_AllChildrenClosed(t *testing.T) {
 		},
 	}
 
-	gh := github.New("owner/repo")
+	gh := github.New("owner/repo", config.ForgeConfig{})
 	proc := NewProcessor(cfg, gh)
 
 	proc.IsIssueClosedFn = func(number int) (bool, error) {
@@ -389,7 +389,7 @@ func TestProcessMissions_Disabled(t *testing.T) {
 		},
 	}
 
-	gh := github.New("owner/repo")
+	gh := github.New("owner/repo", config.ForgeConfig{})
 	proc := NewProcessor(cfg, gh)
 
 	s := state.NewState()

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -90,7 +90,7 @@ type Orchestrator struct {
 	reviewProduceMu       sync.Mutex
 	reviewProduceInFlight map[int]bool
 	// reviewProduceFn is the production seam (tests). nil = produceReviewStreams.
-	reviewProduceFn func(prNumber int, headSHA string, streams []string, rp config.ReviewProducerConfig)
+	reviewProduceFn func(prNumber int, headSHA string, streams []string, rp config.ReviewProducerConfig, fc config.ForgeConfig)
 	router                *router.Router
 	repo                  string
 	binaryVersion         string
@@ -257,7 +257,7 @@ func New(cfg *config.Config) *Orchestrator {
 		n.SetDigestMode(true)
 		log.Printf("[orch] digest mode enabled — notifications will be batched per cycle")
 	}
-	gh := github.New(cfg.Repo)
+	gh := github.New(cfg.Repo, cfg.Forge)
 	o := &Orchestrator{
 		cfg:      cfg,
 		notifier: n,

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3811,7 +3811,7 @@ func TestMergeReadyPR_BehindMainRebaseFailsMarksConflict(t *testing.T) {
 	o := &Orchestrator{
 		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: true},
 		notifier: &notify.Notifier{},
-		gh:       github.New("owner/repo"),
+		gh:       github.New("owner/repo", config.ForgeConfig{}),
 		ghMergePRFn: func(prNumber int) error {
 			return fmt.Errorf("gh pr merge 10: the head branch is not up to date with the base branch")
 		},
@@ -8643,7 +8643,7 @@ func TestSyncProject_DisabledByDefault(t *testing.T) {
 	// When github_projects is not enabled, syncProject should be a no-op (not panic)
 	o := &Orchestrator{
 		cfg: &config.Config{Repo: "owner/repo"},
-		gh:  github.New("owner/repo"),
+		gh:  github.New("owner/repo", config.ForgeConfig{}),
 	}
 	// Should not panic or make any API calls
 	o.syncProject(42, github.ProjectStatusInProgress)
@@ -8658,7 +8658,7 @@ func TestSyncProject_DisabledWhenNoProjectNumber(t *testing.T) {
 				ProjectNumber: 0, // not set
 			},
 		},
-		gh: github.New("owner/repo"),
+		gh: github.New("owner/repo", config.ForgeConfig{}),
 	}
 	// Should not panic or make any API calls
 	o.syncProject(42, github.ProjectStatusInProgress)
@@ -8827,7 +8827,7 @@ func TestRunOncePersistsProjectStatusSyncAfterReconcile(t *testing.T) {
 	syncCalls := 0
 	o := &Orchestrator{
 		cfg:      cfg,
-		gh:       github.New(cfg.Repo),
+		gh:       github.New(cfg.Repo, cfg.Forge),
 		notifier: &notify.Notifier{},
 		router:   router.New(cfg),
 		repo:     cfg.Repo,

--- a/internal/orchestrator/pipeline_test.go
+++ b/internal/orchestrator/pipeline_test.go
@@ -18,7 +18,7 @@ func pipelineOrchestrator(cfg *config.Config) *Orchestrator {
 	return &Orchestrator{
 		cfg:      cfg,
 		notifier: notify.NewWithToken("", "", "", "http://localhost:0"),
-		gh:       github.New(cfg.Repo),
+		gh:       github.New(cfg.Repo, cfg.Forge),
 		router:   router.New(cfg),
 		repo:     cfg.Repo,
 	}

--- a/internal/orchestrator/review_producer.go
+++ b/internal/orchestrator/review_producer.go
@@ -2,12 +2,15 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"os"
 	"strings"
 	"time"
 
 	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/forge"
+	"github.com/befeast/maestro/internal/forgejo"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/review"
 )
@@ -64,13 +67,14 @@ func (o *Orchestrator) maybeProduceMissingReview(prNumber int, headSHA string, v
 	// this call and the hot-reload writes, so reading o.cfg here is
 	// race-free, while the spawned goroutine below must never touch it.
 	rp := o.cfg.ReviewProducer
+	fc := o.cfg.Forge
 	go func() {
 		defer func() {
 			o.reviewProduceMu.Lock()
 			delete(o.reviewProduceInFlight, prNumber)
 			o.reviewProduceMu.Unlock()
 		}()
-		produce(prNumber, headSHA, missing, rp)
+		produce(prNumber, headSHA, missing, rp, fc)
 	}()
 }
 
@@ -115,17 +119,40 @@ func reviewLenses(streams []string, rp config.ReviewProducerConfig) []review.Len
 	return lenses
 }
 
-// produceReviewStreams runs the producer for one PR head. The forge is the
-// GitHub client for now; per-project forge selection (Forgejo) arrives with
-// the Forgejo project wiring — the producer itself is already forge-agnostic.
-// Runs on the producer goroutine: everything it needs arrives by value.
-func (o *Orchestrator) produceReviewStreams(prNumber int, headSHA string, streams []string, rp config.ReviewProducerConfig) {
+// reviewForge selects the producer's forge client per row (#1172): a forgejo
+// row gets a Forgejo REST client built from the row's forge config, every
+// other row keeps the GitHub gh-CLI forge. The PAT resolves from the
+// environment HERE, at use time (config never reads env); an empty token is an
+// explicit error — fail closed rather than silently reviewing the GitHub
+// mirror of a Forgejo repo. fc travels by value: this runs on the producer
+// goroutine, which must not read o.cfg (hot-reloaded without a lock).
+func reviewForge(fc config.ForgeConfig) (forge.Client, error) {
+	if !fc.IsForgejo() {
+		return github.NewForge(), nil
+	}
+	token := strings.TrimSpace(os.Getenv(fc.EffectiveTokenEnv()))
+	if token == "" {
+		return nil, fmt.Errorf("forge token env %s is empty; export it in the daemon environment", fc.EffectiveTokenEnv())
+	}
+	return forgejo.New(fc.APIRoot(), token), nil
+}
+
+// produceReviewStreams runs the producer for one PR head. The forge is
+// selected per row from the snapshotted forge config (#1172); the producer
+// itself is forge-agnostic. Runs on the producer goroutine: everything it
+// needs arrives by value.
+func (o *Orchestrator) produceReviewStreams(prNumber int, headSHA string, streams []string, rp config.ReviewProducerConfig, fc config.ForgeConfig) {
 	lenses := reviewLenses(streams, rp)
 	if len(lenses) == 0 {
 		return
 	}
+	fg, err := reviewForge(fc)
+	if err != nil {
+		log.Printf("[orch] PR #%d: llm-review producer: %v", prNumber, err)
+		return
+	}
 	p := &review.Producer{
-		Forge:             github.NewForge(),
+		Forge:             fg,
 		Repo:              o.repo,
 		Lenses:            lenses,
 		PendingStaleAfter: rp.EffectivePendingStale(),

--- a/internal/orchestrator/review_producer_forge_test.go
+++ b/internal/orchestrator/review_producer_forge_test.go
@@ -1,0 +1,59 @@
+package orchestrator
+
+// Producer forge selection tests (#1172 M2): the llm-review producer must
+// pick its forge per row — the Forgejo REST client on forgejo rows, the gh
+// Forge everywhere else — and fail closed on a missing token, because the
+// repos are mirrored: a fallback to the gh forge would post the review to the
+// GitHub mirror instead of the Forgejo original.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/forgejo"
+	"github.com/befeast/maestro/internal/github"
+)
+
+func TestReviewForgeSelectsGitHubByDefault(t *testing.T) {
+	fg, err := reviewForge(config.ForgeConfig{})
+	if err != nil {
+		t.Fatalf("reviewForge(zero) = %v", err)
+	}
+	if _, ok := fg.(*github.Forge); !ok {
+		t.Fatalf("forge = %T, want *github.Forge for a zero/github row", fg)
+	}
+}
+
+func TestReviewForgeSelectsForgejoWithToken(t *testing.T) {
+	t.Setenv("TEST_FORGEJO_TOKEN", "tok")
+	fg, err := reviewForge(config.ForgeConfig{
+		Kind:     "forgejo",
+		BaseURL:  "https://git.example.test",
+		TokenEnv: "TEST_FORGEJO_TOKEN",
+	})
+	if err != nil {
+		t.Fatalf("reviewForge(forgejo) = %v", err)
+	}
+	if _, ok := fg.(*forgejo.Client); !ok {
+		t.Fatalf("forge = %T, want *forgejo.Client for a forgejo row", fg)
+	}
+}
+
+func TestReviewForgeMissingTokenFailsClosed(t *testing.T) {
+	t.Setenv("TEST_FORGEJO_TOKEN", "   ")
+	fg, err := reviewForge(config.ForgeConfig{
+		Kind:     "forgejo",
+		BaseURL:  "https://git.example.test",
+		TokenEnv: "TEST_FORGEJO_TOKEN",
+	})
+	if err == nil {
+		t.Fatalf("reviewForge = %T with an empty token, want a fail-closed error (a gh fallback would review the GitHub mirror)", fg)
+	}
+	if !strings.Contains(err.Error(), "TEST_FORGEJO_TOKEN") {
+		t.Fatalf("err = %v, want the token env named so the fix is obvious", err)
+	}
+	if fg != nil {
+		t.Fatalf("forge = %T alongside an error, want nil", fg)
+	}
+}

--- a/internal/orchestrator/review_producer_test.go
+++ b/internal/orchestrator/review_producer_test.go
@@ -22,7 +22,7 @@ func produceRecorder(o *Orchestrator) (*[]producedCall, *sync.WaitGroup) {
 	var mu sync.Mutex
 	var calls []producedCall
 	var wg sync.WaitGroup
-	o.reviewProduceFn = func(pr int, head string, streams []string, rp config.ReviewProducerConfig) {
+	o.reviewProduceFn = func(pr int, head string, streams []string, rp config.ReviewProducerConfig, fc config.ForgeConfig) {
 		mu.Lock()
 		calls = append(calls, producedCall{pr: pr, head: head, streams: streams})
 		mu.Unlock()
@@ -93,7 +93,7 @@ func TestMaybeProduceMissingReview_InFlightDedup(t *testing.T) {
 	started := 0
 	release := make(chan struct{})
 	done := make(chan struct{}, 2)
-	o.reviewProduceFn = func(pr int, head string, streams []string, rp config.ReviewProducerConfig) {
+	o.reviewProduceFn = func(pr int, head string, streams []string, rp config.ReviewProducerConfig, fc config.ForgeConfig) {
 		mu.Lock()
 		started++
 		mu.Unlock()

--- a/internal/orchestrator/terminal_polling_test.go
+++ b/internal/orchestrator/terminal_polling_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/befeast/maestro/internal/config"
 	"github.com/befeast/maestro/internal/github"
 	"github.com/befeast/maestro/internal/state"
 )
@@ -57,7 +58,7 @@ func TestMergedIssueLookupsShareOneClosedPRSnapshotPerCycle(t *testing.T) {
 				{Number: 12, State: "closed", MergedAt: "2026-07-18T00:01:00Z", Body: "Fixes #102", HeadRefName: "fix/102"},
 			}, nil
 		},
-		gh: github.New("BeFeast/maestro"),
+		gh: github.New("BeFeast/maestro", config.ForgeConfig{}),
 	}
 	o.beginCycle()
 	defer o.endCycle()

--- a/internal/server/fleet_build.go
+++ b/internal/server/fleet_build.go
@@ -22,7 +22,7 @@ func WireFleetProjectGitHub(proj *FleetProject) {
 	if cfg == nil {
 		return
 	}
-	gh := github.New(cfg.Repo)
+	gh := github.New(cfg.Repo, cfg.Forge)
 	proj.SetActionGH(gh)
 	if cfg.GitHubProjects.Enabled && cfg.GitHubProjects.ProjectNumber > 0 {
 		proj.SetBoardClient(gh, cfg.GitHubProjects.ProjectNumber)

--- a/internal/supervisor/outcome_repair.go
+++ b/internal/supervisor/outcome_repair.go
@@ -53,8 +53,8 @@ type futileRecoveryEvent struct {
 }
 
 var (
-	newOutcomeRepairIssueClient = func(repo string) outcomeRepairIssueClient {
-		return github.New(repo)
+	newOutcomeRepairIssueClient = func(repo string, fc config.ForgeConfig) outcomeRepairIssueClient {
+		return github.New(repo, fc)
 	}
 	newFutileRecoveryNotifier = func(cfg *config.Config) futileRecoveryNotifier {
 		n := notify.NewWithToken(cfg.Telegram.Token(), cfg.Telegram.Target, cfg.Telegram.Mode, cfg.Telegram.OpenclawURL)
@@ -117,7 +117,7 @@ func dispatchFutileOutcomeRecovery(cfg *config.Config, now time.Time) {
 			return
 		}
 
-		client := newOutcomeRepairIssueClient(cfg.Repo)
+		client := newOutcomeRepairIssueClient(cfg.Repo, cfg.Forge)
 		title := fmt.Sprintf("Outcome recovery blocked: %s is failing — repair delivery infrastructure", gate)
 		body := outcomeRepairIssueBody(gate, fingerprint, attempts, *health)
 		labels := outcomeRepairLabels(client, cfg)

--- a/internal/supervisor/outcome_repair_test.go
+++ b/internal/supervisor/outcome_repair_test.go
@@ -124,7 +124,7 @@ func installOutcomeRepairStubs(t *testing.T, client *fakeOutcomeRepairClient, no
 		newOutcomeRepairIssueClient = originalClient
 		newFutileRecoveryNotifier = originalNotifier
 	})
-	newOutcomeRepairIssueClient = func(string) outcomeRepairIssueClient { return client }
+	newOutcomeRepairIssueClient = func(string, config.ForgeConfig) outcomeRepairIssueClient { return client }
 	newFutileRecoveryNotifier = func(*config.Config) futileRecoveryNotifier { return notifier }
 }
 

--- a/internal/supervisor/outcome_streaks.go
+++ b/internal/supervisor/outcome_streaks.go
@@ -141,7 +141,7 @@ func defaultGateFailStreakIntake(cfg *config.Config, event outcome.GateStreakEve
 	if cfg == nil || strings.TrimSpace(cfg.Repo) == "" {
 		return 0, fmt.Errorf("gate-fail-streak intake: no repo configured")
 	}
-	client := github.New(cfg.Repo)
+	client := github.New(cfg.Repo, cfg.Forge)
 	title := fmt.Sprintf("gate failure streak: %s failing %d consecutive scheduled runs", event.Gate, event.ConsecutiveFailures)
 	return client.CreateIssue(title, gateFailStreakIssueBody(event), nil)
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -208,7 +208,7 @@ type Engine struct {
 
 func NewEngine(cfg *config.Config, reader Reader) *Engine {
 	if reader == nil {
-		reader = github.New(cfg.Repo)
+		reader = github.New(cfg.Repo, cfg.Forge)
 	}
 	eng := &Engine{
 		cfg:               cfg,
@@ -347,7 +347,7 @@ func RunOnce(ctx context.Context, cfg *config.Config, reader Reader, opts ...Run
 		fmt.Fprintf(os.Stderr, "[supervisor] migrated %d unstamped approval(s) to repo=%s (#489)\n", migrated, cfg.Repo)
 	}
 	if reader == nil {
-		reader = github.New(cfg.Repo)
+		reader = github.New(cfg.Repo, cfg.Forge)
 	}
 	// NOTE: approval execution must NOT run in dry-run mode (greptile
 	// P1 on #480) — the side effects are real GH/fs operations and the
@@ -4924,7 +4924,7 @@ func executeApprovedDeliveries(cfg *config.Config, st *state.State, reader Reade
 		// The normal supervisor reader may be mirror-first and intentionally
 		// omit this freshness-only API. Execution must consult GitHub directly;
 		// a cached mirror is not authoritative for a just-landed merge.
-		latestReader = github.New(cfg.Repo)
+		latestReader = github.New(cfg.Repo, cfg.Forge)
 	}
 	var checkout approver.CheckoutPreparer
 	if provider, ok := reader.(interface {
@@ -5000,12 +5000,12 @@ func executeApprovedApprovals(cfg *config.Config, st *state.State, reader Reader
 	// Reader (the broader supervisor surface) is satisfied by *github.Client,
 	// which also satisfies approver.GitHubClient. We assert the narrower
 	// interface — when it fails (mocks/tests/Mutator-only), we still try to
-	// fall back to a fresh github.New(cfg.Repo).
+	// fall back to a fresh github.New(cfg.Repo, cfg.Forge).
 	var gh approver.GitHubClient
 	if candidate, ok := reader.(approver.GitHubClient); ok {
 		gh = candidate
 	} else {
-		gh = github.New(cfg.Repo)
+		gh = github.New(cfg.Repo, cfg.Forge)
 	}
 	ex := &approver.Executor{
 		GH:        gh,


### PR DESCRIPTION
## Summary

M2 of the Forgejo migration (#1172): the transport switch inside `internal/github.Client` plus Forgejo-backed core reads. Consumers are untouched by design — on a `forge.kind: forgejo` row, ported methods route to the Forgejo REST API and **every** unported method fails loud with `github.ErrForgejoNotSupported`.

### Transport switch
- `github.New(repo string, fc config.ForgeConfig)` — the M1 config block now drives construction at all 21 production sites (plus tests). Zero-value config = GitHub, byte-identical behavior for existing rows.
- Every path from a receiver method to the gh CLI goes through forgejo-guarded chokes (`c.ghAPI`/`c.ghAPIWithArgs`/`c.ghExec`/…). This kills the P0 hazard of mirrored repos: without it, a forgejo row would silently read/write the **GitHub mirror** of the same `owner/name`. Guard coverage is grep-verified and enforced by a test that stubs the gh runner to fail if ever invoked in forgejo mode.
- Missing/empty `token_env` value → constructor records the error, every forgejo call surfaces it.
- Review producer (#1162) now selects the forge per row: `forgejo.New(APIRoot, token)` on forgejo rows (cfg snapshotted on the loop goroutine), `github.NewForge()` otherwise.

### Ported core reads (funnel-level dispatch, derived methods work unchanged)
Issues list/get (+body/closed), PR list/get (details, head SHA, merge info/commit SHA, merged/mergeable), issue comments, PR labels/commits/files, visual evidence, default branch, branch head SHA, latest merged PR generations. Forgejo JSON is mapped into the existing `restIssue`/`restPull`/`IssueComment` structs in `internal/github/forgejo_port.go`; `internal/forgejo` gained the read methods with bounded pagination (`limit=50`, hard page cap, `x-total-count` cross-check — a lower server clamp fails loud instead of silently truncating).

### Explicitly NOT ported (fail loud, by slice)
All writes (M3); check-runs family + `PRMergeStatus` (`mergeable_state` has no Forgejo equivalent — status-rollup semantics land in M4); review-gate comment family (M4); GraphQL review threads + Projects (Projects already config-blocked on forgejo rows); `RateLimit`; delivery-freshness checker (GitHub-anchored — guarded, fail-closed).

### Live-verified contract
Coded against a read-only field-contract verification of the live Forgejo 16.0.1 instance + its swagger (recorded in code comments/fixtures). Notable live findings baked in: issues `labels=` filter **silently ignores unknown label names** (client-side re-filter belt added); real issues carry `pull_request: null` (filter tests non-null, not key presence); default `/pulls` order is index-desc, so `sort=recentupdate` is pinned for closed-PR recency semantics; comments/labels endpoints are unpaginated.

### Review (pre-PR, 3 adversarial lenses + fixer)
Confirmed and fixed: **[P1]** mirror-first read source would serve GitHub webhook-fed state to forgejo rows (config validation now rejects `github_mirror.source: mirror-first` on forgejo kind + daemon read-source/reconcile guards); **[P2]** delivery-freshness checker guarded off on forgejo (fail-closed); **[P2]** Forgejo reports `mergeable:false` for every draft PR — mapped to `UNKNOWN` to avoid a per-cycle repair loop; **[P2]** pagination clamp truncation (above). Deferred flags are listed in the tracking issue: outcome-repair issue URL (M3), mergeable transient + `base=` server filter + rate-limit/ETag parity layers (M4).

## Testing

`go build ./...`, `go vet ./...` clean. `internal/forgejo` (pagination loop, clamp fail-loud, field mapping), `internal/github` (end-to-end forgejo-mode httptest against real `forgejo.Client`, fail-loud sample per file with gh-runner-must-not-run stub, github-mode regression), `internal/config`, `internal/daemon`, `internal/orchestrator`, `internal/supervisor` green. Full suite green except the 3 pre-existing `internal/worker` umask-0002 failures (reproduced on clean main).

Part of #1172 (M2). 32 files, +2910/−127.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches the shared GitHub client used fleet-wide, forge token routing, and mirrored-repo read paths — a silent fallback would read/write the wrong forge. Unported write/CI/review paths now fail closed on forgejo rows.
> 
> **Overview**
> Enables **Forgejo-backed core reads** on `forge.kind: forgejo` rows via a transport switch inside `github.Client`. `github.New` now takes `config.ForgeConfig`; zero-value config keeps GitHub behavior byte-identical.
> 
> **Ported reads** (issues, PRs, comments, labels, commits, files, branch/default-branch, merge info) dispatch at the funnel layer and map Forgejo wire types into existing `restIssue`/`restPull` structs so derived methods stay unchanged. Unported methods (writes, check-runs, review gates, GraphQL/Projects, rate limit) fail with `ErrForgejoNotSupported`, and every path to the gh CLI goes through forgejo-guarded chokes so a mirrored `owner/name` cannot silently hit GitHub.
> 
> **Safety belts for mirrored repos:** config rejects `github_mirror.source: mirror-first` on forgejo rows; the daemon skips mirror read/reconcile for forgejo; delivery freshness fails closed; draft `mergeable:false` maps to `UNKNOWN` to avoid repair loops. The review producer also selects its forge per row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a7f8d54df3b538fe868136efce642dd846c3c5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds Forgejo transport selection, REST read support, pagination, response mapping, configuration validation, and isolation from GitHub mirror paths. A blocking Forgejo read still ignores cancellation of the flow that started it, so a stalled endpoint can hold that flow until the HTTP timeout or application shutdown. The earlier open-pull-request window issue is resolved: an endpoint test serving two 50-item pages confirmed that the current code returns all 100 records.

<h3>Confidence Score: 4/5</h3>

The Forgejo read path is not ready to merge until an initiating flow can cancel its own in-flight request.

One validated reliability failure remains: individual flow cancellation is not connected to the context used by Forgejo HTTP reads.

**Files Needing Attention:** internal/github/forgejo_port.go

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding and linked it to the review comment.
- T-Rex validated the Forgejo pagination harness and confirmed the current code fetches both pages, yielding 100 open PRs in total.
- T-Rex produced a second finding-proof for another P1 finding and linked it to its review comment.
- T-Rex demonstrated through tests and logs that per-flow cancellation does not propagate and that process-wide shutdown cancels inflight reads.
- T-Rex validated the open PR window paging harness and verified the two 50-item pages yield 100 open PRs.

<a href="https://app.greptile.com/trex/runs/18377227/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Forgejo GetIssue adapter discards cancellation and can outlive shutdown grace**

   - **Bug**
     - `Client.GetIssue(number int)` routes to `fjGetIssue`, which creates an unrelated `context.Background()` for the Forgejo REST call. A deliberately blocked server showed the direct context-aware transport stopping immediately on cancellation, while the reachable adapter waited for the separate HTTP timeout.
   - **Cause**
     - The reachable public method accepts no context, and `fjGetIssue` explicitly supplies `context.Background()` instead of a caller-derived context.
   - **Fix**
     - Introduce and propagate a context-aware call path for this operation (and audit the other new Forgejo adapters that use `context.Background()`); retain a compatibility wrapper only where necessary with an explicit lifecycle-bound context.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Ctx-less Forgejo reads ignore individual flow cancellation**

   - **Bug**
     - A real blocking Forgejo `Client.GetIssue` request remained in flight after a separate flow context was canceled. The request terminated only after `BeginShutdown()` was called, rather than when the individual flow was canceled.
   - **Cause**
     - `forgejoCallContext` at `internal/github/forgejo_port.go:74-91` creates a fresh context from `context.Background()` and its watcher selects only on `ghShutdownChan()` or that internally-created context's completion. The ctx-less adapter calls it at line 165, so no individual caller/flow context can be attached to the Forgejo HTTP request.
   - **Fix**
     - Modernize the affected legacy read APIs and their callers to accept and pass a caller/flow `context.Context` into the Forgejo transport; retain shutdown cancellation as an additional parent/cancellation condition.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
internal/github/forgejo_port.go:74
**Flow cancellation remains disconnected**

`forgejoCallContext` creates its request context from `context.Background()` and only observes process-wide shutdown. Consequently, a Forgejo `GetIssue` request that is already in flight cannot be canceled when its individual flow is canceled; it remains blocked until the HTTP transport timeout or global shutdown. Thread the caller's context through these Forgejo read paths so request lifetime follows the flow that initiated it.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(github): 100-item bounded window par..."](https://github.com/befeast/maestro/commit/9a7f8d54df3b538fe868136efce642dd846c3c5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52310415)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->