### PR TITLE
feat(github): forgejo write port with merge-sentinel hardening (#1172 M3)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -545,6 +545,27 @@ func (f ForgeConfig) APIRoot() string {
 	return strings.TrimRight(f.BaseURL, "/") + "/api/v1"
 }
 
+// IssueWebURL returns the human-facing web URL of one issue on this forge
+// (#1172 M3): https://github.com/{repo}/issues/{n} for the GitHub/zero kind,
+// {base_url}/{repo}/issues/{n} for Forgejo. Human-link consumers must use
+// these helpers instead of hardcoding the github.com shape.
+func (f ForgeConfig) IssueWebURL(repo string, n int) string {
+	if f.IsForgejo() {
+		return fmt.Sprintf("%s/%s/issues/%d", strings.TrimRight(f.BaseURL, "/"), repo, n)
+	}
+	return fmt.Sprintf("https://github.com/%s/issues/%d", repo, n)
+}
+
+// PRWebURL is IssueWebURL's pull-request sibling. The path segment DIVERGES
+// between the forges: GitHub uses /pull/{n} (singular), Forgejo /pulls/{n}
+// (plural) — the same divergence that bans scraping PR numbers from URLs.
+func (f ForgeConfig) PRWebURL(repo string, n int) string {
+	if f.IsForgejo() {
+		return fmt.Sprintf("%s/%s/pulls/%d", strings.TrimRight(f.BaseURL, "/"), repo, n)
+	}
+	return fmt.Sprintf("https://github.com/%s/pull/%d", repo, n)
+}
+
 // GitHubAppConfig holds credentials for authenticating as a GitHub App
 // installation instead of a personal access token (#823). When populated the
 // daemon signs a JWT with the App's private key, exchanges it for a

--- a/internal/config/forge_test.go
+++ b/internal/config/forge_test.go
@@ -224,3 +224,50 @@ func TestParseStrict_AcceptsForgeBlock(t *testing.T) {
 		t.Fatalf("strict decode should name the misspelled forge child key, got: %v", err)
 	}
 }
+
+// #1172 M3 — the forge-aware web-URL helpers. GitHub and Forgejo diverge on
+// the PR path segment (/pull/N vs /pulls/N), which is exactly why human links
+// must come from these helpers instead of hardcoded github.com shapes.
+func TestForgeConfigWebURLs(t *testing.T) {
+	cases := []struct {
+		name      string
+		fc        ForgeConfig
+		wantIssue string
+		wantPR    string
+	}{
+		{
+			name:      "zero config (github default)",
+			fc:        ForgeConfig{},
+			wantIssue: "https://github.com/o/r/issues/7",
+			wantPR:    "https://github.com/o/r/pull/7",
+		},
+		{
+			name:      "explicit github kind",
+			fc:        ForgeConfig{Kind: ForgeKindGitHub},
+			wantIssue: "https://github.com/o/r/issues/7",
+			wantPR:    "https://github.com/o/r/pull/7",
+		},
+		{
+			name:      "forgejo",
+			fc:        ForgeConfig{Kind: ForgeKindForgejo, BaseURL: "https://forge.example.com"},
+			wantIssue: "https://forge.example.com/o/r/issues/7",
+			wantPR:    "https://forge.example.com/o/r/pulls/7",
+		},
+		{
+			name:      "forgejo trailing slash trimmed",
+			fc:        ForgeConfig{Kind: ForgeKindForgejo, BaseURL: "https://forge.example.com/"},
+			wantIssue: "https://forge.example.com/o/r/issues/7",
+			wantPR:    "https://forge.example.com/o/r/pulls/7",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.fc.IssueWebURL("o/r", 7); got != tc.wantIssue {
+				t.Errorf("IssueWebURL = %q, want %q", got, tc.wantIssue)
+			}
+			if got := tc.fc.PRWebURL("o/r", 7); got != tc.wantPR {
+				t.Errorf("PRWebURL = %q, want %q", got, tc.wantPR)
+			}
+		})
+	}
+}

--- a/internal/forgejo/forgejo.go
+++ b/internal/forgejo/forgejo.go
@@ -120,9 +120,29 @@ func (c *Client) doHeader(ctx context.Context, method, path string, payload any)
 		if len(excerpt) > 512 {
 			excerpt = excerpt[:512]
 		}
-		return nil, nil, fmt.Errorf("%s %s: HTTP %d: %s", method, path, resp.StatusCode, excerpt)
+		return nil, nil, &StatusError{Method: method, Path: path, StatusCode: resp.StatusCode, Body: excerpt}
 	}
 	return out, resp.Header, nil
+}
+
+// StatusError is the typed non-2xx transport error. Its text is identical to
+// the fmt.Errorf form it replaced; the type exists so callers that must
+// branch on the response (MergePull's out-of-date classification, the github
+// layer's refusal mapping) reach the status code and body via errors.As
+// through the identity-preserving wrap chains instead of string-matching
+// their own error rendering.
+type StatusError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	// Body is the trimmed response-body excerpt, bounded at 512 bytes.
+	// Forgejo errors are APIError {message, url} JSON — short, and exactly
+	// what body-text classification inspects.
+	Body string
+}
+
+func (e *StatusError) Error() string {
+	return fmt.Sprintf("%s %s: HTTP %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
 }
 
 // GetPR returns the PR metadata. An empty head SHA is rejected per the

--- a/internal/forgejo/writes.go
+++ b/internal/forgejo/writes.go
@@ -1,0 +1,390 @@
+// Write methods for the #1172 transport switch (M3). These back the
+// internal/github write funnels on forgejo-mode rows; comment-then-close
+// orchestration (abort on failed comment, skip on empty comment) lives in the
+// github layer — this file is the REST surface only.
+//
+// Contract notes pinned from swagger.v1.json (Forgejo 16.0.1+gitea-1.22.0,
+// fetched 2026-08-11; writes are NEVER exercised against the live instance):
+//
+//   - every create endpoint answers 201, merge/update answer 200 empty, the
+//     label delete answers 204 — all inside do()'s 2xx window;
+//   - CreatePull/CreateIssue return the number from the RESPONSE JSON —
+//     never scraped from a web URL (gh scrapes /pull/N; Forgejo web URLs are
+//     /pulls/N, so URL scraping would be wrong on exactly this forge);
+//   - CreateIssueOption.labels is []int64 ("list of label ids") — names must
+//     be resolved against the repo label list first; IssueLabelsOption.labels
+//     and the DELETE {identifier} path param accept NAMES directly ("Labels
+//     can be a list of integers ... or a list of strings", "name or id of the
+//     label to remove") — no resolution on the add/remove path;
+//   - MergePullRequestOption's wire casing is mixed and pinned verbatim:
+//     `Do` and Go-cased friends vs `head_commit_id`/`delete_branch_after_merge`;
+//   - the merge endpoint documents 405 with an EMPTY body and 409 with an
+//     APIError body, with NO per-code out-of-date semantics — classification
+//     of "head/base moved" refusals is therefore body-text-based and
+//     conservative (see mergeRefusalOutOfDate); a bodyless refusal stays a
+//     raw loud error, never the sentinel;
+//   - CreateLabelOption REQUIRES color; the default for a caller that did not
+//     provide one is the github layer's business ("#ededed" per the gh
+//     parity contract), not this transport's — an empty color here is a loud
+//     pre-flight error;
+//   - CreateReleaseOption has no notes-generation equivalent (gh
+//     --generate-notes divergence): the release body stays empty, the tag
+//     must already exist (pushed by CommitAndTag) and target_commitish is
+//     deliberately omitted so the release anchors to it.
+package forgejo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// CreatePull opens a pull request and returns its number, taken from the
+// response JSON `number` field. A response without a positive number is a
+// loud error: every downstream op (labels, gates, merge) keys off it, so a
+// zero would poison state instead of failing the create.
+func (c *Client) CreatePull(ctx context.Context, repo, title, body, base, head string) (int, error) {
+	payload := map[string]any{
+		"title": title,
+		"body":  body,
+		"base":  base,
+		"head":  head,
+	}
+	out, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/pulls", repo), payload)
+	if err != nil {
+		return 0, fmt.Errorf("create pull on %s: %w", repo, err)
+	}
+	var created struct {
+		Number int `json:"number"`
+	}
+	if err := json.Unmarshal(out, &created); err != nil {
+		return 0, fmt.Errorf("parse created pull on %s: %w", repo, err)
+	}
+	if created.Number <= 0 {
+		return 0, fmt.Errorf("create pull on %s: response carries no pull number", repo)
+	}
+	return created.Number, nil
+}
+
+// Edit is the body/state subset of EditPullRequestOption/EditIssueOption the
+// port needs. A nil Body leaves the body unchanged; a non-nil Body is a FULL
+// replace (empty string allowed). An empty State leaves the state unchanged;
+// otherwise it goes on the wire verbatim — the swagger types state as a free
+// string, "open"/"closed" are the live values.
+type Edit struct {
+	Body  *string
+	State string
+}
+
+func (e Edit) payload() map[string]any {
+	p := map[string]any{}
+	if e.Body != nil {
+		p["body"] = *e.Body
+	}
+	if e.State != "" {
+		p["state"] = e.State
+	}
+	return p
+}
+
+// EditPull PATCHes one pull request. An empty edit is a loud error — a
+// field-less PATCH would be a silent green no-op.
+func (c *Client) EditPull(ctx context.Context, repo string, index int, edit Edit) error {
+	payload := edit.payload()
+	if len(payload) == 0 {
+		return fmt.Errorf("edit pull %s#%d: empty edit", repo, index)
+	}
+	if _, err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/repos/%s/pulls/%d", repo, index), payload); err != nil {
+		return fmt.Errorf("edit pull %s#%d: %w", repo, index, err)
+	}
+	return nil
+}
+
+// EditIssue PATCHes one issue (shared number space with pulls — but the
+// /issues PATCH is the issue-semantics endpoint; pulls go through EditPull).
+func (c *Client) EditIssue(ctx context.Context, repo string, index int, edit Edit) error {
+	payload := edit.payload()
+	if len(payload) == 0 {
+		return fmt.Errorf("edit issue %s#%d: empty edit", repo, index)
+	}
+	if _, err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/repos/%s/issues/%d", repo, index), payload); err != nil {
+		return fmt.Errorf("edit issue %s#%d: %w", repo, index, err)
+	}
+	return nil
+}
+
+// ErrMergeOutOfDate marks a merge refusal whose response body says the
+// head/base moved since the caller's read (head_commit_id mismatch, branch
+// out of date). The github layer maps it onto its own AutoRebase sentinel via
+// errors.Is; the message deliberately contains the legacy "not up to date"
+// needle as a belt for any string-matching consumer.
+var ErrMergeOutOfDate = errors.New("pull head/base not up to date for merge")
+
+// mergeRefusalOutOfDate reports whether a 405/409 merge-refusal body belongs
+// to the out-of-date/head-mismatch family. The needles are the known Forgejo
+// texts ("head commit is out of date" on a head_commit_id mismatch) plus the
+// field name itself and the gh-style phrasing; anything else — including an
+// EMPTY 405 body, which the swagger documents — stays unclassified and
+// surfaces as the raw loud error. Never classify blindly.
+func mergeRefusalOutOfDate(body string) bool {
+	b := strings.ToLower(body)
+	for _, needle := range []string{"out of date", "not up to date", "head_commit_id"} {
+		if strings.Contains(b, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// MergeOptions selects the merge behavior for MergePull. The wire casing of
+// MergePullRequestOption is mixed and pinned verbatim in the payload: `Do`
+// is Go-cased, `head_commit_id`/`delete_branch_after_merge` are snake.
+type MergeOptions struct {
+	// Do is the merge strategy (swagger enum: merge, rebase, rebase-merge,
+	// squash, fast-forward-only, manually-merged). Required by the swagger.
+	Do string
+	// HeadCommitID, when set, makes the server refuse the merge unless the
+	// pull head still matches — the force-push race belt
+	// (gh --match-head-commit parity). Whether it may be empty is the
+	// caller's contract; this transport only omits the field when it is.
+	HeadCommitID string
+	// DeleteBranchAfterMerge deletes the head branch on success
+	// (gh --delete-branch parity).
+	DeleteBranchAfterMerge bool
+}
+
+// MergePull merges one pull request. A 405/409 refusal whose body indicates
+// the out-of-date/head-mismatch family comes back wrapped with
+// ErrMergeOutOfDate (the full HTTP status and body text stay in the chain);
+// every other refusal — including a bodyless 405 — is the raw loud error.
+func (c *Client) MergePull(ctx context.Context, repo string, index int, opts MergeOptions) error {
+	if strings.TrimSpace(opts.Do) == "" {
+		return fmt.Errorf("merge pull %s#%d: merge strategy (Do) is required", repo, index)
+	}
+	payload := map[string]any{
+		"Do":                        opts.Do,
+		"delete_branch_after_merge": opts.DeleteBranchAfterMerge,
+	}
+	if opts.HeadCommitID != "" {
+		payload["head_commit_id"] = opts.HeadCommitID
+	}
+	if _, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/pulls/%d/merge", repo, index), payload); err != nil {
+		var se *StatusError
+		if errors.As(err, &se) &&
+			(se.StatusCode == http.StatusMethodNotAllowed || se.StatusCode == http.StatusConflict) &&
+			mergeRefusalOutOfDate(se.Body) {
+			return fmt.Errorf("merge pull %s#%d: %w: %w", repo, index, ErrMergeOutOfDate, err)
+		}
+		return fmt.Errorf("merge pull %s#%d: %w", repo, index, err)
+	}
+	return nil
+}
+
+// UpdatePullBranch merges the base branch into the pull's head branch
+// (POST /update). style=merge is explicit — parity with the gh default; the
+// #547 contract (the head SHA moves, stale approvals must not merge in the
+// same pass) is the caller's to honor.
+func (c *Client) UpdatePullBranch(ctx context.Context, repo string, index int) error {
+	if _, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/pulls/%d/update?style=merge", repo, index), nil); err != nil {
+		return fmt.Errorf("update pull branch %s#%d: %w", repo, index, err)
+	}
+	return nil
+}
+
+// RepoLabel is one repository label. Color is the wire form: bare rrggbb
+// WITHOUT a leading '#' (live-verified) — compare accordingly.
+type RepoLabel struct {
+	ID          int64  `json:"id"`
+	Name        string `json:"name"`
+	Color       string `json:"color"`
+	Description string `json:"description"`
+}
+
+// ListRepoLabels returns every label defined on the repo. The endpoint is
+// paginated (live-verified: limit honored, x-total-count present), so it goes
+// through the pager, all pages — label resolution must see the full set.
+func (c *Client) ListRepoLabels(ctx context.Context, repo string) ([]RepoLabel, error) {
+	labels, err := listPages[RepoLabel](ctx, c, fmt.Sprintf("/repos/%s/labels", repo), true)
+	if err != nil {
+		return nil, fmt.Errorf("list repo labels %s: %w", repo, err)
+	}
+	return labels, nil
+}
+
+// ResolveLabelIDs maps label names to repo label ids, preserving order —
+// CreateIssueOption.labels demands ids ("list of label ids"). An exact name
+// match wins over a case-insensitive one (the fold mirrors the read side's
+// hasLabel belt); a name that resolves to nothing is a loud error naming the
+// label, gh parity — outcome_repair calls EnsureLabel first, so a miss here
+// means a genuinely unknown label, not a race it should paper over.
+func (c *Client) ResolveLabelIDs(ctx context.Context, repo string, names []string) ([]int64, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+	labels, err := c.ListRepoLabels(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]int64, 0, len(names))
+	for _, name := range names {
+		id, ok := findLabelID(labels, name)
+		if !ok {
+			return nil, fmt.Errorf("label %q does not exist on %s", name, repo)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func findLabelID(labels []RepoLabel, name string) (int64, bool) {
+	for _, l := range labels {
+		if l.Name == name {
+			return l.ID, true
+		}
+	}
+	for _, l := range labels {
+		if strings.EqualFold(l.Name, name) {
+			return l.ID, true
+		}
+	}
+	return 0, false
+}
+
+// CreateIssue opens an issue and returns its number from the response JSON.
+// Label names are resolved to ids first (order preserved) and applied at
+// create time; an unknown name aborts before anything is created.
+func (c *Client) CreateIssue(ctx context.Context, repo, title, body string, labels []string) (int, error) {
+	ids, err := c.ResolveLabelIDs(ctx, repo, labels)
+	if err != nil {
+		return 0, fmt.Errorf("create issue on %s: %w", repo, err)
+	}
+	payload := map[string]any{
+		"title": title,
+		"body":  body,
+	}
+	if len(ids) > 0 {
+		payload["labels"] = ids
+	}
+	out, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/issues", repo), payload)
+	if err != nil {
+		return 0, fmt.Errorf("create issue on %s: %w", repo, err)
+	}
+	var created struct {
+		Number int `json:"number"`
+	}
+	if err := json.Unmarshal(out, &created); err != nil {
+		return 0, fmt.Errorf("parse created issue on %s: %w", repo, err)
+	}
+	if created.Number <= 0 {
+		return 0, fmt.Errorf("create issue on %s: response carries no issue number", repo)
+	}
+	return created.Number, nil
+}
+
+// AddIssueLabels adds labels to an issue/PR by NAME — IssueLabelsOption
+// accepts "a list of strings representing label names" on this instance, so
+// no id resolution happens here. Adding an already-present label is a server-
+// side no-op (the response is the resulting label list, discarded).
+func (c *Client) AddIssueLabels(ctx context.Context, repo string, index int, names []string) error {
+	if len(names) == 0 {
+		return fmt.Errorf("add labels on %s#%d: no label names given", repo, index)
+	}
+	payload := map[string]any{"labels": names}
+	if _, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/issues/%d/labels", repo, index), payload); err != nil {
+		return fmt.Errorf("add labels %s on %s#%d: %w", strings.Join(names, ","), repo, index, err)
+	}
+	return nil
+}
+
+// RemoveIssueLabel removes one label from an issue/PR by NAME — the DELETE
+// {identifier} path param is "name or id of the label to remove" (string), so
+// no id resolution happens here either. The name is path-escaped (label names
+// carry spaces and slashes).
+//
+// Semantics pinned for gh parity: removing a label the issue does not carry
+// answers 204 (the server deletes zero rows) and stays a no-op SUCCESS;
+// removing a label that does not exist on the repo at all answers 404/422
+// with an APIError body and stays a loud error. Nothing non-2xx is ever
+// converted into a no-op here — the split rides on the server's own status
+// codes, never on this client guessing.
+func (c *Client) RemoveIssueLabel(ctx context.Context, repo string, index int, name string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("remove label on %s#%d: empty name", repo, index)
+	}
+	path := fmt.Sprintf("/repos/%s/issues/%d/labels/%s", repo, index, url.PathEscape(name))
+	if _, err := c.do(ctx, http.MethodDelete, path, nil); err != nil {
+		return fmt.Errorf("remove label %q on %s#%d: %w", name, repo, index, err)
+	}
+	return nil
+}
+
+// CreateLabel creates one repo label. Color is REQUIRED by CreateLabelOption
+// — the default for an omitted color belongs to the CALLER (the github
+// layer's EnsureLabel sends "#ededed"), so an empty color here fails loud
+// instead of inventing one. The server accepts both "#rrggbb" and bare
+// "rrggbb" and stores bare.
+func (c *Client) CreateLabel(ctx context.Context, repo, name, color, description string) error {
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("create label on %s: empty name", repo)
+	}
+	if strings.TrimSpace(color) == "" {
+		return fmt.Errorf("create label %q on %s: color is required", name, repo)
+	}
+	payload := map[string]any{
+		"name":  name,
+		"color": color,
+	}
+	if description != "" {
+		payload["description"] = description
+	}
+	if _, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/labels", repo), payload); err != nil {
+		return fmt.Errorf("create label %q on %s: %w", name, repo, err)
+	}
+	return nil
+}
+
+// EditLabel updates one repo label by id, sending ONLY the provided fields
+// (EditLabelOption is all-optional) — the upsert-update arm of EnsureLabel:
+// empty means "not provided, leave unchanged", never "clear". A field-less
+// PATCH would be a silent green no-op, so an empty edit fails loud; the
+// caller skips the call when it has nothing to update.
+func (c *Client) EditLabel(ctx context.Context, repo string, id int64, color, description string) error {
+	payload := map[string]any{}
+	if color != "" {
+		payload["color"] = color
+	}
+	if description != "" {
+		payload["description"] = description
+	}
+	if len(payload) == 0 {
+		return fmt.Errorf("edit label %d on %s: no fields to update", id, repo)
+	}
+	if _, err := c.do(ctx, http.MethodPatch, fmt.Sprintf("/repos/%s/labels/%d", repo, id), payload); err != nil {
+		return fmt.Errorf("edit label %d on %s: %w", id, repo, err)
+	}
+	return nil
+}
+
+// CreateRelease creates a release anchored to an EXISTING tag (pushed by
+// CommitAndTag before this runs) — target_commitish is deliberately omitted
+// so Forgejo anchors to that tag. There is no notes-generation equivalent in
+// the swagger (gh --generate-notes divergence, documented in the port), so
+// the release body stays empty. A release already existing for the tag
+// answers 409 and surfaces loud.
+func (c *Client) CreateRelease(ctx context.Context, repo, tag, title string) error {
+	if strings.TrimSpace(tag) == "" {
+		return fmt.Errorf("create release on %s: tag is required", repo)
+	}
+	payload := map[string]any{
+		"tag_name": tag,
+		"name":     title,
+	}
+	if _, err := c.do(ctx, http.MethodPost, fmt.Sprintf("/repos/%s/releases", repo), payload); err != nil {
+		return fmt.Errorf("create release %q on %s: %w", tag, repo, err)
+	}
+	return nil
+}

