### PR TITLE
feat(github): status-only CI rollup and review-gate reads on forgejo (#1172 M4)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2408,6 +2408,20 @@ func validateForge(cfg *Config) error {
 		// orchestrator reads from the GitHub MIRROR's state (#1172 M2).
 		return fmt.Errorf("config: github_mirror.source %q is not supported with forge.kind %q — the mirror store is fed by GitHub webhooks, so mirror-first reads would serve the GitHub mirror's state instead of the Forgejo original; set github_mirror.source: %q or drop the block", GitHubSourceMirrorFirst, ForgeKindForgejo, GitHubSourceAPI)
 	}
+	// #1172 M4: reject review streams that cannot observe a forgejo row.
+	// Greptile and the simplicity lens are GitHub-integrated reviewers (check
+	// runs / GitHub App webhooks) and never post on a Forgejo instance — a
+	// forgejo row gated on them would wait forever on a reviewer that cannot
+	// appear. This validates the EFFECTIVE streams, so the silent default is
+	// caught too: review_gate's absent default is "greptile", meaning a
+	// forgejo row MUST set review_gate: llm-review (or none), or list only
+	// llm-review streams in review_gate_streams.
+	for _, stream := range cfg.EffectiveReviewGateStreams() {
+		switch stream {
+		case "greptile", "simplicity":
+			return fmt.Errorf("config: review stream %q is not available with forge.kind %q (GitHub-only reviewer — it would leave the review gate unobserved forever); set review_gate: llm-review or review_gate: none, or list only llm-review streams in review_gate_streams", stream, ForgeKindForgejo)
+		}
+	}
 	return nil
 }
 

