### PR TITLE
ci(forgejo): port ci and agent-lint workflows to Forgejo Actions (#1172 M4-ops)

### DIFF
--- a/.forgejo/workflows/agent-lint.yml
+++ b/.forgejo/workflows/agent-lint.yml
@@ -1,0 +1,64 @@
+# Forgejo Actions port of .github/workflows/agent-lint.yml (#1172 M4-ops).
+#
+# Deltas from the GitHub original, and why:
+#
+#   - the lint job runs .github/actions/agent-lint/agent-lint.sh directly
+#     instead of `uses: ./.github/actions/agent-lint`. The script, not the
+#     composite action, is the shared unit; calling it directly avoids relying
+#     on local-composite-action resolution and on whether `github.token`
+#     renders inside a composite input default on Forgejo. The env block below
+#     reproduces exactly the contract .github/actions/agent-lint/action.yml
+#     passes on GitHub (GH_TOKEN / AGENT_LINT_PR / AGENT_LINT_REPO); the
+#     allowlist and override-label inputs are omitted because the workflow uses
+#     their defaults and the script defaults are identical.
+#
+#   - AGENT_LINT_FORGE=forgejo selects the script's Forgejo fetch arm by an
+#     explicit signal. The script can also auto-detect from GITHUB_API_URL, but
+#     CI should not depend on sniffing.
+#
+#   - `ready_for_review` and `converted_to_draft` are NOT in `types`. Forgejo
+#     never emits those pull_request actions — modules/actions/workflows.go
+#     lists both as unsupported — so keeping them would be inert entries that
+#     look like coverage. KNOWN GAP: the draft check (warn-only on GitHub) is
+#     not re-run at the moment a PR flips draft state; it still runs on the
+#     next opened/edited/reopened/synchronize/labeled/unlabeled event, which
+#     covers the practical cases. The remaining six types map 1:1 (Forgejo
+#     translates its internal synchronized/label_updated/label_cleared hook
+#     actions to synchronize/labeled/unlabeled before matching).
+name: agent-lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  # Lint the actual PR (closing keywords, artifacts, secrets, draft warning).
+  agent-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: agent-lint
+        env:
+          AGENT_LINT_FORGE: forgejo
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AGENT_LINT_PR: ${{ github.event.pull_request.number }}
+          AGENT_LINT_REPO: ${{ github.repository }}
+        run: bash .github/actions/agent-lint/agent-lint.sh
+
+  # Continuously prove the fixtures still trip each check (acceptance criterion 1).
+  self-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Fixture self-test
+        run: bash .github/actions/agent-lint/agent-lint.sh --self-test

--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -1,0 +1,88 @@
+# Forgejo Actions port of .github/workflows/ci.yml (#1172 M4-ops).
+#
+# Both trees coexist until the repo cuts over to Forgejo (#1172 M8): GitHub only
+# reads .github/workflows and Forgejo only reads .forgejo/workflows, so the two
+# files are maintained in parallel and must be kept in sync by hand.
+#
+# Deltas from the GitHub original, and why:
+#
+#   - runs-on: blacksmith-4vcpu-ubuntu-2404 -> ubuntu-latest. The BeFeast
+#     org-scoped runner maps the `ubuntu-latest` label to
+#     ghcr.io/catthehacker/ubuntu:act-24.04.
+#
+#   - added an explicit ripgrep install. scripts/check-design-tokens.sh and
+#     scripts/check-design-recipes.sh shell out to `rg`, which the act-24.04
+#     image does not ship (its package set is ssh/gawk/curl/jq/wget/sudo/... —
+#     no ripgrep) whereas the GitHub-shaped Blacksmith image does. Both guards
+#     wrap the call as `HITS=$(rg ... || true)`, so a missing `rg` yields exit
+#     127, an empty HITS and a cheerful "OK" — the guard would pass without
+#     having checked anything. Installing the tool keeps the guard real.
+#
+#   - `uses:` strings are unchanged. The instance sets no DEFAULT_ACTIONS_URL,
+#     so actions resolve against code.forgejo.org, which mirrors
+#     actions/checkout@v7, actions/setup-go@v7 and oven-sh/setup-bun@v2 at
+#     exactly these versions.
+#
+# Everything else (job graph, `needs` ordering, step order, the design-token and
+# recipe guards, the committed-bundle staleness check and its ::error::
+# annotation, and the permissions block) is byte-identical to the original.
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  frontend-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install ripgrep (design guards depend on it)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends ripgrep
+          rg --version
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - name: Install MC deps
+        working-directory: internal/server/web/mc
+        run: bun install --frozen-lockfile
+      - name: Design token guard
+        run: bash scripts/check-design-tokens.sh
+      - name: Design recipe guard
+        run: bash scripts/check-design-recipes.sh
+      - name: Design recipe nesting guard
+        run: bash scripts/check-design-recipe-nesting.sh
+      - name: Test MC frontend
+        working-directory: internal/server/web/mc
+        run: bun test
+      - name: Build MC bundle
+        working-directory: internal/server/web/mc
+        run: bun run build
+      - name: Verify committed bundle matches build
+        run: |
+          if ! git diff --quiet -- internal/server/web/static/mc; then
+            echo "::error::Committed MC bundle is stale. Run 'bun run build' in internal/server/web/mc and commit the result."
+            git diff --stat -- internal/server/web/static/mc
+            exit 1
+          fi
+
+  build:
+    needs: frontend-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./...

--- a/.github/actions/agent-lint/agent-lint.sh
+++ b/.github/actions/agent-lint/agent-lint.sh
@@ -22,9 +22,10 @@
 # Modes:
 #   --self-test       run built-in fixtures; each forbidden pattern must trip its
 #                     check and a clean input must pass. Exit non-zero on any
-#                     unexpected result. No network/`gh` needed.
-#   (AGENT_LINT_PR set)   fetch the PR title/body/draft/labels/diff via `gh` and
-#                         lint it. Used by the composite action in CI.
+#                     unexpected result. No network and no `gh` needed (`jq` is).
+#   (PR resolvable)   fetch the PR title/body/draft/labels/diff from the forge
+#                     and lint it. Used by CI. Two arms, see forge_kind:
+#                     GitHub via the `gh` CLI, Forgejo via curl + the REST API.
 #   (otherwise)       offline dry-run: lint the values passed directly via
 #                     AGENT_LINT_TITLE / _BODY / _DRAFT / _LABELS / _FILES / _DIFF.
 #
@@ -35,6 +36,12 @@ REPO="${AGENT_LINT_REPO:-${GITHUB_REPOSITORY:-}}"
 PR="${AGENT_LINT_PR:-}"
 OVERRIDE_LABEL="${AGENT_LINT_OVERRIDE_LABEL:-agent-lint:override}"
 ALLOWLIST="${AGENT_LINT_ARTIFACT_ALLOWLIST:-}"
+
+# API token. The GitHub composite action plumbs its `github-token` input into
+# GH_TOKEN (what the gh CLI reads); the Forgejo workflow passes the job token
+# the same way, and Forgejo Actions also exports GITHUB_TOKEN. Accept either so
+# neither arm needs a bespoke variable.
+TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
 
 # Lint subjects (populated by gh-fetch, offline env, or self-test fixtures).
 TITLE="" BODY="" DRAFT="false" LABELS="" FILES="" DIFF=""
@@ -48,6 +55,74 @@ mask() {
 }
 
 lc() { printf '%s' "$1" | tr '[:upper:]' '[:lower:]'; }
+
+# forge_kind picks which fetch arm loads the PR: "github" or "forgejo".
+#
+# Explicit signal wins: AGENT_LINT_FORGE=github|forgejo|gitea. CI sets it
+# (.forgejo/workflows/agent-lint.yml passes `forgejo`) so a real run never
+# depends on sniffing.
+#
+# The fallback discriminator is GITHUB_API_URL, which both runners export as
+# their own API root: GitHub uses https://api.github.com (GitHub Enterprise:
+# https://<host>/api/v3) while Forgejo and Gitea use https://<host>/api/v1. The
+# `/api/v1` path suffix is therefore the signal — deliberately NOT the hostname,
+# because a Forgejo instance lives on an arbitrary domain (git.oklabs.uk here)
+# and hostname matching would need a hardcoded allowlist. Unknown or unset ->
+# github, which preserves the historical behaviour of this script.
+forge_kind() {
+	case "$(lc "${AGENT_LINT_FORGE:-}")" in
+		github) printf 'github'; return 0 ;;
+		forgejo|gitea) printf 'forgejo'; return 0 ;;
+		'') ;;
+		*) echo "::warning::agent-lint: unrecognised AGENT_LINT_FORGE '${AGENT_LINT_FORGE}' — falling back to auto-detection." >&2 ;;
+	esac
+	case "${GITHUB_API_URL:-}" in
+		*/api/v1|*/api/v1/) printf 'forgejo' ;;
+		*) printf 'github' ;;
+	esac
+}
+
+# files_from_diff derives the changed-file list from a unified diff, standing in
+# for `gh pr diff --name-only` on forges without the gh CLI.
+#
+# It mirrors `git diff --name-only`: both sides of every file header are
+# emitted (so a rename reports the old and the new path, and a deletion still
+# reports the removed path — matching what the gh arm feeds check_artifacts),
+# /dev/null is dropped, the a/ and b/ prefixes are stripped, and duplicates are
+# collapsed while preserving first-seen order.
+#
+# Header lines are only honoured between a `diff --git` line and the `+++` that
+# closes that header, so hunk content that happens to look like a header (an
+# added line reading "++ b/foo.log" arrives as "+++ b/foo.log") cannot inject a
+# phantom path. A file with no ---/+++ pair at all — a pure rename, or a binary
+# or mode-only change — falls back to parsing the `diff --git a/X b/Y` line.
+files_from_diff() {
+	printf '%s\n' "$1" | awk '
+		function emit(p) {
+			sub(/\t.*$/, "", p)
+			if (p == "/dev/null" || p == "") return
+			sub(/^[ab]\//, "", p)
+			if (p == "" || (p in seen)) return
+			seen[p] = 1
+			print p
+		}
+		function flush_hdr(   n) {
+			if (hdr == "") return
+			n = hdr
+			sub(/^diff --git /, "", n)
+			if (match(n, / b\//)) {
+				emit(substr(n, 1, RSTART - 1))
+				emit(substr(n, RSTART + 1))
+			}
+			hdr = ""
+		}
+		/^diff --git /      { flush_hdr(); hdr = $0; inhdr = 1; next }
+		inhdr && /^--- /    { emit(substr($0, 5)); next }
+		inhdr && /^\+\+\+ / { emit(substr($0, 5)); hdr = ""; inhdr = 0; next }
+		{ next }
+		END { flush_hdr() }
+	'
+}
 
 # is_artifact reports whether a committed path is a forbidden build/run artifact.
 is_artifact() {
@@ -186,12 +261,96 @@ run_lint() {
 	return 0
 }
 
-# fetch_pr loads the lint subjects from a real PR via the gh CLI.
-fetch_pr() {
-	if [[ -z "$REPO" || -z "$PR" ]]; then
-		echo "::notice::agent-lint: no pull_request context (AGENT_LINT_PR/REPO unset) — skipping."
-		exit 0
+# resolve_pr fills REPO/PR from the Actions event payload when the workflow did
+# not pass them explicitly.
+#
+# GitHub's pull_request payload and Forgejo's Gitea-shaped one both carry
+# `.pull_request.number` (Forgejo's PR object numbers by per-repo index, which
+# is exactly the {index} its REST API wants) and `.repository.full_name`, so one
+# lookup serves both. Forgejo additionally repeats the index at the top level as
+# `.number`; it is tried second as a belt-and-braces fallback. This matters
+# because the composite action's `${{ github.event.pull_request.number }}`
+# default is the only source on GitHub, and an empty render there would silently
+# drop the script into offline dry-run mode and report a false green.
+resolve_pr() {
+	local ev="${GITHUB_EVENT_PATH:-}"
+	[[ -n "$PR" && -n "$REPO" ]] && return 0
+	[[ -n "$ev" && -r "$ev" ]] || return 0
+	if [[ -z "$PR" ]]; then
+		PR="$(jq -r '(.pull_request.number // .number // empty) | tostring' "$ev" 2>/dev/null || true)"
+		[[ "$PR" == "null" ]] && PR=""
 	fi
+	if [[ -z "$REPO" ]]; then
+		REPO="$(jq -r '.repository.full_name // empty' "$ev" 2>/dev/null || true)"
+	fi
+	return 0
+}
+
+# fj_get performs one authenticated Forgejo REST GET, printing the response body
+# on stdout and returning non-zero on transport failure or a non-2xx status (the
+# body is still printed so the caller can quote the API's error JSON).
+fj_get() {
+	local url="$1" accept="${2:-application/json}" resp code
+	local hdrs=(-H "Accept: ${accept}")
+	[[ -n "$TOKEN" ]] && hdrs+=(-H "Authorization: token ${TOKEN}")
+	if ! resp="$(curl -sS -L --max-time 60 "${hdrs[@]}" -w $'\n%{http_code}' "$url" 2>&1)"; then
+		printf '%s' "$resp"
+		return 1
+	fi
+	code="${resp##*$'\n'}"
+	printf '%s' "${resp%$'\n'*}"
+	case "$code" in 2*) return 0 ;; esac
+	return 1
+}
+
+# apply_forgejo_meta maps one Forgejo pull-request object onto the lint subjects.
+# Split out from fetch_pr_forgejo so the self-test can exercise the field
+# mapping without a network. Forgejo names the draft flag `.draft` where gh's
+# JSON calls it `isDraft`; both are normalised to the same "true"/"false"
+# strings that check_draft expects.
+apply_forgejo_meta() {
+	local meta="$1"
+	TITLE="$(printf '%s' "$meta" | jq -r '.title // ""')"
+	BODY="$(printf '%s' "$meta" | jq -r '.body // ""')"
+	DRAFT="$(printf '%s' "$meta" | jq -r 'if (.draft // false) then "true" else "false" end')"
+	LABELS="$(printf '%s' "$meta" | jq -r '(.labels // [])[].name')"
+}
+
+# fetch_pr_forgejo loads the lint subjects from a Forgejo/Gitea instance. The gh
+# CLI cannot talk to Forgejo, so this arm uses curl + jq against the REST API:
+#
+#   GET /repos/{owner}/{repo}/pulls/{index}        -> title, body, draft, labels[].name
+#   GET /repos/{owner}/{repo}/pulls/{index}.diff   -> the unified diff
+#
+# The changed-file list is derived from the diff (see files_from_diff) rather
+# than from GET /repos/{owner}/{repo}/pulls/{index}/files: it is one request
+# fewer, it has no pagination to get wrong (that endpoint pages, and a silently
+# truncated first page would shrink the artifact check to the first N files),
+# and it guarantees FILES and DIFF describe the same bytes.
+fetch_pr_forgejo() {
+	local api meta
+	api="${AGENT_LINT_API_URL:-${GITHUB_API_URL:-}}"
+	api="${api%/}"
+	if [[ -z "$api" ]]; then
+		echo "::error::agent-lint: Forgejo mode selected but neither AGENT_LINT_API_URL nor GITHUB_API_URL is set."
+		exit 1
+	fi
+	if ! meta="$(fj_get "${api}/repos/${REPO}/pulls/${PR}")"; then
+		echo "::error::agent-lint: unable to read PR #${PR} in ${REPO}: ${meta}"
+		exit 1
+	fi
+	apply_forgejo_meta "$meta"
+	# Unlike the gh arm this fails loud: a diff we cannot read would silently
+	# disable the artifact and secret checks.
+	if ! DIFF="$(fj_get "${api}/repos/${REPO}/pulls/${PR}.diff" 'text/plain')"; then
+		echo "::error::agent-lint: unable to read the diff for PR #${PR} in ${REPO}: ${DIFF}"
+		exit 1
+	fi
+	FILES="$(files_from_diff "$DIFF")"
+}
+
+# fetch_pr_github loads the lint subjects from a real PR via the gh CLI.
+fetch_pr_github() {
 	local meta
 	if ! meta="$(gh pr view "$PR" --repo "$REPO" --json title,body,isDraft,labels 2>&1)"; then
 		echo "::error::agent-lint: unable to read PR #${PR} in ${REPO}: ${meta}"
@@ -203,6 +362,18 @@ fetch_pr() {
 	LABELS="$(printf '%s' "$meta" | jq -r '.labels[].name')"
 	FILES="$(gh pr diff "$PR" --repo "$REPO" --name-only 2>/dev/null || true)"
 	DIFF="$(gh pr diff "$PR" --repo "$REPO" 2>/dev/null || true)"
+}
+
+# fetch_pr dispatches to the arm for the forge this run is on.
+fetch_pr() {
+	if [[ -z "$REPO" || -z "$PR" ]]; then
+		echo "::notice::agent-lint: no pull_request context (AGENT_LINT_PR/REPO unset) — skipping."
+		exit 0
+	fi
+	case "$(forge_kind)" in
+		forgejo) fetch_pr_forgejo ;;
+		*) fetch_pr_github ;;
+	esac
 }
 
 # ---- self-test --------------------------------------------------------------
@@ -254,6 +425,130 @@ self_test() {
 	_reset; BODY=$'Fixes #1\n<!-- agent-lint:allow -->'; _expect "override: body marker downgrades failure" 0 run_lint
 	_reset; BODY="Fixes #1"; _expect "no override: failure blocks" 1 run_lint
 
+	# 5. Forgejo fetch arm — everything that can be checked without a network:
+	#    the forge discriminator, the diff -> changed-file derivation, and the
+	#    PR-object field mapping. The HTTP calls themselves are not covered.
+	_kv() {
+		local desc="$1" want="$2" got="$3"
+		if [[ "$got" == "$want" ]]; then
+			echo "ok   - $desc"
+		else
+			echo "FAIL - $desc"
+			echo "       got:  $(printf '%s' "$got" | tr '\n' '|')"
+			echo "       want: $(printf '%s' "$want" | tr '\n' '|')"
+			fails=$((fails + 1))
+		fi
+	}
+
+	# 5a. forge_kind: explicit signal beats auto-detection, both ways.
+	_kv "forge: explicit forgejo beats a github api url" "forgejo" \
+		"$(AGENT_LINT_FORGE=forgejo; GITHUB_API_URL=https://api.github.com; forge_kind)"
+	_kv "forge: explicit github beats a forgejo api url" "github" \
+		"$(AGENT_LINT_FORGE=github; GITHUB_API_URL=https://git.example.org/api/v1; forge_kind)"
+	_kv "forge: auto-detect /api/v1 → forgejo" "forgejo" \
+		"$(AGENT_LINT_FORGE=; GITHUB_API_URL=https://git.example.org/api/v1; forge_kind)"
+	_kv "forge: auto-detect trailing-slash /api/v1/ → forgejo" "forgejo" \
+		"$(AGENT_LINT_FORGE=; GITHUB_API_URL=https://git.example.org/api/v1/; forge_kind)"
+	_kv "forge: auto-detect api.github.com → github" "github" \
+		"$(AGENT_LINT_FORGE=; GITHUB_API_URL=https://api.github.com; forge_kind)"
+	_kv "forge: auto-detect GHES /api/v3 → github" "github" \
+		"$(AGENT_LINT_FORGE=; GITHUB_API_URL=https://ghe.example.com/api/v3; forge_kind)"
+	_kv "forge: no api url → github" "github" \
+		"$(AGENT_LINT_FORGE=; GITHUB_API_URL=; forge_kind)"
+
+	# 5b. files_from_diff: mirrors `git diff --name-only` off a unified diff.
+	_kv "diff→files: modified file" "internal/x.go" \
+		"$(files_from_diff "$(printf '%s\n' \
+			'diff --git a/internal/x.go b/internal/x.go' \
+			'index 1111111..2222222 100644' \
+			'--- a/internal/x.go' \
+			'+++ b/internal/x.go' \
+			'@@ -1 +1 @@' \
+			'-old' \
+			'+new')")"
+	_kv "diff→files: added file drops /dev/null" "tmp/scratch.txt" \
+		"$(files_from_diff "$(printf '%s\n' \
+			'diff --git a/tmp/scratch.txt b/tmp/scratch.txt' \
+			'new file mode 100644' \
+			'--- /dev/null' \
+			'+++ b/tmp/scratch.txt' \
+			'@@ -0,0 +1 @@' \
+			'+hi')")"
+	_kv "diff→files: deleted file still reported" "debug.log" \
+		"$(files_from_diff "$(printf '%s\n' \
+			'diff --git a/debug.log b/debug.log' \
+			'deleted file mode 100644' \
+			'--- a/debug.log' \
+			'+++ /dev/null' \
+			'@@ -1 +0,0 @@' \
+			'-noise')")"
+	_kv "diff→files: pure rename reports both paths" $'docs/old.md\ndocs/new.md' \
+		"$(files_from_diff "$(printf '%s\n' \
+			'diff --git a/docs/old.md b/docs/new.md' \
+			'similarity index 100%' \
+			'rename from docs/old.md' \
+			'rename to docs/new.md')")"
+	_kv "diff→files: binary change falls back to the git header" "assets/logo.png" \
+		"$(files_from_diff "$(printf '%s\n' \
+			'diff --git a/assets/logo.png b/assets/logo.png' \
+			'index 3333333..4444444 100644' \
+			'Binary files a/assets/logo.png and b/assets/logo.png differ')")"
+	_kv "diff→files: hunk content cannot inject a phantom path" "README.md" \
+		"$(files_from_diff "$(printf '%s\n' \
+			'diff --git a/README.md b/README.md' \
+			'--- a/README.md' \
+			'+++ b/README.md' \
+			'@@ -1,2 +1,3 @@' \
+			' context' \
+			'+++ b/phantom.log' \
+			'--- a/phantom.log')")"
+	_kv "diff→files: multiple files keep order and dedup" $'a.go\nb.go' \
+		"$(files_from_diff "$(printf '%s\n' \
+			'diff --git a/a.go b/a.go' \
+			'--- a/a.go' \
+			'+++ b/a.go' \
+			'@@ -1 +1 @@' \
+			'-x' \
+			'+y' \
+			'diff --git a/b.go b/b.go' \
+			'--- a/b.go' \
+			'+++ b/b.go' \
+			'@@ -1 +1 @@' \
+			'-x' \
+			'+y')")"
+	_kv "diff→files: empty diff yields nothing" "" "$(files_from_diff "")"
+
+	# 5c. the derived FILES must feed the existing checks unchanged.
+	_reset
+	DIFF="$(printf '%s\n' \
+		'diff --git a/.maestro/verify.sh b/.maestro/verify.sh' \
+		'new file mode 100755' \
+		'--- /dev/null' \
+		'+++ b/.maestro/verify.sh' \
+		'@@ -0,0 +1 @@' \
+		'+echo hi')"
+	FILES="$(files_from_diff "$DIFF")"
+	_expect "forgejo arm: derived FILES trips the artifact check" 1 check_artifacts
+
+	# 5d. apply_forgejo_meta: Forgejo PR object → lint subjects.
+	_reset
+	apply_forgejo_meta '{"title":"feat: thing (#5)","body":"Refs #5","draft":true,"labels":[{"name":"size:small"},{"name":"area:ci"}]}'
+	_kv "forgejo meta: title" "feat: thing (#5)" "$TITLE"
+	_kv "forgejo meta: body" "Refs #5" "$BODY"
+	_kv "forgejo meta: .draft true → \"true\"" "true" "$DRAFT"
+	_kv "forgejo meta: labels newline-joined" $'size:small\narea:ci' "$LABELS"
+	_reset
+	apply_forgejo_meta '{"title":"t","body":null,"labels":null}'
+	_kv "forgejo meta: null body → empty" "" "$BODY"
+	_kv "forgejo meta: missing .draft → \"false\"" "false" "$DRAFT"
+	_kv "forgejo meta: null labels → empty" "" "$LABELS"
+	_reset
+	apply_forgejo_meta '{"title":"t","body":"Fixes #1","draft":false,"labels":[{"name":"'"$OVERRIDE_LABEL"'"}]}'
+	_expect "forgejo meta: override label still downgrades failure" 0 run_lint
+	_reset
+	apply_forgejo_meta '{"title":"t","body":"Fixes #1","draft":false,"labels":[]}'
+	_expect "forgejo meta: no override still blocks" 1 run_lint
+
 	echo "----"
 	if (( fails > 0 )); then
 		echo "agent-lint self-test: ${fails} failure(s)"
@@ -270,6 +565,10 @@ main() {
 		self_test
 		exit $?
 	fi
+
+	# Recover REPO/PR from the event payload if the workflow did not pass them,
+	# so a blank expression render cannot demote a real CI run to dry-run.
+	resolve_pr
 
 	if [[ -n "$PR" ]]; then
 		fetch_pr

--- a/.gitignore
+++ b/.gitignore
@@ -12,12 +12,13 @@
 # Config files with secrets
 *.yaml
 *.yml
-# But keep CI workflows and composite actions
+# But keep CI workflows and composite actions, on both forges
 !.github/workflows/*.yml
 !.github/dependabot.yml
 !.github/ISSUE_TEMPLATE/*.yml
 !.github/actions/**/*.yml
 !.github/actions/**/*.yaml
+!.forgejo/workflows/*.yml
 .claude/
 
 # Frontend build


### PR DESCRIPTION
## Summary

M4-ops of the Forgejo migration (#1172): `.forgejo/workflows/ci.yml` and `.forgejo/workflows/agent-lint.yml`, plus the script work that makes agent-lint actually function on a non-GitHub forge. `.github/workflows/*` is untouched and stays authoritative for GitHub — each forge reads only its own directory, so both trees coexist until the maestro repo itself cuts over (M8).

**No runner to provision:** `forgejo-runner.service` v13.0.0 is already live on `baldr` (org `BeFeast`, capacity 2, labels `heavy:host` / `docker` / `ubuntu-latest` on `catthehacker/ubuntu:act-24.04`). All `uses:` actions are mirrored on `code.forgejo.org` at the exact versions this repo pins (`actions/checkout@v7`, `actions/setup-go@v7`, `oven-sh/setup-bun@v2`), and the instance resolves there by default — so the action references are byte-identical to the GitHub originals.

## ci.yml — mechanical, with one real fix

`runs-on: blacksmith-4vcpu-ubuntu-2404` → `ubuntu-latest`. Jobs, ordering, guards, the committed-bundle staleness check and its `::error::` annotation are unchanged.

The exception: **`ripgrep` is not in the act image**, and `scripts/check-design-tokens.sh` / `check-design-recipes.sh` do `HITS=$(rg … || true)`. A missing `rg` exits 127, leaves `HITS` empty, and the guard prints `OK:` — green without checking anything. The ported workflow installs ripgrep explicitly rather than shipping two accidentally-passing guards. **Follow-up (forge-independent, affects GitHub too if that image ever drops the tool): those guards should hard-fail on a missing `rg` instead of swallowing 127.**

## agent-lint — the part that did not port for free

`agent-lint.sh` loaded PR data exclusively through the gh CLI (`gh pr view --json …`, `gh pr diff`). On Forgejo that is a dead path, so a copied workflow would have produced a green job with zero checks performed. Added a second fetch arm:

- **Discriminator:** explicit `AGENT_LINT_FORGE` (set by the Forgejo workflow, so a real run never sniffs), falling back to the `/api/v1` suffix of `GITHUB_API_URL` — deliberately not hostname matching, since a Forgejo instance lives on an arbitrary domain. Unknown/unset → `github`, preserving historical behaviour.
- **Endpoints:** `GET /repos/{owner}/{repo}/pulls/{index}` (title, body, draft, labels) and `…/pulls/{index}.diff`. Changed files are derived from the diff rather than from `/pulls/{index}/files`: one request fewer, no pagination to truncate silently, and `FILES` can never disagree with the `DIFF` the secret scan reads.
- **PR number:** the composite action's `${{ github.event.pull_request.number }}` was the only source; a blank render used to drop the script into offline dry-run, which reports *"all checks passed"*. Added a `GITHUB_EVENT_PATH` fallback (`.pull_request.number // .number`), closing that false-green on both forges.
- Lint semantics are identical — both arms populate the same six subjects feeding the same checks and the same `::error::` output. One deliberate asymmetry: the gh arm swallows diff-fetch failures (`|| true`, silently disabling two checks); the Forgejo arm fails loud.

Also: **`.gitignore` ignored `*.yml` globally** with per-path negations for `.github/…`, so `.forgejo/workflows/*.yml` was silently unstageable. Added the matching negation.

## Documented gaps (not silent degradations)

- **`ready_for_review` / `converted_to_draft` dropped from the Forgejo trigger list** — Forgejo never emits them (`modules/actions/workflows.go`), so keeping them would be inert entries masquerading as coverage. Consequence: the warn-only draft check does not re-run at the instant a PR flips draft state; it still runs on the next `opened/edited/reopened/synchronize/labeled/unlabeled`. The other six map 1:1.
- **`unlabeled`** maps from Forgejo's `label_cleared` hook, so its semantics differ slightly from "one label removed".
- **The Forgejo job calls the script directly** instead of `uses: ./.github/actions/agent-lint`, with the same env contract — avoids depending on local-composite-action resolution and on whether `github.token` renders inside a composite input default, neither verifiable without a live run. `action.yml` is unmodified.
- **Unverifiable until M8** (repo not on Forgejo yet, so no smoke run is possible): that `secrets.GITHUB_TOKEN` renders and can read PRs, that the event expression renders (mitigated by the payload fallback), and the live HTTP behaviour of the two endpoints. The self-test covers parsing and dispatch, not transport.

## Testing

`agent-lint --self-test`: **44/44 pass**, up from 19 — the 19 originals are byte-identical and still pass. New coverage: discriminator selection, diff→files derivation (rename → both paths, deletion, `/dev/null`, binary fallback to the `diff --git` header, ordering/dedup, and a phantom-path injection where an added line `++ b/foo.log` arrives as `+++ b/foo.log`), the derived-`FILES` → artifact-check handoff, and Forgejo field mapping including null body/labels. End-to-end against a local stub API (loopback, no external network): auto-detect, explicit env, bad token → loud failure, no-PR-context → dry-run unchanged. All four workflows parse under PyYAML; `go build ./...` and `go vet ./...` clean (no Go touched); `shellcheck -S warning` shows no new finding classes.

Part of #1172 (M4-ops). This completes M4; M5 (webhooks) is next.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI gating and agent-lint's PR-fetch path (including secret/artifact checks), but GitHub workflows stay unchanged and the Forgejo tree is not live until cutover.
> 
> **Overview**
> Adds **Forgejo Actions** ports of CI and agent-lint under `.forgejo/workflows/`, kept in parallel with the existing GitHub workflows until cutover.
> 
> **`agent-lint.sh`** gains a Forgejo fetch arm (curl + REST) beside the existing `gh` path, selected by `AGENT_LINT_FORGE` or `/api/v1` auto-detect. Changed files are derived from the unified diff, and a `GITHUB_EVENT_PATH` fallback avoids a blank PR number silently skipping checks. Self-tests cover the new discriminator, diff→files parsing, and Forgejo field mapping.
> 
> The Forgejo **CI** workflow swaps the Blacksmith runner for `ubuntu-latest` and installs **ripgrep** so design-token/recipe guards cannot pass vacuously on the act image. `.gitignore` is updated so `.forgejo/workflows/*.yml` can be committed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80fdd8507585cab5b7bc2cf0164c30c9bf50128a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds Forgejo workflows and extends agent-lint with Forgejo pull-request metadata and diff handling. A real Forgejo-style pull-request diff containing a Git-quoted filename allowed a forbidden `.log` artifact to pass linting, so the changed-file parser needs to decode quoted path headers before applying artifact rules.

The reported repository-token exposure was disproved: Forgejo fork pull requests do not receive repository secrets, so `${{ secrets.GITHUB_TOKEN }}` does not provide an exfiltratable token to the checked-out pull-request script.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until quoted diff filenames are normalized before forbidden-artifact checks.

The remaining failure was reproduced through the actual Forgejo metadata fetch, unified-diff parsing, and artifact-checking path, with an equivalent unquoted filename correctly rejected as a control.

**Files Needing Attention:** .github/actions/agent-lint/agent-lint.sh needs Git quoted-path decoding in files_from_diff and regression coverage for quoted diff headers.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- RAN the Narrow Forgejo quoted-filename validation harness to reproduce the P1 finding and observed that a quoted log filename is accepted by agent-lint while an unquoted filename is rejected.
- SUBMITTED a proof for the posted P1 finding.
- PERFORMED a safe-simulation contract validation showing the shell step would run a checked-out PR replacement and could read GH\_TOKEN if supplied, with no secret used or printed; Forgejo semantics indicate there is no repository secret to supply.
- IDENTIFIED the exact location in agent-lint.sh where header token handling caused a mismatch, confirming the issue stems from quoted filename parsing rather than unquoted path handling.

<a href="https://app.greptile.com/trex/runs/18412780/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Quoted Forgejo diff paths bypass forbidden-artifact detection**

   - **Bug**
     - A real Git unified diff for a tab-containing filename `x<TAB>name.log` uses quoted headers. Through the actual Forgejo fetch path, agent-lint exited 0 and printed `agent-lint: all checks passed.`, despite `.log` being forbidden. An ordinary `x-name.log` control was rejected.
   - **Cause**
     - `files_from_diff` sends `+++ "b/x\	name.log"` to `emit` unchanged. `emit` only strips literal `a/` or `b/` prefixes, retains the surrounding quote and Git escape sequence, and `is_artifact` therefore cannot match its `*.log` glob.
   - **Fix**
     - Parse Git quoted pathnames before artifact matching: recognize quoted `---`/`+++` header values, decode Git's C-style escaping, then strip the decoded `a/`/`b/` prefix. Add a self-test fixture using a real quoted header for a forbidden `.log` or `tmp/` path.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/actions/agent-lint/agent-lint.sh:101-105
**Quoted Forgejo diff paths bypass artifact checks**

Forgejo can return Git-quoted unified-diff headers for filenames containing characters such as tabs. `emit` retains the quotes and escape sequence and only strips a literal `a/` or `b/` prefix. A forbidden file such as `x<TAB>name.log` is therefore treated as `"b/x\\tname.log"`, which does not match the `*.log` artifact rule and lets the lint job pass. Decode Git-quoted pathnames before stripping the diff-side prefix and matching artifact patterns, and add a quoted-path self-test fixture.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(forgejo): port ci and agent-lint work..."](https://github.com/befeast/maestro/commit/80fdd8507585cab5b7bc2cf0164c30c9bf50128a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52414042)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->