--- a/internal/forgejo/writes.go
+++ b/internal/forgejo/writes.go
@@ -287,8 +287,17 @@ func (c *Client) CreateIssue(ctx context.Context, repo, title, body string, labe
 
 // AddIssueLabels adds labels to an issue/PR by NAME — IssueLabelsOption
 // accepts "a list of strings representing label names" on this instance, so
-// no id resolution happens here. Adding an already-present label is a server-
-// side no-op (the response is the resulting label list, discarded).
+// no id resolution happens here (spec-pinned for #1172 M3). Adding an
+// already-present label is a server-side no-op (the response is the resulting
+// label list, discarded).
+//
+// KNOWN GAP (flagged #1172 follow-up, not fixable without leaving the spec's
+// pass-the-name contract): the Gitea 1.22 lineage resolves names server-side
+// and silently DROPS names that do not resolve, answering 200 with the
+// unchanged list — so adding a renamed/deleted label reports success without
+// applying anything, where the gh path fails loud on the same input. Client-
+// side ResolveLabelIDs would restore loud parity at the cost of a read per
+// add; carried as a follow-up decision, not smuggled into M3.
 func (c *Client) AddIssueLabels(ctx context.Context, repo string, index int, names []string) error {
 	if len(names) == 0 {
 		return fmt.Errorf("add labels on %s#%d: no label names given", repo, index)

--- a/internal/forgejo/writes_test.go
+++ b/internal/forgejo/writes_test.go
@@ -1,0 +1,658 @@
+package forgejo
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// writeReq captures one request the writes fixture server saw, including the
+// DECODED JSON payload — every write test asserts method + path + exact
+// payload fields, so a stray or missing wire field fails the test, not the
+// live forge.
+type writeReq struct {
+	Method string
+	Path   string
+	Query  url.Values
+	// JSON is the decoded request body; nil when the request carried none.
+	JSON map[string]any
+}
+
+func newWritesClient(t *testing.T, fn func(r *http.Request) (int, string)) (*Client, *[]writeReq) {
+	t.Helper()
+	var seen []writeReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read %s %s body: %v", r.Method, r.URL.Path, err)
+		}
+		var decoded map[string]any
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &decoded); err != nil {
+				t.Errorf("decode %s %s payload: %v (raw: %s)", r.Method, r.URL.Path, err, raw)
+			}
+		}
+		seen = append(seen, writeReq{
+			Method: r.Method,
+			Path:   r.URL.EscapedPath(),
+			Query:  r.URL.Query(),
+			JSON:   decoded,
+		})
+		status, body := fn(r)
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return New(srv.URL, "sekrit"), &seen
+}
+
+// staticWrites is newWritesClient with one fixed response.
+func staticWrites(t *testing.T, status int, body string) (*Client, *[]writeReq) {
+	t.Helper()
+	return newWritesClient(t, func(*http.Request) (int, string) { return status, body })
+}
+
+// assertOneWrite asserts the fixture saw exactly one request with the given
+// method, path, and exact decoded payload (nil wantJSON = no body at all).
+func assertOneWrite(t *testing.T, seen *[]writeReq, method, path string, wantJSON map[string]any) writeReq {
+	t.Helper()
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %d, want 1: %+v", len(*seen), *seen)
+	}
+	req := (*seen)[0]
+	if req.Method != method || req.Path != path {
+		t.Fatalf("request = %s %s, want %s %s", req.Method, req.Path, method, path)
+	}
+	if !reflect.DeepEqual(req.JSON, wantJSON) {
+		t.Fatalf("payload = %#v, want %#v", req.JSON, wantJSON)
+	}
+	return req
+}
+
+func TestCreatePull(t *testing.T) {
+	// The number comes from the response JSON `number`, never from html_url —
+	// Forgejo web URLs are /pulls/N where gh scrapes /pull/N; the decoy URL
+	// carries a different number to catch any scraping regression.
+	c, seen := staticWrites(t, 201,
+		`{"id":99,"number":7,"html_url":"https://forge/o/r/pulls/1","state":"open","draft":false}`)
+	n, err := c.CreatePull(context.Background(), "owner/repo", "feat: title", "the body", "main", "feat/x")
+	if err != nil {
+		t.Fatalf("CreatePull: %v", err)
+	}
+	if n != 7 {
+		t.Fatalf("number = %d, want 7 (from response JSON, not the html_url decoy)", n)
+	}
+	assertOneWrite(t, seen, http.MethodPost, "/repos/owner/repo/pulls", map[string]any{
+		"title": "feat: title",
+		"body":  "the body",
+		"base":  "main",
+		"head":  "feat/x",
+	})
+}
+
+func TestCreatePull_MissingNumberFailsLoud(t *testing.T) {
+	c, _ := staticWrites(t, 201, `{"id":99}`)
+	if _, err := c.CreatePull(context.Background(), "owner/repo", "t", "b", "main", "h"); err == nil {
+		t.Fatal("a created pull without a number must error — downstream keys off it")
+	}
+}
+
+func TestCreatePull_HTTPError(t *testing.T) {
+	c, _ := staticWrites(t, 422, `{"message":"head branch does not exist","url":""}`)
+	_, err := c.CreatePull(context.Background(), "owner/repo", "t", "b", "main", "gone")
+	if err == nil {
+		t.Fatal("a 422 must surface as an error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 422") || !strings.Contains(err.Error(), "head branch does not exist") {
+		t.Fatalf("error must carry status and body, got: %v", err)
+	}
+}
+
+func TestEditPull_Body(t *testing.T) {
+	c, seen := staticWrites(t, 201, `{}`)
+	body := "replaced"
+	if err := c.EditPull(context.Background(), "owner/repo", 5, Edit{Body: &body}); err != nil {
+		t.Fatalf("EditPull: %v", err)
+	}
+	// Full replace of body ONLY — a stray state field would close/reopen.
+	assertOneWrite(t, seen, http.MethodPatch, "/repos/owner/repo/pulls/5", map[string]any{"body": "replaced"})
+}
+
+func TestEditPull_EmptyBodyReplaceIsSent(t *testing.T) {
+	// Body is *string: non-nil empty means "replace with empty", and the
+	// field must go on the wire.
+	c, seen := staticWrites(t, 201, `{}`)
+	body := ""
+	if err := c.EditPull(context.Background(), "owner/repo", 5, Edit{Body: &body}); err != nil {
+		t.Fatalf("EditPull: %v", err)
+	}
+	assertOneWrite(t, seen, http.MethodPatch, "/repos/owner/repo/pulls/5", map[string]any{"body": ""})
+}
+
+func TestEditPull_Close(t *testing.T) {
+	c, seen := staticWrites(t, 201, `{}`)
+	if err := c.EditPull(context.Background(), "owner/repo", 5, Edit{State: "closed"}); err != nil {
+		t.Fatalf("EditPull: %v", err)
+	}
+	assertOneWrite(t, seen, http.MethodPatch, "/repos/owner/repo/pulls/5", map[string]any{"state": "closed"})
+}
+
+func TestEditPull_EmptyEditIsError(t *testing.T) {
+	c, seen := staticWrites(t, 201, `{}`)
+	if err := c.EditPull(context.Background(), "owner/repo", 5, Edit{}); err == nil {
+		t.Fatal("a field-less PATCH must be rejected — it would be a silent green no-op")
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("an empty edit must not reach the API, saw %+v", *seen)
+	}
+}
+
+func TestEditIssue_BodyAndClose(t *testing.T) {
+	c, seen := staticWrites(t, 201, `{}`)
+	body := "new body"
+	if err := c.EditIssue(context.Background(), "owner/repo", 36, Edit{Body: &body}); err != nil {
+		t.Fatalf("EditIssue body: %v", err)
+	}
+	if err := c.EditIssue(context.Background(), "owner/repo", 36, Edit{State: "closed"}); err != nil {
+		t.Fatalf("EditIssue close: %v", err)
+	}
+	if len(*seen) != 2 {
+		t.Fatalf("requests = %d, want 2", len(*seen))
+	}
+	for i, want := range []map[string]any{{"body": "new body"}, {"state": "closed"}} {
+		req := (*seen)[i]
+		if req.Method != http.MethodPatch || req.Path != "/repos/owner/repo/issues/36" {
+			t.Fatalf("request %d = %s %s", i, req.Method, req.Path)
+		}
+		if !reflect.DeepEqual(req.JSON, want) {
+			t.Fatalf("payload %d = %#v, want %#v", i, req.JSON, want)
+		}
+	}
+}
+
+func TestEditIssue_EmptyEditIsError(t *testing.T) {
+	c, seen := staticWrites(t, 201, `{}`)
+	if err := c.EditIssue(context.Background(), "owner/repo", 36, Edit{}); err == nil {
+		t.Fatal("a field-less PATCH must be rejected")
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("an empty edit must not reach the API, saw %+v", *seen)
+	}
+}
+
+func TestMergePull(t *testing.T) {
+	c, seen := staticWrites(t, 200, ``)
+	err := c.MergePull(context.Background(), "owner/repo", 9, MergeOptions{
+		Do:                     "squash",
+		HeadCommitID:           "59e99c49c27d3e2f73bae1657f07cd2f9a15f926",
+		DeleteBranchAfterMerge: true,
+	})
+	if err != nil {
+		t.Fatalf("MergePull: %v", err)
+	}
+	// The exact mixed wire casing of MergePullRequestOption: Go-cased `Do`,
+	// snake `head_commit_id`/`delete_branch_after_merge`.
+	assertOneWrite(t, seen, http.MethodPost, "/repos/owner/repo/pulls/9/merge", map[string]any{
+		"Do":                        "squash",
+		"head_commit_id":            "59e99c49c27d3e2f73bae1657f07cd2f9a15f926",
+		"delete_branch_after_merge": true,
+	})
+}
+
+func TestMergePull_OmitsEmptyHeadCommitID(t *testing.T) {
+	c, seen := staticWrites(t, 200, ``)
+	if err := c.MergePull(context.Background(), "owner/repo", 9, MergeOptions{Do: "merge"}); err != nil {
+		t.Fatalf("MergePull: %v", err)
+	}
+	assertOneWrite(t, seen, http.MethodPost, "/repos/owner/repo/pulls/9/merge", map[string]any{
+		"Do":                        "merge",
+		"delete_branch_after_merge": false,
+	})
+}
+
+func TestMergePull_EmptyDoIsError(t *testing.T) {
+	c, seen := staticWrites(t, 200, ``)
+	if err := c.MergePull(context.Background(), "owner/repo", 9, MergeOptions{}); err == nil {
+		t.Fatal("Do is swagger-required — an empty strategy must fail pre-flight")
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("a pre-flight failure must not reach the API, saw %+v", *seen)
+	}
+}
+
+func TestMergePull_HeadMismatch409IsClassified(t *testing.T) {
+	// The live Forgejo head_commit_id-mismatch refusal: 409 with an APIError
+	// body whose text is the out-of-date family.
+	c, _ := staticWrites(t, 409, `{"message":"head commit is out of date","url":""}`)
+	err := c.MergePull(context.Background(), "owner/repo", 9, MergeOptions{Do: "squash", HeadCommitID: "abc"})
+	if err == nil {
+		t.Fatal("a 409 refusal must surface as an error")
+	}
+	if !errors.Is(err, ErrMergeOutOfDate) {
+		t.Fatalf("a head-mismatch 409 must wrap ErrMergeOutOfDate, got: %v", err)
+	}
+	// The raw refusal must stay in the chain — classification adds, never
+	// replaces.
+	if !strings.Contains(err.Error(), "HTTP 409") || !strings.Contains(err.Error(), "head commit is out of date") {
+		t.Fatalf("error must keep the raw status and body, got: %v", err)
+	}
+	var se *StatusError
+	if !errors.As(err, &se) || se.StatusCode != 409 {
+		t.Fatalf("StatusError must survive the wrap chain, got: %v", err)
+	}
+}
+
+func TestMergePull_405OutOfDateBodyIsClassified(t *testing.T) {
+	c, _ := staticWrites(t, 405, `{"message":"Please update your branch: it is not up to date with the base branch","url":""}`)
+	err := c.MergePull(context.Background(), "owner/repo", 9, MergeOptions{Do: "squash"})
+	if !errors.Is(err, ErrMergeOutOfDate) {
+		t.Fatalf("a 405 with out-of-date body text must wrap ErrMergeOutOfDate, got: %v", err)
+	}
+}
+
+func TestMergePull_Bodyless405StaysRaw(t *testing.T) {
+	// The swagger documents 405 with an EMPTY body ("APIEmpty") — with no
+	// text to inspect, classification must NOT fire (never classify blindly):
+	// the caller gets the loud raw error, not the AutoRebase sentinel.
+	c, _ := staticWrites(t, 405, ``)
+	err := c.MergePull(context.Background(), "owner/repo", 9, MergeOptions{Do: "squash"})
+	if err == nil {
+		t.Fatal("a 405 refusal must surface as an error")
+	}
+	if errors.Is(err, ErrMergeOutOfDate) {
+		t.Fatalf("a bodyless 405 must stay unclassified, got: %v", err)
+	}
+}
+
+func TestMergePull_Conflict409StaysRaw(t *testing.T) {
+	// A 409 that is NOT the out-of-date family (e.g. a merge conflict) must
+	// not trigger AutoRebase semantics.
+	c, _ := staticWrites(t, 409, `{"message":"merge conflict between base and head","url":""}`)
+	err := c.MergePull(context.Background(), "owner/repo", 9, MergeOptions{Do: "squash"})
+	if err == nil {
+		t.Fatal("a 409 refusal must surface as an error")
+	}
+	if errors.Is(err, ErrMergeOutOfDate) {
+		t.Fatalf("an unrelated 409 body must stay unclassified, got: %v", err)
+	}
+}
+
+func TestMergePull_OutOfDateOnNon405409StaysRaw(t *testing.T) {
+	// Classification is gated on the two documented refusal codes: matching
+	// body text on any other status (here a 500 echoing the phrase) must not
+	// mint the sentinel.
+	c, _ := staticWrites(t, 500, `{"message":"internal: out of date","url":""}`)
+	err := c.MergePull(context.Background(), "owner/repo", 9, MergeOptions{Do: "squash"})
+	if err == nil {
+		t.Fatal("a 500 must surface as an error")
+	}
+	if errors.Is(err, ErrMergeOutOfDate) {
+		t.Fatalf("a non-405/409 status must stay unclassified, got: %v", err)
+	}
+}
+
+func TestUpdatePullBranch(t *testing.T) {
+	c, seen := staticWrites(t, 200, ``)
+	if err := c.UpdatePullBranch(context.Background(), "owner/repo", 8); err != nil {
+		t.Fatalf("UpdatePullBranch: %v", err)
+	}
+	req := assertOneWrite(t, seen, http.MethodPost, "/repos/owner/repo/pulls/8/update", nil)
+	// style=merge is explicit — gh-default parity, never rebase.
+	if got := req.Query.Get("style"); got != "merge" {
+		t.Fatalf("style = %q, want merge (full query: %v)", got, req.Query)
+	}
+}
+
+func TestUpdatePullBranch_HTTPError(t *testing.T) {
+	c, _ := staticWrites(t, 409, `{"message":"cannot update: conflict","url":""}`)
+	if err := c.UpdatePullBranch(context.Background(), "owner/repo", 8); err == nil {
+		t.Fatal("a 409 must surface as an error")
+	}
+}
+
+func TestCreateIssue_ResolvesLabelNamesToIDs(t *testing.T) {
+	// CreateIssueOption.labels is []int64 ("list of label ids") — names go
+	// through the repo label list first, order preserved.
+	c, seen := newWritesClient(t, func(r *http.Request) (int, string) {
+		if r.Method == http.MethodGet {
+			return 200, `[{"id":23,"name":"blocked","color":"d93f0b"},{"id":5,"name":"maestro-ready","color":"00aabb"}]`
+		}
+		return 201, `{"number":42}`
+	})
+	n, err := c.CreateIssue(context.Background(), "owner/repo", "issue title", "issue body",
+		[]string{"maestro-ready", "blocked"})
+	if err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	if n != 42 {
+		t.Fatalf("number = %d, want 42", n)
+	}
+	if len(*seen) != 2 {
+		t.Fatalf("requests = %d, want 2 (label list, then create): %+v", len(*seen), *seen)
+	}
+	list := (*seen)[0]
+	if list.Method != http.MethodGet || list.Path != "/repos/owner/repo/labels" {
+		t.Fatalf("first request = %s %s, want the repo label list", list.Method, list.Path)
+	}
+	if list.Query.Get("limit") != strconv.Itoa(pageSize) || list.Query.Get("page") != "1" {
+		t.Fatalf("label list must be paginated, query = %v", list.Query)
+	}
+	create := (*seen)[1]
+	if create.Method != http.MethodPost || create.Path != "/repos/owner/repo/issues" {
+		t.Fatalf("second request = %s %s", create.Method, create.Path)
+	}
+	want := map[string]any{
+		"title":  "issue title",
+		"body":   "issue body",
+		"labels": []any{float64(5), float64(23)}, // ids in the caller's name order
+	}
+	if !reflect.DeepEqual(create.JSON, want) {
+		t.Fatalf("payload = %#v, want %#v", create.JSON, want)
+	}
+}
+
+func TestCreateIssue_NoLabelsSkipsResolution(t *testing.T) {
+	c, seen := staticWrites(t, 201, `{"number":43}`)
+	n, err := c.CreateIssue(context.Background(), "owner/repo", "t", "b", nil)
+	if err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	if n != 43 {
+		t.Fatalf("number = %d, want 43", n)
+	}
+	// One request only — no label-list read — and no labels key at all.
+	assertOneWrite(t, seen, http.MethodPost, "/repos/owner/repo/issues", map[string]any{
+		"title": "t",
+		"body":  "b",
+	})
+}
+
+func TestCreateIssue_UnknownLabelFailsLoudBeforeCreate(t *testing.T) {
+	// gh parity: an unknown label fails the create, naming the label; the
+	// issue must NOT be created without it.
+	c, seen := newWritesClient(t, func(r *http.Request) (int, string) {
+		if r.Method == http.MethodGet {
+			return 200, `[{"id":23,"name":"blocked","color":"d93f0b"}]`
+		}
+		return 201, `{"number":44}`
+	})
+	_, err := c.CreateIssue(context.Background(), "owner/repo", "t", "b", []string{"maestro-ready"})
+	if err == nil {
+		t.Fatal("an unknown label must abort the create")
+	}
+	if !strings.Contains(err.Error(), `"maestro-ready"`) {
+		t.Fatalf("error must name the unknown label, got: %v", err)
+	}
+	if len(*seen) != 1 || (*seen)[0].Method != http.MethodGet {
+		t.Fatalf("only the label list may be read — no create call, saw %+v", *seen)
+	}
+}
+
+func TestCreateIssue_MissingNumberFailsLoud(t *testing.T) {
+	c, _ := staticWrites(t, 201, `{}`)
+	if _, err := c.CreateIssue(context.Background(), "owner/repo", "t", "b", nil); err == nil {
+		t.Fatal("a created issue without a number must error")
+	}
+}
+
+func TestResolveLabelIDs_ExactMatchWinsOverFold(t *testing.T) {
+	c, _ := staticWrites(t, 200, `[{"id":1,"name":"Bug","color":"ededed"},{"id":2,"name":"bug","color":"ededed"}]`)
+	ids, err := c.ResolveLabelIDs(context.Background(), "owner/repo", []string{"bug"})
+	if err != nil {
+		t.Fatalf("ResolveLabelIDs: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != 2 {
+		t.Fatalf("ids = %v, want [2] (exact match preferred over case fold)", ids)
+	}
+}
+
+func TestResolveLabelIDs_CaseInsensitiveFallback(t *testing.T) {
+	c, _ := staticWrites(t, 200, `[{"id":7,"name":"Maestro-Ready","color":"00aabb"}]`)
+	ids, err := c.ResolveLabelIDs(context.Background(), "owner/repo", []string{"maestro-ready"})
+	if err != nil {
+		t.Fatalf("ResolveLabelIDs: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != 7 {
+		t.Fatalf("ids = %v, want [7] (case-folded match, mirroring the read-side hasLabel belt)", ids)
+	}
+}
+
+func TestResolveLabelIDs_EmptyNamesSkipsFetch(t *testing.T) {
+	c, seen := staticWrites(t, 200, `[]`)
+	ids, err := c.ResolveLabelIDs(context.Background(), "owner/repo", nil)
+	if err != nil || ids != nil {
+		t.Fatalf("ids = %v err = %v, want nil/nil", ids, err)
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("no names must mean no fetch, saw %+v", *seen)
+	}
+}
+
+func TestAddIssueLabels_PassesNamesVerbatim(t *testing.T) {
+	// IssueLabelsOption accepts label NAMES on this instance — no id
+	// resolution call may happen.
+	c, seen := staticWrites(t, 200, `[{"id":23,"name":"blocked","color":"d93f0b"}]`)
+	if err := c.AddIssueLabels(context.Background(), "owner/repo", 3, []string{"needs-info", "blocked"}); err != nil {
+		t.Fatalf("AddIssueLabels: %v", err)
+	}
+	assertOneWrite(t, seen, http.MethodPost, "/repos/owner/repo/issues/3/labels", map[string]any{
+		"labels": []any{"needs-info", "blocked"},
+	})
+}
+
+func TestAddIssueLabels_EmptyIsError(t *testing.T) {
+	c, seen := staticWrites(t, 200, `[]`)
+	if err := c.AddIssueLabels(context.Background(), "owner/repo", 3, nil); err == nil {
+		t.Fatal("an empty label add must fail pre-flight")
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("an empty add must not reach the API, saw %+v", *seen)
+	}
+}
+
+func TestRemoveIssueLabel_ByNamePathEscaped(t *testing.T) {
+	// The DELETE identifier is name-accepting; names carry spaces, so the
+	// path segment must be percent-escaped. A 204 — including the zero-rows
+	// case of a label the issue does not carry — is a no-op SUCCESS
+	// (gh parity).
+	c, seen := staticWrites(t, 204, ``)
+	if err := c.RemoveIssueLabel(context.Background(), "owner/repo", 3, "in progress"); err != nil {
+		t.Fatalf("RemoveIssueLabel: %v", err)
+	}
+	assertOneWrite(t, seen, http.MethodDelete, "/repos/owner/repo/issues/3/labels/in%20progress", nil)
+}
+
+func TestRemoveIssueLabel_UnknownRepoLabelFailsLoud(t *testing.T) {
+	// A label that does not exist on the repo at all answers 404/422 — that
+	// must stay a loud error (gh parity), never be converted into a no-op.
+	c, _ := staticWrites(t, 422, `{"message":"label does not exist","url":""}`)
+	err := c.RemoveIssueLabel(context.Background(), "owner/repo", 3, "ghost")
+	if err == nil {
+		t.Fatal("removing a label missing from the repo must error")
+	}
+	if !strings.Contains(err.Error(), "label does not exist") {
+		t.Fatalf("error must carry the server body, got: %v", err)
+	}
+}
+
+func TestRemoveIssueLabel_EmptyNameIsError(t *testing.T) {
+	c, seen := staticWrites(t, 204, ``)
+	if err := c.RemoveIssueLabel(context.Background(), "owner/repo", 3, "  "); err == nil {
+		t.Fatal("an empty label name must fail pre-flight")
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("an empty name must not reach the API, saw %+v", *seen)
+	}
+}
+
+func TestListRepoLabels(t *testing.T) {
+	// Wire color is bare rrggbb (no leading '#') — carried verbatim.
+	c, seen := staticWrites(t, 200,
+		`[{"id":23,"name":"blocked","exclusive":false,"is_archived":false,"color":"d93f0b","description":"waiting","url":"https://forge/api/v1/repos/o/r/labels/23"}]`)
+	labels, err := c.ListRepoLabels(context.Background(), "owner/repo")
+	if err != nil {
+		t.Fatalf("ListRepoLabels: %v", err)
+	}
+	want := RepoLabel{ID: 23, Name: "blocked", Color: "d93f0b", Description: "waiting"}
+	if len(labels) != 1 || labels[0] != want {
+		t.Fatalf("labels = %+v, want [%+v]", labels, want)
+	}
+	req := (*seen)[0]
+	if req.Method != http.MethodGet || req.Path != "/repos/owner/repo/labels" {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+	// The endpoint is paginated (live-verified x-total-count) — the pager
+	// must drive it.
+	if req.Query.Get("limit") != strconv.Itoa(pageSize) || req.Query.Get("page") != "1" {
+		t.Fatalf("repo labels must be paginated, query = %v", req.Query)
+	}
+}
+
+func TestListRepoLabels_Pagination(t *testing.T) {
+	labelsPage := func(from, n int) string {
+		items := make([]string, 0, n)
+		for i := 0; i < n; i++ {
+			items = append(items, `{"id":`+strconv.Itoa(from+i)+`,"name":"l`+strconv.Itoa(from+i)+`","color":"ededed"}`)
+		}
+		return "[" + strings.Join(items, ",") + "]"
+	}
+	c, seen := newWritesClient(t, func(r *http.Request) (int, string) {
+		switch r.URL.Query().Get("page") {
+		case "1":
+			return 200, labelsPage(1, pageSize)
+		case "2":
+			return 200, labelsPage(1+pageSize, 2)
+		default:
+			return 500, `{"message":"unexpected page"}`
+		}
+	})
+	labels, err := c.ListRepoLabels(context.Background(), "owner/repo")
+	if err != nil {
+		t.Fatalf("ListRepoLabels: %v", err)
+	}
+	if len(labels) != pageSize+2 {
+		t.Fatalf("labels = %d, want %d (resolution must see the full set)", len(labels), pageSize+2)
+	}
+	if len(*seen) != 2 {
+		t.Fatalf("requests = %d, want 2", len(*seen))
+	}
+}
+
+func TestCreateLabel(t *testing.T) {
+	c, seen := staticWrites(t, 201, `{"id":30,"name":"maestro-ready","color":"ededed"}`)
+	if err := c.CreateLabel(context.Background(), "owner/repo", "maestro-ready", "#ededed", "dispatch gate"); err != nil {
+		t.Fatalf("CreateLabel: %v", err)
+	}
+	assertOneWrite(t, seen, http.MethodPost, "/repos/owner/repo/labels", map[string]any{
+		"name":        "maestro-ready",
+		"color":       "#ededed",
+		"description": "dispatch gate",
+	})
+}
+
+func TestCreateLabel_OmitsEmptyDescription(t *testing.T) {
+	c, seen := staticWrites(t, 201, `{"id":31,"name":"x","color":"ededed"}`)
+	if err := c.CreateLabel(context.Background(), "owner/repo", "x", "ededed", ""); err != nil {
+		t.Fatalf("CreateLabel: %v", err)
+	}
+	assertOneWrite(t, seen, http.MethodPost, "/repos/owner/repo/labels", map[string]any{
+		"name":  "x",
+		"color": "ededed",
+	})
+}
+
+func TestCreateLabel_EmptyColorIsError(t *testing.T) {
+	// CreateLabelOption REQUIRES color; the "#ededed" default belongs to the
+	// CALLER (github-layer EnsureLabel), so the transport fails loud instead
+	// of inventing one.
+	c, seen := staticWrites(t, 201, `{}`)
+	if err := c.CreateLabel(context.Background(), "owner/repo", "x", " ", "d"); err == nil {
+		t.Fatal("an empty color must fail pre-flight — the swagger requires it")
+	}
+	if err := c.CreateLabel(context.Background(), "owner/repo", "", "ededed", ""); err == nil {
+		t.Fatal("an empty name must fail pre-flight")
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("pre-flight failures must not reach the API, saw %+v", *seen)
+	}
+}
+
+func TestEditLabel_SendsOnlyProvidedFields(t *testing.T) {
+	c, seen := staticWrites(t, 200, `{"id":23,"name":"blocked","color":"00aabb"}`)
+	if err := c.EditLabel(context.Background(), "owner/repo", 23, "00aabb", ""); err != nil {
+		t.Fatalf("EditLabel: %v", err)
+	}
+	// EnsureLabel's update arm: only the provided fields go on the wire —
+	// an absent description must NOT be cleared.
+	assertOneWrite(t, seen, http.MethodPatch, "/repos/owner/repo/labels/23", map[string]any{
+		"color": "00aabb",
+	})
+}
+
+func TestEditLabel_EmptyEditIsError(t *testing.T) {
+	c, seen := staticWrites(t, 200, `{}`)
+	if err := c.EditLabel(context.Background(), "owner/repo", 23, "", ""); err == nil {
+		t.Fatal("a field-less label PATCH must be rejected")
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("an empty edit must not reach the API, saw %+v", *seen)
+	}
+}
+
+func TestCreateRelease(t *testing.T) {
+	c, seen := staticWrites(t, 201, `{"id":12,"tag_name":"v1.2.3"}`)
+	if err := c.CreateRelease(context.Background(), "owner/repo", "v1.2.3", "v1.2.3 — cadence"); err != nil {
+		t.Fatalf("CreateRelease: %v", err)
+	}
+	// Exactly tag_name + name: no body (no --generate-notes equivalent in
+	// the swagger) and no target_commitish (the tag already exists — the
+	// release must anchor to it, not to a branch head).
+	assertOneWrite(t, seen, http.MethodPost, "/repos/owner/repo/releases", map[string]any{
+		"tag_name": "v1.2.3",
+		"name":     "v1.2.3 — cadence",
+	})
+}
+
+func TestCreateRelease_EmptyTagIsError(t *testing.T) {
+	c, seen := staticWrites(t, 201, `{}`)
+	if err := c.CreateRelease(context.Background(), "owner/repo", " ", "t"); err == nil {
+		t.Fatal("tag_name is swagger-required — an empty tag must fail pre-flight")
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("a pre-flight failure must not reach the API, saw %+v", *seen)
+	}
+}
+
+func TestCreateRelease_ExistingReleaseConflictPropagates(t *testing.T) {
+	c, _ := staticWrites(t, 409, `{"message":"release tag already exist","url":""}`)
+	err := c.CreateRelease(context.Background(), "owner/repo", "v1.2.3", "t")
+	if err == nil {
+		t.Fatal("a 409 (release exists) must surface as an error")
+	}
+	if !strings.Contains(err.Error(), "HTTP 409") {
+		t.Fatalf("error must carry the status, got: %v", err)
+	}
+}
+
+func TestWrites_ContextCanceled(t *testing.T) {
+	c, seen := staticWrites(t, 200, ``)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := c.CreatePull(ctx, "owner/repo", "t", "b", "main", "h"); err == nil {
+		t.Fatal("CreatePull must fail on a canceled context")
+	}
+	if err := c.MergePull(ctx, "owner/repo", 1, MergeOptions{Do: "squash"}); err == nil {
+		t.Fatal("MergePull must fail on a canceled context")
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("a canceled context must not reach the API, saw %+v", *seen)
+	}
+}

--- a/internal/github/forgejo_failloud_test.go
+++ b/internal/github/forgejo_failloud_test.go
@@ -71,9 +71,10 @@ func TestForgejoModeFailsLoud(t *testing.T) {
 		{"RateLimit", func() error { _, err := c.RateLimit(); return err }},
 		// github.go — c.ghAPIWithArgs funnel.
 		{"checkRunsForSHA", func() error { _, err := c.checkRunsForSHA("59e99c49c27d3e2f73bae1657f07cd2f9a15f926"); return err }},
-		// github.go — c.ghExec funnel (writes).
-		{"CreatePR", func() error { _, err := c.CreatePR("t", "b", "main", "head"); return err }},
-		{"CreateRelease", func() error { return c.CreateRelease("v0.0.1", "t") }},
+		// github.go — c.ghExec funnel: the writes are ported in M3, so the one
+		// remaining write-shaped guard is MarkPRReady (EditPullRequestOption
+		// has no draft toggle on 16.0.1 — explicit guard until M7).
+		{"MarkPRReady", func() error { return c.MarkPRReady(1) }},
 		// github_projects.go — c.ghOutputContext funnel (GraphQL Projects).
 		{"DiscoverProject", func() error { _, err := c.DiscoverProject(1); return err }},
 		// review_threads.go — GraphQL through c.ghExec.
@@ -126,8 +127,11 @@ func TestForgejoModeEmptyTokenSurfacesForgeErr(t *testing.T) {
 		{"GetIssue", func() error { _, err := c.GetIssue(1); return err }, false},
 		{"ListOpenPRs", func() error { _, err := c.ListOpenPRs(); return err }, false},
 		{"BranchHeadSHA", func() error { _, err := c.BranchHeadSHA("main"); return err }, false},
+		// Ported write (M3): same contract as the reads — the token fault
+		// without the sentinel.
+		{"CreatePR", func() error { _, err := c.CreatePR("t", "b", "main", "head"); return err }, false},
 		// Unported write: sentinel, with the token fault in the message.
-		{"CreatePR", func() error { _, err := c.CreatePR("t", "b", "main", "head"); return err }, true},
+		{"MarkPRReady", func() error { return c.MarkPRReady(1) }, true},
 	}
 	for _, s := range samples {
 		err := s.call()

--- a/internal/github/forgejo_port.go
+++ b/internal/github/forgejo_port.go
@@ -542,7 +542,9 @@ func (c *Client) fjEditIssueBody(number int, body string) error {
 
 // fjAddIssueLabel passes the NAME verbatim — IssueLabelsOption accepts label
 // names on this instance (contract §6), so no id resolution happens; adding
-// an already-present label is a server-side no-op (idempotent-safe).
+// an already-present label is a server-side no-op (idempotent-safe). Known
+// gap flagged as a #1172 follow-up: the server silently drops unknown names
+// (see forgejo.AddIssueLabels).
 func (c *Client) fjAddIssueLabel(issueNumber int, label string) error {
 	fj, err := c.fjTransport()
 	if err != nil {
@@ -575,11 +577,15 @@ const fjEnsureLabelDefaultColor = "#ededed"
 
 // fjEnsureLabel is the upsert (`gh label create --force` parity). The name is
 // already trimmed/non-empty (shared pre-flight in EnsureLabel). Existing label
-// (matched case-insensitively, like the forge's own label semantics): PATCH
-// only the provided fields, skipping the call when there is nothing to update.
-// Missing: POST with the default color when the caller omitted one. Its only
-// consumer (outcome_repair) tolerates failure, so errors stay informative
-// rather than swallowed.
+// (exact name match first, then case-insensitive — same order as the
+// transport's findLabelID, because Forgejo does not enforce name uniqueness
+// under case folding): PATCH only the provided fields, skipping the call when
+// there is nothing to update. Missing: POST with the default color when the
+// caller omitted one. The caller's color goes on the wire verbatim, leading
+// '#' intact, where the gh path strips it (gh wants bare rrggbb) — Forgejo
+// accepts both forms and stores bare, so only the wire differs, not the
+// outcome. Its only consumer (outcome_repair) tolerates failure, so errors
+// stay informative rather than swallowed.
 func (c *Client) fjEnsureLabel(name, color, description string) error {
 	fj, err := c.fjTransport()
 	if err != nil {
@@ -593,10 +599,7 @@ func (c *Client) fjEnsureLabel(name, color, description string) error {
 	if err != nil {
 		return fmt.Errorf("ensure label %q: %w", name, err)
 	}
-	for _, l := range labels {
-		if !strings.EqualFold(l.Name, name) {
-			continue
-		}
+	if l, ok := fjFindRepoLabel(labels, name); ok {
 		if color == "" && description == "" {
 			return nil // exists, nothing to update — a field-less PATCH is banned
 		}
@@ -612,6 +615,23 @@ func (c *Client) fjEnsureLabel(name, color, description string) error {
 		return fmt.Errorf("ensure label %q: %w", name, err)
 	}
 	return nil
+}
+
+// fjFindRepoLabel returns the repo label matching name; an exact match wins
+// over a case-insensitive one (mirrors the transport's findLabelID), so a repo
+// carrying both "Bug" and "bug" gets the exact one PATCHed.
+func fjFindRepoLabel(labels []forgejo.RepoLabel, name string) (forgejo.RepoLabel, bool) {
+	for _, l := range labels {
+		if l.Name == name {
+			return l, true
+		}
+	}
+	for _, l := range labels {
+		if strings.EqualFold(l.Name, name) {
+			return l, true
+		}
+	}
+	return forgejo.RepoLabel{}, false
 }
 
 // fjComment serves CommentIssue AND CommentPR — pulls share the issue number

--- a/internal/github/forgejo_port.go
+++ b/internal/github/forgejo_port.go
@@ -384,3 +384,257 @@ func (c *Client) fjPRChangedFiles(prNumber int) ([]string, error) {
 	}
 	return files, nil
 }
+
+// ---------------------------------------------------------------------------
+// Writes (#1172 M3). Same dispatch shape as the reads above: the exported
+// github.go method branches into the fj* sibling, REST specifics live in
+// internal/forgejo. The semantic contracts preserved here — comment-then-close
+// abort, number-from-response-JSON, label-name resolution, EnsureLabel upsert
+// — are pinned by the forgejo-mode write tests. MarkPRReady is the one write
+// with NO forgejo sibling: EditPullRequestOption has no draft toggle on
+// 16.0.1, so it keeps the fail-loud guard in github.go.
+// ---------------------------------------------------------------------------
+
+// fjCreatePR returns the new PR number from the response JSON `number` —
+// never scraped from a URL: gh output carries /pull/N where Forgejo web URLs
+// are /pulls/N, so URL scraping would break on exactly this forge.
+func (c *Client) fjCreatePR(title, body, base, head string) (int, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return 0, err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	n, err := fj.CreatePull(ctx, c.Repo, title, body, base, head)
+	if err != nil {
+		return 0, fmt.Errorf("create PR: %w", err)
+	}
+	return n, nil
+}
+
+func (c *Client) fjUpdatePRBody(prNumber int, body string) error {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	if err := fj.EditPull(ctx, c.Repo, prNumber, forgejo.Edit{Body: &body}); err != nil {
+		return fmt.Errorf("update PR %d body: %w", prNumber, err)
+	}
+	return nil
+}
+
+// fjClosePR preserves the gh path's comment-then-close contract: a non-empty
+// comment is posted FIRST and its failure aborts the close (the PR stays open
+// so the explanation is never lost); an empty comment skips the comment step
+// entirely. Pulls share the issue number space, so the comment goes through
+// the issue-comments route.
+func (c *Client) fjClosePR(prNumber int, comment string) error {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	if comment != "" {
+		if err := fj.CreateComment(ctx, c.Repo, prNumber, comment); err != nil {
+			return fmt.Errorf("comment PR %d: %w", prNumber, err)
+		}
+	}
+	if err := fj.EditPull(ctx, c.Repo, prNumber, forgejo.Edit{State: "closed"}); err != nil {
+		return fmt.Errorf("close PR %d: %w", prNumber, err)
+	}
+	return nil
+}
+
+// fjMergePRAtHead is the squash + delete-branch + head-bound merge —
+// `gh pr merge --squash --delete-branch --match-head-commit` parity via
+// MergePullRequestOption. The empty-SHA pre-flight already ran in
+// MergePRAtHead (shared with the gh path). A refusal the transport classified
+// as out-of-date/head-mismatch (forgejo.ErrMergeOutOfDate) is re-wrapped with
+// the package sentinel so the orchestrator's AutoRebase branch matches it via
+// errors.Is; every other failure surfaces raw and loud.
+func (c *Client) fjMergePRAtHead(prNumber int, expectedHeadSHA string) error {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	err = fj.MergePull(ctx, c.Repo, prNumber, forgejo.MergeOptions{
+		Do:                     "squash",
+		HeadCommitID:           expectedHeadSHA,
+		DeleteBranchAfterMerge: true,
+	})
+	if err != nil {
+		if errors.Is(err, forgejo.ErrMergeOutOfDate) {
+			return fmt.Errorf("merge PR %d at head %s: %w: %w", prNumber, expectedHeadSHA, ErrMergeNotUpToDate, err)
+		}
+		return fmt.Errorf("merge PR %d at head %s: %w", prNumber, expectedHeadSHA, err)
+	}
+	return nil
+}
+
+// fjUpdateBranch merges base into the PR head server-side, style=merge — the
+// gh `pr update-branch` default. The #547 contract carries over: the head SHA
+// moves, so callers must not merge in the same pass.
+func (c *Client) fjUpdateBranch(prNumber int) error {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	if err := fj.UpdatePullBranch(ctx, c.Repo, prNumber); err != nil {
+		return fmt.Errorf("update branch of PR %d: %w", prNumber, err)
+	}
+	return nil
+}
+
+// fjCloseIssue mirrors fjClosePR's comment-then-close contract on the issue
+// PATCH route.
+func (c *Client) fjCloseIssue(number int, comment string) error {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	if comment != "" {
+		if err := fj.CreateComment(ctx, c.Repo, number, comment); err != nil {
+			return fmt.Errorf("comment issue %d: %w", number, err)
+		}
+	}
+	if err := fj.EditIssue(ctx, c.Repo, number, forgejo.Edit{State: "closed"}); err != nil {
+		return fmt.Errorf("close issue %d: %w", number, err)
+	}
+	return nil
+}
+
+// fjCreateIssue returns the new issue number from the response JSON. Label
+// names are resolved to ids inside the transport (CreateIssueOption.labels is
+// []int64); an unknown label name aborts loudly BEFORE the issue is created —
+// gh parity, and outcome_repair calls EnsureLabel first so a miss here is a
+// genuinely unknown label.
+func (c *Client) fjCreateIssue(title, body string, labels []string) (int, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return 0, err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	return fj.CreateIssue(ctx, c.Repo, title, body, labels)
+}
+
+func (c *Client) fjEditIssueBody(number int, body string) error {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	if err := fj.EditIssue(ctx, c.Repo, number, forgejo.Edit{Body: &body}); err != nil {
+		return fmt.Errorf("edit issue %d body: %w", number, err)
+	}
+	return nil
+}
+
+// fjAddIssueLabel passes the NAME verbatim — IssueLabelsOption accepts label
+// names on this instance (contract §6), so no id resolution happens; adding
+// an already-present label is a server-side no-op (idempotent-safe).
+func (c *Client) fjAddIssueLabel(issueNumber int, label string) error {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	return fj.AddIssueLabels(ctx, c.Repo, issueNumber, []string{label})
+}
+
+// fjRemoveIssueLabel removes by NAME (the DELETE path param is name-or-id).
+// gh-parity split, riding on the server's own status codes: a label the issue
+// does not carry answers 204 (no-op success); a label missing from the repo
+// entirely answers non-2xx and stays a loud error.
+func (c *Client) fjRemoveIssueLabel(issueNumber int, label string) error {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	return fj.RemoveIssueLabel(ctx, c.Repo, issueNumber, label)
+}
+
+// fjEnsureLabelDefaultColor is sent when the caller provided no color for a
+// label that must be CREATED — CreateLabelOption requires one (the gh path
+// can omit --color because gh picks a color itself). Forgejo accepts both
+// "#rrggbb" and bare "rrggbb" and stores bare.
+const fjEnsureLabelDefaultColor = "#ededed"
+
+// fjEnsureLabel is the upsert (`gh label create --force` parity). The name is
+// already trimmed/non-empty (shared pre-flight in EnsureLabel). Existing label
+// (matched case-insensitively, like the forge's own label semantics): PATCH
+// only the provided fields, skipping the call when there is nothing to update.
+// Missing: POST with the default color when the caller omitted one. Its only
+// consumer (outcome_repair) tolerates failure, so errors stay informative
+// rather than swallowed.
+func (c *Client) fjEnsureLabel(name, color, description string) error {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	color = strings.TrimSpace(color)
+	description = strings.TrimSpace(description)
+	labels, err := fj.ListRepoLabels(ctx, c.Repo)
+	if err != nil {
+		return fmt.Errorf("ensure label %q: %w", name, err)
+	}
+	for _, l := range labels {
+		if !strings.EqualFold(l.Name, name) {
+			continue
+		}
+		if color == "" && description == "" {
+			return nil // exists, nothing to update — a field-less PATCH is banned
+		}
+		if err := fj.EditLabel(ctx, c.Repo, l.ID, color, description); err != nil {
+			return fmt.Errorf("ensure label %q: %w", name, err)
+		}
+		return nil
+	}
+	if color == "" {
+		color = fjEnsureLabelDefaultColor
+	}
+	if err := fj.CreateLabel(ctx, c.Repo, name, color, description); err != nil {
+		return fmt.Errorf("ensure label %q: %w", name, err)
+	}
+	return nil
+}
+
+// fjComment serves CommentIssue AND CommentPR — pulls share the issue number
+// space, so one comments route covers both (contract §9).
+func (c *Client) fjComment(number int, body string) error {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	return fj.CreateComment(ctx, c.Repo, number, body)
+}
+
+// fjCreateRelease anchors the release to the already-pushed tag. Divergence
+// from the gh path, documented: Forgejo has no --generate-notes equivalent
+// anywhere in its swagger, so the release body stays empty.
+func (c *Client) fjCreateRelease(tag, title string) error {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	return fj.CreateRelease(ctx, c.Repo, tag, title)
+}

--- a/internal/github/forgejo_port_writes_test.go
+++ b/internal/github/forgejo_port_writes_test.go
@@ -1,0 +1,578 @@
+package github
+
+// End-to-end forgejo-mode tests for the ported WRITE funnels (#1172 M3).
+// Same construction as forgejo_port_test.go — config.ForgeConfig → github.New
+// → internal/forgejo.Client → httptest fixtures, gh transport armed to fail on
+// any leak — plus request-body capture: every write asserts METHOD + PATH +
+// the exact decoded JSON payload, so a stray or missing wire field fails the
+// test here instead of on the live forge (writes are NEVER exercised live).
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/forgejo"
+)
+
+// fjWriteReq is one request the write fixture server observed, including the
+// DECODED JSON payload (nil when the request carried no body).
+type fjWriteReq struct {
+	Method string
+	Path   string
+	Query  url.Values
+	JSON   map[string]any
+}
+
+// fjWriteResp is one canned fixture response.
+type fjWriteResp struct {
+	Status int
+	Body   string
+}
+
+// newForgejoWriteClient mirrors newForgejoPortClient with payload capture.
+func newForgejoWriteClient(t *testing.T, fn func(r *http.Request) fjWriteResp) (*Client, *[]fjWriteReq, *atomic.Int64) {
+	t.Helper()
+	ghCalls := stubGHNeverCalled(t)
+	var seen []fjWriteReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.EscapedPath(), "/api/v1/") {
+			t.Errorf("request outside the API root: %s", r.URL.EscapedPath())
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read %s %s body: %v", r.Method, r.URL.Path, err)
+		}
+		var decoded map[string]any
+		if len(raw) > 0 {
+			if err := json.Unmarshal(raw, &decoded); err != nil {
+				t.Errorf("decode %s %s payload: %v (raw: %s)", r.Method, r.URL.Path, err, raw)
+			}
+		}
+		seen = append(seen, fjWriteReq{
+			Method: r.Method,
+			Path:   strings.TrimPrefix(r.URL.EscapedPath(), "/api/v1"),
+			Query:  r.URL.Query(),
+			JSON:   decoded,
+		})
+		resp := fn(r)
+		w.WriteHeader(resp.Status)
+		if resp.Body != "" {
+			_, _ = w.Write([]byte(resp.Body))
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	t.Setenv("TEST_FORGEJO_TOKEN", "test-token")
+	c := New(fjTestRepo, config.ForgeConfig{
+		Kind:     "forgejo",
+		BaseURL:  srv.URL,
+		TokenEnv: "TEST_FORGEJO_TOKEN",
+	})
+	if c.fj == nil || c.forgeErr != nil {
+		t.Fatalf("client not in forgejo transport state: fj=%v forgeErr=%v", c.fj, c.forgeErr)
+	}
+	return c, &seen, ghCalls
+}
+
+// fjWriteRoute serves canned responses keyed by "METHOD /path" (path relative
+// to the API root, query stripped). Unrouted requests fail the test.
+func fjWriteRoute(t *testing.T, routes map[string]fjWriteResp) func(r *http.Request) fjWriteResp {
+	t.Helper()
+	return func(r *http.Request) fjWriteResp {
+		key := r.Method + " " + strings.TrimPrefix(r.URL.EscapedPath(), "/api/v1")
+		if resp, ok := routes[key]; ok {
+			return resp
+		}
+		t.Errorf("unrouted fixture request: %s", key)
+		return fjWriteResp{Status: 404, Body: `{"message":"no fixture"}`}
+	}
+}
+
+// assertWrite asserts request i has the given method, path, and exact decoded
+// payload (nil wantJSON = no body at all).
+func assertWrite(t *testing.T, seen *[]fjWriteReq, i int, method, path string, wantJSON map[string]any) fjWriteReq {
+	t.Helper()
+	if len(*seen) <= i {
+		t.Fatalf("requests = %d, want at least %d: %+v", len(*seen), i+1, *seen)
+	}
+	req := (*seen)[i]
+	if req.Method != method || req.Path != path {
+		t.Fatalf("request %d = %s %s, want %s %s", i, req.Method, req.Path, method, path)
+	}
+	if !reflect.DeepEqual(req.JSON, wantJSON) {
+		t.Fatalf("request %d payload = %#v, want %#v", i, req.JSON, wantJSON)
+	}
+	return req
+}
+
+// --- PRs -----------------------------------------------------------------------
+
+func TestForgejoWriteCreatePR(t *testing.T) {
+	c, seen, ghCalls := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		// html_url is a decoy with a DIFFERENT number: the number must come
+		// from the response JSON, never from URL scraping (Forgejo web URLs
+		// are /pulls/N where the gh path scrapes /pull/N).
+		"POST /repos/" + fjTestRepo + "/pulls": {201, `{"id":99,"number":7,"html_url":"https://forge/BeFeast/apertune/pulls/1","state":"open","draft":false}`},
+	}))
+	n, err := c.CreatePR("feat: title", "the body", "main", "feat/x")
+	if err != nil {
+		t.Fatalf("CreatePR: %v", err)
+	}
+	if n != 7 {
+		t.Fatalf("number = %d, want 7 (from response JSON, not the html_url decoy)", n)
+	}
+	assertWrite(t, seen, 0, http.MethodPost, "/repos/"+fjTestRepo+"/pulls", map[string]any{
+		"title": "feat: title",
+		"body":  "the body",
+		"base":  "main",
+		"head":  "feat/x",
+	})
+	if len(*seen) != 1 || ghCalls.Load() != 0 {
+		t.Fatalf("requests = %d, gh calls = %d; want 1 and 0", len(*seen), ghCalls.Load())
+	}
+}
+
+func TestForgejoWriteUpdatePRBody(t *testing.T) {
+	c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		"PATCH /repos/" + fjTestRepo + "/pulls/5": {201, `{}`},
+	}))
+	if err := c.UpdatePRBody(5, "replacement body"); err != nil {
+		t.Fatalf("UpdatePRBody: %v", err)
+	}
+	assertWrite(t, seen, 0, http.MethodPatch, "/repos/"+fjTestRepo+"/pulls/5", map[string]any{
+		"body": "replacement body",
+	})
+}
+
+func TestForgejoWriteClosePRCommentThenClose(t *testing.T) {
+	c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		"POST /repos/" + fjTestRepo + "/issues/9/comments": {201, `{"id":1}`},
+		"PATCH /repos/" + fjTestRepo + "/pulls/9":          {201, `{}`},
+	}))
+	if err := c.ClosePR(9, "superseded by #10"); err != nil {
+		t.Fatalf("ClosePR: %v", err)
+	}
+	// ORDER is the contract: the explanation lands before the state flips.
+	assertWrite(t, seen, 0, http.MethodPost, "/repos/"+fjTestRepo+"/issues/9/comments", map[string]any{
+		"body": "superseded by #10",
+	})
+	assertWrite(t, seen, 1, http.MethodPatch, "/repos/"+fjTestRepo+"/pulls/9", map[string]any{
+		"state": "closed",
+	})
+	if len(*seen) != 2 {
+		t.Fatalf("requests = %d, want exactly comment then close", len(*seen))
+	}
+}
+
+func TestForgejoWriteClosePREmptyCommentSkips(t *testing.T) {
+	c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		"PATCH /repos/" + fjTestRepo + "/pulls/9": {201, `{}`},
+	}))
+	if err := c.ClosePR(9, ""); err != nil {
+		t.Fatalf("ClosePR: %v", err)
+	}
+	assertWrite(t, seen, 0, http.MethodPatch, "/repos/"+fjTestRepo+"/pulls/9", map[string]any{
+		"state": "closed",
+	})
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %d, want the comment step skipped entirely", len(*seen))
+	}
+}
+
+func TestForgejoWriteClosePRAbortsWhenCommentFails(t *testing.T) {
+	c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		"POST /repos/" + fjTestRepo + "/issues/9/comments": {500, `{"message":"boom"}`},
+	}))
+	err := c.ClosePR(9, "explanation that must not be lost")
+	if err == nil {
+		t.Fatal("a failed comment must abort the close")
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %+v, want NO close PATCH after the failed comment (PR stays open)", *seen)
+	}
+}
+
+func TestForgejoWriteCloseIssue(t *testing.T) {
+	t.Run("comment then close, in order", func(t *testing.T) {
+		c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+			"POST /repos/" + fjTestRepo + "/issues/4/comments": {201, `{"id":1}`},
+			"PATCH /repos/" + fjTestRepo + "/issues/4":         {201, `{}`},
+		}))
+		if err := c.CloseIssue(4, "fixed in #5"); err != nil {
+			t.Fatalf("CloseIssue: %v", err)
+		}
+		assertWrite(t, seen, 0, http.MethodPost, "/repos/"+fjTestRepo+"/issues/4/comments", map[string]any{
+			"body": "fixed in #5",
+		})
+		assertWrite(t, seen, 1, http.MethodPatch, "/repos/"+fjTestRepo+"/issues/4", map[string]any{
+			"state": "closed",
+		})
+		if len(*seen) != 2 {
+			t.Fatalf("requests = %d, want exactly comment then close", len(*seen))
+		}
+	})
+	t.Run("empty comment skips the comment step", func(t *testing.T) {
+		c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+			"PATCH /repos/" + fjTestRepo + "/issues/4": {201, `{}`},
+		}))
+		if err := c.CloseIssue(4, ""); err != nil {
+			t.Fatalf("CloseIssue: %v", err)
+		}
+		if len(*seen) != 1 {
+			t.Fatalf("requests = %+v, want the close PATCH only", *seen)
+		}
+	})
+	t.Run("failed comment aborts the close", func(t *testing.T) {
+		c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+			"POST /repos/" + fjTestRepo + "/issues/4/comments": {500, `{"message":"boom"}`},
+		}))
+		if err := c.CloseIssue(4, "why"); err == nil {
+			t.Fatal("a failed comment must abort the close")
+		}
+		if len(*seen) != 1 {
+			t.Fatalf("requests = %+v, want NO close PATCH after the failed comment", *seen)
+		}
+	})
+}
+
+// --- merge ---------------------------------------------------------------------
+
+const fjWriteHeadSHA = "59e99c49c27d3e2f73bae1657f07cd2f9a15f926"
+
+func TestForgejoWriteMergePRAtHeadPayload(t *testing.T) {
+	c, seen, ghCalls := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		"POST /repos/" + fjTestRepo + "/pulls/12/merge": {200, ``},
+	}))
+	if err := c.MergePRAtHead(12, fjWriteHeadSHA); err != nil {
+		t.Fatalf("MergePRAtHead: %v", err)
+	}
+	// gh parity: --squash --delete-branch --match-head-commit, with the
+	// swagger's mixed wire casing pinned exactly.
+	assertWrite(t, seen, 0, http.MethodPost, "/repos/"+fjTestRepo+"/pulls/12/merge", map[string]any{
+		"Do":                        "squash",
+		"head_commit_id":            fjWriteHeadSHA,
+		"delete_branch_after_merge": true,
+	})
+	if ghCalls.Load() != 0 {
+		t.Fatalf("gh runner invoked %d time(s), want 0", ghCalls.Load())
+	}
+}
+
+func TestForgejoWriteMergePRAtHeadEmptySHAPreflight(t *testing.T) {
+	c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{}))
+	err := c.MergePRAtHead(12, "   ")
+	if err == nil || !strings.Contains(err.Error(), "merge PR 12: expected head SHA is required") {
+		t.Fatalf("err = %v, want the shared gh-parity pre-flight message", err)
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("requests = %+v, want none — the pre-flight must run before any call", *seen)
+	}
+}
+
+// TestForgejoWriteMergeRefusalClassification pins the sentinel contract end to
+// end: a 405/409 refusal whose body indicates the out-of-date/head-mismatch
+// family maps onto github.ErrMergeNotUpToDate (and keeps the legacy
+// "not up to date" needle in its text for string-matching consumers); every
+// other refusal — bodyless 405 included — stays a raw loud error.
+func TestForgejoWriteMergeRefusalClassification(t *testing.T) {
+	cases := []struct {
+		name         string
+		status       int
+		body         string
+		wantSentinel bool
+	}{
+		{"409 out-of-date body", 409, `{"message":"Please update your branch: it is not up to date with the base branch","url":""}`, true},
+		{"405 head_commit_id mismatch body", 405, `{"message":"head_commit_id is out of date","url":""}`, true},
+		{"bodyless 405 stays raw", 405, ``, false},
+		{"409 unrelated conflict body stays raw", 409, `{"message":"merge conflict detected in web/app.css","url":""}`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+				"POST /repos/" + fjTestRepo + "/pulls/12/merge": {tc.status, tc.body},
+			}))
+			err := c.MergePRAtHead(12, fjWriteHeadSHA)
+			if err == nil {
+				t.Fatal("a merge refusal must surface as an error")
+			}
+			if got := errors.Is(err, ErrMergeNotUpToDate); got != tc.wantSentinel {
+				t.Fatalf("errors.Is(err, ErrMergeNotUpToDate) = %v, want %v (err = %v)", got, tc.wantSentinel, err)
+			}
+			if got := errors.Is(err, forgejo.ErrMergeOutOfDate); got != tc.wantSentinel {
+				t.Fatalf("errors.Is(err, forgejo.ErrMergeOutOfDate) = %v, want %v (err = %v)", got, tc.wantSentinel, err)
+			}
+			if tc.wantSentinel && !strings.Contains(err.Error(), "not up to date") {
+				t.Fatalf("classified error must keep the legacy needle for string-matching consumers, got: %v", err)
+			}
+			var se *forgejo.StatusError
+			if !errors.As(err, &se) || se.StatusCode != tc.status {
+				t.Fatalf("the raw *forgejo.StatusError must survive the wrap chain, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestForgejoWriteUpdateBranch(t *testing.T) {
+	c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		"POST /repos/" + fjTestRepo + "/pulls/3/update": {200, ``},
+	}))
+	if err := c.UpdateBranch(3); err != nil {
+		t.Fatalf("UpdateBranch: %v", err)
+	}
+	req := assertWrite(t, seen, 0, http.MethodPost, "/repos/"+fjTestRepo+"/pulls/3/update", nil)
+	if got := req.Query.Get("style"); got != "merge" {
+		t.Fatalf("style = %q, want the explicit merge style (gh default parity, not rebase)", got)
+	}
+}
+
+// --- issues ---------------------------------------------------------------------
+
+func TestForgejoWriteCreateIssueResolvesLabelNames(t *testing.T) {
+	labelsList := `[{"id":5,"name":"maestro-ready","exclusive":false,"is_archived":false,"color":"00aabb","description":""},
+		{"id":9,"name":"bug","exclusive":false,"is_archived":false,"color":"ee0000","description":""}]`
+	c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		"GET /repos/" + fjTestRepo + "/labels":  {200, labelsList},
+		"POST /repos/" + fjTestRepo + "/issues": {201, `{"id":77,"number":31,"html_url":"https://forge/BeFeast/apertune/issues/2"}`},
+	}))
+	n, err := c.CreateIssue("issue title", "issue body", []string{"bug", "maestro-ready"})
+	if err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+	if n != 31 {
+		t.Fatalf("number = %d, want 31 from the response JSON", n)
+	}
+	if len(*seen) != 2 {
+		t.Fatalf("requests = %+v, want label resolution then create", *seen)
+	}
+	if (*seen)[0].Method != http.MethodGet || (*seen)[0].Path != "/repos/"+fjTestRepo+"/labels" {
+		t.Fatalf("request 0 = %s %s, want the repo labels read", (*seen)[0].Method, (*seen)[0].Path)
+	}
+	// CreateIssueOption.labels is []int64 — ids in CALLER order, not repo order.
+	assertWrite(t, seen, 1, http.MethodPost, "/repos/"+fjTestRepo+"/issues", map[string]any{
+		"title":  "issue title",
+		"body":   "issue body",
+		"labels": []any{float64(9), float64(5)},
+	})
+}
+
+func TestForgejoWriteCreateIssueUnknownLabelAbortsBeforeCreate(t *testing.T) {
+	c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		"GET /repos/" + fjTestRepo + "/labels": {200, `[{"id":5,"name":"bug","color":"ee0000","description":""}]`},
+	}))
+	_, err := c.CreateIssue("t", "b", []string{"bug", "no-such-label"})
+	if err == nil || !strings.Contains(err.Error(), `label "no-such-label" does not exist`) {
+		t.Fatalf("err = %v, want the unknown label named loudly", err)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %+v, want NO issue created after the failed resolution", *seen)
+	}
+}
+
+func TestForgejoWriteCreateIssueNoLabelsSkipsResolution(t *testing.T) {
+	c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		"POST /repos/" + fjTestRepo + "/issues": {201, `{"number":32}`},
+	}))
+	n, err := c.CreateIssue("t", "b", nil)
+	if err != nil || n != 32 {
+		t.Fatalf("CreateIssue = %d, %v", n, err)
+	}
+	// No labels key at all when none were requested, and no labels read.
+	assertWrite(t, seen, 0, http.MethodPost, "/repos/"+fjTestRepo+"/issues", map[string]any{
+		"title": "t",
+		"body":  "b",
+	})
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %+v, want the create only", *seen)
+	}
+}
+
+func TestForgejoWriteEditIssueBody(t *testing.T) {
+	c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		"PATCH /repos/" + fjTestRepo + "/issues/4": {201, `{}`},
+	}))
+	if err := c.EditIssueBody(4, "replaced body"); err != nil {
+		t.Fatalf("EditIssueBody: %v", err)
+	}
+	assertWrite(t, seen, 0, http.MethodPatch, "/repos/"+fjTestRepo+"/issues/4", map[string]any{
+		"body": "replaced body",
+	})
+}
+
+// --- labels ---------------------------------------------------------------------
+
+func TestForgejoWriteAddIssueLabelByName(t *testing.T) {
+	c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		"POST /repos/" + fjTestRepo + "/issues/6/labels": {200, `[]`},
+	}))
+	if err := c.AddIssueLabel(6, "blocked"); err != nil {
+		t.Fatalf("AddIssueLabel: %v", err)
+	}
+	// IssueLabelsOption accepts NAMES on this instance — verbatim, no id
+	// resolution round trip.
+	assertWrite(t, seen, 0, http.MethodPost, "/repos/"+fjTestRepo+"/issues/6/labels", map[string]any{
+		"labels": []any{"blocked"},
+	})
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %+v, want the label add only (no resolution read)", *seen)
+	}
+}
+
+func TestForgejoWriteRemoveIssueLabel(t *testing.T) {
+	t.Run("by name, path-escaped, 204 is success", func(t *testing.T) {
+		c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+			"DELETE /repos/" + fjTestRepo + "/issues/6/labels/needs%20info": {204, ``},
+		}))
+		if err := c.RemoveIssueLabel(6, "needs info"); err != nil {
+			t.Fatalf("RemoveIssueLabel: %v", err)
+		}
+		// A label the issue does not carry also answers 204 (zero rows
+		// deleted) — the same green path, gh's no-op parity.
+		assertWrite(t, seen, 0, http.MethodDelete, "/repos/"+fjTestRepo+"/issues/6/labels/needs%20info", nil)
+	})
+	t.Run("label missing from the repo fails loud", func(t *testing.T) {
+		c, _, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+			"DELETE /repos/" + fjTestRepo + "/issues/6/labels/ghost": {404, `{"message":"label does not exist","url":""}`},
+		}))
+		err := c.RemoveIssueLabel(6, "ghost")
+		if err == nil || !strings.Contains(err.Error(), "404") {
+			t.Fatalf("err = %v, want the repo-missing label loud (gh parity)", err)
+		}
+	})
+}
+
+func TestForgejoWriteEnsureLabelUpsert(t *testing.T) {
+	existing := `[{"id":23,"name":"Blocked","exclusive":false,"is_archived":false,"color":"cccccc","description":"old"}]`
+	t.Run("existing label is PATCHed with only the provided fields", func(t *testing.T) {
+		c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+			"GET /repos/" + fjTestRepo + "/labels":      {200, existing},
+			"PATCH /repos/" + fjTestRepo + "/labels/23": {200, `{}`},
+		}))
+		// Case-insensitive name match: "blocked" finds "Blocked" (id 23).
+		if err := c.EnsureLabel("blocked", "d93f0b", "now blocking"); err != nil {
+			t.Fatalf("EnsureLabel: %v", err)
+		}
+		assertWrite(t, seen, 1, http.MethodPatch, "/repos/"+fjTestRepo+"/labels/23", map[string]any{
+			"color":       "d93f0b",
+			"description": "now blocking",
+		})
+	})
+	t.Run("existing label with nothing to update makes no write", func(t *testing.T) {
+		c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+			"GET /repos/" + fjTestRepo + "/labels": {200, existing},
+		}))
+		if err := c.EnsureLabel("Blocked", "", ""); err != nil {
+			t.Fatalf("EnsureLabel: %v", err)
+		}
+		if len(*seen) != 1 {
+			t.Fatalf("requests = %+v, want the list read only (a field-less PATCH is banned)", *seen)
+		}
+	})
+	t.Run("missing label is created with the caller color", func(t *testing.T) {
+		c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+			"GET /repos/" + fjTestRepo + "/labels":  {200, `[]`},
+			"POST /repos/" + fjTestRepo + "/labels": {201, `{}`},
+		}))
+		if err := c.EnsureLabel("maestro-repair", "D93F0B", "repair work"); err != nil {
+			t.Fatalf("EnsureLabel: %v", err)
+		}
+		assertWrite(t, seen, 1, http.MethodPost, "/repos/"+fjTestRepo+"/labels", map[string]any{
+			"name":        "maestro-repair",
+			"color":       "D93F0B",
+			"description": "repair work",
+		})
+	})
+	t.Run("missing label with no caller color gets the documented default", func(t *testing.T) {
+		c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+			"GET /repos/" + fjTestRepo + "/labels":  {200, `[]`},
+			"POST /repos/" + fjTestRepo + "/labels": {201, `{}`},
+		}))
+		// CreateLabelOption REQUIRES color; gh picks one itself, so the
+		// forgejo arm supplies the fixed "#ededed" default. Description is
+		// omitted when empty.
+		if err := c.EnsureLabel("bare-label", "", ""); err != nil {
+			t.Fatalf("EnsureLabel: %v", err)
+		}
+		assertWrite(t, seen, 1, http.MethodPost, "/repos/"+fjTestRepo+"/labels", map[string]any{
+			"name":  "bare-label",
+			"color": "#ededed",
+		})
+	})
+	t.Run("empty name is a pre-flight error, no request", func(t *testing.T) {
+		c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{}))
+		err := c.EnsureLabel("   ", "d93f0b", "x")
+		if err == nil || !strings.Contains(err.Error(), "ensure label: empty name") {
+			t.Fatalf("err = %v, want the shared empty-name pre-flight", err)
+		}
+		if len(*seen) != 0 {
+			t.Fatalf("requests = %+v, want none", *seen)
+		}
+	})
+}
+
+// --- comments / releases ----------------------------------------------------------
+
+func TestForgejoWriteCommentIssueAndPR(t *testing.T) {
+	// One shared route serves both: pulls live in the issue number space.
+	c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		"POST /repos/" + fjTestRepo + "/issues/9/comments":  {201, `{"id":1}`},
+		"POST /repos/" + fjTestRepo + "/issues/11/comments": {201, `{"id":2}`},
+	}))
+	if err := c.CommentIssue(9, "issue note"); err != nil {
+		t.Fatalf("CommentIssue: %v", err)
+	}
+	if err := c.CommentPR(11, "pr note"); err != nil {
+		t.Fatalf("CommentPR: %v", err)
+	}
+	assertWrite(t, seen, 0, http.MethodPost, "/repos/"+fjTestRepo+"/issues/9/comments", map[string]any{
+		"body": "issue note",
+	})
+	assertWrite(t, seen, 1, http.MethodPost, "/repos/"+fjTestRepo+"/issues/11/comments", map[string]any{
+		"body": "pr note",
+	})
+}
+
+func TestForgejoWriteCreateRelease(t *testing.T) {
+	c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+		"POST /repos/" + fjTestRepo + "/releases": {201, `{"id":3}`},
+	}))
+	if err := c.CreateRelease("v1.2.3", "Release v1.2.3"); err != nil {
+		t.Fatalf("CreateRelease: %v", err)
+	}
+	// Exactly tag_name + name: no body (no --generate-notes equivalent — the
+	// documented divergence) and no target_commitish (the release anchors to
+	// the already-pushed tag).
+	assertWrite(t, seen, 0, http.MethodPost, "/repos/"+fjTestRepo+"/releases", map[string]any{
+		"tag_name": "v1.2.3",
+		"name":     "Release v1.2.3",
+	})
+}
+
+// --- the one write that stays guarded ---------------------------------------------
+
+func TestForgejoWriteMarkPRReadyStaysGuarded(t *testing.T) {
+	c, seen, ghCalls := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{}))
+	err := c.MarkPRReady(1)
+	if err == nil {
+		t.Fatal("MarkPRReady must fail loud on forgejo — EditPullRequestOption has no draft toggle on 16.0.1")
+	}
+	if !errors.Is(err, ErrForgejoNotSupported) {
+		t.Fatalf("err = %v, want ErrForgejoNotSupported (draft semantics land with M7)", err)
+	}
+	if len(*seen) != 0 {
+		t.Fatalf("requests = %+v, want none — the guard must fire before any transport touch", *seen)
+	}
+	if ghCalls.Load() != 0 {
+		t.Fatalf("gh runner invoked %d time(s), want 0", ghCalls.Load())
+	}
+}