--- a/internal/config/forge_test.go
+++ b/internal/config/forge_test.go
@@ -34,7 +34,9 @@ func TestParse_ForgeExplicitGitHubKindAccepted(t *testing.T) {
 }
 
 func TestParse_ForgejoValidBlockAccepted(t *testing.T) {
-	yamlDoc := "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com/\n"
+	// review_gate: llm-review is REQUIRED on forgejo rows since M4 — the
+	// defaulted greptile gate is rejected (see TestParse_ForgeValidation).
+	yamlDoc := "repo: o/r\nreview_gate: llm-review\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com/\n"
 	cfg, err := Parse([]byte(yamlDoc))
 	if err != nil {
 		t.Fatalf("valid forgejo block should parse: %v", err)
@@ -51,7 +53,7 @@ func TestParse_ForgejoValidBlockAccepted(t *testing.T) {
 }
 
 func TestParse_ForgejoTokenEnvOverride(t *testing.T) {
-	yamlDoc := "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n  token_env: MY_FORGE_PAT\n"
+	yamlDoc := "repo: o/r\nreview_gate: llm-review\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n  token_env: MY_FORGE_PAT\n"
 	cfg, err := Parse([]byte(yamlDoc))
 	if err != nil {
 		t.Fatalf("forgejo block with token_env should parse: %v", err)
@@ -165,6 +167,29 @@ func TestParse_ForgeValidation(t *testing.T) {
 			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\ngithub_mirror:\n  source: mirror-first\n",
 			wantSub: "fed by GitHub webhooks",
 		},
+		{
+			// #1172 M4: review_gate's absent default is "greptile" — a
+			// GitHub-only reviewer that never posts on forgejo, so the
+			// DEFAULTED gate is rejected too, not just an explicit one.
+			name:    "forgejo with defaulted greptile review gate",
+			yaml:    "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n",
+			wantSub: `review stream "greptile" is not available`,
+		},
+		{
+			name:    "forgejo with explicit greptile review gate",
+			yaml:    "repo: o/r\nreview_gate: greptile\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n",
+			wantSub: `review stream "greptile" is not available`,
+		},
+		{
+			name:    "forgejo with greptile in review_gate_streams",
+			yaml:    "repo: o/r\nreview_gate: llm-review\nreview_gate_streams: [greptile]\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n",
+			wantSub: `review stream "greptile" is not available`,
+		},
+		{
+			name:    "forgejo with simplicity in review_gate_streams",
+			yaml:    "repo: o/r\nreview_gate: llm-review\nreview_gate_streams: [llm-review, simplicity]\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n",
+			wantSub: `review stream "simplicity" is not available`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -195,7 +220,7 @@ func TestParse_GitHubProjectsEnabledWithoutForgeBlockAccepted(t *testing.T) {
 }
 
 func TestParse_ForgejoWithDisabledGitHubProjectsAccepted(t *testing.T) {
-	yamlDoc := "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\ngithub_projects:\n  enabled: false\n"
+	yamlDoc := "repo: o/r\nreview_gate: llm-review\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\ngithub_projects:\n  enabled: false\n"
 	if _, err := Parse([]byte(yamlDoc)); err != nil {
 		t.Fatalf("forgejo with explicitly disabled github_projects should parse: %v", err)
 	}
@@ -206,16 +231,30 @@ func TestParse_ForgejoWithDisabledGitHubProjectsAccepted(t *testing.T) {
 // reconcile cadence) must keep parsing — only mirror-served reads are the
 // cross-forge hazard.
 func TestParse_ForgejoWithAPIDirectMirrorAccepted(t *testing.T) {
-	yamlDoc := "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\ngithub_mirror:\n  source: api\n"
+	yamlDoc := "repo: o/r\nreview_gate: llm-review\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\ngithub_mirror:\n  source: api\n"
 	if _, err := Parse([]byte(yamlDoc)); err != nil {
 		t.Fatalf("forgejo with api-direct github_mirror should parse: %v", err)
+	}
+}
+
+// #1172 M4: review_gate: none disables the gate entirely — nil effective
+// streams — and must stay valid on forgejo rows (some projects merge on CI +
+// human approval alone).
+func TestParse_ForgejoWithReviewGateNoneAccepted(t *testing.T) {
+	yamlDoc := "repo: o/r\nreview_gate: none\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n"
+	cfg, err := Parse([]byte(yamlDoc))
+	if err != nil {
+		t.Fatalf("forgejo with review_gate none should parse: %v", err)
+	}
+	if streams := cfg.EffectiveReviewGateStreams(); len(streams) != 0 {
+		t.Fatalf("EffectiveReviewGateStreams() = %v, want empty for review_gate none", streams)
 	}
 }
 
 // The strict write path must accept the new forge block by name (KnownFields),
 // while still rejecting a misspelled child key inside it.
 func TestParseStrict_AcceptsForgeBlock(t *testing.T) {
-	yamlDoc := "repo: o/r\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n  token_env: FORGEJO_TOKEN\n"
+	yamlDoc := "repo: o/r\nreview_gate: llm-review\nforge:\n  kind: forgejo\n  base_url: https://forge.example.com\n  token_env: FORGEJO_TOKEN\n"
 	if _, err := ParseStrict([]byte(yamlDoc)); err != nil {
 		t.Fatalf("strict decode of a valid forge block should pass: %v", err)
 	}

--- a/internal/forgejo/reads.go
+++ b/internal/forgejo/reads.go
@@ -18,6 +18,17 @@
 //     updated-first requires an explicit sort=recentupdate;
 //   - issue comments and issue labels have NO page/limit params and return
 //     everything in one response — they must not go through the pager.
+//
+// M4 additions (#1172, contract pinned by the stage-A live probe):
+//
+//   - the combined-status aggregate lives in the top-level `state` field while
+//     each per-status state lives in `.status` (never `.state`); a SHA with
+//     zero statuses answers 200 {"state":"","total_count":0,"statuses":null} —
+//     EMPTY-STRING aggregate plus null statuses is the no-signal shape;
+//   - review-comment reads report the new-file line number in `position`
+//     (x-go-name LineNum) — there is NO `line` and NO `new_position` on the
+//     read side — and the per-review comments endpoint has no page/limit
+//     params, so it must not go through the pager.
 package forgejo
 
 import (
@@ -111,6 +122,13 @@ type Pull struct {
 	HeadRef        string
 	HeadSHA        string
 	BaseRef        string
+	// MergeBase is the merge-base SHA between head and base (wire
+	// `merge_base`, 40-hex; live-verified present on both open and merged
+	// pulls). On an up-to-date open pull it equals the base branch head; after
+	// a merge base.sha moves on while merge_base stays — so "behind" synthesis
+	// must compare it against BranchHeadSHA(BaseRef), never against base.sha
+	// from the same payload. Carried verbatim; empty when the wire omits it.
+	MergeBase string
 }
 
 // wirePull is the nested wire shape of GET /repos/{repo}/pulls[/{index}].
@@ -123,6 +141,7 @@ type wirePull struct {
 	Mergeable      *bool   `json:"mergeable"`
 	MergedAt       *string `json:"merged_at"`
 	MergeCommitSHA string  `json:"merge_commit_sha"`
+	MergeBase      string  `json:"merge_base"`
 	Head           struct {
 		Ref string `json:"ref"`
 		SHA string `json:"sha"`
@@ -142,6 +161,7 @@ func (wp wirePull) pull() Pull {
 		Mergeable:      wp.Mergeable,
 		MergedAt:       wp.MergedAt,
 		MergeCommitSHA: wp.MergeCommitSHA,
+		MergeBase:      wp.MergeBase,
 		HeadRef:        wp.Head.Ref,
 		HeadSHA:        wp.Head.SHA,
 		BaseRef:        wp.Base.Ref,
@@ -454,4 +474,207 @@ func (c *Client) BranchHeadSHA(ctx context.Context, repo, branch string) (string
 		return "", fmt.Errorf("branch %s@%s has an empty head sha", repo, branch)
 	}
 	return sha, nil
+}
+
+// CommitStatus is one per-context row of the combined-status read. State is
+// decoded from Forgejo's per-status `.status` wire field — NOT `.state`, which
+// does not exist per status here (the live-verified 16.0.1 gotcha the
+// forge.Client CommitStatuses already normalizes). The vocabulary (swagger
+// CommitStatusState) is pending|success|error|failure|warning|skipped, carried
+// lowercased but otherwise verbatim: "warning" and "skipped" are real values
+// (skipped live-verified) and must reach the gh layer undamaged so its failure
+// mapping never miscounts them. CreatedAt is the RFC3339 wire string
+// byte-for-byte — the gh layer mixes it into the CI rollup fingerprint
+// (`status:<context>:<state>:<created_at>`), so it must not round-trip through
+// time.Time.
+type CommitStatus struct {
+	Context     string
+	State       string
+	Description string
+	TargetURL   string
+	CreatedAt   string
+}
+
+// CombinedStatus is the aggregate view of one SHA's commit statuses: the
+// server-computed rollup over the latest status per context, plus the rows.
+//
+// NO-SIGNAL SHAPE (live-verified): a SHA with zero statuses answers HTTP 200
+// {"state":"","total_count":0,"statuses":null} — State is the EMPTY STRING and
+// Statuses is nil (JSON null, not []). Both together mean "no signal"; neither
+// is an error and neither may be read as an unknown state.
+type CombinedStatus struct {
+	State    string
+	Statuses []CommitStatus
+}
+
+// CombinedStatus returns one SHA's combined status. forge.Client's
+// CommitStatuses stays untouched as the producer surface (it drops the
+// aggregate); this is the transport-switch sibling exposing BOTH the top-level
+// aggregate and the per-context rows.
+//
+// The statuses array is paginated (swagger page/limit; not exercisable live —
+// no probe SHA carries >1 page), so the loop cannot go through listPages (the
+// payload is an object, not a bare array) and cannot lean on x-total-count
+// semantics that were never pinned for this endpoint. It uses the short-page
+// stop plus the maxListPages cap: on a server that ignored the page param, a
+// >=pageSize set would keep answering full pages and hit the cap as an
+// explicit error — never a silently duplicated or truncated set. The
+// aggregate is taken from page 1.
+func (c *Client) CombinedStatus(ctx context.Context, repo, sha string) (CombinedStatus, error) {
+	var combined CombinedStatus
+	for page := 1; ; page++ {
+		if page > maxListPages {
+			return CombinedStatus{}, fmt.Errorf("combined status for %s@%s: more than %d pages (%d statuses so far); refusing to truncate silently", repo, sha, maxListPages, len(combined.Statuses))
+		}
+		path := fmt.Sprintf("/repos/%s/commits/%s/status?limit=%d&page=%d", repo, sha, pageSize, page)
+		out, err := c.do(ctx, http.MethodGet, path, nil)
+		if err != nil {
+			return CombinedStatus{}, fmt.Errorf("combined status for %s@%s: %w", repo, sha, err)
+		}
+		var wire struct {
+			State    string `json:"state"`
+			Statuses []struct {
+				Context     string `json:"context"`
+				Status      string `json:"status"`
+				Description string `json:"description"`
+				TargetURL   string `json:"target_url"`
+				CreatedAt   string `json:"created_at"`
+			} `json:"statuses"`
+		}
+		if err := json.Unmarshal(out, &wire); err != nil {
+			return CombinedStatus{}, fmt.Errorf("parse combined status for %s@%s: %w", repo, sha, err)
+		}
+		if page == 1 {
+			combined.State = strings.ToLower(strings.TrimSpace(wire.State))
+		}
+		for _, st := range wire.Statuses {
+			combined.Statuses = append(combined.Statuses, CommitStatus{
+				Context:     st.Context,
+				State:       strings.ToLower(strings.TrimSpace(st.Status)),
+				Description: st.Description,
+				TargetURL:   st.TargetURL,
+				CreatedAt:   strings.TrimSpace(st.CreatedAt),
+			})
+		}
+		if len(wire.Statuses) < pageSize {
+			return combined, nil
+		}
+	}
+}
+
+// PullReview is one review on a pull request, flattened to what the gh layer
+// maps. State is the ReviewStateType VERBATIM — uppercase "APPROVED" /
+// "COMMENT" / "REQUEST_CHANGES" / "PENDING" / "REQUEST_REVIEW" — vocabulary
+// mapping is the gh layer's job, and the full set is not enumerated in
+// swagger, so nothing is normalized or filtered here. CommitID can
+// legitimately be "" (live-proven on GitHub-migrated reviews); the per-comment
+// commit_id IS populated in that case, so head-anchoring callers must fall
+// back review CommitID -> comment CommitID.
+type PullReview struct {
+	ID          int64
+	User        string // user.login; "" when the wire user is null
+	State       string
+	Body        string
+	CommitID    string
+	SubmittedAt string // RFC3339 verbatim
+	// CommentsCount is the wire comments_count (x-go-name CodeCommentsCount):
+	// the number of inline code comments in this review — lets callers skip
+	// the per-review comments round trip for body-only reviews.
+	CommentsCount int64
+}
+
+// ListPullReviews returns the reviews on one pull request in server order
+// (ascending by id/submitted_at, live-verified). Paginated (page/limit +
+// x-total-count live-verified; past-the-end pages answer 200 []), so it goes
+// through the pager.
+func (c *Client) ListPullReviews(ctx context.Context, repo string, index int, allPages bool) ([]PullReview, error) {
+	type wireReview struct {
+		ID   int64 `json:"id"`
+		User struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		State         string `json:"state"`
+		Body          string `json:"body"`
+		CommitID      string `json:"commit_id"`
+		SubmittedAt   string `json:"submitted_at"`
+		CommentsCount int64  `json:"comments_count"`
+	}
+	wires, err := listPages[wireReview](ctx, c, fmt.Sprintf("/repos/%s/pulls/%d/reviews", repo, index), allPages)
+	if err != nil {
+		return nil, fmt.Errorf("list reviews %s#%d: %w", repo, index, err)
+	}
+	reviews := make([]PullReview, 0, len(wires))
+	for _, w := range wires {
+		reviews = append(reviews, PullReview{
+			ID:            w.ID,
+			User:          w.User.Login,
+			State:         w.State,
+			Body:          w.Body,
+			CommitID:      w.CommitID,
+			SubmittedAt:   w.SubmittedAt,
+			CommentsCount: w.CommentsCount,
+		})
+	}
+	return reviews, nil
+}
+
+// PullReviewComment is one inline comment of a review. THE LINE FIELD
+// (live-pinned, the one most likely to be mis-mapped): the read side has NO
+// `line` and NO `new_position` — the write-side new_position comes back as
+// `position` (x-go-name LineNum), the NEW-file LINE NUMBER, not a diff
+// offset; `original_position` (OldLineNum) carries the old-file line, 0 when
+// the comment targets the new side. Line/OldLine map them 1:1. CommitID is
+// populated even when the parent review's commit_id is "" — it is the
+// reliable head anchor.
+type PullReviewComment struct {
+	ID               int64
+	Body             string
+	Author           string // user.login
+	Path             string
+	CommitID         string
+	OriginalCommitID string
+	Line             int64  // wire `position`: new-file line number
+	OldLine          int64  // wire `original_position`: old-file line number
+	CreatedAt        string // RFC3339 verbatim
+}
+
+// ListPullReviewComments returns all inline comments of one review. The
+// endpoint has NO page/limit params (swagger: only owner/repo/index/id) and
+// returns everything in one response — it must not go through the pager.
+func (c *Client) ListPullReviewComments(ctx context.Context, repo string, index int, reviewID int64) ([]PullReviewComment, error) {
+	out, err := c.do(ctx, http.MethodGet, fmt.Sprintf("/repos/%s/pulls/%d/reviews/%d/comments", repo, index, reviewID), nil)
+	if err != nil {
+		return nil, fmt.Errorf("list review comments %s#%d review %d: %w", repo, index, reviewID, err)
+	}
+	var wire []struct {
+		ID   int64  `json:"id"`
+		Body string `json:"body"`
+		User struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		Path             string `json:"path"`
+		CommitID         string `json:"commit_id"`
+		OriginalCommitID string `json:"original_commit_id"`
+		Position         int64  `json:"position"`
+		OriginalPosition int64  `json:"original_position"`
+		CreatedAt        string `json:"created_at"`
+	}
+	if err := json.Unmarshal(out, &wire); err != nil {
+		return nil, fmt.Errorf("parse review comments %s#%d review %d: %w", repo, index, reviewID, err)
+	}
+	comments := make([]PullReviewComment, 0, len(wire))
+	for _, wc := range wire {
+		comments = append(comments, PullReviewComment{
+			ID:               wc.ID,
+			Body:             wc.Body,
+			Author:           wc.User.Login,
+			Path:             wc.Path,
+			CommitID:         wc.CommitID,
+			OriginalCommitID: wc.OriginalCommitID,
+			Line:             wc.Position,
+			OldLine:          wc.OriginalPosition,
+			CreatedAt:        wc.CreatedAt,
+		})
+	}
+	return comments, nil
 }

--- a/internal/forgejo/reads.go
+++ b/internal/forgejo/reads.go
@@ -515,13 +515,21 @@ type CombinedStatus struct {
 // The statuses array is paginated (swagger page/limit; not exercisable live —
 // no probe SHA carries >1 page), so the loop cannot go through listPages (the
 // payload is an object, not a bare array) and cannot lean on x-total-count
-// semantics that were never pinned for this endpoint. It uses the short-page
-// stop plus the maxListPages cap: on a server that ignored the page param, a
+// header semantics that were never pinned for this endpoint. Instead the belt
+// uses the payload's own `total_count` (live-pinned: 0 on the no-signal shape,
+// equal to len(statuses) on gate-test PR#2's head — the across-pages total,
+// GitHub-shape parity): a short page that strands the accumulated set below
+// the server total (a server paging clamp below pageSize) is an explicit
+// error, never a silently truncated set fed to the verdict/fingerprint. The
+// maxListPages cap stays: on a server that ignored the page param, a
 // >=pageSize set would keep answering full pages and hit the cap as an
-// explicit error — never a silently duplicated or truncated set. The
-// aggregate is taken from page 1.
+// explicit error — never a silently duplicated set. The aggregate is taken
+// from page 1; total is re-read each page so a set that legitimately shrinks
+// mid-scan does not false-alarm, and reaching the total on a full page ends
+// the loop without demanding one empty page.
 func (c *Client) CombinedStatus(ctx context.Context, repo, sha string) (CombinedStatus, error) {
 	var combined CombinedStatus
+	total := -1 // -1: total_count absent, truncation belt disabled
 	for page := 1; ; page++ {
 		if page > maxListPages {
 			return CombinedStatus{}, fmt.Errorf("combined status for %s@%s: more than %d pages (%d statuses so far); refusing to truncate silently", repo, sha, maxListPages, len(combined.Statuses))
@@ -532,8 +540,9 @@ func (c *Client) CombinedStatus(ctx context.Context, repo, sha string) (Combined
 			return CombinedStatus{}, fmt.Errorf("combined status for %s@%s: %w", repo, sha, err)
 		}
 		var wire struct {
-			State    string `json:"state"`
-			Statuses []struct {
+			State      string `json:"state"`
+			TotalCount *int   `json:"total_count"`
+			Statuses   []struct {
 				Context     string `json:"context"`
 				Status      string `json:"status"`
 				Description string `json:"description"`
@@ -547,6 +556,9 @@ func (c *Client) CombinedStatus(ctx context.Context, repo, sha string) (Combined
 		if page == 1 {
 			combined.State = strings.ToLower(strings.TrimSpace(wire.State))
 		}
+		if wire.TotalCount != nil && *wire.TotalCount >= 0 {
+			total = *wire.TotalCount
+		}
 		for _, st := range wire.Statuses {
 			combined.Statuses = append(combined.Statuses, CommitStatus{
 				Context:     st.Context,
@@ -557,6 +569,12 @@ func (c *Client) CombinedStatus(ctx context.Context, repo, sha string) (Combined
 			})
 		}
 		if len(wire.Statuses) < pageSize {
+			if total >= 0 && len(combined.Statuses) < total {
+				return CombinedStatus{}, fmt.Errorf("combined status for %s@%s: page %d came back short at %d items with only %d of %d total statuses accumulated (server page clamp below %d?); refusing to truncate silently", repo, sha, page, len(wire.Statuses), len(combined.Statuses), total, pageSize)
+			}
+			return combined, nil
+		}
+		if total >= 0 && len(combined.Statuses) >= total {
 			return combined, nil
 		}
 	}

--- a/internal/forgejo/reads_test.go
+++ b/internal/forgejo/reads_test.go
@@ -520,8 +520,9 @@ func TestGetPull_Merged(t *testing.T) {
 		`{"number":2,"title":"gate","body":"pr body","state":"closed","draft":false,
 		  "mergeable":true,"merged":true,"merged_at":"2026-07-31T21:55:11Z",
 		  "merge_commit_sha":"dfc9446cb6a16c60075286299cd07d2cb655769a",
+		  "merge_base":"63d046eb546c32ca4492c724ac6371f04507b18d",
 		  "head":{"ref":"canary/llm-review-e2e","sha":"59e99c49c27d3e2f73bae1657f07cd2f9a15f926"},
-		  "base":{"ref":"main"}}`)
+		  "base":{"ref":"main","sha":"0000000000000000000000000000000000000bad"}}`)
 	p, err := c.GetPull(context.Background(), "owner/repo", 2)
 	if err != nil {
 		t.Fatalf("GetPull: %v", err)
@@ -543,6 +544,13 @@ func TestGetPull_Merged(t *testing.T) {
 	}
 	if p.HeadRef != "canary/llm-review-e2e" || p.BaseRef != "main" {
 		t.Fatalf("refs = %q / %q — slashes must survive verbatim", p.HeadRef, p.BaseRef)
+	}
+	// merge_base survives verbatim and is NOT the payload's base.sha decoy:
+	// base.sha moves on after a merge (live-verified on the gate-test merged
+	// pull), so "behind" synthesis compares MergeBase against a fresh
+	// BranchHeadSHA read — the transport must carry the wire field untouched.
+	if p.MergeBase != "63d046eb546c32ca4492c724ac6371f04507b18d" {
+		t.Fatalf("merge_base = %q, want the wire merge_base verbatim", p.MergeBase)
 	}
 	req := (*seen)[0]
 	if req.Path != "/repos/owner/repo/pulls/2" {
@@ -567,6 +575,9 @@ func TestGetPull_Unmerged(t *testing.T) {
 	}
 	if p.Body != "" {
 		t.Fatalf("a null body must decode to empty, got %q", p.Body)
+	}
+	if p.MergeBase != "" {
+		t.Fatalf("an absent merge_base must decode to empty, got %q", p.MergeBase)
 	}
 }
 
@@ -765,5 +776,321 @@ func TestReads_ContextCanceled(t *testing.T) {
 	}
 	if len(*seen) != 0 {
 		t.Fatalf("a canceled context must not reach the API, saw %v", *seen)
+	}
+}
+
+func TestCombinedStatus(t *testing.T) {
+	// The live-verified shape: aggregate in top-level `state`, per-status state
+	// in `.status`. Each row plants a contradictory `.state` decoy so a
+	// regression to the GitHub per-status field name fails loudly.
+	c, seen := staticReads(t, 200, `{"state":"SUCCESS","total_count":2,"statuses":[
+		{"context":"llm-review","status":"success","state":"failure","description":"smoke",
+		 "target_url":"","created_at":"2026-07-31T21:55:09Z","id":1},
+		{"context":"ci/build","status":"PENDING","state":"failure","description":"",
+		 "target_url":"https://x/run/7","created_at":"2026-08-10T12:00:00Z","id":1}]}`)
+	combined, err := c.CombinedStatus(context.Background(), "owner/repo", "fjsha1")
+	if err != nil {
+		t.Fatalf("CombinedStatus: %v", err)
+	}
+	if combined.State != "success" {
+		t.Fatalf("aggregate = %q, want top-level state normalized lowercase", combined.State)
+	}
+	if len(combined.Statuses) != 2 {
+		t.Fatalf("statuses = %+v, want 2", combined.Statuses)
+	}
+	first := combined.Statuses[0]
+	if first.State != "success" {
+		t.Fatalf("first state = %q — the impl must read Forgejo's .status, never .state", first.State)
+	}
+	if first.Context != "llm-review" || first.Description != "smoke" || first.TargetURL != "" {
+		t.Fatalf("first status = %+v", first)
+	}
+	if first.CreatedAt != "2026-07-31T21:55:09Z" {
+		t.Fatalf("first created_at = %q, want the RFC3339 wire string verbatim (fingerprint input)", first.CreatedAt)
+	}
+	if second := combined.Statuses[1]; second.State != "pending" || second.TargetURL != "https://x/run/7" {
+		t.Fatalf("second status = %+v", second)
+	}
+	req := (*seen)[0]
+	if req.Method != http.MethodGet || req.Path != "/repos/owner/repo/commits/fjsha1/status" {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+	if req.Query.Get("limit") != strconv.Itoa(pageSize) || req.Query.Get("page") != "1" {
+		t.Fatalf("the statuses array is paginated — query = %v", req.Query)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %d, want 1 (a short statuses page ends the loop)", len(*seen))
+	}
+}
+
+func TestCombinedStatus_NoSignalShape(t *testing.T) {
+	// Live-verified: zero statuses answer 200 with an EMPTY-STRING aggregate
+	// and a null statuses array. Both must survive as-is — empty state + nil
+	// slice is the no-signal shape downstream parity logic keys on.
+	c, _ := staticReads(t, 200, `{"state":"","total_count":0,"statuses":null}`)
+	combined, err := c.CombinedStatus(context.Background(), "owner/repo", "dfc9446cb6a16c60075286299cd07d2cb655769a")
+	if err != nil {
+		t.Fatalf("CombinedStatus: %v", err)
+	}
+	if combined.State != "" {
+		t.Fatalf("aggregate = %q, want empty string on a no-signal SHA", combined.State)
+	}
+	if combined.Statuses != nil {
+		t.Fatalf("statuses = %#v, want nil (wire null must not become an invented row)", combined.Statuses)
+	}
+}
+
+func TestCombinedStatus_WarningAndSkippedSurviveVerbatim(t *testing.T) {
+	// "warning" and "skipped" are real CommitStatusState values (skipped
+	// live-verified from Actions-sourced statuses) — they must reach the
+	// caller verbatim, never collapsed into the four-state write vocabulary.
+	c, _ := staticReads(t, 200, `{"state":"pending","total_count":2,"statuses":[
+		{"context":"a","status":"warning","created_at":"2026-08-10T12:00:00Z"},
+		{"context":"b","status":"skipped","created_at":"2026-08-10T12:00:01Z"}]}`)
+	combined, err := c.CombinedStatus(context.Background(), "owner/repo", "sha")
+	if err != nil {
+		t.Fatalf("CombinedStatus: %v", err)
+	}
+	if len(combined.Statuses) != 2 ||
+		combined.Statuses[0].State != "warning" || combined.Statuses[1].State != "skipped" {
+		t.Fatalf("statuses = %+v, want warning and skipped verbatim", combined.Statuses)
+	}
+}
+
+func TestCombinedStatus_Pagination(t *testing.T) {
+	statusRow := func(i int) string {
+		return fmt.Sprintf(`{"context":"ctx-%d","status":"success","created_at":"2026-08-10T12:00:00Z"}`, i)
+	}
+	statusPage := func(state string, from, n int) string {
+		rows := make([]string, 0, n)
+		for i := 0; i < n; i++ {
+			rows = append(rows, statusRow(from+i))
+		}
+		return fmt.Sprintf(`{"state":%q,"total_count":%d,"statuses":[%s]}`, state, pageSize+2, strings.Join(rows, ","))
+	}
+	// Page 2 reports a contradictory aggregate: the result must carry page 1's
+	// (deterministic page-1-wins, both pages describe the same rollup live).
+	c, seen := newReadsClient(t, func(r *http.Request) (int, string) {
+		switch r.URL.Query().Get("page") {
+		case "1":
+			return 200, statusPage("pending", 1, pageSize)
+		case "2":
+			return 200, statusPage("success", 1+pageSize, 2)
+		default:
+			return 500, `{"message":"unexpected page"}`
+		}
+	})
+	combined, err := c.CombinedStatus(context.Background(), "owner/repo", "sha")
+	if err != nil {
+		t.Fatalf("CombinedStatus: %v", err)
+	}
+	if combined.State != "pending" {
+		t.Fatalf("aggregate = %q, want page 1's", combined.State)
+	}
+	if len(combined.Statuses) != pageSize+2 {
+		t.Fatalf("statuses = %d, want %d", len(combined.Statuses), pageSize+2)
+	}
+	if combined.Statuses[0].Context != "ctx-1" || combined.Statuses[pageSize+1].Context != fmt.Sprintf("ctx-%d", pageSize+2) {
+		t.Fatalf("order broken: first=%q last=%q", combined.Statuses[0].Context, combined.Statuses[pageSize+1].Context)
+	}
+	if len(*seen) != 2 {
+		t.Fatalf("requests = %d, want 2", len(*seen))
+	}
+}
+
+func TestCombinedStatus_PageCapFailsLoud(t *testing.T) {
+	// Every page full — including on a server that ignores the page param and
+	// re-serves the same clamped page forever — must end at the cap with a
+	// loud error, never a silently duplicated or truncated set.
+	full := make([]string, pageSize)
+	for i := range full {
+		full[i] = fmt.Sprintf(`{"context":"ctx-%d","status":"success","created_at":"2026-08-10T12:00:00Z"}`, i)
+	}
+	c, seen := staticReads(t, 200,
+		fmt.Sprintf(`{"state":"success","statuses":[%s]}`, strings.Join(full, ",")))
+	_, err := c.CombinedStatus(context.Background(), "owner/repo", "sha")
+	if err == nil {
+		t.Fatal("an over-cap statuses listing must error")
+	}
+	if !strings.Contains(err.Error(), "refusing to truncate") {
+		t.Fatalf("error should name the cap, got: %v", err)
+	}
+	if len(*seen) != maxListPages {
+		t.Fatalf("requests = %d, want exactly %d", len(*seen), maxListPages)
+	}
+}
+
+func TestCombinedStatus_HTTPError(t *testing.T) {
+	c, _ := staticReads(t, 500, `{"message":"boom"}`)
+	if _, err := c.CombinedStatus(context.Background(), "owner/repo", "sha"); err == nil {
+		t.Fatal("a non-2xx combined read must surface as an error, not a no-signal shape")
+	}
+}
+
+func TestListPullReviews(t *testing.T) {
+	// Row 1 is the live migrated shape (Ghost user, EMPTY commit_id); row 2 a
+	// native-style review. State must stay VERBATIM uppercase — vocabulary
+	// mapping is the gh layer's job.
+	c, seen := staticReads(t, 200, `[
+		{"id":45,"user":{"id":-1,"login":"Ghost"},"team":null,"state":"COMMENT","body":"migrated",
+		 "commit_id":"","stale":false,"official":false,"dismissed":false,"comments_count":3,
+		 "submitted_at":"2026-07-30T10:00:00Z","updated_at":"2026-07-30T10:00:00Z"},
+		{"id":46,"user":{"id":7,"login":"maestro-bot"},"team":null,"state":"APPROVED","body":"lgtm",
+		 "commit_id":"64b09cb367f467272a86ba1c7fd08becae54981c","stale":false,"official":true,
+		 "dismissed":false,"comments_count":0,"submitted_at":"2026-07-31T11:00:00Z"}]`)
+	reviews, err := c.ListPullReviews(context.Background(), "owner/repo", 42, true)
+	if err != nil {
+		t.Fatalf("ListPullReviews: %v", err)
+	}
+	if len(reviews) != 2 {
+		t.Fatalf("reviews = %+v, want 2 in server order", reviews)
+	}
+	first := reviews[0]
+	if first.ID != 45 || first.User != "Ghost" || first.Body != "migrated" {
+		t.Fatalf("first review = %+v", first)
+	}
+	if first.State != "COMMENT" {
+		t.Fatalf("state = %q, want the ReviewStateType verbatim (uppercase)", first.State)
+	}
+	if first.CommitID != "" {
+		t.Fatalf("commit_id = %q — an empty review-level commit_id is legitimate (migrated reviews) and must survive as empty for the per-comment fallback", first.CommitID)
+	}
+	if first.SubmittedAt != "2026-07-30T10:00:00Z" || first.CommentsCount != 3 {
+		t.Fatalf("first review = %+v", first)
+	}
+	second := reviews[1]
+	if second.State != "APPROVED" || second.CommitID != "64b09cb367f467272a86ba1c7fd08becae54981c" {
+		t.Fatalf("second review = %+v", second)
+	}
+	req := (*seen)[0]
+	if req.Method != http.MethodGet || req.Path != "/repos/owner/repo/pulls/42/reviews" {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+	if req.Query.Get("limit") != strconv.Itoa(pageSize) || req.Query.Get("page") != "1" {
+		t.Fatalf("reviews list must be paginated, query = %v", req.Query)
+	}
+}
+
+func TestListPullReviews_NullUserMapsToEmpty(t *testing.T) {
+	// creator/user can be null (live-proven on Actions-sourced statuses; the
+	// reviews contract does not promise non-null either) — a null user must
+	// decode to an empty login, not error.
+	c, _ := staticReads(t, 200,
+		`[{"id":9,"user":null,"state":"COMMENT","body":"b","commit_id":"","comments_count":0,
+		   "submitted_at":"2026-07-30T10:00:00Z"}]`)
+	reviews, err := c.ListPullReviews(context.Background(), "owner/repo", 1, true)
+	if err != nil {
+		t.Fatalf("ListPullReviews: %v", err)
+	}
+	if len(reviews) != 1 || reviews[0].User != "" {
+		t.Fatalf("reviews = %+v, want one review with empty User", reviews)
+	}
+}
+
+func TestListPullReviews_Pagination(t *testing.T) {
+	reviewsPage := func(from, n int) string {
+		rows := make([]string, 0, n)
+		for i := 0; i < n; i++ {
+			rows = append(rows, fmt.Sprintf(
+				`{"id":%d,"user":{"login":"u"},"state":"COMMENT","body":"b","commit_id":"","comments_count":1,"submitted_at":"2026-07-30T10:00:00Z"}`,
+				from+i))
+		}
+		return "[" + strings.Join(rows, ",") + "]"
+	}
+	c, seen := newReadsClient(t, func(r *http.Request) (int, string) {
+		switch r.URL.Query().Get("page") {
+		case "1":
+			return 200, reviewsPage(1, pageSize)
+		case "2":
+			return 200, reviewsPage(1+pageSize, 2)
+		default:
+			return 200, "[]" // past-the-end pages answer 200 [] live
+		}
+	})
+	reviews, err := c.ListPullReviews(context.Background(), "owner/repo", 42, true)
+	if err != nil {
+		t.Fatalf("ListPullReviews: %v", err)
+	}
+	if len(reviews) != pageSize+2 {
+		t.Fatalf("reviews = %d, want %d", len(reviews), pageSize+2)
+	}
+	if reviews[0].ID != 1 || reviews[pageSize+1].ID != int64(pageSize+2) {
+		t.Fatalf("order broken: first=%d last=%d", reviews[0].ID, reviews[pageSize+1].ID)
+	}
+	if len(*seen) != 2 {
+		t.Fatalf("requests = %d, want 2", len(*seen))
+	}
+}
+
+func TestListPullReviews_HTTPError(t *testing.T) {
+	c, _ := staticReads(t, 404, `{"message":"not found"}`)
+	if _, err := c.ListPullReviews(context.Background(), "owner/repo", 999, true); err == nil {
+		t.Fatal("a 404 must surface as an error")
+	}
+}
+
+func TestListPullReviewComments(t *testing.T) {
+	// The live tx10-clock shape. THE LINE TRAP: the read side has no `line` /
+	// `new_position` — the new-file line number is `position`. The fixture
+	// plants both GitHub-style decoys so a regression to either field name
+	// fails loudly. commit_id is populated per comment even when the parent
+	// review's is empty (the head-anchor fallback).
+	c, seen := staticReads(t, 200, `[
+		{"id":70,"body":"finding one","user":{"id":-1,"login":"Ghost"},"resolver":null,
+		 "pull_request_review_id":45,"path":"cmd/main.go",
+		 "commit_id":"64b09cb367f467272a86ba1c7fd08becae54981c","original_commit_id":"",
+		 "position":609,"original_position":0,"line":999,"new_position":888,
+		 "diff_hunk":"@@ -0,0 +1,1758 @@","extra_lines_count":0,
+		 "created_at":"2026-07-30T10:00:00Z","updated_at":"2026-07-30T10:00:00Z"},
+		{"id":71,"body":"old-side note","user":{"id":7,"login":"maestro-bot"},
+		 "pull_request_review_id":45,"path":"web/app.css",
+		 "commit_id":"64b09cb367f467272a86ba1c7fd08becae54981c",
+		 "original_commit_id":"63d046eb546c32ca4492c724ac6371f04507b18d",
+		 "position":0,"original_position":12,
+		 "created_at":"2026-07-30T10:01:00Z"}]`)
+	comments, err := c.ListPullReviewComments(context.Background(), "owner/repo", 42, 45)
+	if err != nil {
+		t.Fatalf("ListPullReviewComments: %v", err)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("comments = %+v, want 2", comments)
+	}
+	first := comments[0]
+	if first.Line != 609 {
+		t.Fatalf("Line = %d, want 609 from `position` — never from the `line`/`new_position` decoys", first.Line)
+	}
+	if first.OldLine != 0 {
+		t.Fatalf("OldLine = %d, want 0 (new-side comment)", first.OldLine)
+	}
+	if first.ID != 70 || first.Body != "finding one" || first.Author != "Ghost" || first.Path != "cmd/main.go" {
+		t.Fatalf("first comment = %+v", first)
+	}
+	if first.CommitID != "64b09cb367f467272a86ba1c7fd08becae54981c" || first.OriginalCommitID != "" {
+		t.Fatalf("commit ids = %q / %q", first.CommitID, first.OriginalCommitID)
+	}
+	if first.CreatedAt != "2026-07-30T10:00:00Z" {
+		t.Fatalf("created_at = %q, want verbatim", first.CreatedAt)
+	}
+	if second := comments[1]; second.Line != 0 || second.OldLine != 12 {
+		t.Fatalf("second comment lines = %d/%d, want 0/12 (old-side comment)", second.Line, second.OldLine)
+	}
+	req := (*seen)[0]
+	if req.Method != http.MethodGet || req.Path != "/repos/owner/repo/pulls/42/reviews/45/comments" {
+		t.Fatalf("request = %s %s", req.Method, req.Path)
+	}
+	// No page/limit params exist on this endpoint — sending them would be dead
+	// weight at best and a behavior change on a future server at worst.
+	if req.Query.Get("page") != "" || req.Query.Get("limit") != "" {
+		t.Fatalf("review comments must not be paginated, query = %v", req.Query)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %d, want 1 (single-response endpoint)", len(*seen))
+	}
+}
+
+func TestListPullReviewComments_HTTPError(t *testing.T) {
+	c, _ := staticReads(t, 500, `{"message":"boom"}`)
+	if _, err := c.ListPullReviewComments(context.Background(), "owner/repo", 42, 45); err == nil {
+		t.Fatal("a 500 must surface as an error, not an empty comment set")
 	}
 }

--- a/internal/forgejo/reads_test.go
+++ b/internal/forgejo/reads_test.go
@@ -898,6 +898,47 @@ func TestCombinedStatus_Pagination(t *testing.T) {
 	}
 }
 
+func TestCombinedStatus_ShortPageBelowTotalFailsLoud(t *testing.T) {
+	// A server whose paging clamp sits below our pageSize answers a short page
+	// while total_count says more statuses exist. Trusting the short-page stop
+	// there would feed a silently truncated set into the verdict/fingerprint —
+	// the belt must turn it into an explicit error instead (same contract as
+	// listPages' X-Total-Count belt; total_count semantics live-pinned:
+	// across-pages total, 0 on the no-signal shape).
+	c, _ := staticReads(t, 200, `{"state":"pending","total_count":5,"statuses":[
+		{"context":"a","status":"success","created_at":"2026-08-10T12:00:00Z"},
+		{"context":"b","status":"pending","created_at":"2026-08-10T12:00:01Z"}]}`)
+	_, err := c.CombinedStatus(context.Background(), "owner/repo", "sha")
+	if err == nil {
+		t.Fatal("a short page below total_count must error, never truncate silently")
+	}
+	if !strings.Contains(err.Error(), "refusing to truncate silently") {
+		t.Fatalf("error should name the truncation belt, got: %v", err)
+	}
+}
+
+func TestCombinedStatus_TotalReachedOnFullPageStops(t *testing.T) {
+	// Exactly pageSize statuses with a matching total_count: reaching the
+	// total on a full page must end the loop without demanding one empty
+	// page (and without tripping the page cap at exact multiples).
+	full := make([]string, pageSize)
+	for i := range full {
+		full[i] = fmt.Sprintf(`{"context":"ctx-%d","status":"success","created_at":"2026-08-10T12:00:00Z"}`, i)
+	}
+	c, seen := staticReads(t, 200,
+		fmt.Sprintf(`{"state":"success","total_count":%d,"statuses":[%s]}`, pageSize, strings.Join(full, ",")))
+	combined, err := c.CombinedStatus(context.Background(), "owner/repo", "sha")
+	if err != nil {
+		t.Fatalf("CombinedStatus: %v", err)
+	}
+	if len(combined.Statuses) != pageSize {
+		t.Fatalf("statuses = %d, want %d", len(combined.Statuses), pageSize)
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("requests = %d, want 1 (total reached on a full page ends the loop)", len(*seen))
+	}
+}
+
 func TestCombinedStatus_PageCapFailsLoud(t *testing.T) {
 	// Every page full — including on a server that ignores the page param and
 	// re-serves the same clamped page forever — must end at the cap with a

--- a/internal/github/forgejo_failloud_test.go
+++ b/internal/github/forgejo_failloud_test.go
@@ -59,26 +59,42 @@ func TestForgejoModeFailsLoud(t *testing.T) {
 		name string
 		call func() error
 	}{
-		// github.go — explicit early guards (their first transport touch is a
-		// ported read, or they swallow downstream errors by design; without
-		// the guard they would half-work — see the M2 spec's NOT-ported list).
-		{"PRCIStatus", func() error { _, err := c.PRCIStatus(1); return err }},
-		{"PRMergeStatus", func() error { _, _, err := c.PRMergeStatus(1); return err }},
-		{"PRChecksOutput", func() error { _, err := c.PRChecksOutput(1); return err }},
-		{"CIFailureSummary", func() error { _, err := c.CIFailureSummary(1); return err }},
-		{"CollectPRReviewFeedback", func() error { _, err := c.CollectPRReviewFeedback(1, nil); return err }},
+		// M4 flip note (#1172): the check-runs/status consumer family moved
+		// OUT of this list — PRCIStatus, PRCheckRollup, PRMergeStatus,
+		// PRChecksOutput, PRFailingChecks, CIFailureSummary,
+		// CollectPRReviewFeedback, greptileReviewComments,
+		// PRReviewGateVerdict/namedReviewStreamVerdict,
+		// PRHasCriticalReviewOnHead, CollectReviewFeedback,
+		// PRBlockingReviewFindingsOnHead, and PRUnresolvedReviewThreadsOnHead
+		// are ported (forgejo-mode httptest coverage lives in
+		// forgejo_port_m4_test.go). What stays guarded below is the
+		// greptile-only family (new explicit guards), the raw check-run /
+		// commit reads that have no forgejo equivalent (funnel chokes), and
+		// the unported write + Projects surface.
+
+		// github.go — NEW explicit greptile-only guards (M4): their reads are
+		// all ported now, so without the guard each would half-work — forever
+		// "pending"/"no findings" on a reviewer that never posts on forgejo.
+		{"PRGreptileApproved", func() error { _, _, err := c.PRGreptileApproved(1); return err }},
+		{"prGreptileReviewStreamVerdict", func() error { _, err := c.prGreptileReviewStreamVerdict(1); return err }},
+		{"PRHighSeverityReviewOnHead", func() error { _, _, _, err := c.PRHighSeverityReviewOnHead(1); return err }},
 		// github.go — c.ghAPI funnel.
 		{"RateLimit", func() error { _, err := c.RateLimit(); return err }},
-		// github.go — c.ghAPIWithArgs funnel.
+		// github.go — c.ghAPI funnel: commit timestamp read, only reachable
+		// from the greptile comment fallback (behind the guard above), kept
+		// loud in its own right.
+		{"commitCommittedAt", func() error { _, err := c.commitCommittedAt("59e99c49c27d3e2f73bae1657f07cd2f9a15f926"); return err }},
+		// github.go — c.ghAPIWithArgs funnel: the raw check-run reads. No
+		// check-runs API exists on forgejo; the M4 rollup consumers dispatch
+		// to statuses-only siblings BEFORE ever reaching these.
 		{"checkRunsForSHA", func() error { _, err := c.checkRunsForSHA("59e99c49c27d3e2f73bae1657f07cd2f9a15f926"); return err }},
+		{"checkRunAnnotations", func() error { _, err := c.checkRunAnnotations(1); return err }},
 		// github.go — c.ghExec funnel: the writes are ported in M3, so the one
 		// remaining write-shaped guard is MarkPRReady (EditPullRequestOption
 		// has no draft toggle on 16.0.1 — explicit guard until M7).
 		{"MarkPRReady", func() error { return c.MarkPRReady(1) }},
 		// github_projects.go — c.ghOutputContext funnel (GraphQL Projects).
 		{"DiscoverProject", func() error { _, err := c.DiscoverProject(1); return err }},
-		// review_threads.go — GraphQL through c.ghExec.
-		{"PRUnresolvedReviewThreadsOnHead", func() error { _, _, err := c.PRUnresolvedReviewThreadsOnHead(1); return err }},
 	}
 	for _, s := range samples {
 		err := s.call()

--- a/internal/github/forgejo_port.go
+++ b/internal/github/forgejo_port.go
@@ -22,8 +22,9 @@
 //     server's Mergeable() predicate, forced false on drafts and during the
 //     async conflict re-check — see fjPullToREST for the parity mapping;
 //   - mergeable_state has NO Forgejo equivalent: restPull.MergeableState is
-//     always "" here, which is why PRMergeStatus keeps an explicit
-//     NOT-ported guard (an empty raw state reads as "don't know, proceed");
+//     always "" here; PRMergeStatus instead SYNTHESIZES its vocabulary in
+//     fjPRMergeStatus (#1172 M4) — "behind" / "dirty" / "" only, never
+//     "clean" / "unstable";
 //   - draft is a plain bool.
 //
 // Methods that stay UNPORTED keep failing loud with ErrForgejoNotSupported
@@ -657,4 +658,334 @@ func (c *Client) fjCreateRelease(tag, title string) error {
 	ctx, cancel := forgejoCallContext()
 	defer cancel()
 	return fj.CreateRelease(ctx, c.Repo, tag, title)
+}
+
+// ---------------------------------------------------------------------------
+// CI/status rollup + review-gate reads + merge-state synthesis (#1172 M4).
+// Forgejo has NO check-runs API, NO mergeable_state, and NO review-thread
+// resolution API — the siblings below map what DOES exist (commit statuses,
+// reviews + review comments, merge_base) onto the existing internal shapes so
+// the shared aggregation/decision helpers (ciStatusFromREST,
+// formatChecksOverview, namedStatusDecision, filterStreamFindings, ...) run
+// unchanged on both forges.
+// ---------------------------------------------------------------------------
+
+// fjCombinedStatusForSHA maps forgejo's combined commit status onto the
+// gh-wire combinedStatusResponse. Two live-pinned gotchas are already
+// normalized by the transport: the per-status state arrives in the wire
+// `.status` field (NOT `.state`), and the no-signal shape is
+// {"state":"","total_count":0,"statuses":null} — which maps to State "" plus
+// nil Statuses here, exactly the no-signal shape ciStatusFromREST treats as
+// carrying no signal. CreatedAt is threaded through (RFC3339 verbatim) so the
+// rollup fingerprint advances on a status re-run — forgejo has no check-run
+// IDs to do that job.
+func (c *Client) fjCombinedStatusForSHA(sha string) (combinedStatusResponse, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return combinedStatusResponse{}, err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	combined, err := fj.CombinedStatus(ctx, c.Repo, sha)
+	if err != nil {
+		return combinedStatusResponse{}, err
+	}
+	out := combinedStatusResponse{State: combined.State}
+	for _, st := range combined.Statuses {
+		out.Statuses = append(out.Statuses, combinedStatusEntry{
+			Context:     st.Context,
+			State:       st.State,
+			Description: st.Description,
+			TargetURL:   st.TargetURL,
+			CreatedAt:   st.CreatedAt,
+		})
+	}
+	return out, nil
+}
+
+// fjPRCheckRollup is the statuses-only rollup: check-runs do not exist on
+// forgejo, so Verdict is ciStatusFromREST(nil, combined) and
+// PendingCheckRuns stays false (it means "a check-RUN is live"; a pending
+// commit status surfaces as Verdict "pending" and as a pending commit_status
+// signal instead — which is exactly why the supervisor's #425 escape must be
+// disabled on forgejo rows: here statuses ARE the CI).
+//
+// NO-SIGNAL PARITY — DOCUMENTED LOUDLY, READ BEFORE RELYING ON IT: a head
+// with ZERO commit statuses rolls up as Verdict "success", byte-identical to
+// the GitHub no-signal behavior (a repo with no CI at all must not deadlock
+// every PR). On the canary forgejo row the producer posts pending-first
+// statuses (the llm-review pair) so a real head is never signal-free for
+// long; CI statuses proper arrive with the Actions runner (M4-ops). Until
+// then a PR whose producer never posts anything would read green — the
+// review gate (default llm-review pair, pending until observed) is what
+// still blocks its merge.
+func (c *Client) fjPRCheckRollup(prNumber int) (PRCheckRollup, error) {
+	sha, err := c.pullHeadSHA(prNumber)
+	if err != nil {
+		return PRCheckRollup{Verdict: "unknown"}, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
+	}
+	combined, err := c.fjCombinedStatusForSHA(sha)
+	if err != nil {
+		// Identity-wrapped (%w), unlike the gh path's joint %v formatting:
+		// there is only one CI source here and its transport faults (token
+		// env, *forgejo.StatusError) must stay errors.Is/As-matchable.
+		return PRCheckRollup{HeadSHA: sha, Verdict: "unknown"}, fmt.Errorf("get statuses for PR %d: %w", prNumber, err)
+	}
+	rollup := PRCheckRollup{
+		HeadSHA:          sha,
+		Verdict:          ciStatusFromREST(nil, combined),
+		Complete:         true,
+		PendingCheckRuns: false,
+	}
+	rollup.Fingerprint = ciCheckRollupFingerprint(nil, combined)
+	rollup.Signals = ciCheckRollupSignals(nil, combined)
+	return rollup, nil
+}
+
+// fjPRChecksOutput renders the statuses-only overview through the shared
+// formatter (name, state, description columns; "no checks\n" when empty).
+func (c *Client) fjPRChecksOutput(prNumber int) (string, error) {
+	sha, err := c.pullHeadSHA(prNumber)
+	if err != nil {
+		return "", fmt.Errorf("get pull %d head sha: %w", prNumber, err)
+	}
+	combined, err := c.fjCombinedStatusForSHA(sha)
+	if err != nil {
+		return "", fmt.Errorf("get statuses for PR %d: %w", prNumber, err)
+	}
+	return formatChecksOverview(nil, combined), nil
+}
+
+// fjFailingStatusState reports whether a commit-status state is a hard CI
+// failure. ONLY "failure" and "error" qualify — "warning" and "skipped" are
+// real Forgejo per-status states (live-verified) and must never be classified
+// as failing, mirroring how ciStatusFromREST's aggregate arm only hardens on
+// failure/error.
+func fjFailingStatusState(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "failure", "error":
+		return true
+	}
+	return false
+}
+
+// fjPRFailingChecks maps failing commit statuses onto FailingCheck. The
+// status Description is the only actionable text a forgejo status carries
+// (no check-run output, no annotations), so it is threaded through as the
+// excerpt — empty descriptions degrade to name + conclusion, same contract
+// as the gh path (#857).
+func (c *Client) fjPRFailingChecks(prNumber int) ([]FailingCheck, error) {
+	sha, err := c.pullHeadSHA(prNumber)
+	if err != nil {
+		return nil, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
+	}
+	combined, err := c.fjCombinedStatusForSHA(sha)
+	if err != nil {
+		return nil, fmt.Errorf("get statuses for PR %d: %w", prNumber, err)
+	}
+	var failing []FailingCheck
+	for _, st := range combined.Statuses {
+		if !fjFailingStatusState(st.State) {
+			continue
+		}
+		failing = append(failing, FailingCheck{
+			Name:       st.Context,
+			Conclusion: st.State,
+			Excerpt:    strings.TrimSpace(st.Description),
+		})
+	}
+	return failing, nil
+}
+
+// fjCIFailureSummary mirrors the gh CIFailureSummary shape — overview, then a
+// section per failed status — with the status description standing in for the
+// check-run output (nothing else exists on forgejo) and the same 8000-byte
+// cap. Downstream errors are swallowed exactly like the gh path: the summary
+// degrades to the overview, and the overview itself degrades to the error
+// text, because this string feeds a retry-worker prompt and must never abort
+// the retry.
+func (c *Client) fjCIFailureSummary(prNumber int) (string, error) {
+	overview, err := c.fjPRChecksOutput(prNumber)
+	if err != nil {
+		overview = err.Error()
+	}
+	sha, err := c.pullHeadSHA(prNumber)
+	if err != nil || sha == "" {
+		return overview, nil
+	}
+	combined, err := c.fjCombinedStatusForSHA(sha)
+	if err != nil {
+		return overview, nil
+	}
+	var failed []combinedStatusEntry
+	for _, st := range combined.Statuses {
+		if fjFailingStatusState(st.State) {
+			failed = append(failed, st)
+		}
+	}
+	if len(failed) == 0 {
+		return overview, nil
+	}
+
+	var result strings.Builder
+	result.WriteString("CI Check Overview:\n")
+	result.WriteString(overview)
+	result.WriteString("\n\n")
+	for _, st := range failed {
+		result.WriteString(fmt.Sprintf("=== Failed check: %s ===\n", st.Context))
+		if desc := strings.TrimSpace(st.Description); desc != "" {
+			result.WriteString(desc)
+			result.WriteString("\n")
+		}
+		if st.TargetURL != "" {
+			result.WriteString("Details: ")
+			result.WriteString(st.TargetURL)
+			result.WriteString("\n")
+		}
+		result.WriteString("\n")
+	}
+	s := result.String()
+	if len(s) > 8000 {
+		s = s[:8000] + "\n... (truncated)"
+	}
+	return s, nil
+}
+
+// fjPRMergeStatus synthesizes the mergeable_state vocabulary forgejo does not
+// have (#1172 M4 D3). The mergeable verdict is the shared
+// mergeableFromRESTPull over fjPullToREST (draft-contaminated false → nil →
+// "UNKNOWN" rule included). The synthesized mergeStateStatus is:
+//
+//   - "dirty"  — non-draft wire mergeable == false (a real conflict, or the
+//     seconds-long async re-check window — same accepted transient as
+//     PRMergeable's CONFLICTING). Checked FIRST: GitHub reports a conflicting
+//     PR as dirty even when it is also behind, and the conflict routing
+//     (approver execution_failed on CONFLICTING) is the stronger signal.
+//   - "behind" — the pull's merge_base differs from the CURRENT base-branch
+//     head (BranchHeadSHA(BaseRef), a second read — never base.sha from the
+//     same payload, which moves after merges and would mask "behind").
+//     This revives the approver's behind→UpdateBranch routing on forgejo.
+//   - ""       — everything else: callers read it as "not computed, proceed".
+//
+// "clean" and "unstable" are DELIBERATELY never synthesized. Both unlock
+// GitHub-semantics escapes that assert "every required check passed", which
+// has no forgejo equivalent until branch protection + Actions land:
+//
+//   - the #424 pending→success promotion (orchestrator
+//     pr_gate_progress.go observePRGateCI) requires "clean" — permanently
+//     inert on forgejo rows;
+//   - mergeStateAllowsMerge (supervisor #425 escape and review_repair's
+//     CI-pending arm) requires "clean"/"unstable" — both arms permanently
+//     inert on forgejo rows (M7 observation item; the supervisor
+//     additionally hard-gates the #425 escape on !IsForgejo so the
+//     inertness is double-guarded).
+//
+// An error from the base-branch head read fails the whole call (identity-
+// wrapped): callers treat a PRMergeStatus error as "no signal" and stay on
+// their conservative paths.
+func (c *Client) fjPRMergeStatus(prNumber int) (mergeable string, mergeStateStatus string, err error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return "", "", err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	p, err := fj.GetPull(ctx, c.Repo, prNumber)
+	if err != nil {
+		return "", "", fmt.Errorf("get pull %d: %w", prNumber, err)
+	}
+	mergeable = mergeableFromRESTPull(fjPullToREST(p))
+	if !p.Draft && p.Mergeable != nil && !*p.Mergeable {
+		return mergeable, "dirty", nil
+	}
+	mergeBase := strings.TrimSpace(p.MergeBase)
+	baseRef := strings.TrimSpace(p.BaseRef)
+	if mergeBase == "" || baseRef == "" {
+		// merge_base absent on the wire: "behind" cannot be determined, and
+		// "" is the honest "not computed" answer — never a guess.
+		return mergeable, "", nil
+	}
+	baseHead, err := fj.BranchHeadSHA(ctx, c.Repo, baseRef)
+	if err != nil {
+		return "", "", fmt.Errorf("get base branch %q head for PR %d: %w", baseRef, prNumber, err)
+	}
+	if !strings.EqualFold(mergeBase, strings.TrimSpace(baseHead)) {
+		return mergeable, "behind", nil
+	}
+	return mergeable, "", nil
+}
+
+// fjReviewComments is the forgejo arm of greptileReviewComments (the generic
+// inline-comment reader): reviews list + per-review comments, flattened into
+// the gh review-comment shape.
+//
+// CommitID head-anchoring contract (D4): the REVIEW's commit_id is the
+// primary anchor — the llm-review producer writes one-comment COMMENT reviews
+// anchored to the head it reviewed, and without that anchor
+// reviewCommentTargetsHead degenerates to "matches every head" and historical
+// findings leak across pushes. A review-level commit_id can legitimately be
+// "" (live-proven on migrated reviews), so the per-comment commit_id — always
+// populated — is the fallback. OriginalCommitID is deliberately left empty:
+// reviewCommentTargetsHead consults it FIRST when non-empty, and forgejo's
+// original_commit_id semantics across force-pushes are unpinned — the
+// review-anchored CommitID is the reliable head test.
+//
+// Body-only reviews (CommentsCount == 0) skip the per-review round trip.
+func (c *Client) fjReviewComments(prNumber int) ([]greptileReviewComment, error) {
+	fj, err := c.fjTransport()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := forgejoCallContext()
+	defer cancel()
+	reviews, err := fj.ListPullReviews(ctx, c.Repo, prNumber, true)
+	if err != nil {
+		return nil, fmt.Errorf("list PR %d reviews: %w", prNumber, err)
+	}
+	var comments []greptileReviewComment
+	for _, review := range reviews {
+		if review.CommentsCount == 0 {
+			continue
+		}
+		rcs, err := fj.ListPullReviewComments(ctx, c.Repo, prNumber, review.ID)
+		if err != nil {
+			return nil, fmt.Errorf("list PR %d review %d comments: %w", prNumber, review.ID, err)
+		}
+		for _, rc := range rcs {
+			commitID := strings.TrimSpace(review.CommitID)
+			if commitID == "" {
+				commitID = strings.TrimSpace(rc.CommitID)
+			}
+			cm := greptileReviewComment{
+				Body: rc.Body,
+				Path: rc.Path,
+				// Line ← the wire `position` field (transport PullReviewComment
+				// .Line), which on the forgejo READ side is the NEW-file line
+				// number (x-go-name LineNum) — NOT a diff offset; there is no
+				// `line`/`new_position` on reads (stage-A live pin).
+				Line:     int(rc.Line),
+				CommitID: commitID,
+			}
+			cm.User.Login = rc.Author
+			comments = append(comments, cm)
+		}
+	}
+	return comments, nil
+}
+
+// fjUnresolvedReviewThreadsOnHead is the D5 mergegate shim: forgejo has no
+// unresolved-conversations API, so it answers "no unresolved threads" while
+// still providing the boundary's second independent head read from the ported
+// pull read. An empty head refuses loudly — the same refusal the gh GraphQL
+// parse enforces — so the compare/claim boundary never anchors to "".
+func (c *Client) fjUnresolvedReviewThreadsOnHead(prNumber int) (string, []ReviewThread, error) {
+	rp, err := c.fjGetRESTPull(prNumber)
+	if err != nil {
+		return "", nil, fmt.Errorf("read review threads for PR %d: %w", prNumber, err)
+	}
+	head := strings.TrimSpace(rp.Head.SHA)
+	if head == "" {
+		return "", nil, fmt.Errorf("read review threads for PR %d: pull request head SHA is empty", prNumber)
+	}
+	return head, nil, nil
 }

--- a/internal/github/forgejo_port.go
+++ b/internal/github/forgejo_port.go
@@ -718,7 +718,11 @@ func (c *Client) fjCombinedStatusForSHA(sha string) (combinedStatusResponse, err
 // long; CI statuses proper arrive with the Actions runner (M4-ops). Until
 // then a PR whose producer never posts anything would read green — the
 // review gate (default llm-review pair, pending until observed) is what
-// still blocks its merge.
+// still blocks its merge. That backstop has exactly two operator opt-outs:
+// `review_gate: none` (no review gate at all) and a configured
+// `review_retrigger.missing_after_minutes` grace expiring against a dead
+// producer — under either, a zero-signal PR can merge (GitHub no-signal
+// parity; deliberate operator trade, not an escape).
 func (c *Client) fjPRCheckRollup(prNumber int) (PRCheckRollup, error) {
 	sha, err := c.pullHeadSHA(prNumber)
 	if err != nil {

--- a/internal/github/forgejo_port_m4_test.go
+++ b/internal/github/forgejo_port_m4_test.go
@@ -1,0 +1,700 @@
+package github
+
+// Forgejo-mode tests for the #1172 M4 port: statuses-only CI rollup (D1),
+// PRMergeStatus synthesis (D3), review-gate reads (D4), and the mergegate
+// review-thread shim (D5). Same harness as forgejo_port_test.go: the REAL
+// stack against an httptest fixture server with contract-verified Forgejo
+// 16.0.1 JSON shapes, gh transport armed so any leak fails the test.
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+const (
+	fjM4Head     = "59e99c49c27d3e2f73bae1657f07cd2f9a15f926"
+	fjM4BaseHead = "63d046eb546c32ca4492c724ac6371f04507b18d"
+)
+
+var (
+	fjM4PullPath    = "/repos/" + fjTestRepo + "/pulls/7"
+	fjM4StatusPath  = "/repos/" + fjTestRepo + "/commits/" + fjM4Head + "/status"
+	fjM4BranchPath  = "/repos/" + fjTestRepo + "/branches/main"
+	fjM4ReviewsPath = "/repos/" + fjTestRepo + "/pulls/7/reviews"
+)
+
+// fjM4PullJSON is an open non-draft pull fixture; merge_base is parameterized
+// for the D3 synthesis tests.
+func fjM4PullJSON(mergeable, draft bool, mergeBase string) string {
+	return fmt.Sprintf(`{"number":7,"title":"t","body":"","state":"open","draft":%t,"mergeable":%t,`+
+		`"merged_at":null,"merge_commit_sha":null,"merge_base":%q,`+
+		`"head":{"ref":"feat/x","sha":%q},"base":{"ref":"main"}}`, draft, mergeable, mergeBase, fjM4Head)
+}
+
+func fjM4BranchJSON() string {
+	return fmt.Sprintf(`{"name":"main","commit":{"id":%q,"message":"m"}}`, fjM4BaseHead)
+}
+
+func fjM4CountPaths(seen []fjSeenReq, sub string) int {
+	n := 0
+	for _, req := range seen {
+		if strings.Contains(req.Path, sub) {
+			n++
+		}
+	}
+	return n
+}
+
+// --- D1: statuses-only rollup ------------------------------------------------
+
+func TestForgejoM4PRCheckRollup_StatusesOnly(t *testing.T) {
+	c, seen, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath: fjM4PullJSON(true, false, fjM4BaseHead),
+		// Per-status state lives in `.status`; `"state"` per row is a DECOY
+		// that must not be decoded (contract gotcha #1).
+		fjM4StatusPath: `{"state":"pending","total_count":2,"statuses":[
+			{"id":1,"context":"llm-review-opus","status":"pending","state":"success","description":"queued","target_url":"","created_at":"2026-08-11T10:00:00Z"},
+			{"id":2,"context":"llm-review-terra","status":"success","state":"failure","description":"ok","target_url":"","created_at":"2026-08-11T10:05:00Z"}
+		]}`,
+	}))
+	rollup, err := c.PRCheckRollup(7)
+	if err != nil {
+		t.Fatalf("PRCheckRollup: %v", err)
+	}
+	if rollup.HeadSHA != fjM4Head || rollup.Verdict != "pending" || !rollup.Complete {
+		t.Fatalf("rollup = %+v, want head=%s verdict=pending complete", rollup, fjM4Head)
+	}
+	if rollup.PendingCheckRuns {
+		t.Fatal("PendingCheckRuns must stay false on forgejo — no check-runs exist; the pending signal is the Verdict")
+	}
+	if len(rollup.Fingerprint) != 16 {
+		t.Fatalf("fingerprint = %q, want 16-char digest", rollup.Fingerprint)
+	}
+	if len(rollup.Signals) != 2 {
+		t.Fatalf("signals = %+v, want two commit_status entries", rollup.Signals)
+	}
+	for _, sig := range rollup.Signals {
+		if sig.Source != "commit_status" || sig.Status != sig.Conclusion {
+			t.Fatalf("signal %+v: want commit_status with Status==Conclusion (GitHub statuses parity)", sig)
+		}
+	}
+	if rollup.Signals[0].Name != "llm-review-opus" || rollup.Signals[0].Status != "pending" ||
+		rollup.Signals[1].Name != "llm-review-terra" || rollup.Signals[1].Status != "success" {
+		t.Fatalf("signals mis-mapped (the per-row .state decoy must lose to .status): %+v", rollup.Signals)
+	}
+	if n := fjM4CountPaths(*seen, "check-runs"); n != 0 {
+		t.Fatalf("a check-runs read was attempted on forgejo (%d)", n)
+	}
+
+	// PRCIStatus rides the same rollup.
+	status, err := c.PRCIStatus(7)
+	if err != nil || status != "pending" {
+		t.Fatalf("PRCIStatus = %q, %v; want pending, nil", status, err)
+	}
+}
+
+// TestForgejoM4PRCheckRollup_NoSignalIsSuccess pins the LOUDLY-documented
+// GitHub no-signal parity: the live no-signal shape (state:"", statuses:null)
+// rolls up as "success". The review gate — not CI — is what still blocks such
+// a head until the producer's pending-first statuses land.
+func TestForgejoM4PRCheckRollup_NoSignalIsSuccess(t *testing.T) {
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath:   fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4StatusPath: `{"state":"","total_count":0,"statuses":null}`,
+	}))
+	rollup, err := c.PRCheckRollup(7)
+	if err != nil {
+		t.Fatalf("PRCheckRollup: %v", err)
+	}
+	if rollup.Verdict != "success" || !rollup.Complete {
+		t.Fatalf("rollup = %+v, want no-signal verdict=success (GitHub parity)", rollup)
+	}
+	if len(rollup.Signals) != 0 {
+		t.Fatalf("signals = %+v, want none", rollup.Signals)
+	}
+	if rollup.Fingerprint == "" {
+		t.Fatal("fingerprint must still be present (the combined= part) so no-signal->signal advances it")
+	}
+}
+
+func TestForgejoM4PRCheckRollup_FailureAndNonFailureStates(t *testing.T) {
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath: fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4StatusPath: `{"state":"failure","total_count":2,"statuses":[
+			{"id":1,"context":"ci/test","status":"failure","description":"2 tests failed","target_url":"","created_at":"2026-08-11T10:00:00Z"},
+			{"id":2,"context":"agent-lint","status":"success","description":"","target_url":"","created_at":"2026-08-11T10:01:00Z"}
+		]}`,
+	}))
+	rollup, err := c.PRCheckRollup(7)
+	if err != nil || rollup.Verdict != "failure" {
+		t.Fatalf("rollup = %+v, %v; want verdict=failure", rollup, err)
+	}
+
+	// warning/skipped are real per-status values and must NOT read as failure.
+	c2, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath: fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4StatusPath: `{"state":"warning","total_count":2,"statuses":[
+			{"id":1,"context":"lint","status":"warning","description":"","target_url":"","created_at":"2026-08-11T10:00:00Z"},
+			{"id":2,"context":"optional","status":"skipped","description":"","target_url":"","created_at":"2026-08-11T10:01:00Z"}
+		]}`,
+	}))
+	rollup2, err := c2.PRCheckRollup(7)
+	if err != nil {
+		t.Fatalf("PRCheckRollup(warning/skipped): %v", err)
+	}
+	if rollup2.Verdict != "success" {
+		t.Fatalf("verdict = %q for warning+skipped statuses, want success (never failure)", rollup2.Verdict)
+	}
+}
+
+// TestForgejoM4RollupFingerprintAdvancesOnStatusRerun pins the D1 fingerprint
+// contract: forgejo has no check-run IDs, so a re-posted status with an
+// UNCHANGED context+state must still advance the fingerprint via created_at —
+// otherwise a manual producer re-run looks identical to the exhausted run it
+// replaced and material progress never fires.
+func TestForgejoM4RollupFingerprintAdvancesOnStatusRerun(t *testing.T) {
+	statusBody := func(createdAt string) string {
+		return fmt.Sprintf(`{"state":"pending","total_count":1,"statuses":[
+			{"id":1,"context":"llm-review-opus","status":"pending","description":"","target_url":"","created_at":%q}]}`, createdAt)
+	}
+	run := func(createdAt string) string {
+		c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+			fjM4PullPath:   fjM4PullJSON(true, false, fjM4BaseHead),
+			fjM4StatusPath: statusBody(createdAt),
+		}))
+		rollup, err := c.PRCheckRollup(7)
+		if err != nil {
+			t.Fatalf("PRCheckRollup: %v", err)
+		}
+		return rollup.Fingerprint
+	}
+	first := run("2026-08-11T10:00:00Z")
+	same := run("2026-08-11T10:00:00Z")
+	rerun := run("2026-08-11T11:30:00Z")
+	if first != same {
+		t.Fatalf("identical statuses produced different fingerprints: %q vs %q", first, same)
+	}
+	if first == rerun {
+		t.Fatalf("re-run (new created_at, same context+state) did not advance the fingerprint: %q", first)
+	}
+}
+
+// TestGitHubFingerprintUnchangedByCreatedAtField pins github-mode invariance
+// of the M4 struct change: the gh path never populates CreatedAt (json:"-"),
+// so a gh-parsed status fingerprints exactly like the pre-M4 format.
+func TestGitHubFingerprintUnchangedByCreatedAtField(t *testing.T) {
+	var withField combinedStatusResponse
+	withField.State = "pending"
+	withField.Statuses = []combinedStatusEntry{{Context: "legacy", State: "pending"}}
+	parsed, err := parseCombinedStatus([]byte(`{"state":"pending","statuses":[{"context":"legacy","state":"pending","created_at":"2026-08-11T10:00:00Z"}]}`))
+	if err != nil {
+		t.Fatalf("parseCombinedStatus: %v", err)
+	}
+	if parsed.Statuses[0].CreatedAt != "" {
+		t.Fatalf("gh parse populated CreatedAt %q — GitHub fingerprints would all advance once on deploy", parsed.Statuses[0].CreatedAt)
+	}
+	if got, want := ciCheckRollupFingerprint(nil, parsed), ciCheckRollupFingerprint(nil, withField); got != want {
+		t.Fatalf("gh-parsed fingerprint %q != literal fingerprint %q", got, want)
+	}
+}
+
+func TestForgejoM4PRCheckRollup_HTTPError(t *testing.T) {
+	c, _, _ := newForgejoPortClient(t, func(r *http.Request) (int, string) {
+		if strings.HasSuffix(r.URL.Path, "/pulls/7") {
+			return 200, fjM4PullJSON(true, false, fjM4BaseHead)
+		}
+		return 500, `{"message":"boom"}`
+	})
+	rollup, err := c.PRCheckRollup(7)
+	if err == nil {
+		t.Fatal("a 500 on the status read must surface as an error")
+	}
+	if rollup.Verdict != "unknown" || rollup.HeadSHA != fjM4Head {
+		t.Fatalf("rollup = %+v, want verdict=unknown with the head preserved", rollup)
+	}
+	if errors.Is(err, ErrForgejoNotSupported) {
+		t.Fatalf("err = %v: a transport failure on a PORTED read must not claim not-supported", err)
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Fatalf("err = %v, want the HTTP status visible", err)
+	}
+}
+
+func TestForgejoM4PRChecksOutput(t *testing.T) {
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath: fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4StatusPath: `{"state":"pending","total_count":2,"statuses":[
+			{"id":1,"context":"llm-review-opus","status":"pending","description":"review queued","target_url":"","created_at":"2026-08-11T10:00:00Z"},
+			{"id":2,"context":"ci/test","status":"success","description":"","target_url":"","created_at":"2026-08-11T10:01:00Z"}
+		]}`,
+	}))
+	out, err := c.PRChecksOutput(7)
+	if err != nil {
+		t.Fatalf("PRChecksOutput: %v", err)
+	}
+	if !strings.Contains(out, "llm-review-opus\tpending\treview queued") || !strings.Contains(out, "ci/test\tsuccess") {
+		t.Fatalf("overview = %q, want status rows with description column", out)
+	}
+
+	c2, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath:   fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4StatusPath: `{"state":"","total_count":0,"statuses":null}`,
+	}))
+	out2, err := c2.PRChecksOutput(7)
+	if err != nil || out2 != "no checks\n" {
+		t.Fatalf("no-signal overview = %q, %v; want \"no checks\\n\"", out2, err)
+	}
+}
+
+func TestForgejoM4PRFailingChecks(t *testing.T) {
+	c, seen, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath: fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4StatusPath: `{"state":"failure","total_count":5,"statuses":[
+			{"id":1,"context":"ci/test","status":"failure","description":"2 tests failed in internal/worker","target_url":"","created_at":"2026-08-11T10:00:00Z"},
+			{"id":2,"context":"llm-review-opus","status":"error","description":"producer credentials missing","target_url":"","created_at":"2026-08-11T10:01:00Z"},
+			{"id":3,"context":"lint","status":"warning","description":"style nit","target_url":"","created_at":"2026-08-11T10:02:00Z"},
+			{"id":4,"context":"optional","status":"skipped","description":"","target_url":"","created_at":"2026-08-11T10:03:00Z"},
+			{"id":5,"context":"build","status":"success","description":"","target_url":"","created_at":"2026-08-11T10:04:00Z"}
+		]}`,
+	}))
+	failing, err := c.PRFailingChecks(7)
+	if err != nil {
+		t.Fatalf("PRFailingChecks: %v", err)
+	}
+	if len(failing) != 2 {
+		t.Fatalf("failing = %+v, want exactly failure+error (warning/skipped/success excluded)", failing)
+	}
+	if failing[0].Name != "ci/test" || failing[0].Conclusion != "failure" || failing[0].Excerpt != "2 tests failed in internal/worker" {
+		t.Fatalf("failing[0] = %+v: the status description must be the excerpt", failing[0])
+	}
+	if failing[1].Name != "llm-review-opus" || failing[1].Conclusion != "error" || failing[1].Excerpt != "producer credentials missing" {
+		t.Fatalf("failing[1] = %+v", failing[1])
+	}
+	if n := fjM4CountPaths(*seen, "check-runs"); n != 0 {
+		t.Fatal("check-run/annotation reads must not happen on forgejo")
+	}
+}
+
+func TestForgejoM4CIFailureSummary(t *testing.T) {
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath: fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4StatusPath: `{"state":"failure","total_count":2,"statuses":[
+			{"id":1,"context":"ci/test","status":"failure","description":"TestUmask failed","target_url":"https://forge.example.com/run/1","created_at":"2026-08-11T10:00:00Z"},
+			{"id":2,"context":"build","status":"success","description":"","target_url":"","created_at":"2026-08-11T10:01:00Z"}
+		]}`,
+	}))
+	summary, err := c.CIFailureSummary(7)
+	if err != nil {
+		t.Fatalf("CIFailureSummary: %v", err)
+	}
+	for _, want := range []string{
+		"CI Check Overview:",
+		"=== Failed check: ci/test ===",
+		"TestUmask failed",
+		"Details: https://forge.example.com/run/1",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("summary %q missing %q", summary, want)
+		}
+	}
+	if strings.Contains(summary, "=== Failed check: build ===") {
+		t.Fatal("a successful status must not get a failed-check section")
+	}
+
+	// No failed statuses -> the summary degrades to the plain overview.
+	c2, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath:   fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4StatusPath: `{"state":"success","total_count":1,"statuses":[{"id":1,"context":"build","status":"success","description":"","target_url":"","created_at":"2026-08-11T10:00:00Z"}]}`,
+	}))
+	summary2, err := c2.CIFailureSummary(7)
+	if err != nil || strings.Contains(summary2, "CI Check Overview:") {
+		t.Fatalf("summary = %q, %v; want the bare overview when nothing failed", summary2, err)
+	}
+}
+
+func TestForgejoM4CIFailureSummary_CapAt8000(t *testing.T) {
+	long := strings.Repeat("x", 9000)
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath:   fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4StatusPath: fmt.Sprintf(`{"state":"failure","total_count":1,"statuses":[{"id":1,"context":"ci/test","status":"failure","description":%q,"target_url":"","created_at":"2026-08-11T10:00:00Z"}]}`, long),
+	}))
+	summary, err := c.CIFailureSummary(7)
+	if err != nil {
+		t.Fatalf("CIFailureSummary: %v", err)
+	}
+	if !strings.HasSuffix(summary, "\n... (truncated)") || len(summary) > 8000+len("\n... (truncated)") {
+		t.Fatalf("summary length %d, truncated=%v; want the gh path's 8000-byte cap", len(summary), strings.HasSuffix(summary, "(truncated)"))
+	}
+}
+
+// --- D3: PRMergeStatus synthesis ---------------------------------------------
+
+func TestForgejoM4PRMergeStatus_UpToDate(t *testing.T) {
+	c, seen, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath:   fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4BranchPath: fjM4BranchJSON(),
+	}))
+	mergeable, mergeState, err := c.PRMergeStatus(7)
+	if err != nil {
+		t.Fatalf("PRMergeStatus: %v", err)
+	}
+	if mergeable != "MERGEABLE" || mergeState != "" {
+		t.Fatalf("= (%q, %q), want (MERGEABLE, \"\") for merge_base == base head", mergeable, mergeState)
+	}
+	if n := fjM4CountPaths(*seen, "/branches/"); n != 1 {
+		t.Fatalf("base branch head read %d times, want exactly 1 (never base.sha from the payload)", n)
+	}
+}
+
+func TestForgejoM4PRMergeStatus_Behind(t *testing.T) {
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath:   fjM4PullJSON(true, false, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		fjM4BranchPath: fjM4BranchJSON(),
+	}))
+	mergeable, mergeState, err := c.PRMergeStatus(7)
+	if err != nil {
+		t.Fatalf("PRMergeStatus: %v", err)
+	}
+	if mergeable != "MERGEABLE" || mergeState != "behind" {
+		t.Fatalf("= (%q, %q), want (MERGEABLE, behind): merge_base != current base head", mergeable, mergeState)
+	}
+}
+
+func TestForgejoM4PRMergeStatus_DirtyConflict(t *testing.T) {
+	c, seen, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath: fjM4PullJSON(false, false, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+	}))
+	mergeable, mergeState, err := c.PRMergeStatus(7)
+	if err != nil {
+		t.Fatalf("PRMergeStatus: %v", err)
+	}
+	if mergeable != "CONFLICTING" || mergeState != "dirty" {
+		t.Fatalf("= (%q, %q), want (CONFLICTING, dirty): non-draft wire mergeable=false wins over behind", mergeable, mergeState)
+	}
+	if n := fjM4CountPaths(*seen, "/branches/"); n != 0 {
+		t.Fatal("dirty must short-circuit before the base-head read")
+	}
+}
+
+// TestForgejoM4PRMergeStatus_DraftFalseMergeableIsNotDirty pins the draft rule
+// carried over from fjPullToREST: a draft's wire mergeable=false carries zero
+// conflict information (the server forces it false on every draft), so it maps
+// to UNKNOWN — and must NOT synthesize "dirty".
+func TestForgejoM4PRMergeStatus_DraftFalseMergeableIsNotDirty(t *testing.T) {
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath:   fjM4PullJSON(false, true, fjM4BaseHead),
+		fjM4BranchPath: fjM4BranchJSON(),
+	}))
+	mergeable, mergeState, err := c.PRMergeStatus(7)
+	if err != nil {
+		t.Fatalf("PRMergeStatus: %v", err)
+	}
+	if mergeable != "UNKNOWN" || mergeState != "" {
+		t.Fatalf("= (%q, %q), want (UNKNOWN, \"\") for a draft with the contaminated false", mergeable, mergeState)
+	}
+}
+
+func TestForgejoM4PRMergeStatus_EmptyMergeBase(t *testing.T) {
+	c, seen, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath: fjM4PullJSON(true, false, ""),
+	}))
+	mergeable, mergeState, err := c.PRMergeStatus(7)
+	if err != nil {
+		t.Fatalf("PRMergeStatus: %v", err)
+	}
+	if mergeable != "MERGEABLE" || mergeState != "" {
+		t.Fatalf("= (%q, %q), want (MERGEABLE, \"\") when merge_base is absent", mergeable, mergeState)
+	}
+	if n := fjM4CountPaths(*seen, "/branches/"); n != 0 {
+		t.Fatal("no base-head read without a merge_base to compare against")
+	}
+}
+
+// TestForgejoM4PRMergeStatus_NeverCleanOrUnstable sweeps the synthesis inputs
+// and pins the D3 invariant that unlocks nothing GitHub-shaped: "clean" and
+// "unstable" (the #424 promotion and mergeStateAllowsMerge triggers) are never
+// produced on forgejo.
+func TestForgejoM4PRMergeStatus_NeverCleanOrUnstable(t *testing.T) {
+	cases := []struct {
+		name      string
+		pull      string
+		wantState string
+	}{
+		{"up-to-date green", fjM4PullJSON(true, false, fjM4BaseHead), ""},
+		{"behind", fjM4PullJSON(true, false, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), "behind"},
+		{"conflict", fjM4PullJSON(false, false, fjM4BaseHead), "dirty"},
+		{"draft", fjM4PullJSON(false, true, fjM4BaseHead), ""},
+		{"no merge_base", fjM4PullJSON(true, false, ""), ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+				fjM4PullPath:   tc.pull,
+				fjM4BranchPath: fjM4BranchJSON(),
+			}))
+			_, mergeState, err := c.PRMergeStatus(7)
+			if err != nil {
+				t.Fatalf("PRMergeStatus: %v", err)
+			}
+			if mergeState == "clean" || mergeState == "unstable" {
+				t.Fatalf("mergeState = %q — must never be synthesized on forgejo (#424/#425 escapes)", mergeState)
+			}
+			if mergeState != tc.wantState {
+				t.Fatalf("mergeState = %q, want %q", mergeState, tc.wantState)
+			}
+		})
+	}
+}
+
+// --- D4: review-gate reads ---------------------------------------------------
+
+// fjM4ReviewFixtures wires reviews + per-review comments for the inline
+// reader: review 45 is a producer-style one-comment COMMENT review anchored
+// to the head; review 46 is a migrated review with an EMPTY review-level
+// commit_id (per-comment commit_id is the fallback); review 47 is body-only
+// (comments_count 0) and must not trigger a comments round trip.
+func fjM4ReviewFixtures() map[string]string {
+	return map[string]string{
+		fjM4ReviewsPath: fmt.Sprintf(`[
+			{"id":45,"user":{"login":"oklabs-bot"},"state":"COMMENT","body":"","commit_id":%q,"submitted_at":"2026-08-11T10:00:00Z","comments_count":1},
+			{"id":46,"user":{"login":"Ghost"},"state":"COMMENT","body":"","commit_id":"","submitted_at":"2026-08-11T10:01:00Z","comments_count":1},
+			{"id":47,"user":{"login":"oklabs-bot"},"state":"APPROVED","body":"lgtm","commit_id":%q,"submitted_at":"2026-08-11T10:02:00Z","comments_count":0}
+		]`, fjM4Head, fjM4Head),
+		fjM4ReviewsPath + "/45/comments": `[
+			{"id":901,"body":"[P0] llm-review-opus: nil deref in reconcile","user":{"login":"oklabs-bot"},"path":"internal/x/x.go","commit_id":"1111111111111111111111111111111111111111","original_commit_id":"","position":12,"original_position":0,"created_at":"2026-08-11T10:00:00Z","line":999,"new_position":888}
+		]`,
+		fjM4ReviewsPath + "/46/comments": fmt.Sprintf(`[
+			{"id":902,"body":"[P2] llm-review-terra: naming nit","user":{"login":"Ghost"},"path":"internal/y/y.go","commit_id":%q,"original_commit_id":"","position":3,"original_position":0,"created_at":"2026-08-11T10:01:00Z"}
+		]`, fjM4Head),
+	}
+}
+
+func TestForgejoM4ReviewComments_MappingAndAnchoring(t *testing.T) {
+	routes := fjM4ReviewFixtures()
+	routes[fjM4PullPath] = fjM4PullJSON(true, false, fjM4BaseHead)
+	c, seen, _ := newForgejoPortClient(t, fjRoute(t, routes))
+
+	comments, err := c.greptileReviewComments(7)
+	if err != nil {
+		t.Fatalf("greptileReviewComments: %v", err)
+	}
+	if len(comments) != 2 {
+		t.Fatalf("comments = %+v, want two (body-only review skipped)", comments)
+	}
+	// Review 45: the REVIEW-level commit_id anchors, beating the per-comment
+	// decoy — without this reviewCommentTargetsHead leaks historical findings
+	// across heads.
+	if comments[0].CommitID != fjM4Head {
+		t.Fatalf("comment[0].CommitID = %q, want the review-level anchor %q (per-comment decoy must lose)", comments[0].CommitID, fjM4Head)
+	}
+	// Line comes from `position` (the read-side line number); the `line` /
+	// `new_position` decoys in the fixture must not be decoded.
+	if comments[0].Line != 12 {
+		t.Fatalf("comment[0].Line = %d, want 12 (wire position)", comments[0].Line)
+	}
+	if comments[0].User.Login != "oklabs-bot" || comments[0].Path != "internal/x/x.go" {
+		t.Fatalf("comment[0] = %+v", comments[0])
+	}
+	if comments[0].OriginalCommitID != "" {
+		t.Fatalf("OriginalCommitID = %q, want empty (deliberately unmapped — CommitID is the head anchor)", comments[0].OriginalCommitID)
+	}
+	// Review 46: empty review-level commit_id falls back to the per-comment one.
+	if comments[1].CommitID != fjM4Head {
+		t.Fatalf("comment[1].CommitID = %q, want the per-comment fallback %q", comments[1].CommitID, fjM4Head)
+	}
+	for _, req := range *seen {
+		if strings.Contains(req.Path, "/47/comments") {
+			t.Fatal("a body-only review (comments_count 0) must not trigger a comments round trip")
+		}
+	}
+}
+
+// TestForgejoM4PRReviewGateVerdict_DefaultStreamsAndSuccess pins the D4
+// default: a forgejo-mode client with EMPTY streams gates on the llm-review
+// pair (never the greptile default, which would sit unobserved forever).
+func TestForgejoM4PRReviewGateVerdict_DefaultStreamsAndSuccess(t *testing.T) {
+	c, seen, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath: fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4StatusPath: `{"state":"success","total_count":2,"statuses":[
+			{"id":1,"context":"llm-review-opus","status":"success","description":"","target_url":"","created_at":"2026-08-11T10:00:00Z"},
+			{"id":2,"context":"llm-review-terra","status":"success","description":"","target_url":"","created_at":"2026-08-11T10:01:00Z"}
+		]}`,
+		fjM4ReviewsPath: `[]`,
+	}))
+	verdict, err := c.PRReviewGateVerdict(7, nil)
+	if err != nil {
+		t.Fatalf("PRReviewGateVerdict: %v", err)
+	}
+	if len(verdict.Streams) != 2 || verdict.Streams[0].Name != "llm-review-opus" || verdict.Streams[1].Name != "llm-review-terra" {
+		t.Fatalf("streams = %+v, want the llm-review pair as the forgejo default", verdict.Streams)
+	}
+	if !verdict.Passed || verdict.Pending || !verdict.Observed {
+		t.Fatalf("verdict = %+v, want passed+observed on two success statuses", verdict)
+	}
+	if n := fjM4CountPaths(*seen, "check-runs"); n != 0 {
+		t.Fatal("the check-runs read must be skipped entirely on forgejo")
+	}
+}
+
+// TestForgejoM4NamedStreamVerdict_ErrorStatusIsRejection pins the #1148
+// producer escape on forgejo: a creds-missing lens posts state "error", which
+// must read as found-NOT-passed (hard rejection with the named finding) —
+// never as pending, which would hold the PR forever.
+func TestForgejoM4NamedStreamVerdict_ErrorStatusIsRejection(t *testing.T) {
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath:    fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4StatusPath:  `{"state":"error","total_count":1,"statuses":[{"id":1,"context":"llm-review-opus","status":"error","description":"credentials missing","target_url":"","created_at":"2026-08-11T10:00:00Z"}]}`,
+		fjM4ReviewsPath: `[]`,
+	}))
+	verdict, err := c.PRReviewGateVerdict(7, []string{"llm-review-opus"})
+	if err != nil {
+		t.Fatalf("PRReviewGateVerdict: %v", err)
+	}
+	if verdict.Passed || verdict.Pending {
+		t.Fatalf("verdict = %+v, want rejection (not passed, NOT pending) on an error status", verdict)
+	}
+	if len(verdict.Streams) != 1 || !verdict.Streams[0].Observed {
+		t.Fatalf("streams = %+v, want one observed stream", verdict.Streams)
+	}
+	findings := verdict.BlockingFindings()
+	if len(findings) != 1 || findings[0].Body != "llm-review-opus review check did not pass" {
+		t.Fatalf("findings = %+v, want the named did-not-pass finding", findings)
+	}
+}
+
+func TestForgejoM4NamedStreamVerdict_PendingStatusBlocks(t *testing.T) {
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath:    fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4StatusPath:  `{"state":"pending","total_count":1,"statuses":[{"id":1,"context":"llm-review-opus","status":"pending","description":"queued","target_url":"","created_at":"2026-08-11T10:00:00Z"}]}`,
+		fjM4ReviewsPath: `[]`,
+	}))
+	verdict, err := c.PRReviewGateVerdict(7, []string{"llm-review-opus"})
+	if err != nil {
+		t.Fatalf("PRReviewGateVerdict: %v", err)
+	}
+	if !verdict.Pending || verdict.Passed || !verdict.Observed {
+		t.Fatalf("verdict = %+v, want pending+observed on a pending status", verdict)
+	}
+}
+
+// TestForgejoM4SimplicityStreamUnobserved pins the D4 decision that a stream
+// without AllowCommitStatus has NO external verdict source on forgejo: no
+// status read happens and the stream reports unobserved-pending (the
+// missing-review policy's signal), not a fabricated verdict.
+func TestForgejoM4SimplicityStreamUnobserved(t *testing.T) {
+	c, seen, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath:    fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4ReviewsPath: `[]`,
+	}))
+	verdict, err := c.PRReviewGateVerdict(7, []string{"simplicity"})
+	if err != nil {
+		t.Fatalf("PRReviewGateVerdict: %v", err)
+	}
+	if len(verdict.Streams) != 1 {
+		t.Fatalf("streams = %+v", verdict.Streams)
+	}
+	sv := verdict.Streams[0]
+	if !sv.Pending || sv.Observed || sv.LookupFailed {
+		t.Fatalf("simplicity stream = %+v, want unobserved pending with clean reads", sv)
+	}
+	if n := fjM4CountPaths(*seen, "/status"); n != 0 {
+		t.Fatal("a stream without AllowCommitStatus must not read the combined status")
+	}
+}
+
+func TestForgejoM4PRHasCriticalReviewOnHead(t *testing.T) {
+	routes := fjM4ReviewFixtures()
+	routes[fjM4PullPath] = fjM4PullJSON(true, false, fjM4BaseHead)
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, routes))
+
+	// llm arm live: the P0 comment on head from the fleet bot blocks when the
+	// llm streams are configured.
+	critical, err := c.PRHasCriticalReviewOnHead(7, []string{"llm-review"})
+	if err != nil {
+		t.Fatalf("PRHasCriticalReviewOnHead: %v", err)
+	}
+	if !critical {
+		t.Fatal("a P0 llm-review comment on head must block with llm streams configured")
+	}
+	// Without llm streams the llm arm is off, and the greptile arm never
+	// matches on forgejo (no greptile bot) — naturally skipped, not guarded.
+	critical, err = c.PRHasCriticalReviewOnHead(7, nil)
+	if err != nil {
+		t.Fatalf("PRHasCriticalReviewOnHead(nil streams): %v", err)
+	}
+	if critical {
+		t.Fatal("without llm streams the fleet-bot P0 must not count (greptile arm cannot match on forgejo)")
+	}
+}
+
+func TestForgejoM4CollectReviewFeedback(t *testing.T) {
+	routes := fjM4ReviewFixtures()
+	routes[fjM4PullPath] = fjM4PullJSON(true, false, fjM4BaseHead)
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, routes))
+
+	comments, err := c.CollectReviewFeedback(7, []string{"llm-review"})
+	if err != nil {
+		t.Fatalf("CollectReviewFeedback: %v", err)
+	}
+	if len(comments) != 1 || comments[0].User != "oklabs-bot" || comments[0].Path != "internal/x/x.go" || comments[0].Line != 12 {
+		t.Fatalf("comments = %+v, want exactly the head-anchored oklabs-bot finding (Ghost is not a collectable login)", comments)
+	}
+}
+
+func TestForgejoM4CollectPRReviewFeedback(t *testing.T) {
+	routes := fjM4ReviewFixtures()
+	routes[fjM4PullPath] = fjM4PullJSON(true, false, fjM4BaseHead)
+	routes["/repos/"+fjTestRepo+"/issues/7/comments"] = `[
+		{"id":1,"body":"llm-review summary: changes requested in internal/x/x.go:12","user":{"login":"oklabs-bot"},"created_at":"2026-08-11T10:00:00Z"},
+		{"id":2,"body":"unrelated human chatter","user":{"login":"oleg"},"created_at":"2026-08-11T10:01:00Z"}
+	]`
+	c, seen, _ := newForgejoPortClient(t, fjRoute(t, routes))
+
+	feedback, err := c.CollectPRReviewFeedback(7, []string{"llm-review"})
+	if err != nil {
+		t.Fatalf("CollectPRReviewFeedback: %v", err)
+	}
+	if !strings.Contains(feedback, "llm-review summary: changes requested") {
+		t.Fatalf("feedback %q missing the issue-level summary section", feedback)
+	}
+	if !strings.Contains(feedback, "internal/x/x.go") || !strings.Contains(feedback, "[P0] llm-review-opus") {
+		t.Fatalf("feedback %q missing the inline finding", feedback)
+	}
+	if strings.Contains(feedback, "unrelated human chatter") {
+		t.Fatal("non-reviewer comments must not be collected")
+	}
+	if n := fjM4CountPaths(*seen, "/issues/7/comments"); n != 1 {
+		t.Fatalf("issue comments read %d times via the forgejo route, want 1", n)
+	}
+}
+
+// --- D5: mergegate review-thread shim ----------------------------------------
+
+func TestForgejoM4ReviewThreadShim(t *testing.T) {
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath: fjM4PullJSON(true, false, fjM4BaseHead),
+	}))
+	head, threads, err := c.PRUnresolvedReviewThreadsOnHead(7)
+	if err != nil {
+		t.Fatalf("PRUnresolvedReviewThreadsOnHead: %v", err)
+	}
+	if head != fjM4Head {
+		t.Fatalf("head = %q, want the pull's current head %q (the boundary's second head read)", head, fjM4Head)
+	}
+	if threads != nil {
+		t.Fatalf("threads = %+v, want nil (no unresolved-conversations API on forgejo)", threads)
+	}
+}
+
+func TestForgejoM4ReviewThreadShim_EmptyHeadRefuses(t *testing.T) {
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath: `{"number":7,"title":"t","body":"","state":"open","draft":false,"mergeable":true,"merged_at":null,"merge_commit_sha":null,"merge_base":"","head":{"ref":"feat/x","sha":""},"base":{"ref":"main"}}`,
+	}))
+	_, _, err := c.PRUnresolvedReviewThreadsOnHead(7)
+	if err == nil || !strings.Contains(err.Error(), "head SHA is empty") {
+		t.Fatalf("err = %v, want the empty-head refusal preserved", err)
+	}
+}

--- a/internal/github/forgejo_port_m4_test.go
+++ b/internal/github/forgejo_port_m4_test.go
@@ -512,6 +512,47 @@ func TestForgejoM4ReviewComments_MappingAndAnchoring(t *testing.T) {
 	}
 }
 
+// TestForgejoM4ReviewComments_BothCommitIDsEmptyMatchesEveryHead pins the
+// degenerate end of the D4 anchoring chain: when BOTH the review-level and the
+// per-comment commit_id are empty there is no anchor left, CommitID maps to ""
+// and reviewCommentTargetsHead's lenient arm (the same one gh-mode comments
+// take) matches EVERY head — so such a finding is never filtered out by a
+// force-push and can leak across heads. Not a regression to fix here: it is
+// exactly the gh behavior for an anchorless comment, and the llm-review
+// producer always anchors. Pinned so any future change to that arm is visible.
+func TestForgejoM4ReviewComments_BothCommitIDsEmptyMatchesEveryHead(t *testing.T) {
+	c, _, _ := newForgejoPortClient(t, fjRoute(t, map[string]string{
+		fjM4PullPath: fjM4PullJSON(true, false, fjM4BaseHead),
+		fjM4ReviewsPath: `[
+			{"id":48,"user":{"login":"Ghost"},"state":"COMMENT","body":"","commit_id":"","submitted_at":"2026-08-11T10:03:00Z","comments_count":1}
+		]`,
+		fjM4ReviewsPath + "/48/comments": `[
+			{"id":903,"body":"[P1] anchorless legacy finding","user":{"login":"Ghost"},"path":"internal/z/z.go","commit_id":"","original_commit_id":"","position":7,"created_at":"2026-08-11T10:03:00Z"}
+		]`,
+	}))
+
+	comments, err := c.greptileReviewComments(7)
+	if err != nil {
+		t.Fatalf("greptileReviewComments: %v", err)
+	}
+	if len(comments) != 1 {
+		t.Fatalf("comments = %+v, want one", comments)
+	}
+	if comments[0].CommitID != "" {
+		t.Fatalf("CommitID = %q, want empty — neither the review nor the comment carried an anchor", comments[0].CommitID)
+	}
+	if comments[0].OriginalCommitID != "" {
+		t.Fatalf("OriginalCommitID = %q, want empty (deliberately unmapped)", comments[0].OriginalCommitID)
+	}
+	// The lenient arm: an anchorless comment targets any head, including one
+	// that is not the head it was written against.
+	for _, head := range []string{fjM4Head, strings.Repeat("f", 40), ""} {
+		if !reviewCommentTargetsHead(comments[0], head) {
+			t.Fatalf("reviewCommentTargetsHead(head=%q) = false, want true (empty CommitID matches every head, gh-mode parity)", head)
+		}
+	}
+}
+
 // TestForgejoM4PRReviewGateVerdict_DefaultStreamsAndSuccess pins the D4
 // default: a forgejo-mode client with EMPTY streams gates on the llm-review
 // pair (never the greptile default, which would sit unobserved forever).

--- a/internal/github/forgejo_port_test.go
+++ b/internal/github/forgejo_port_test.go
@@ -646,7 +646,12 @@ func TestForgejoPortHTTPErrorSurfaces(t *testing.T) {
 // TestForgejoPortGuardsMakeNoRequests pins the explicit NOT-ported guards: the
 // methods that would half-work now that their underlying funnels are ported
 // must fail with the sentinel BEFORE any Forgejo request — a half-executed
-// read would waste quota and, worse, look like partial support.
+// read would waste quota and, worse, look like partial support. M4 flipped
+// the check-runs/status + review-gate + merge-state family to ported (their
+// forgejo-mode coverage lives in forgejo_port_m4_test.go); what remains
+// guarded is the greptile-only family — every read they'd make IS ported, so
+// each would otherwise half-work forever ("pending"/"no findings" on a
+// reviewer that never posts on forgejo).
 func TestForgejoPortGuardsMakeNoRequests(t *testing.T) {
 	c, seen, ghCalls := newForgejoPortClient(t, func(*http.Request) (int, string) {
 		return 200, `{}`
@@ -655,12 +660,10 @@ func TestForgejoPortGuardsMakeNoRequests(t *testing.T) {
 		name string
 		call func() error
 	}{
-		{"PRMergeStatus", func() error { _, _, err := c.PRMergeStatus(1); return err }},
-		{"PRCheckRollup", func() error { _, err := c.PRCheckRollup(1); return err }},
-		{"PRCIStatus", func() error { _, err := c.PRCIStatus(1); return err }},
-		{"PRChecksOutput", func() error { _, err := c.PRChecksOutput(1); return err }},
-		{"CIFailureSummary", func() error { _, err := c.CIFailureSummary(1); return err }},
-		{"CollectPRReviewFeedback", func() error { _, err := c.CollectPRReviewFeedback(1, nil); return err }},
+		{"PRGreptileApproved", func() error { _, _, err := c.PRGreptileApproved(1); return err }},
+		{"prGreptileReviewStreamVerdict", func() error { _, err := c.prGreptileReviewStreamVerdict(1); return err }},
+		{"greptileReviewStreamVerdict", func() error { _, err := c.greptileReviewStreamVerdict(1); return err }},
+		{"PRHighSeverityReviewOnHead", func() error { _, _, _, err := c.PRHighSeverityReviewOnHead(1); return err }},
 	}
 	for _, g := range guards {
 		err := g.call()

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -51,14 +51,23 @@ type checkRunsResponse struct {
 	CheckRuns []greptileCheckRun `json:"check_runs"`
 }
 
+// combinedStatusEntry is one per-context row of a combined commit status.
+// CreatedAt is deliberately json:"-": it is populated ONLY by the forgejo
+// mapping (fjCombinedStatusForSHA). Forgejo has no check-run IDs, so a
+// status's created_at is what advances the CI rollup fingerprint on a re-run;
+// on the gh path the field stays empty (GitHub's wire created_at is NOT
+// decoded), keeping GitHub fingerprints byte-identical to their pre-M4 form.
+type combinedStatusEntry struct {
+	Context     string `json:"context"`
+	State       string `json:"state"`
+	Description string `json:"description"`
+	TargetURL   string `json:"target_url"`
+	CreatedAt   string `json:"-"`
+}
+
 type combinedStatusResponse struct {
-	State    string `json:"state"`
-	Statuses []struct {
-		Context     string `json:"context"`
-		State       string `json:"state"`
-		Description string `json:"description"`
-		TargetURL   string `json:"target_url"`
-	} `json:"statuses"`
+	State    string                `json:"state"`
+	Statuses []combinedStatusEntry `json:"statuses"`
 }
 
 type greptileReviewComment struct {
@@ -2467,11 +2476,10 @@ type PRCheckSignal struct {
 // partial poll cannot fabricate material progress.
 func (c *Client) PRCheckRollup(prNumber int) (PRCheckRollup, error) {
 	if c.isForgejo() {
-		// NOT ported in M2 (status rollup is M4), guarded explicitly: the
-		// head-SHA read below is ported and would succeed, and the joint
-		// check-runs/status failure after it formats with %v — which would
-		// strip errors.Is matchability from the sentinel.
-		return PRCheckRollup{Verdict: "unknown"}, c.forgejoUnsupported("PRCheckRollup (check-runs/status rollup; M4)")
+		// #1172 M4: statuses-only rollup — Forgejo has no check-runs API, so
+		// the combined commit status IS the whole CI signal (see
+		// fjPRCheckRollup for the no-signal parity contract).
+		return c.fjPRCheckRollup(prNumber)
 	}
 	sha, err := c.pullHeadSHA(prNumber)
 	if err != nil {
@@ -2522,8 +2530,18 @@ func ciCheckRollupFingerprint(checks []greptileCheckRun, combined combinedStatus
 			check.ID, strings.TrimSpace(check.Name), strings.ToLower(strings.TrimSpace(check.Status)), strings.ToLower(strings.TrimSpace(check.Conclusion))))
 	}
 	for _, status := range combined.Statuses {
-		parts = append(parts, fmt.Sprintf("status:%s:%s",
-			strings.TrimSpace(status.Context), strings.ToLower(strings.TrimSpace(status.State))))
+		part := fmt.Sprintf("status:%s:%s",
+			strings.TrimSpace(status.Context), strings.ToLower(strings.TrimSpace(status.State)))
+		// Forgejo (#1172 M4): statuses are the ONLY CI signal — there are no
+		// check-run IDs to advance the fingerprint on a re-run, so each
+		// status's created_at (RFC3339, verbatim wire string) is mixed in and
+		// a re-posted status with an unchanged state still advances material
+		// progress. Empty on the gh path (see combinedStatusEntry), where the
+		// part format therefore stays exactly `status:<context>:<state>`.
+		if createdAt := strings.TrimSpace(status.CreatedAt); createdAt != "" {
+			part += ":" + createdAt
+		}
+		parts = append(parts, part)
 	}
 	sort.Strings(parts)
 	h := sha256.New()
@@ -2584,13 +2602,11 @@ func (c *Client) PRMergeable(prNumber int) (string, error) {
 // computed it yet (caller should treat that as "don't know, proceed").
 func (c *Client) PRMergeStatus(prNumber int) (mergeable string, mergeStateStatus string, err error) {
 	if c.isForgejo() {
-		// NOT ported in M2, guarded explicitly: getRESTPull IS ported, so
-		// without this the method would "work" — returning the mergeable
-		// verdict plus a permanently-empty mergeable_state, which callers
-		// read as "GitHub has not computed it yet, proceed". Forgejo has no
-		// mergeable_state equivalent; the behind-vs-conflict semantics land
-		// in M4. PRMergeable (the bool verdict alone) IS ported.
-		return "", "", c.forgejoUnsupported("PRMergeStatus (no mergeable_state equivalent on forgejo; M4)")
+		// #1172 M4: forgejo has no mergeable_state — fjPRMergeStatus
+		// SYNTHESIZES the vocabulary from merge_base + the wire mergeable
+		// bool ("behind" / "dirty" / ""), and deliberately NEVER "clean" or
+		// "unstable" — see fjPRMergeStatus for the full consequence map.
+		return c.fjPRMergeStatus(prNumber)
 	}
 	pr, err := c.getRESTPull(prNumber)
 	if err != nil {
@@ -2615,6 +2631,13 @@ func (c *Client) PRMergeStatus(prNumber int) (mergeable string, mergeStateStatus
 //   - comment found but not approving → approved=false, pending=false
 //   - no greptile signal at all → pending=true
 func (c *Client) PRGreptileApproved(prNumber int) (approved bool, pending bool, err error) {
+	if c.isForgejo() {
+		// Greptile is a GitHub-integrated product and never posts on a
+		// Forgejo instance — a forgejo row consulting this gate would wait
+		// forever on a reviewer that cannot appear. Explicit sentinel guard
+		// (#1172 M4); forgejo rows use the llm-review streams instead.
+		return false, false, c.forgejoUnsupported("PRGreptileApproved (greptile is GitHub-only)")
+	}
 	verdict, err := c.prGreptileReviewStreamVerdict(prNumber)
 	if err != nil {
 		return false, false, err
@@ -2645,6 +2668,14 @@ var (
 )
 
 func (c *Client) prGreptileReviewStreamVerdict(prNumber int) (ReviewStreamVerdict, error) {
+	if c.isForgejo() {
+		// Explicit sentinel guard (#1172 M4): the head-SHA and comment reads
+		// below are ported, so without it this greptile-only verdict would
+		// half-work — permanently "pending, unobserved" on a reviewer that
+		// never posts on forgejo. The commitCommittedAt comment fallback stays
+		// github-only behind this guard (unreachable on forgejo).
+		return ReviewStreamVerdict{}, c.forgejoUnsupported("greptile review stream verdict (greptile is GitHub-only)")
+	}
 	// checkLookupFailed marks a degraded read: absence of a signal below then
 	// means "unknown", not "the reviewer is silent".
 	var checkLookupFailed bool
@@ -3118,6 +3149,14 @@ func (c *Client) PRHasCriticalReviewOnHead(prNumber int, streams []string) (bool
 // path takes over) and a non-nil error only when the upstream lookups
 // fail — never use error as a "no findings" signal.
 func (c *Client) PRHighSeverityReviewOnHead(prNumber int) (sha string, findings []ReviewComment, hasFindings bool, err error) {
+	if c.isForgejo() {
+		// Explicit sentinel guard (#1172 M4): both reads below are ported, so
+		// this greptile-only scan (isGreptileLogin filter) would half-work on
+		// forgejo — always hasFindings=false with a nil error, silently
+		// disabling the repair scope. llm-review findings flow through
+		// PRBlockingReviewFindingsOnHead, which IS live on forgejo.
+		return "", nil, false, c.forgejoUnsupported("PRHighSeverityReviewOnHead (greptile is GitHub-only)")
+	}
 	sha, err = c.pullHeadSHA(prNumber)
 	if err != nil {
 		return "", nil, false, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
@@ -3147,6 +3186,13 @@ func (c *Client) PRHighSeverityReviewOnHead(prNumber int) (sha string, findings 
 }
 
 func (c *Client) greptileReviewComments(prNumber int) ([]greptileReviewComment, error) {
+	if c.isForgejo() {
+		// #1172 M4: the generic inline-comment reader (despite the name) —
+		// forgejo has no flat pulls/{n}/comments endpoint, so this walks
+		// reviews + per-review comments. See fjReviewComments for the
+		// CommitID head-anchoring contract.
+		return c.fjReviewComments(prNumber)
+	}
 	// Routed through the shared wrapper (#797) so this per-cycle read gets the
 	// rate-limit backoff, the conditional-request cache, and usage accounting.
 	out, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/pulls/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
@@ -3189,10 +3235,8 @@ func (c *Client) ClosePR(prNumber int, comment string) error {
 // capturing CI failure details to pass to retry workers.
 func (c *Client) PRChecksOutput(prNumber int) (string, error) {
 	if c.isForgejo() {
-		// NOT ported in M2, guarded explicitly: same %v-formatting hazard as
-		// PRCheckRollup — the ported head-SHA read would succeed and the
-		// joint failure below would lose the sentinel.
-		return "", c.forgejoUnsupported("PRChecksOutput (check-runs/status rollup; M4)")
+		// #1172 M4: statuses-only overview (no check-runs exist on forgejo).
+		return c.fjPRChecksOutput(prNumber)
 	}
 	sha, err := c.pullHeadSHA(prNumber)
 	if err != nil {
@@ -3225,6 +3269,12 @@ type FailingCheck struct {
 // failing leaves the excerpt empty rather than erroring, so the caller still
 // names the check. A nil slice means no check is failing.
 func (c *Client) PRFailingChecks(prNumber int) ([]FailingCheck, error) {
+	if c.isForgejo() {
+		// #1172 M4: on forgejo the failing "checks" are commit statuses in
+		// state failure/error, and the status Description is the only
+		// actionable text (there are no check-run outputs or annotations).
+		return c.fjPRFailingChecks(prNumber)
+	}
 	sha, err := c.pullHeadSHA(prNumber)
 	if err != nil {
 		return nil, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
@@ -4196,6 +4246,15 @@ func (c *Client) CollectReviewFeedback(prNumber int, streams []string) ([]Review
 }
 
 func (c *Client) PRReviewGateVerdict(prNumber int, streams []string) (ReviewGateVerdict, error) {
+	if c.isForgejo() && len(streams) == 0 {
+		// #1172 M4: normalizeReviewStreams's empty default is ["greptile"],
+		// but Greptile dies with GitHub — a forgejo row falling into that
+		// default would sit unobserved forever (the bot never posts there).
+		// Forgejo-mode clients default to the llm-review pair instead; config
+		// validation independently rejects greptile/simplicity streams on
+		// forgejo rows, so this belt only catches callers passing no streams.
+		streams = []string{"llm-review-opus", "llm-review-terra"}
+	}
 	normalized := normalizeReviewStreams(streams)
 	verdict := ReviewGateVerdict{Passed: true}
 	if len(normalized) == 0 {
@@ -4319,25 +4378,56 @@ func (c *Client) namedReviewStreamVerdict(prNumber int, spec reviewStreamSpec) (
 	if err != nil {
 		return ReviewStreamVerdict{}, fmt.Errorf("get pull %d head sha: %w", prNumber, err)
 	}
-	checks, checkErr := c.checkRunsForSHA(sha)
-	var checkFound, checkPassed, checkPending bool
-	if checkErr == nil {
-		checkFound, checkPassed, checkPending = namedCheckDecision(checks, spec.CheckContains)
-	}
-	// The llm-review glue posts plain commit statuses (a normal token cannot
-	// create check runs — those need a GitHub App). When no check run spoke
-	// for this stream, look at the combined status for the same needles.
-	var statusErr error
-	if spec.AllowCommitStatus && !checkFound {
-		var combined combinedStatusResponse
-		combined, statusErr = c.combinedStatusForSHA(sha)
-		if statusErr == nil {
-			checkFound, checkPassed, checkPending = namedStatusDecision(combined, spec.CheckContains)
+	var (
+		checkFound, checkPassed, checkPending bool
+		checkErr, statusErr                   error
+	)
+	if c.isForgejo() {
+		// #1172 M4: forgejo has NO check-runs API — the check-runs read is
+		// skipped entirely and a stream's external verdict can only arrive as
+		// a commit status. Streams without AllowCommitStatus (simplicity)
+		// therefore have no external verdict source on forgejo and stay
+		// unobserved unless they post inline findings — deliberate: the
+		// missing-review policy handles the silent gate, it must not hang.
+		// Note namedStatusDecision maps state "error" to found-not-passed
+		// (hard rejection, the #1148 creds-missing escape), never pending.
+		if spec.AllowCommitStatus {
+			var combined combinedStatusResponse
+			combined, statusErr = c.fjCombinedStatusForSHA(sha)
+			if statusErr == nil {
+				checkFound, checkPassed, checkPending = namedStatusDecision(combined, spec.CheckContains)
+			}
+		}
+	} else {
+		var checks []greptileCheckRun
+		checks, checkErr = c.checkRunsForSHA(sha)
+		if checkErr == nil {
+			checkFound, checkPassed, checkPending = namedCheckDecision(checks, spec.CheckContains)
+		}
+		// The llm-review glue posts plain commit statuses (a normal token cannot
+		// create check runs — those need a GitHub App). When no check run spoke
+		// for this stream, look at the combined status for the same needles.
+		if spec.AllowCommitStatus && !checkFound {
+			var combined combinedStatusResponse
+			combined, statusErr = c.combinedStatusForSHA(sha)
+			if statusErr == nil {
+				checkFound, checkPassed, checkPending = namedStatusDecision(combined, spec.CheckContains)
+			}
 		}
 	}
 	findings, commentsErr := c.reviewFindingsForStream(prNumber, sha, spec)
-	if commentsErr != nil && checkErr != nil {
-		return ReviewStreamVerdict{}, commentsErr
+	if commentsErr != nil {
+		if checkErr != nil {
+			return ReviewStreamVerdict{}, commentsErr
+		}
+		// Forgejo: comments are one of only two evidence sources (no check
+		// runs exist). When the status read also failed — or was never
+		// attempted because the stream cannot post statuses — nothing was
+		// read at all, so fail loud like the gh joint-failure arm above
+		// instead of returning a verdict built on zero evidence.
+		if c.isForgejo() && (statusErr != nil || !spec.AllowCommitStatus) {
+			return ReviewStreamVerdict{}, commentsErr
+		}
 	}
 	sv := ReviewStreamVerdict{Name: spec.Name, Passed: false, Pending: false, Findings: findings}
 	// A check run in any state, or an inline finding, means the reviewer spoke
@@ -4630,11 +4720,10 @@ func FormatReviewFeedback(comments []ReviewComment) string {
 // CIFailureSummary gets the CI check run failure summary for a PR.
 func (c *Client) CIFailureSummary(prNumber int) (string, error) {
 	if c.isForgejo() {
-		// NOT ported in M2, guarded explicitly: every downstream error here
-		// is deliberately swallowed (the summary degrades to the overview),
-		// so without a guard forgejo mode would return an error STRING as a
-		// nil-error "summary" and feed it into a retry-worker prompt.
-		return "", c.forgejoUnsupported("CIFailureSummary (check-runs; M4)")
+		// #1172 M4: overview + per-failed-status description (no check-run
+		// Output/annotations exist on forgejo), same 8000-byte cap and the
+		// same error-swallowing degradation semantics as the gh path.
+		return c.fjCIFailureSummary(prNumber)
 	}
 	// 1. Get check overview
 	overview, err := c.PRChecksOutput(prNumber)
@@ -4704,19 +4793,22 @@ func (c *Client) CIFailureSummary(prNumber int) (string, error) {
 // into a worker prompt, or empty string if no actionable review feedback
 // exists.
 func (c *Client) CollectPRReviewFeedback(prNumber int, streams []string) (string, error) {
-	if c.isForgejo() {
-		// NOT ported in M2 (review-gate family is M4), guarded explicitly:
-		// both reads below swallow errors by design ("no feedback" degrades
-		// to empty), so forgejo mode would silently report "no review
-		// feedback" with a nil error instead of failing loud.
-		return "", c.forgejoUnsupported("CollectPRReviewFeedback (review-gate family; M4)")
-	}
 	var sections []string
 
-	// 1. Fetch issue-level comments (Greptile summary with confidence score),
-	// via the shared wrapper (#797) for backoff + conditional caching.
-	issueCommentsOut, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, prNumber), "--paginate")
-	if err == nil {
+	// 1. Fetch issue-level summary comments. Forgejo (#1172 M4): via the
+	// ported issue-comments read (pulls share the issue number space); gh: via
+	// the shared wrapper (#797) for backoff + conditional caching. Both arms
+	// keep the historical error-swallowing semantics — a failed comments read
+	// degrades to "no summary sections", never an error.
+	if c.isForgejo() {
+		if comments, err := c.fjListIssueComments(prNumber); err == nil {
+			for _, cm := range comments {
+				if isCollectableReviewFeedbackLogin(cm.Author, streams) && isActionableReviewSummary(cm.Body) {
+					sections = append(sections, cm.Body)
+				}
+			}
+		}
+	} else if issueCommentsOut, err := c.ghAPIWithArgs(fmt.Sprintf("repos/%s/issues/%d/comments?per_page=100", c.Repo, prNumber), "--paginate"); err == nil {
 		var comments []struct {
 			Body string `json:"body"`
 			User struct {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -1784,6 +1784,35 @@ func ciStatusFromREST(checks []greptileCheckRun, combined combinedStatusResponse
 	// An empty combined status carries no signal and must not override the
 	// check-runs verdict; only honor pending/failure when statuses exist.
 	if len(combined.Statuses) > 0 {
+		// Per-status scan FIRST, server aggregate second. On GitHub the two
+		// are equivalent by construction (aggregate = failure iff any context
+		// is failure/error, else pending iff any context is pending), so the
+		// scan changes nothing there. On Forgejo they are NOT equivalent: its
+		// worst-wins priorities rank "warning" BELOW "pending"
+		// (error < failure < warning < pending < success < skipped, verified
+		// against v16.0.1 modules/structs/commit_status.go), so a coexisting
+		// warning context MASKS a pending one — {ci: pending, lint: warning}
+		// aggregates to "warning", which the aggregate arms below ignore, and
+		// a mid-run head would roll up "success". failure/error can never be
+		// masked (nothing ranks below them but each other); the scan hardens
+		// on them too so any aggregate-ordering surprise fails closed.
+		hasFailing, hasPending := false, false
+		for _, st := range combined.Statuses {
+			switch strings.ToLower(strings.TrimSpace(st.State)) {
+			case "failure", "error":
+				hasFailing = true
+			case "pending":
+				hasPending = true
+			}
+		}
+		if hasFailing {
+			return "failure"
+		}
+		if hasPending {
+			return "pending"
+		}
+		// Aggregate belt: a pending/failing server aggregate over per-status
+		// vocabulary the scan does not know still blocks.
 		if strings.EqualFold(combined.State, "pending") {
 			return "pending"
 		}
@@ -4253,6 +4282,12 @@ func (c *Client) PRReviewGateVerdict(prNumber int, streams []string) (ReviewGate
 		// Forgejo-mode clients default to the llm-review pair instead; config
 		// validation independently rejects greptile/simplicity streams on
 		// forgejo rows, so this belt only catches callers passing no streams.
+		// NOTE: today no production caller reaches here with empty streams
+		// (orchestrator short-circuits len(streams)==0 before calling; the
+		// supervisor only calls under review_gate "llm-review"), so a future
+		// caller passing nil for a review_gate:"none" forgejo row gets a
+		// FORCED llm-review gate here where the orchestrator treats "none" as
+		// gate-passes — fail-closed by design; revisit if such a caller lands.
 		streams = []string{"llm-review-opus", "llm-review-terra"}
 	}
 	normalized := normalizeReviewStreams(streams)
@@ -4486,7 +4521,15 @@ func namedStatusDecision(combined combinedStatusResponse, needles []string) (fou
 			return true, true, false
 		case "pending":
 			return true, false, true
-		default: // "failure", "error"
+		default:
+			// "failure"/"error" on both forges, plus the forgejo-only
+			// "warning"/"skipped": all read as found-NOT-passed (hard
+			// rejection). Deliberate — the producer contract is
+			// pending/success/error only, and this mirrors gh-mode
+			// namedCheckDecision, whose fall-through hard-rejects a "skipped"
+			// check-run the same way. A review lens that did not actually run
+			// must fail loud with the named finding, never silently pass or
+			// hold the PR as unobserved-pending forever.
 			return true, false, false
 		}
 	}

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -263,6 +263,36 @@ func TestCIStatusFromREST(t *testing.T) {
 			combined: combinedStatusResponse{State: "failure", Statuses: []combinedStatusEntry{{Context: "ci/build", State: "failure"}}},
 			want:     "failure",
 		},
+		{
+			// Forgejo priorities rank warning BELOW pending, so the server
+			// aggregate for {pending, warning} is "warning" — the per-status
+			// scan must still surface the pending context, never "success".
+			name: "forgejo warning aggregate cannot mask a pending status",
+			combined: combinedStatusResponse{State: "warning", Statuses: []combinedStatusEntry{
+				{Context: "lint", State: "warning"},
+				{Context: "ci/build", State: "pending"},
+			}},
+			want: "pending",
+		},
+		{
+			// A failing context hardens the verdict regardless of what the
+			// server aggregate claims (aggregate-ordering surprises fail closed).
+			name: "per-status failure hardens over a non-failing aggregate",
+			combined: combinedStatusResponse{State: "warning", Statuses: []combinedStatusEntry{
+				{Context: "lint", State: "warning"},
+				{Context: "ci/build", State: "failure"},
+			}},
+			want: "failure",
+		},
+		{
+			// warning/skipped alone stay non-failing (pinned forgejo semantics).
+			name: "warning and skipped statuses alone stay success",
+			combined: combinedStatusResponse{State: "warning", Statuses: []combinedStatusEntry{
+				{Context: "lint", State: "warning"},
+				{Context: "optional", State: "skipped"},
+			}},
+			want: "success",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -252,26 +252,16 @@ func TestCIStatusFromREST(t *testing.T) {
 			want:     "success",
 		},
 		{
-			name:   "combined pending wins when a status entry is pending",
-			checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}},
-			combined: combinedStatusResponse{State: "pending", Statuses: []struct {
-				Context     string `json:"context"`
-				State       string `json:"state"`
-				Description string `json:"description"`
-				TargetURL   string `json:"target_url"`
-			}{{Context: "ci/build", State: "pending"}}},
-			want: "pending",
+			name:     "combined pending wins when a status entry is pending",
+			checks:   []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}},
+			combined: combinedStatusResponse{State: "pending", Statuses: []combinedStatusEntry{{Context: "ci/build", State: "pending"}}},
+			want:     "pending",
 		},
 		{
-			name:   "combined failure wins when a status entry failed",
-			checks: []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}},
-			combined: combinedStatusResponse{State: "failure", Statuses: []struct {
-				Context     string `json:"context"`
-				State       string `json:"state"`
-				Description string `json:"description"`
-				TargetURL   string `json:"target_url"`
-			}{{Context: "ci/build", State: "failure"}}},
-			want: "failure",
+			name:     "combined failure wins when a status entry failed",
+			checks:   []greptileCheckRun{{Name: "test", Status: "completed", Conclusion: "success"}},
+			combined: combinedStatusResponse{State: "failure", Statuses: []combinedStatusEntry{{Context: "ci/build", State: "failure"}}},
+			want:     "failure",
 		},
 	}
 

--- a/internal/github/llm_review_stream_test.go
+++ b/internal/github/llm_review_stream_test.go
@@ -144,12 +144,7 @@ func TestNamedCheckDecision_LLMReviewCheckNames(t *testing.T) {
 
 func TestNamedStatusDecision_CommitStatusStates(t *testing.T) {
 	var combined combinedStatusResponse
-	combined.Statuses = []struct {
-		Context     string `json:"context"`
-		State       string `json:"state"`
-		Description string `json:"description"`
-		TargetURL   string `json:"target_url"`
-	}{
+	combined.Statuses = []combinedStatusEntry{
 		{Context: "llm-review-opus", State: "success"},
 		{Context: "llm-review-terra", State: "failure"},
 		{Context: "ci/build", State: "pending"},

--- a/internal/github/llm_review_stream_test.go
+++ b/internal/github/llm_review_stream_test.go
@@ -166,6 +166,24 @@ func TestNamedStatusDecision_CommitStatusStates(t *testing.T) {
 	if !found || passed || !pending {
 		t.Fatalf("pending status: found=%v passed=%v pending=%v, want true/false/true", found, passed, pending)
 	}
+
+	// Forgejo-only vocabulary: "warning" and "skipped" read as found-NOT-passed
+	// (hard rejection), mirroring namedCheckDecision's fall-through for a
+	// skipped check-run in gh-mode — a lens that did not actually run must
+	// fail loud, never silently pass or hold the PR as pending forever.
+	var fjOnly combinedStatusResponse
+	fjOnly.Statuses = []combinedStatusEntry{
+		{Context: "llm-review-opus", State: "skipped"},
+		{Context: "llm-review-terra", State: "warning"},
+	}
+	found, passed, pending = namedStatusDecision(fjOnly, []string{"llm-review-opus"})
+	if !found || passed || pending {
+		t.Fatalf("skipped status: found=%v passed=%v pending=%v, want true/false/false (rejection)", found, passed, pending)
+	}
+	found, passed, pending = namedStatusDecision(fjOnly, []string{"llm-review-terra"})
+	if !found || passed || pending {
+		t.Fatalf("warning status: found=%v passed=%v pending=%v, want true/false/false (rejection)", found, passed, pending)
+	}
 }
 
 // --- inline finding attribution + severity contract --------------------------

--- a/internal/github/pr_check_rollup_test.go
+++ b/internal/github/pr_check_rollup_test.go
@@ -8,12 +8,7 @@ func TestCICheckRollupFingerprint_IsOrderStableAndSemantic(t *testing.T) {
 		{ID: 20, Name: "test", Status: "in_progress"},
 	}
 	combined := combinedStatusResponse{State: "pending"}
-	combined.Statuses = append(combined.Statuses, struct {
-		Context     string `json:"context"`
-		State       string `json:"state"`
-		Description string `json:"description"`
-		TargetURL   string `json:"target_url"`
-	}{Context: "legacy", State: "pending", Description: "private detail", TargetURL: "https://private.invalid"})
+	combined.Statuses = append(combined.Statuses, combinedStatusEntry{Context: "legacy", State: "pending", Description: "private detail", TargetURL: "https://private.invalid"})
 
 	first := ciCheckRollupFingerprint(checks, combined)
 	reordered := ciCheckRollupFingerprint([]greptileCheckRun{checks[1], checks[0]}, combined)
@@ -50,12 +45,7 @@ func TestCICheckRollupFingerprintIgnoresSupersededAttemptHistory(t *testing.T) {
 func TestCICheckRollupSignals_CarriesNonSecretCheckIdentity(t *testing.T) {
 	checks := []greptileCheckRun{{ID: 10, Name: "Android SDK license acceptance gate", Status: "completed", Conclusion: "failure"}}
 	combined := combinedStatusResponse{State: "failure"}
-	combined.Statuses = append(combined.Statuses, struct {
-		Context     string `json:"context"`
-		State       string `json:"state"`
-		Description string `json:"description"`
-		TargetURL   string `json:"target_url"`
-	}{Context: "legacy/legal-gate", State: "pending", Description: "private detail", TargetURL: "https://private.invalid"})
+	combined.Statuses = append(combined.Statuses, combinedStatusEntry{Context: "legacy/legal-gate", State: "pending", Description: "private detail", TargetURL: "https://private.invalid"})
 
 	signals := ciCheckRollupSignals(checks, combined)
 	if len(signals) != 2 {

--- a/internal/github/review_threads.go
+++ b/internal/github/review_threads.go
@@ -55,6 +55,17 @@ type reviewThreadsGraphQLResponse struct {
 // head. Aggregate review/check conclusions are deliberately not consulted:
 // thread resolution is its own live merge gate.
 func (c *Client) PRUnresolvedReviewThreadsOnHead(prNumber int) (string, []ReviewThread, error) {
+	if c.isForgejo() {
+		// #1172 M4 shim: Forgejo has NO unresolved-conversations API (no
+		// GraphQL, no REST thread-resolution surface on 16.0.1), so the
+		// `review-thread:*` refusal class simply does not exist on forgejo
+		// rows. The mergegate boundary's REAL safety — the double head read
+		// this call provides, the claim, and the head-changed refusals — is
+		// fully preserved: the shim returns the pull's current head from the
+		// ported read (empty head refuses loudly, same as the gh parse path).
+		// Carried flag: revisit if Forgejo grows a thread-resolution API.
+		return c.fjUnresolvedReviewThreadsOnHead(prNumber)
+	}
 	owner, name, ok := strings.Cut(strings.TrimSpace(c.Repo), "/")
 	if !ok || strings.TrimSpace(owner) == "" || strings.TrimSpace(name) == "" {
 		return "", nil, fmt.Errorf("read review threads for PR %d: invalid repo %q", prNumber, c.Repo)

--- a/internal/supervisor/forgejo_merge_gate_test.go
+++ b/internal/supervisor/forgejo_merge_gate_test.go
@@ -1,0 +1,103 @@
+package supervisor
+
+// #1172 M4 D2: the #425 legacy-status escape is DISABLED on forgejo rows. On
+// GitHub, commit statuses can be legacy noise next to check-runs and a
+// "status-only pending" head may merge once mergeable_state confirms the
+// required checks; on forgejo, commit statuses ARE the CI — including the
+// pending llm-review producer statuses — so the same escape would merge a PR
+// whose review is still pending. Both arms are pinned here against the SAME
+// reader state: only the config's forge kind flips the outcome.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/github"
+	"github.com/befeast/maestro/internal/state"
+)
+
+// legacyStatusOnlyPendingRollup is exactly the #425 shape: aggregate pending,
+// every check-run complete and green, one legacy commit status stuck pending.
+func legacyStatusOnlyPendingRollup() github.PRCheckRollup {
+	return github.PRCheckRollup{
+		HeadSHA:  strings.Repeat("a", 40),
+		Verdict:  "pending",
+		Complete: true,
+		Signals: []github.PRCheckSignal{
+			{Source: "check_run", Name: "build", Status: "completed", Conclusion: "success"},
+			{Source: "commit_status", Name: "legacy-bot", Status: "pending", Conclusion: "pending"},
+		},
+	}
+}
+
+func forgejoEscapeReader(pr github.PR) *fakeReader {
+	return &fakeReader{
+		prs:          []github.PR{pr},
+		checkRollups: map[int]github.PRCheckRollup{pr.Number: legacyStatusOnlyPendingRollup()},
+		// mergeable_state "clean" makes mergeStateAllowsMerge answer true —
+		// the strongest possible pro-escape signal, so the forgejo arm below
+		// proves the config gate (not the synthesis) is what blocks.
+		mergeStates: map[int]string{pr.Number: "clean"},
+	}
+}
+
+func TestOpenPRReadyToMerge_LegacyStatusEscape_GitHubArm(t *testing.T) {
+	cfg := testConfig(t)
+	pr := github.PR{Number: 7, Mergeable: "MERGEABLE"}
+	eng := testEngine(cfg, forgejoEscapeReader(pr))
+	sess := &state.Session{IssueNumber: 3, PRNumber: 7}
+
+	ready, headSHA, reasons := eng.openPRReadyToMerge("slot-1", sess, pr)
+	if !ready {
+		t.Fatalf("github row: ready = false, want the #425 escape to authorize the merge (rollup=legacy-status-only pending, mergeable_state=clean)")
+	}
+	if headSHA != strings.Repeat("a", 40) {
+		t.Fatalf("headSHA = %q, want the rollup head", headSHA)
+	}
+	found := false
+	for _, reason := range reasons {
+		if strings.Contains(reason, "mergeable_state confirms required checks passed") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("reasons = %v, want the #425 override recorded", reasons)
+	}
+}
+
+func TestOpenPRReadyToMerge_LegacyStatusEscape_DisabledOnForgejo(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Forge = config.ForgeConfig{Kind: config.ForgeKindForgejo, BaseURL: "https://forge.example.com"}
+	pr := github.PR{Number: 7, Mergeable: "MERGEABLE"}
+	eng := testEngine(cfg, forgejoEscapeReader(pr))
+	sess := &state.Session{IssueNumber: 3, PRNumber: 7}
+
+	ready, _, _ := eng.openPRReadyToMerge("slot-1", sess, pr)
+	if ready {
+		t.Fatal("forgejo row: the #425 escape merged a PR with a pending commit status — on forgejo statuses ARE the CI (pending llm-review included), the escape must be disabled")
+	}
+}
+
+// TestOpenPRReadyToMerge_ForgejoSuccessStillMerges proves the forgejo gate
+// above only disables the ESCAPE, not the normal green path: a success
+// verdict on a forgejo row still authorizes the merge.
+func TestOpenPRReadyToMerge_ForgejoSuccessStillMerges(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Forge = config.ForgeConfig{Kind: config.ForgeKindForgejo, BaseURL: "https://forge.example.com"}
+	pr := github.PR{Number: 7, Mergeable: "MERGEABLE"}
+	reader := forgejoEscapeReader(pr)
+	rollup := reader.checkRollups[7]
+	rollup.Verdict = "success"
+	rollup.Signals = []github.PRCheckSignal{
+		{Source: "commit_status", Name: "llm-review-opus", Status: "success", Conclusion: "success"},
+	}
+	reader.checkRollups[7] = rollup
+	eng := testEngine(cfg, reader)
+	sess := &state.Session{IssueNumber: 3, PRNumber: 7}
+
+	ready, _, _ := eng.openPRReadyToMerge("slot-1", sess, pr)
+	if !ready {
+		t.Fatal("forgejo row with CI success must still be merge-ready — the M4 gate only disables the pending-escape")
+	}
+}

--- a/internal/supervisor/forgejo_merge_gate_test.go
+++ b/internal/supervisor/forgejo_merge_gate_test.go
@@ -9,6 +9,7 @@ package supervisor
 // reader state: only the config's forge kind flips the outcome.
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -99,5 +100,113 @@ func TestOpenPRReadyToMerge_ForgejoSuccessStillMerges(t *testing.T) {
 	ready, _, _ := eng.openPRReadyToMerge("slot-1", sess, pr)
 	if !ready {
 		t.Fatal("forgejo row with CI success must still be merge-ready — the M4 gate only disables the pending-escape")
+	}
+}
+
+// --- #1172 M4 D4: the Greptile review-gate arm on forgejo rows ---------------
+
+// greptileUnsupportedReader is the production forgejo shape: PRGreptileApproved
+// answers with the ErrForgejoNotSupported sentinel (github.Client does exactly
+// this on a forgejo-mode client) instead of the fakeReader's default approval.
+type greptileUnsupportedReader struct {
+	*fakeReader
+	calls int
+}
+
+func (r *greptileUnsupportedReader) PRGreptileApproved(prNumber int) (bool, bool, error) {
+	r.calls++
+	return false, false, fmt.Errorf("PRGreptileApproved (greptile is GitHub-only): %w", github.ErrForgejoNotSupported)
+}
+
+func greenRollupReader(pr github.PR) *greptileUnsupportedReader {
+	reader := forgejoEscapeReader(pr)
+	rollup := reader.checkRollups[pr.Number]
+	rollup.Verdict = "success"
+	rollup.Signals = []github.PRCheckSignal{
+		{Source: "commit_status", Name: "llm-review-opus", Status: "success", Conclusion: "success"},
+	}
+	reader.checkRollups[pr.Number] = rollup
+	return &greptileUnsupportedReader{fakeReader: reader}
+}
+
+// TestOpenPRReadyToMerge_GreptileArm_ForgejoSkips pins the fix: on a forgejo
+// row whose review_gate is not "llm-review" (in practice "none" — config
+// validation rejects greptile/simplicity as effective streams on forgejo), the
+// Greptile arm is skipped rather than consulted. Before the fix the sentinel
+// error pinned the row at permanently not-ready with no recorded reason, while
+// the orchestrator treats the same row as gate-passes.
+func TestOpenPRReadyToMerge_GreptileArm_ForgejoSkips(t *testing.T) {
+	cfg := testConfig(t)
+	cfg.Forge = config.ForgeConfig{Kind: config.ForgeKindForgejo, BaseURL: "https://forge.example.com"}
+	cfg.ReviewGate = "none"
+	pr := github.PR{Number: 7, Mergeable: "MERGEABLE"}
+	reader := greenRollupReader(pr)
+	eng := testEngine(cfg, reader)
+	sess := &state.Session{IssueNumber: 3, PRNumber: 7}
+
+	ready, headSHA, reasons := eng.openPRReadyToMerge("slot-1", sess, pr)
+	if !ready {
+		t.Fatalf("forgejo row: ready = false — the Greptile sentinel must not block a review_gate:none row (reasons=%v)", reasons)
+	}
+	if headSHA != strings.Repeat("a", 40) {
+		t.Fatalf("headSHA = %q, want the rollup head", headSHA)
+	}
+	if reader.calls != 0 {
+		t.Fatalf("PRGreptileApproved called %d times on a forgejo row, want 0 (arm must be short-circuited)", reader.calls)
+	}
+	skipped := false
+	for _, reason := range reasons {
+		if strings.Contains(reason, "Greptile review gate skipped on forgejo") {
+			skipped = true
+		}
+		if strings.Contains(reason, "Greptile review approved") {
+			t.Fatalf("reasons = %v, must not claim a Greptile approval that cannot exist on forgejo", reasons)
+		}
+	}
+	if !skipped {
+		t.Fatalf("reasons = %v, want the skip recorded explicitly (never a silent pass)", reasons)
+	}
+}
+
+// TestOpenPRReadyToMerge_GreptileArm_GitHubUnchanged is the other arm against
+// the SAME reader state: on a github row the Greptile read still runs and its
+// error still fails closed. Only forge.kind flips the outcome.
+func TestOpenPRReadyToMerge_GreptileArm_GitHubUnchanged(t *testing.T) {
+	cfg := testConfig(t)
+	pr := github.PR{Number: 7, Mergeable: "MERGEABLE"}
+	reader := greenRollupReader(pr)
+	eng := testEngine(cfg, reader)
+	sess := &state.Session{IssueNumber: 3, PRNumber: 7}
+
+	ready, _, _ := eng.openPRReadyToMerge("slot-1", sess, pr)
+	if ready {
+		t.Fatal("github row: a Greptile read error must keep the merge path closed")
+	}
+	if reader.calls != 1 {
+		t.Fatalf("PRGreptileApproved called %d times on a github row, want 1 (arm unchanged)", reader.calls)
+	}
+}
+
+// TestOpenPRReadyToMerge_GreptileArm_GitHubApprovedReasonUnchanged proves the
+// happy-path github reason string is byte-identical after the fix.
+func TestOpenPRReadyToMerge_GreptileArm_GitHubApprovedReasonUnchanged(t *testing.T) {
+	cfg := testConfig(t)
+	pr := github.PR{Number: 7, Mergeable: "MERGEABLE"}
+	reader := greenRollupReader(pr).fakeReader
+	eng := testEngine(cfg, reader)
+	sess := &state.Session{IssueNumber: 3, PRNumber: 7}
+
+	ready, _, reasons := eng.openPRReadyToMerge("slot-1", sess, pr)
+	if !ready {
+		t.Fatalf("github row with an approving Greptile read must be merge-ready (reasons=%v)", reasons)
+	}
+	found := false
+	for _, reason := range reasons {
+		if reason == "PR #7 Greptile review approved" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("reasons = %v, want the unchanged github approval reason", reasons)
 	}
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -3280,6 +3280,18 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 
 	ciLower := strings.ToLower(strings.TrimSpace(ciStatus))
 	if ciLower != "success" {
+		// #1172 M4: the #425 escape below is DISABLED on forgejo rows. It
+		// exists for GitHub repos where commit statuses are legacy noise next
+		// to check-runs; on forgejo commit statuses ARE the CI — including
+		// the pending llm-review producer statuses — so a "status-only
+		// pending" head is a genuinely pending head, and the escape would
+		// merge PRs with review still pending. (Belt: fjPRMergeStatus never
+		// synthesizes "clean"/"unstable", so mergeStateAllowsMerge could not
+		// pass anyway — this gate makes the intent explicit and survivable
+		// against future synthesis changes.)
+		if e.cfg != nil && e.cfg.Forge.IsForgejo() {
+			return false, "", nil
+		}
 		if pendingCheckRuns || !legacyStatusOnlyPending(rollup) {
 			return false, "", nil
 		}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -3314,6 +3314,7 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 	// before merge_pr executes). For the stream-based llm-review gate
 	// (#1148) the aggregate verdict is the signal; the historical
 	// greptile-only setup keeps the Greptile read.
+	forgejoGreptileSkipReason := ""
 	if e.cfg != nil && e.cfg.ReviewGate == "llm-review" {
 		if reviewReader, ok := e.reader.(prReviewGateVerdictReader); ok {
 			verdict, err := reviewReader.PRReviewGateVerdict(pr.Number, e.cfg.EffectiveReviewGateStreams())
@@ -3321,6 +3322,20 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 				return false, "", nil
 			}
 		}
+	} else if e.cfg != nil && e.cfg.Forge.IsForgejo() {
+		// #1172 M4: the Greptile arm is SKIPPED on forgejo rows (same gating
+		// style as the #425 escape above). Greptile is a GitHub-integrated
+		// reviewer that never posts on a Forgejo instance, so
+		// PRGreptileApproved returns the ErrForgejoNotSupported sentinel there
+		// — the arm below would take the err branch and pin the row at
+		// permanently not-ready with NO reason recorded, while the
+		// orchestrator treats the same `review_gate: none` row as
+		// gate-passes. Fail-closed, but asymmetric and silent. Config
+		// validation already rejects greptile/simplicity as EFFECTIVE streams
+		// on a forgejo row, so reaching here means the row has no
+		// GitHub-only review gate to consult at all; skip it and record why.
+		// GitHub rows never enter this arm and are byte-identical.
+		forgejoGreptileSkipReason = fmt.Sprintf("PR #%d Greptile review gate skipped on forgejo (GitHub-only reviewer; review_gate=%q)", pr.Number, e.cfg.ReviewGate)
 	} else if greptileReader, ok := e.reader.(prGreptileReader); ok {
 		approved, pending, err := greptileReader.PRGreptileApproved(pr.Number)
 		if err != nil {
@@ -3361,7 +3376,9 @@ func (e *Engine) openPRReadyToMerge(slot string, sess *state.Session, pr github.
 			fmt.Sprintf("PR #%d aggregate CI status=%s; mergeable_state confirms required checks passed", pr.Number, ciStatus),
 		)
 	}
-	if _, ok := e.reader.(prGreptileReader); ok {
+	if forgejoGreptileSkipReason != "" {
+		reasons = append(reasons, forgejoGreptileSkipReason)
+	} else if _, ok := e.reader.(prGreptileReader); ok {
 		reasons = append(reasons, fmt.Sprintf("PR #%d Greptile review approved", pr.Number))
 	}
 	return true, rollupHeadSHA, reasons

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -15,6 +15,9 @@ worktree_base: /path/to/worktrees/repo
 # Forgejo PAT (default: FORGEJO_TOKEN) — never the token value itself.
 # Note: github_projects must stay disabled on forgejo rows — the GitHub
 # Projects integration has no Forgejo equivalent (the queue is labels).
+# Note (#1172 M4): forgejo rows must also set review_gate: llm-review (or
+# none) — the default greptile gate is a GitHub-only reviewer and is rejected
+# at parse time on forgejo rows.
 # forge:
 #   kind: forgejo
 #   base_url: https://forge.example.com


### PR DESCRIPTION
## Summary

M4-code of the Forgejo migration (#1172): CI/status semantics on forgejo rows become **commit-status-only** (Forgejo has no Check Runs API), and the review gate can finally read what the daemon producer has been writing since M2 — that asymmetry (producer posts statuses to Forgejo heads, gate fails loud reading them) is what this slice closes.

### CI rollup (status-only)
`PRCheckRollup`/`PRCIStatus`/`PRChecksOutput`/`PRFailingChecks`/`CIFailureSummary` dispatch to a Forgejo combined-status read; check-runs stay absent by construction, `PendingCheckRuns` stays false. Fingerprint mixes each status's `created_at` (no check-run IDs exist on Forgejo) so a re-run advances it; the GitHub fingerprint is provably byte-identical (`created_at` is `json:"-"` on the shared entry type, pinned by a test). Failing statuses carry their `description` as the excerpt — on Forgejo it is the only actionable text for retry prompts, since annotations/log excerpts do not exist (the "no log excerpt available" degradation was already designed for in #857).

**Deliberate:** a head with zero statuses rolls up `success` — GitHub no-signal parity, documented loudly in code. On the canary shape the review gate, not the CI rollup, is what blocks an unreviewed PR.

### Merge-state synthesis
`PRMergeStatus` is unguarded and synthesizes only `behind` (pull's `merge_base` vs a fresh `BranchHeadSHA(base)`), `dirty` (non-draft `mergeable:false`), or `""`. **`clean`/`unstable` are never synthesized** — on GitHub they mean "required checks passed", which has no Forgejo equivalent until branch protection lands. Consequence: the #424 pending→success promotion and `mergeStateAllowsMerge` are structurally inert on forgejo (both require `clean`). The approver's behind→`UpdateBranch` routing revives.

### Review gate
Inline findings are read via `GET /pulls/{n}/reviews` + per-review comments (the producer posts one-comment COMMENT reviews); `CommitID` anchors to the review's commit with a per-comment fallback — live-verified that migrated reviews can carry an empty review-level `commit_id` while the comment-level one is populated. `Line` maps from `position` (swagger `x-go-name: LineNum`; there is no `line`/`new_position` on the read side). `namedReviewStreamVerdict` skips check-runs entirely and decides from statuses via the existing `AllowCommitStatus` path. Forgejo-mode clients default to the llm-review pair instead of greptile, and config now **rejects** `greptile`/`simplicity` streams on a forgejo row — including the silently-defaulted greptile.

Greptile-only methods (`PRGreptileApproved`, `prGreptileReviewStreamVerdict`, `PRHighSeverityReviewOnHead`), plus `commitCommittedAt` and `checkRunAnnotations`, are now explicit fail-loud rows in the guard inventory.

### Merge-safety hardening (found by review, real defect)
Forgejo's commit-status priorities are worst-wins and rank **`warning` below `pending`** (verified against v16.0.1 `modules/structs/commit_status.go`), so `{ci: pending, lint: warning}` aggregates to `warning` — which the aggregate-only arms ignored, rolling the head up as `success`. A PR could have merged mid-CI. `ciStatusFromREST` now scans per-status states **before** honoring the server aggregate (a no-op on GitHub, where aggregate and per-status are equivalent by construction; the aggregate arms remain as a belt for unknown vocabulary). Also: the #425 status-only-pending escape is disabled on forgejo rows (there, statuses *are* the CI, including pending review), and the combined-status pager fails loud rather than truncating when a server clamp strands it below `total_count`.

### mergegate
`PRUnresolvedReviewThreadsOnHead` becomes a `(headSHA, nil, nil)` shim preserving the empty-head refusal. Forgejo has no unresolved-conversations API, so the `review-thread:*` refusal class disappears on forgejo rows; the boundary's real safety — the double independent head read, the durable claim, and head-changed refusals — is fully preserved.

## ⚠️ Deploy ordering (ops)

Config validation now rejects greptile/simplicity review streams on a forgejo row, *including the default*. A pre-M4 forgejo row without an explicit `review_gate:` will fail to parse on this binary and the daemon will not start. **Edit the row first (`review_gate: llm-review`, or `none`), then deploy.** Today only the apertune canary is affected.

## Review (3 lenses + fixer)
One P2 fixed (the warning/pending masking above). P3s fixed: pagination truncation belt, `warning`/`skipped` documented as review hard-rejection, and the forgejo `review_gate: none` path no longer dead-ends in the greptile arm (it was fail-closed, but produced no reason). Carried to the issue: confirm Forgejo's aggregate ordering for mixed sets on the canary; draft + stale `merge_base` synthesizes `behind` (unreachable via `openPRReadyToMerge`).

## Testing
`go build ./...`, `go vet ./...` clean; forgejo, github, config, supervisor, orchestrator, approver, mergegate green. Full suite green except the 3 pre-existing `internal/worker` umask-0002 failures (reproduced on clean main). Forgejo-mode tests carry decoy wire fields (`.state`, `.line`, `.new_position`) so a wrong mapping fails, and the gh transport is armed in forgejo-mode tests so a check-runs leak fails.

Part of #1172 (M4-code). M4-ops (workflow port) follows separately — the Actions runner already exists.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches merge-readiness, CI verdict aggregation, and review-gate logic — paths that decide whether PRs can merge. Also changes config validation so existing forgejo rows without an explicit review_gate will fail to parse.
> 
> **Overview**
> **Closes the Forgejo M4 gap:** CI and review-gate consumers can finally read what the producer posts on Forgejo (commit statuses + llm-review comments), instead of failing loud on GitHub-only check-runs/Greptile APIs.
> 
> **CI becomes statuses-only on forgejo.** `PRCheckRollup`, failing-check summaries, and related helpers dispatch to a new combined-status transport. Fingerprints mix `created_at` so re-runs advance progress (GitHub fingerprints stay unchanged). `ciStatusFromREST` now scans per-status states before the server aggregate so a Forgejo `warning` cannot mask a pending status into a false green.
> 
> **Merge state is synthesized, not invented.** `PRMergeStatus` derives only `behind` / `dirty` / `""` from `merge_base` + wire `mergeable` — never `clean`/`unstable`. The supervisor also disables the #425 status-only-pending escape on forgejo (there, statuses *are* CI, including pending review).
> 
> **Review gate works without Greptile.** Inline findings come from reviews + per-review comments; forgejo clients default to the llm-review pair. Config now **rejects** greptile/simplicity streams on forgejo rows (including the silent greptile default) — deploy must set `review_gate: llm-review` or `none` first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6620d906db1512f7fb1d849e8384d4250d54a523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds Forgejo-native reads, writes, CI rollups, review-gate evaluation, merge-state handling, and forge-aware links while rejecting configuration that would rely on GitHub-only services.

A potential merge bypass was disproved with an HTTP-fixture check against the actual Forgejo client path: a warning aggregate alongside a pending `llm-review-opus` status now remains pending, a pending named review status blocks merging, and an all-green status set succeeds. Supervisor checks also confirmed that Forgejo does not use GitHub’s legacy pending-status escape and that GitHub’s existing fail-closed behavior remains intact.

No defects were found.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the exercised Forgejo status, review-gate, and supervisor merge-decision paths.

The direct Forgejo HTTP transport check exercised both the historical warning-plus-pending state and the expected all-green state. Targeted merge-gate coverage and the affected GitHub, Forgejo, and supervisor package suites also passed.

**Files Needing Attention:** No files require follow-up from this review; the highest-risk behavior was checked in internal/github/github.go and internal/supervisor/supervisor.go.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused Go HTTP-fixture test through the Forgejo-mode client transport to validate verdict behavior across pre-fix and post-change states. The pre-fix commit produced an incorrect green verdict for pending statuses, while the post-change state blocked the decision with pending statuses and allowed a green outcome, and all requests stayed within the Forgejo transport and did not reach the GitHub CLI seam.
- Ran targeted supervisor merge-gate coverage and the complete internal package suites (internal/github, internal/forgejo, internal/supervisor); all tests passed.
- Compared pre-change and post-change results for the focused test, noting the pre-change behaviour with a rollup verdict and pending issues, and the post-change success across pending fail-closed and green paths with fixture requests staying within Forgejo transport and not leaking to GitHub.
- Confirmed there were no production-code changes; the temporary authored test was removed after execution and its exact source was retained as an artifact.

<a href="https://app.greptile.com/trex/runs/18408244/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(github): address M4 review findings ..."](https://github.com/befeast/maestro/commit/6620d906db1512f7fb1d849e8384d4250d54a523) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52406314)</sub>

<!-- /greptile_comment -->