--- a/internal/github/forgejo_port_writes_test.go
+++ b/internal/github/forgejo_port_writes_test.go
@@ -467,6 +467,22 @@ func TestForgejoWriteEnsureLabelUpsert(t *testing.T) {
 			"description": "now blocking",
 		})
 	})
+	t.Run("exact name match wins over a case-insensitive one", func(t *testing.T) {
+		// Forgejo does not enforce name uniqueness under case folding: with
+		// "Blocked" (id 7) listed BEFORE "blocked" (id 23), a fold-first
+		// matcher would PATCH id 7 — the exact match must win.
+		both := `[{"id":7,"name":"Blocked","color":"cccccc","description":""},{"id":23,"name":"blocked","color":"cccccc","description":""}]`
+		c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
+			"GET /repos/" + fjTestRepo + "/labels":      {200, both},
+			"PATCH /repos/" + fjTestRepo + "/labels/23": {200, `{}`},
+		}))
+		if err := c.EnsureLabel("blocked", "d93f0b", ""); err != nil {
+			t.Fatalf("EnsureLabel: %v", err)
+		}
+		assertWrite(t, seen, 1, http.MethodPatch, "/repos/"+fjTestRepo+"/labels/23", map[string]any{
+			"color": "d93f0b",
+		})
+	})
 	t.Run("existing label with nothing to update makes no write", func(t *testing.T) {
 		c, seen, _ := newForgejoWriteClient(t, fjWriteRoute(t, map[string]fjWriteResp{
 			"GET /repos/" + fjTestRepo + "/labels": {200, existing},

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -2330,6 +2330,9 @@ func (c *Client) combinedStatusForSHA(sha string) (combinedStatusResponse, error
 
 // CreatePR opens a pull request and returns its number.
 func (c *Client) CreatePR(title, body, base, head string) (int, error) {
+	if c.isForgejo() {
+		return c.fjCreatePR(title, body, base, head)
+	}
 	args := []string{
 		"pr", "create",
 		"--repo", c.Repo,
@@ -2357,6 +2360,9 @@ func (c *Client) CreatePR(title, body, base, head string) (int, error) {
 
 // UpdatePRBody replaces a pull request body.
 func (c *Client) UpdatePRBody(prNumber int, body string) error {
+	if c.isForgejo() {
+		return c.fjUpdatePRBody(prNumber, body)
+	}
 	out, err := c.ghExec(
 		"pr", "edit", strconv.Itoa(prNumber),
 		"--repo", c.Repo,
@@ -3155,7 +3161,12 @@ func (c *Client) greptileReviewComments(prNumber int) ([]greptileReviewComment, 
 }
 
 // ClosePR closes a PR without merging and leaves a comment explaining why.
+// Comment-then-close: a failed comment ABORTS the close (the PR stays open)
+// and an empty comment skips the comment step — callers rely on both.
 func (c *Client) ClosePR(prNumber int, comment string) error {
+	if c.isForgejo() {
+		return c.fjClosePR(prNumber, comment)
+	}
 	if comment != "" {
 		out, err := c.ghExec("pr", "comment",
 			fmt.Sprint(prNumber),
@@ -3408,13 +3419,34 @@ func formatFailureAnnotations(anns []checkAnnotation) string {
 	return strings.Join(lines, "\n")
 }
 
+// ErrMergeNotUpToDate marks a merge refusal caused by the PR head/base moving
+// since the caller's read: the branch is BEHIND (not conflicting), so
+// update-branch/rebase converges it — the AutoRebase branch keys off this via
+// errors.Is instead of string-matching gh stderr (#1172 M3). Both transports
+// wrap it: the gh path when the CLI output carries the "not up to date"
+// needle, the forgejo path when the REST refusal maps onto
+// forgejo.ErrMergeOutOfDate. The sentinel text deliberately contains the
+// legacy needle so pre-existing strings.Contains consumers keep matching.
+var ErrMergeNotUpToDate = errors.New("pr head/base is not up to date for merge")
+
+// mergeNotUpToDateNeedle is the historical gh stderr fragment ("the head
+// branch is not up to date with the base branch") the orchestrator classified
+// on before the sentinel existed; the gh path still detects on it verbatim.
+const mergeNotUpToDateNeedle = "not up to date"
+
 // MergePRAtHead squash-merges a PR only when its current head still matches
 // expectedHeadSHA. GitHub enforces the comparison atomically with the merge,
 // closing the force-push race between a gate/approval read and execution.
+// The empty-SHA pre-flight is shared by both transports so the fail-loud
+// message stays identical; a refusal meaning "head/base moved" comes back
+// errors.Is-matchable against ErrMergeNotUpToDate on both.
 func (c *Client) MergePRAtHead(prNumber int, expectedHeadSHA string) error {
 	expectedHeadSHA = strings.TrimSpace(expectedHeadSHA)
 	if expectedHeadSHA == "" {
 		return fmt.Errorf("merge PR %d: expected head SHA is required", prNumber)
+	}
+	if c.isForgejo() {
+		return c.fjMergePRAtHead(prNumber, expectedHeadSHA)
 	}
 	out, err := c.ghExec("pr", "merge",
 		fmt.Sprint(prNumber),
@@ -3423,7 +3455,11 @@ func (c *Client) MergePRAtHead(prNumber int, expectedHeadSHA string) error {
 		"--delete-branch",
 		"--match-head-commit", expectedHeadSHA)
 	if err != nil {
-		return fmt.Errorf("gh pr merge %d at head %s: %w\n%s", prNumber, expectedHeadSHA, err, out)
+		wrapped := fmt.Errorf("gh pr merge %d at head %s: %w\n%s", prNumber, expectedHeadSHA, err, out)
+		if strings.Contains(string(out), mergeNotUpToDateNeedle) {
+			return fmt.Errorf("%w: %w", ErrMergeNotUpToDate, wrapped)
+		}
+		return wrapped
 	}
 	return nil
 }
@@ -3432,6 +3468,14 @@ func (c *Client) MergePRAtHead(prNumber int, expectedHeadSHA string) error {
 // `gh pr ready`). `gh pr merge` on a draft fails with "still a draft", so
 // the orchestrator readies a green draft PR before merging it (#697).
 func (c *Client) MarkPRReady(prNumber int) error {
+	if c.isForgejo() {
+		// NOT ported in M3, guarded explicitly: EditPullRequestOption on
+		// Forgejo 16.0.1 carries NO draft/wip toggle of any kind
+		// (swagger-verified, M3 stage A), and emulating it by rewriting a
+		// "WIP:" title prefix is not acceptable. Draft semantics for the
+		// Forgejo worker flow land with the M7 worker-flow decisions.
+		return c.forgejoUnsupported("MarkPRReady (no draft toggle in EditPullRequestOption; M7)")
+	}
 	out, err := c.ghExec("pr", "ready",
 		fmt.Sprint(prNumber),
 		"--repo", c.Repo)
@@ -3452,6 +3496,9 @@ func (c *Client) MarkPRReady(prNumber int) error {
 // same pass; they should let the next supervisor cycle re-validate and
 // re-mint against the new state (#547).
 func (c *Client) UpdateBranch(prNumber int) error {
+	if c.isForgejo() {
+		return c.fjUpdateBranch(prNumber)
+	}
 	out, err := c.ghExec("pr", "update-branch",
 		fmt.Sprint(prNumber),
 		"--repo", c.Repo)
@@ -3461,8 +3508,13 @@ func (c *Client) UpdateBranch(prNumber int) error {
 	return nil
 }
 
-// CloseIssue closes a GitHub issue and leaves a comment explaining why
+// CloseIssue closes an issue and leaves a comment explaining why.
+// Comment-then-close: a failed comment ABORTS the close (the issue stays
+// open) and an empty comment skips the comment step — callers rely on both.
 func (c *Client) CloseIssue(number int, comment string) error {
+	if c.isForgejo() {
+		return c.fjCloseIssue(number, comment)
+	}
 	if comment != "" {
 		out, err := c.ghExec("issue", "comment",
 			fmt.Sprint(number),
@@ -3483,6 +3535,9 @@ func (c *Client) CloseIssue(number int, comment string) error {
 
 // AddIssueLabel adds a label to an issue.
 func (c *Client) AddIssueLabel(issueNumber int, label string) error {
+	if c.isForgejo() {
+		return c.fjAddIssueLabel(issueNumber, label)
+	}
 	out, err := c.ghExec("issue", "edit",
 		strconv.Itoa(issueNumber),
 		"--repo", c.Repo,
@@ -3502,6 +3557,9 @@ func (c *Client) EnsureLabel(name, color, description string) error {
 	if name == "" {
 		return fmt.Errorf("ensure label: empty name")
 	}
+	if c.isForgejo() {
+		return c.fjEnsureLabel(name, color, description)
+	}
 	args := []string{"label", "create", name, "--repo", c.Repo, "--force"}
 	if color = strings.TrimPrefix(strings.TrimSpace(color), "#"); color != "" {
 		args = append(args, "--color", color)
@@ -3516,8 +3574,13 @@ func (c *Client) EnsureLabel(name, color, description string) error {
 	return nil
 }
 
-// RemoveIssueLabel removes a label from an issue.
+// RemoveIssueLabel removes a label from an issue. Removing a label the issue
+// does not carry is a no-op success; removing a label that does not exist on
+// the repo at all is a loud error (gh parity on both forges).
 func (c *Client) RemoveIssueLabel(issueNumber int, label string) error {
+	if c.isForgejo() {
+		return c.fjRemoveIssueLabel(issueNumber, label)
+	}
 	out, err := c.ghExec("issue", "edit",
 		strconv.Itoa(issueNumber),
 		"--repo", c.Repo,
@@ -3531,6 +3594,9 @@ func (c *Client) RemoveIssueLabel(issueNumber int, label string) error {
 
 // CommentIssue leaves a comment on an issue.
 func (c *Client) CommentIssue(issueNumber int, body string) error {
+	if c.isForgejo() {
+		return c.fjComment(issueNumber, body)
+	}
 	out, err := c.ghExec("issue", "comment",
 		strconv.Itoa(issueNumber),
 		"--repo", c.Repo,
@@ -3578,8 +3644,12 @@ func (c *Client) ListIssueComments(issueNumber int) ([]IssueComment, error) {
 	return comments, nil
 }
 
-// CommentPR leaves a comment on a pull request.
+// CommentPR leaves a comment on a pull request. On Forgejo pulls share the
+// issue number space, so the same comment route serves both.
 func (c *Client) CommentPR(prNumber int, body string) error {
+	if c.isForgejo() {
+		return c.fjComment(prNumber, body)
+	}
 	out, err := c.ghExec("pr", "comment",
 		strconv.Itoa(prNumber),
 		"--repo", c.Repo,
@@ -3623,8 +3693,14 @@ func (c *Client) PRCommits(prNumber int) ([]string, error) {
 	return msgs, nil
 }
 
-// CreateRelease creates a GitHub release for the given tag.
+// CreateRelease creates a release for the given tag (already pushed by
+// CommitAndTag). The gh path generates release notes (--generate-notes);
+// Forgejo has no notes-generation equivalent, so there the release body stays
+// empty — a documented divergence, not a bug.
 func (c *Client) CreateRelease(tag, title string) error {
+	if c.isForgejo() {
+		return c.fjCreateRelease(tag, title)
+	}
 	out, err := c.ghExec("release", "create",
 		tag,
 		"--repo", c.Repo,
@@ -3940,8 +4016,11 @@ func FindBlockers(body string, patterns []string) []int {
 	return blockers
 }
 
-// CreateIssue creates a new GitHub issue and returns its number.
+// CreateIssue creates a new issue and returns its number.
 func (c *Client) CreateIssue(title, body string, labels []string) (int, error) {
+	if c.isForgejo() {
+		return c.fjCreateIssue(title, body, labels)
+	}
 	args := []string{
 		"issue", "create",
 		"--repo", c.Repo,
@@ -3970,8 +4049,11 @@ func (c *Client) CreateIssue(title, body string, labels []string) (int, error) {
 	return n, nil
 }
 
-// EditIssueBody updates the body of a GitHub issue.
+// EditIssueBody updates the body of an issue (full replace).
 func (c *Client) EditIssueBody(number int, body string) error {
+	if c.isForgejo() {
+		return c.fjEditIssueBody(number, body)
+	}
 	out, err := c.ghExec("issue", "edit",
 		strconv.Itoa(number),
 		"--repo", c.Repo,

--- a/internal/github/github_mode_writes_test.go
+++ b/internal/github/github_mode_writes_test.go
@@ -135,6 +135,37 @@ func TestGitHubModeWriteArgsUnchanged(t *testing.T) {
 	}
 }
 
+// TestGitHubModeCloseCommentFailureAborts pins the gh-path half of the
+// comment-then-close contract (the forgejo-mode tests pin the other half): a
+// failed comment ABORTS the close — no close invocation follows, so the
+// PR/issue stays open and the explanation is never lost.
+func TestGitHubModeCloseCommentFailureAborts(t *testing.T) {
+	t.Run("ClosePR", func(t *testing.T) {
+		readInvocations := stubGHArgvRecorder(t, "boom", 1)
+		c := New("owner/repo", config.ForgeConfig{})
+		err := c.ClosePR(7, "why closed")
+		if err == nil || !strings.Contains(err.Error(), "gh pr comment 7") {
+			t.Fatalf("err = %v, want the comment failure surfaced", err)
+		}
+		got := readInvocations()
+		if len(got) != 1 || !reflect.DeepEqual(got[0][:2], []string{"pr", "comment"}) {
+			t.Fatalf("gh invocations = %q, want the comment attempt only (close aborted)", got)
+		}
+	})
+	t.Run("CloseIssue", func(t *testing.T) {
+		readInvocations := stubGHArgvRecorder(t, "boom", 1)
+		c := New("owner/repo", config.ForgeConfig{})
+		err := c.CloseIssue(9, "done")
+		if err == nil || !strings.Contains(err.Error(), "gh issue comment 9") {
+			t.Fatalf("err = %v, want the comment failure surfaced", err)
+		}
+		got := readInvocations()
+		if len(got) != 1 || !reflect.DeepEqual(got[0][:2], []string{"issue", "comment"}) {
+			t.Fatalf("gh invocations = %q, want the comment attempt only (close aborted)", got)
+		}
+	})
+}
+
 // TestGitHubModeMergeNotUpToDateWrapsSentinel pins the gh-path half of the
 // merge error contract: the historical "not up to date" stderr needle now
 // also wraps ErrMergeNotUpToDate (errors.Is-matchable) while keeping the full

--- a/internal/github/github_mode_writes_test.go
+++ b/internal/github/github_mode_writes_test.go
@@ -1,0 +1,169 @@
+package github
+
+// GitHub-mode write invocation tests (#1172 M3). The forgejo dispatch added a
+// branch at the top of every write method; these pin that a zero-ForgeConfig
+// client still issues the EXACT historical gh argv for each write — the write
+// sibling of TestGitHubModeCoreReadsUnchanged. The gh CLI is replaced by a
+// recording stub, so nothing touches the network.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+)
+
+// stubGHArgvRecorder points ghExecutable at a script that appends every
+// invocation's argv to a log (one arg per line, invocations separated by a
+// 0x1e record-separator line), prints the canned stdout, and exits with the
+// given code. The returned reader parses the log back into per-invocation
+// argv slices, so assertions compare byte-identical argument vectors.
+func stubGHArgvRecorder(t *testing.T, stdout string, exitCode int) func() [][]string {
+	t.Helper()
+	logPath := filepath.Join(t.TempDir(), "argv.log")
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" >> \"%s\"\nprintf '\\036\\n' >> \"%s\"\nprintf '%%s' '%s'\nexit %d\n",
+		logPath, logPath, stdout, exitCode)
+	stubGHExecutable(t, script)
+	return func() [][]string {
+		raw, err := os.ReadFile(logPath)
+		if err != nil {
+			t.Fatalf("read argv log: %v", err)
+		}
+		var invocations [][]string
+		for _, block := range strings.Split(string(raw), "\x1e\n") {
+			block = strings.TrimSuffix(block, "\n")
+			if block == "" {
+				continue
+			}
+			invocations = append(invocations, strings.Split(block, "\n"))
+		}
+		return invocations
+	}
+}
+
+// TestGitHubModeWriteArgsUnchanged walks every ported write on a github-mode
+// client and asserts the exact pre-M3 gh argv, in order — including the
+// comment-then-close pair, the empty-comment skip, and the URL-derived
+// numbers from CreatePR (/pull/N scrape) and CreateIssue (last path segment).
+func TestGitHubModeWriteArgsUnchanged(t *testing.T) {
+	readInvocations := stubGHArgvRecorder(t, "https://github.com/owner/repo/pull/12", 0)
+	c := New("owner/repo", config.ForgeConfig{})
+	const sha = "59e99c49c27d3e2f73bae1657f07cd2f9a15f926"
+
+	if n, err := c.CreatePR("feat: t", "pr body", "main", "feat/x"); err != nil || n != 12 {
+		t.Fatalf("CreatePR = %d, %v; want 12 scraped from /pull/12", n, err)
+	}
+	if err := c.UpdatePRBody(7, "new body"); err != nil {
+		t.Fatalf("UpdatePRBody: %v", err)
+	}
+	if err := c.ClosePR(7, "why closed"); err != nil {
+		t.Fatalf("ClosePR: %v", err)
+	}
+	if err := c.ClosePR(8, ""); err != nil {
+		t.Fatalf("ClosePR (empty comment): %v", err)
+	}
+	if err := c.MergePRAtHead(7, sha); err != nil {
+		t.Fatalf("MergePRAtHead: %v", err)
+	}
+	if err := c.MarkPRReady(7); err != nil {
+		t.Fatalf("MarkPRReady: %v", err)
+	}
+	if err := c.UpdateBranch(7); err != nil {
+		t.Fatalf("UpdateBranch: %v", err)
+	}
+	if err := c.CloseIssue(9, "done"); err != nil {
+		t.Fatalf("CloseIssue: %v", err)
+	}
+	if n, err := c.CreateIssue("it", "ib", []string{"l1", "l2"}); err != nil || n != 12 {
+		t.Fatalf("CreateIssue = %d, %v; want 12 from the URL's last segment", n, err)
+	}
+	if err := c.EditIssueBody(9, "eb"); err != nil {
+		t.Fatalf("EditIssueBody: %v", err)
+	}
+	if err := c.AddIssueLabel(9, "blocked"); err != nil {
+		t.Fatalf("AddIssueLabel: %v", err)
+	}
+	if err := c.RemoveIssueLabel(9, "blocked"); err != nil {
+		t.Fatalf("RemoveIssueLabel: %v", err)
+	}
+	if err := c.EnsureLabel("lab", "#d93f0b", "desc"); err != nil {
+		t.Fatalf("EnsureLabel: %v", err)
+	}
+	if err := c.CommentIssue(9, "hi"); err != nil {
+		t.Fatalf("CommentIssue: %v", err)
+	}
+	if err := c.CommentPR(7, "yo"); err != nil {
+		t.Fatalf("CommentPR: %v", err)
+	}
+	if err := c.CreateRelease("v1.2.3", "Release title"); err != nil {
+		t.Fatalf("CreateRelease: %v", err)
+	}
+
+	want := [][]string{
+		{"pr", "create", "--repo", "owner/repo", "--title", "feat: t", "--body", "pr body", "--base", "main", "--head", "feat/x"},
+		{"pr", "edit", "7", "--repo", "owner/repo", "--body", "new body"},
+		{"pr", "comment", "7", "--repo", "owner/repo", "--body", "why closed"},
+		{"pr", "close", "7", "--repo", "owner/repo"},
+		{"pr", "close", "8", "--repo", "owner/repo"},
+		{"pr", "merge", "7", "--repo", "owner/repo", "--squash", "--delete-branch", "--match-head-commit", sha},
+		{"pr", "ready", "7", "--repo", "owner/repo"},
+		{"pr", "update-branch", "7", "--repo", "owner/repo"},
+		{"issue", "comment", "9", "--repo", "owner/repo", "--body", "done"},
+		{"issue", "close", "9", "--repo", "owner/repo"},
+		{"issue", "create", "--repo", "owner/repo", "--title", "it", "--body", "ib", "--label", "l1", "--label", "l2"},
+		{"issue", "edit", "9", "--repo", "owner/repo", "--body", "eb"},
+		{"issue", "edit", "9", "--repo", "owner/repo", "--add-label", "blocked"},
+		{"issue", "edit", "9", "--repo", "owner/repo", "--remove-label", "blocked"},
+		{"label", "create", "lab", "--repo", "owner/repo", "--force", "--color", "d93f0b", "--description", "desc"},
+		{"issue", "comment", "9", "--repo", "owner/repo", "--body", "hi"},
+		{"pr", "comment", "7", "--repo", "owner/repo", "--body", "yo"},
+		{"release", "create", "v1.2.3", "--repo", "owner/repo", "--title", "Release title", "--generate-notes"},
+	}
+	got := readInvocations()
+	if len(got) != len(want) {
+		t.Fatalf("gh invocations = %d, want %d:\n%q", len(got), len(want), got)
+	}
+	for i := range want {
+		if !reflect.DeepEqual(got[i], want[i]) {
+			t.Errorf("gh invocation %d:\n got %q\nwant %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestGitHubModeMergeNotUpToDateWrapsSentinel pins the gh-path half of the
+// merge error contract: the historical "not up to date" stderr needle now
+// also wraps ErrMergeNotUpToDate (errors.Is-matchable) while keeping the full
+// gh output in the message; any other merge failure stays unclassified.
+func TestGitHubModeMergeNotUpToDateWrapsSentinel(t *testing.T) {
+	const sha = "59e99c49c27d3e2f73bae1657f07cd2f9a15f926"
+	t.Run("needle match wraps the sentinel", func(t *testing.T) {
+		stubGHArgvRecorder(t, "X Pull Request is not mergeable: the head branch is not up to date with the base branch", 1)
+		c := New("owner/repo", config.ForgeConfig{})
+		err := c.MergePRAtHead(10, sha)
+		if err == nil {
+			t.Fatal("merge must fail when gh exits non-zero")
+		}
+		if !errors.Is(err, ErrMergeNotUpToDate) {
+			t.Fatalf("err = %v, want the sentinel wrapped on the gh needle", err)
+		}
+		if !strings.Contains(err.Error(), "the head branch is not up to date with the base branch") {
+			t.Fatalf("err = %v, want the full gh output preserved in the chain", err)
+		}
+	})
+	t.Run("other failure stays unclassified", func(t *testing.T) {
+		stubGHArgvRecorder(t, "X Pull Request is not mergeable: the merge commit cannot be cleanly created", 1)
+		c := New("owner/repo", config.ForgeConfig{})
+		err := c.MergePRAtHead(10, sha)
+		if err == nil {
+			t.Fatal("merge must fail when gh exits non-zero")
+		}
+		if errors.Is(err, ErrMergeNotUpToDate) {
+			t.Fatalf("err = %v: a real-conflict failure must NOT be classified as out-of-date", err)
+		}
+	})
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -8302,7 +8302,10 @@ func (o *Orchestrator) mergeReadyPRAtExpectedHead(s *state.State, slotName strin
 		// up, or the local rebase fails) fall back to server-side
 		// update-branch (#551) so a behind PR still converges to merge
 		// instead of dead-ending as an unresolvable conflict.
-		if strings.Contains(err.Error(), "not up to date") && o.cfg.AutoRebase {
+		// Belt and braces (#1172 M3): the sentinel is the typed contract both
+		// transports wrap (gh needle match / Forgejo out-of-date refusal); the
+		// legacy text match stays for error paths that predate it.
+		if (errors.Is(err, github.ErrMergeNotUpToDate) || strings.Contains(err.Error(), "not up to date")) && o.cfg.AutoRebase {
 			log.Printf("[orch] PR #%d branch is behind main, updating %s", pr.Number, slotName)
 			rebased := false
 			if strings.TrimSpace(sess.Worktree) != "" {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -3804,6 +3805,64 @@ func TestMergeReadyPR_BehindMainTriggersRebase(t *testing.T) {
 	}
 	if !sess.RebaseAttempted {
 		t.Error("RebaseAttempted should be true after successful rebase")
+	}
+}
+
+// mergeNotUpToDateSentinelOnly wraps github.ErrMergeNotUpToDate WITHOUT the
+// legacy "not up to date" text in its own message — isolating the errors.Is
+// arm of the classification from the string-matching belt (#1172 M3): the
+// sentinel's message contains the needle, so a plain %w-wrapped error can
+// never reach the errors.Is branch alone.
+type mergeNotUpToDateSentinelOnly struct{}
+
+func (mergeNotUpToDateSentinelOnly) Error() string {
+	return "merge PR 10 at head aaa: HTTP 409: head_commit_id mismatch"
+}
+func (mergeNotUpToDateSentinelOnly) Unwrap() error { return github.ErrMergeNotUpToDate }
+
+// #1172 M3 — the AutoRebase branch must classify on the typed sentinel via
+// errors.Is, not only on the legacy gh stderr text: a Forgejo merge refusal
+// carries no gh phrasing of its own.
+func TestMergeReadyPR_SentinelWithoutLegacyTextTriggersRebase(t *testing.T) {
+	if !errors.Is(mergeNotUpToDateSentinelOnly{}, github.ErrMergeNotUpToDate) {
+		t.Fatal("test double must wrap the sentinel")
+	}
+	if strings.Contains(mergeNotUpToDateSentinelOnly{}.Error(), "not up to date") {
+		t.Fatal("test double must NOT carry the legacy needle — it isolates the errors.Is arm")
+	}
+	rebased := false
+	o := &Orchestrator{
+		cfg:      &config.Config{Repo: "owner/repo", AutoRebase: true},
+		notifier: &notify.Notifier{},
+		ghMergePRFn: func(prNumber int) error {
+			return mergeNotUpToDateSentinelOnly{}
+		},
+		rebaseWorktreeFn: func(worktreePath, branch string, autoResolveFiles, autoRestoreFiles []string) error {
+			rebased = true
+			return nil
+		},
+	}
+
+	sess := &state.Session{
+		IssueNumber: 100,
+		IssueTitle:  "test issue",
+		Branch:      "feat/a",
+		Worktree:    "/var/tmp/wt",
+		Status:      state.StatusPROpen,
+		PRNumber:    10,
+	}
+	pr := github.PR{Number: 10, HeadRefName: "feat/a"}
+
+	result := o.mergeReadyPR(state.NewState(), "slot-0", sess, pr)
+
+	if result {
+		t.Fatal("mergeReadyPR should return false when merge fails")
+	}
+	if !rebased {
+		t.Fatal("a sentinel-classified merge refusal must trigger the AutoRebase path via errors.Is")
+	}
+	if sess.Status != state.StatusQueued {
+		t.Errorf("session status = %q, want %q", sess.Status, state.StatusQueued)
 	}
 }
 

--- a/internal/supervisor/outcome_repair.go
+++ b/internal/supervisor/outcome_repair.go
@@ -181,7 +181,7 @@ func dispatchFutileOutcomeRecovery(cfg *config.Config, now time.Time) {
 		Fingerprint: fingerprint,
 		Attempts:    attempts,
 		Issue:       issue,
-		IssueLink:   outcomeRepairIssueLink(cfg.Repo, issue),
+		IssueLink:   outcomeRepairIssueLink(cfg.Forge, cfg.Repo, issue),
 	}
 	if err := notifyFutileRecovery(cfg, event); err != nil {
 		log.Printf("[outcome/recovery] futile_recovery alert failed for %s: %v", gate, err)
@@ -459,9 +459,12 @@ func shortOutcomeFingerprint(fingerprint string) string {
 	return outcomeRepairFingerprintID(fingerprint)
 }
 
-func outcomeRepairIssueLink(repo string, number int) string {
+// outcomeRepairIssueLink builds the human-facing issue link for the
+// futile_recovery alert on whichever forge hosts the repo (#1172 M3); the
+// `#%d` fallback shape is preserved for a missing repo/number.
+func outcomeRepairIssueLink(forge config.ForgeConfig, repo string, number int) string {
 	if repo = strings.TrimSpace(repo); repo != "" && number > 0 {
-		return fmt.Sprintf("https://github.com/%s/issues/%d", repo, number)
+		return forge.IssueWebURL(repo, number)
 	}
 	return fmt.Sprintf("#%d", number)
 }

--- a/internal/supervisor/outcome_repair_test.go
+++ b/internal/supervisor/outcome_repair_test.go
@@ -442,3 +442,22 @@ func containsStringFold(values []string, want string) bool {
 	}
 	return false
 }
+
+// #1172 M3 — the futile_recovery issue link must follow the configured forge;
+// the `#%d` fallback shape survives a missing repo or number.
+func TestOutcomeRepairIssueLinkForgeAware(t *testing.T) {
+	gh := config.ForgeConfig{}
+	fj := config.ForgeConfig{Kind: config.ForgeKindForgejo, BaseURL: "https://forge.example.com/"}
+	if got := outcomeRepairIssueLink(gh, "o/r", 12); got != "https://github.com/o/r/issues/12" {
+		t.Errorf("github link = %q", got)
+	}
+	if got := outcomeRepairIssueLink(fj, "o/r", 12); got != "https://forge.example.com/o/r/issues/12" {
+		t.Errorf("forgejo link = %q (trailing base_url slash must be trimmed)", got)
+	}
+	if got := outcomeRepairIssueLink(fj, "   ", 12); got != "#12" {
+		t.Errorf("missing repo fallback = %q, want #12", got)
+	}
+	if got := outcomeRepairIssueLink(gh, "o/r", 0); got != "#0" {
+		t.Errorf("missing number fallback = %q, want #0", got)
+	}
+}


### PR DESCRIPTION
## Summary

M3 of the Forgejo migration (#1172): the write port. On a `forge.kind: forgejo` row, all write methods now route to the Forgejo REST API via the same funnel-dispatch shape M2 established — except `MarkPRReady`, which stays fail-loud: Forgejo 16.0.1's `EditPullRequestOption` has no draft/WIP toggle, and emulating it by rewriting WIP titles was deliberately rejected (draft semantics land with the M7 worker-flow decisions).

### Ported writes (semantic contracts preserved)
- **PR lifecycle**: `CreatePR` (number from the response JSON — Forgejo web URLs are `/pulls/N`, so the gh path's `/pull/N` scraping was never portable), `UpdatePRBody`, `ClosePR`, `MergePRAtHead` (squash + `head_commit_id` + `delete_branch_after_merge`; empty-SHA pre-flight kept), `UpdateBranch` (`?style=merge`).
- **Issues**: `CreateIssue` (labels resolved name→id — `CreateIssueOption.labels` is `[]int64`; unknown name errors loud), `EditIssueBody`, `CloseIssue`.
- **Comment-then-close ordering is exact**: a failed comment aborts and leaves the PR/issue open; an empty comment skips the comment call entirely (callers exploit both).
- **Labels**: `AddIssueLabel`/`RemoveIssueLabel` pass names directly (`IssueLabelsOption` and the delete `{identifier}` param accept names on this instance); `EnsureLabel` implements true `--force` upsert — exact-name match first (case-insensitive fallback), PATCH only provided fields, POST with default color when creating (`color` is required by `CreateLabelOption`).
- **Releases**: `CreateRelease` anchors to the existing tag; Forgejo has no `--generate-notes` equivalent — release body stays empty (documented divergence; versioning is enabled on the maestro row, which cuts over last).

### Merge error contract hardening
The AutoRebase branch matched on gh's stderr text (`strings.Contains(err, "not up to date")`). This PR adds the exported sentinel `github.ErrMergeNotUpToDate`: the gh path wraps it when the needle matches, the Forgejo path classifies conservatively — a 409 `APIError` body indicating head-mismatch/out-of-date gets the sentinel, a bodyless 405 stays a raw loud error (never classified blindly). The orchestrator now branches on `errors.Is` with the legacy text match kept as a belt. Approver's structural concurrent-merge recovery (`IsPRMerged` after a failed merge) and the `prHeadBoundMerger` assertion are intact.

### Forge-aware issue links (carried M3 flag)
New `config.ForgeConfig.IssueWebURL/PRWebURL` helpers (github → `/issues/N`, `/pull/N`; forgejo → `{base}/issues/N`, `/pulls/N`); `outcomeRepairIssueLink` now threads the row's forge config, so futile-recovery alerts on a forgejo row link to the Forgejo issue.

### Test coverage added
Beyond the forgejo-mode httptest suite (payload/method/path assertions for every write, ordering + abort fixtures, upsert arms, sentinel classification): **github-mode write invocation tests** — none existed before, so gh-path write regressions were uncaught; the exact gh args for every write are now pinned, including the comment-failure abort arms.

## Review (pre-PR, 3 adversarial lenses + fixer)
Confirmed and fixed: `EnsureLabel` first-match-wins under case folding (exact-match-first now, pinned by a fixture with both `Blocked` and `blocked` present); gh-path close-abort coverage gap. Explicitly carried, not silently accepted:
- **Follow-up needed**: Gitea-lineage `AddIssueLabels` may silently drop an unknown label name (200 with unchanged list) — not verifiable without a live write under the no-write rule; flagged in code comments, needs a follow-up issue.
- Watch item for the first live run: exact phrasing of Forgejo's behind-base merge refusal (sentinel classification is conservative by design).
- Digit-only label names are ambiguous against the `{identifier}` delete param — unreachable with the fleet's label vocabulary, noted only.
- **Deferred (new carried flag)**: digest and dashboard links (`digest.go`, `server.go`, `fleet.go`) remain github-hardcoded — cosmetic, high-volume surface, not part of the M3 write contract.

## Testing
`go build ./...`, `go vet ./...` clean; `internal/forgejo`, `internal/github`, `internal/config`, `internal/supervisor`, `internal/orchestrator`, `internal/approver` green; full suite green except the 3 pre-existing `internal/worker` umask-0002 failures (reproduced on clean main).

Part of #1172 (M3).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches merge/AutoRebase classification and all PR/issue/label/release write paths across both forges; bugs could mis-merge, skip closes, or mis-apply labels.
> 
> **Overview**
> **Ports write operations to Forgejo** for `forge.kind: forgejo` rows (M3 of #1172), using the same funnel-dispatch shape as the M2 reads. PR/issue create-edit-close, merge, update-branch, labels, comments, and releases now hit Forgejo REST; **`MarkPRReady` stays fail-loud** (no draft toggle until M7).
> 
> Numbers come from response JSON (not URL scraping — Forgejo uses `/pulls/N`). Comment-then-close ordering is preserved: failed comments abort; empty comments skip. Labels resolve names→ids on create; `EnsureLabel` does a true upsert. Releases omit generated notes (documented Forgejo gap).
> 
> **Hardens merge refusal handling** with `github.ErrMergeNotUpToDate`. Both transports wrap it (gh stderr needle / Forgejo 405–409 body classification via new `StatusError`); the orchestrator AutoRebase path keys off `errors.Is` with the legacy text match kept as a belt.
> 
> Also adds forge-aware `IssueWebURL`/`PRWebURL` helpers and wires them into futile-recovery alert links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6766b89fc7693d98d333e8c721f691eccb8fffb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds Forgejo-backed repository operations, Forgejo-aware issue and pull-request links, and merge-refusal handling. A focused Forgejo client check found that adding a missing required label can return success even when Forgejo leaves the issue’s labels unchanged. This can make outcome-repair work or ready-label actions appear dispatchable when the required label was never applied.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until Forgejo label additions fail when the requested label is missing or confirm that the server applied it.

The Forgejo-mode public client was exercised against the exact successful-but-unchanged response path and returned success despite the requested label being absent.

**Files Needing Attention:** internal/forgejo/writes.go needs label-application verification; internal/github/forgejo_port.go and workflow callers rely on its success result.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Go test to exercise the unknown Forgejo required ready label and produced a dedicated test source artifact.
- Inspected the runtime output from the same test to validate Forgejo's behavior with the unknown label.
- Posted a P1 finding and produced a finding-comment-proof that references the corresponding review comment with the finding details.
- Posted a second P1 finding and produced another finding-comment-proof for the second posted finding.
- Performed general contract validation by reviewing the Forgejo label flow and the referenced code paths, supported by the related source and runtime artifacts.

<a href="https://app.greptile.com/trex/runs/18388753/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Forgejo label additions falsely succeed when an unknown required label is silently dropped**

   - **Bug**
     - `AddIssueLabels` treats every 2xx response as success and discards the resulting label list. The focused Forgejo-mode runtime check simulated the stated Gitea/Forgejo behavior for a missing `maestro-ready` label: POST returned `200 OK` and `[]`, yet public `github.Client.AddIssueLabel(73, "maestro-ready")` returned nil. Thus a renamed/deleted repository label can be reported as applied although it is absent. This can leave outcome-repair's required ready label unapplied during issue refresh and can falsely acknowledge the ready-label safe action.
   - **Cause**
     - `internal/forgejo/writes.go:301-309` sends string names and only checks `c.do` for non-2xx errors; it neither resolves names before posting nor verifies that the successful response contains each requested label. The public Forgejo dispatch preserves this behavior at `internal/github/forgejo_port.go:548-556`.
   - **Fix**
     - Before adding labels, resolve each requested name against repository labels and fail loudly if any are missing, or decode the successful returned label array and verify every requested label is present (with case-handling consistent with project label matching). Apply this validation before returning success to the github-layer callers.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
internal/forgejo/writes.go:301-309
**Forgejo label additions falsely report success**

`AddIssueLabels` accepts every 2xx response without checking whether Forgejo actually applied the requested name. Forgejo can return `200 OK` with an unchanged label list when a label has been renamed or removed, so callers report that `maestro-ready` was added even though it is absent. This can leave outcome-repair issues without their dispatch label and make ready-label actions appear complete. Resolve requested labels before posting, or validate that the successful response contains every requested label before returning success.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(github): address M3 review findings ..."](https://github.com/befeast/maestro/commit/6766b89fc7693d98d333e8c721f691eccb8fffb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52371044)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->