### PR TITLE
feat(webhook): reject gitea-origin deliveries and mark forgejo rows poll-only (#1172 M5)

### DIFF
--- a/docs/webhook-ingestion-runbook.md
+++ b/docs/webhook-ingestion-runbook.md
@@ -151,6 +151,28 @@ journal lines `[webhook] rejected delivery: gitea/forgejo-origin (…) — forge
 rows are poll-only`. Delete the webhook from the Forgejo repository. Retrying
 cannot help; nothing about the delivery is salvageable here.
 
+**Cleaning up deliveries accepted before the guard existed.** The guard is
+ingest-side only: a Forgejo hook that was pointed here *before* #1172 M5 was
+accepted (`202`) and projected, so removing the hook stops new contamination but
+does not undo the old. Spot it by comparing the mirror rows for the mirrored
+`owner/name` against GitHub — Forgejo-derived rows carry Forgejo's id space
+(issue/PR numbers and ids that do not exist on the GitHub side):
+
+```
+sqlite3 ~/.maestro/maestro.db \
+  "SELECT received_at, event_type, repo, sender FROM webhook_deliveries
+     WHERE repo = 'owner/name' ORDER BY received_at DESC LIMIT 20;"
+```
+
+No manual repair is required for the read model: the GitHub row's phase-E
+`runMirrorReconcile` loop snapshots the authoritative GitHub open-issue and
+open-PR sets and rewrites whatever diverged, so the mirror converges on its next
+pass (`mirror reconcile repaired N row(s)` in the journal). Only the mirror
+converges, though — the raw rows in `webhook_deliveries` are kept verbatim and
+are never pruned (see the delivery table note below), so a historical
+Forgejo-origin payload stays queryable there. It is inert: nothing re-projects a
+stored delivery.
+
 **Reading fleet health for a forgejo row.** The top-level `webhooks` block is
 fleet-global and says nothing about a poll-only project. Each entry in
 `projects[]` carries `forge` (`"github"` | `"forgejo"`) and
@@ -200,3 +222,9 @@ sqlite3 ~/.maestro/maestro.db \
 
 The `webhook_deliveries` table is disjoint from the approvals / state tables
 that share the same `maestro.db`.
+
+It has **no retention or pruning** of any kind: every accepted delivery is kept
+with its full payload forever, so the table grows without bound on a busy repo.
+Pre-existing and forge-independent; deleting old rows by `received_at` is safe
+(nothing re-reads a stored delivery — the mirror is fed at accept time and
+repaired by reconciliation), but there is no automation for it yet.

--- a/docs/webhook-ingestion-runbook.md
+++ b/docs/webhook-ingestion-runbook.md
@@ -7,9 +7,17 @@ lands the raw payload plus a parsed envelope durably. Default **OFF** — a daem
 started without `--webhook-secret-file` behaves exactly as before and keeps
 learning GitHub state by polling.
 
-This is **ingestion only** (phase B). Nothing consumes the stored deliveries
-into the orchestration read path yet; that is phase C/D. The goal of phase B is
-to make the deliveries arrive and persist so a later phase can stop polling.
+Stored deliveries **are** consumed: since #825/#826 each newly-accepted delivery
+is projected into the GitHub mirror read model (`mirror_*` tables), and gate
+events (`check_run` / `check_suite` / `status`) wake the matching project flow
+immediately instead of waiting for the next poll. Phase-E reconciliation repairs
+whatever a missed delivery left stale. (Earlier revisions of this runbook claimed
+"ingestion only, nothing consumes the stored deliveries" — that has been false
+since #825.)
+
+Ingestion is **GitHub-only**. Projects on a `forge: kind: forgejo` row are
+poll-only by design and the endpoint actively rejects their deliveries — see
+[Forgejo rows are poll-only](#forgejo-rows-are-poll-only).
 
 ## Why
 
@@ -96,10 +104,58 @@ observability labels, never persistence, so no acknowledged event is dropped.
   replay of an already-stored delivery is a no-op that returns `200` with
   `{"status":"duplicate"}`. A newly stored delivery returns `202`.
 - **Invalid signature → `401`**, counted, payload **not** stored.
+- **Gitea/Forgejo-origin delivery → `422`**, counted, **not** stored and **not**
+  projected. Checked after the signature so an unauthenticated prober still gets
+  `401`. See below.
 - **Missing `X-GitHub-Delivery` → `400`.**
 - **Durable across restart.** The store uses SQLite WAL, so an acknowledged
   delivery survives a daemon restart — GitHub's at-least-once retry plus the
   idempotency key means nothing is lost or double-counted.
+
+## Forgejo rows are poll-only
+
+Projects with `forge: kind: forgejo` (#1172) **do not** use webhook ingestion.
+They learn forge state by polling only, and that is deliberate, not a gap.
+
+**Why.** Forgejo and Gitea deliver GitHub-*aliased* headers — `X-GitHub-Event`,
+`X-GitHub-Delivery`, and `X-Hub-Signature-256` with the identical `sha256=`+hex
+HMAC scheme. A Forgejo hook pointed at this endpoint with the same secret would
+therefore pass signature validation and be stored *and projected* into the
+`mirror_*` tables, which are keyed by the bare `owner/name`. For a repo mirrored
+between GitHub and Forgejo that is the **same key** the GitHub mirror uses, so
+Forgejo entities (different id space, different payload shape) would silently
+overwrite GitHub-derived rows. The mirror read model is GitHub-keyed and config
+validation documents it as GitHub-webhook-fed; a Gitea-format adapter would have
+to reopen that, so M5 enforces poll-only instead.
+
+**What the endpoint does.** A delivery carrying any of these headers is rejected
+with `422 Unprocessable Entity` — never stored, never projected:
+
+```
+X-Forgejo-Event   X-Forgejo-Event-Type   X-Forgejo-Delivery   X-Forgejo-Signature
+X-Gitea-Event     X-Gitea-Event-Type     X-Gitea-Delivery     X-Gitea-Signature
+X-Gogs-Event      X-Gogs-Event-Type      X-Gogs-Delivery      X-Gogs-Signature
+X-Gitea-Hook-Installation-Target-Type
+```
+
+GitHub never sends any of them, so the check cannot mis-fire on real GitHub
+traffic. The check runs **after** signature validation: an unsigned probe still
+gets `401` and learns nothing about which forges this endpoint distinguishes.
+
+`422`, not a quiet `202`-and-ignore: a stored-but-unprojected Gitea delivery
+would inflate `webhooks.total_deliveries` and `by_event_type` and read as healthy
+ingestion, hiding the misconfiguration exactly where an operator looks for it.
+
+**Symptom → fix.** `webhooks.forge_rejected > 0` on `GET /api/v1/fleet`, plus
+journal lines `[webhook] rejected delivery: gitea/forgejo-origin (…) — forgejo
+rows are poll-only`. Delete the webhook from the Forgejo repository. Retrying
+cannot help; nothing about the delivery is salvageable here.
+
+**Reading fleet health for a forgejo row.** The top-level `webhooks` block is
+fleet-global and says nothing about a poll-only project. Each entry in
+`projects[]` carries `forge` (`"github"` | `"forgejo"`) and
+`webhooks_applicable`; when `webhooks_applicable` is `false`, do not read global
+webhook health as covering that row.
 
 ## Diagnostics
 
@@ -118,14 +174,17 @@ observability labels, never persistence, so no acknowledged event is dropped.
     "by_event_type": { "issues": 40, "pull_request": 88 },
     "duplicates": 3,
     "signature_failures": 0,
-    "bad_requests": 0
+    "bad_requests": 0,
+    "forge_rejected": 0
   }
   ```
 
   `total_deliveries` and `by_event_type` are seeded from the durable store on
   startup, so they reflect the persisted total across restarts;
-  `signature_failures` / `duplicates` / `bad_requests` are the current process's
-  tally.
+  `signature_failures` / `duplicates` / `bad_requests` / `forge_rejected` are the
+  current process's tally. `forge_rejected > 0` means a Forgejo/Gitea hook is
+  pointed at this endpoint — see
+  [Forgejo rows are poll-only](#forgejo-rows-are-poll-only).
 
 - **Missed deliveries self-heal.** A dropped or never-emitted delivery leaves the
   mirror stale until the phase-E reconciliation loop repairs it — `last_delivery_at`

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1076,6 +1076,15 @@ func (d *Daemon) refreshPRGateFromWebhook(eventType, repo string) {
 		if flow == nil || flow.cfg == nil || flow.refreshCh == nil || !strings.EqualFold(strings.TrimSpace(flow.cfg.Repo), repo) {
 			continue
 		}
+		// Forgejo rows are poll-only (#1172 M5): they never receive webhook
+		// deliveries, and the repo match above is on the bare owner/name — which a
+		// mirrored GitHub/Forgejo pair SHARES. Without this guard a GitHub check_run
+		// event wakes the forgejo flow too, making it look webhook-driven while its
+		// actual gate state still only ever comes from polling. GitHub flows are
+		// unaffected.
+		if flow.cfg.Forge.IsForgejo() {
+			continue
+		}
 		channels = append(channels, flow.refreshCh)
 	}
 	d.mu.Unlock()

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -172,6 +172,62 @@ func TestCheckWebhookRefreshesOnlyMatchingProjectFlow(t *testing.T) {
 	}
 }
 
+// TestCheckWebhookSkipsForgejoFlows covers the mirrored-pair case (#1172 M5):
+// a GitHub repo mirrored to Forgejo shares the bare owner/name, so matching on
+// the repo alone woke the forgejo flow off a GitHub CI event — making a
+// poll-only row look webhook-driven. The forgejo flow must be skipped while the
+// github flow with the SAME repo name still gets its wake-up.
+func TestCheckWebhookSkipsForgejoFlows(t *testing.T) {
+	d := New(fakeLoader{}, Options{Port: 0})
+	gh := &projectFlow{
+		cfg:       &config.Config{Repo: "BeFeast/maestro"},
+		refreshCh: make(chan struct{}, 1),
+	}
+	fj := &projectFlow{
+		cfg: &config.Config{
+			Repo:  "BeFeast/maestro",
+			Forge: config.ForgeConfig{Kind: config.ForgeKindForgejo, BaseURL: "https://forge.example.com"},
+		},
+		refreshCh: make(chan struct{}, 1),
+	}
+	// An explicit kind: github row must behave exactly like the absent-block row.
+	ghExplicit := &projectFlow{
+		cfg: &config.Config{
+			Repo:  "BeFeast/maestro",
+			Forge: config.ForgeConfig{Kind: config.ForgeKindGitHub},
+		},
+		refreshCh: make(chan struct{}, 1),
+	}
+	d.flows = map[string]*projectFlow{"gh": gh, "fj": fj, "gh-explicit": ghExplicit}
+
+	d.refreshPRGateFromWebhook("check_run", "BeFeast/maestro")
+
+	if got := len(gh.refreshCh); got != 1 {
+		t.Fatalf("github flow refreshes = %d, want 1 (behaviour must be unchanged)", got)
+	}
+	if got := len(ghExplicit.refreshCh); got != 1 {
+		t.Fatalf("explicit-github flow refreshes = %d, want 1", got)
+	}
+	if got := len(fj.refreshCh); got != 0 {
+		t.Fatalf("forgejo flow refreshes = %d, want 0 — forgejo rows are poll-only", got)
+	}
+
+	// Same for the other gate event types.
+	<-gh.refreshCh
+	<-ghExplicit.refreshCh
+	for _, event := range []string{"check_suite", "status"} {
+		d.refreshPRGateFromWebhook(event, "BeFeast/maestro")
+		if got := len(fj.refreshCh); got != 0 {
+			t.Fatalf("forgejo flow refreshes after %q = %d, want 0", event, got)
+		}
+		if got := len(gh.refreshCh); got != 1 {
+			t.Fatalf("github flow refreshes after %q = %d, want 1", event, got)
+		}
+		<-gh.refreshCh
+		<-ghExplicit.refreshCh
+	}
+}
+
 func TestRunSkipsDuplicateFlowIdentity(t *testing.T) {
 	// Two configs that resolve to the same flow identity (same StateDir) are a
 	// true duplicate — the second must be skipped, not silently overwrite the

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1116,6 +1116,10 @@ type fleetWebhookStats struct {
 	Duplicates        int64            `json:"duplicates"`
 	SignatureFailures int64            `json:"signature_failures"`
 	BadRequests       int64            `json:"bad_requests"`
+	// ForgeRejected counts Gitea/Forgejo-origin deliveries refused with 422
+	// (#1172 M5). Non-zero means a Forgejo webhook is pointed at the GitHub
+	// endpoint — forgejo rows are poll-only, so the fix is to remove the hook.
+	ForgeRejected int64 `json:"forge_rejected"`
 }
 
 // webhookStatsSnapshot maps the ingestor's counters into the fleet response
@@ -1135,6 +1139,7 @@ func (s *FleetServer) webhookStatsSnapshot() *fleetWebhookStats {
 		Duplicates:        st.Duplicates,
 		SignatureFailures: st.SignatureFailures,
 		BadRequests:       st.BadRequests,
+		ForgeRejected:     st.ForgeRejected,
 	}
 	if !st.LastDeliveryAt.IsZero() {
 		out.LastDeliveryAt = formatFleetTime(st.LastDeliveryAt)
@@ -1464,6 +1469,14 @@ type fleetClosedIssueOutcome struct {
 type fleetProjectState struct {
 	Name string `json:"name"`
 	Repo string `json:"repo"`
+	// Forge is the row's effective code forge kind — "github" (every legacy row)
+	// or "forgejo" (#1172). WebhooksApplicable reports whether the fleet-global
+	// `webhooks` block says anything about THIS row: forgejo rows are poll-only by
+	// design (the endpoint rejects Gitea-origin deliveries with 422), so a healthy
+	// global webhook block must not be read as covering them. Both are always
+	// present so the SPA never has to infer poll-only from a missing field.
+	Forge              string `json:"forge"`
+	WebhooksApplicable bool   `json:"webhooks_applicable"`
 	// ProjectID is the project's stable UUID identity (#869), omitted for legacy
 	// rows that have none. Descriptive only — it never changes routing/display.
 	ProjectID string `json:"project_id,omitempty"`
@@ -4487,6 +4500,11 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 		ConfigPath:   project.ConfigPath,
 		DashboardURL: project.DashboardURL,
 		Freshness:    newFleetProjectFreshness(),
+		// Default to the historical forge so a row whose config failed to resolve
+		// still reports a concrete kind rather than an empty string; overwritten
+		// from cfg.Forge below as soon as the config is known.
+		Forge:              config.ForgeKindGitHub,
+		WebhooksApplicable: true,
 	}
 	if cfg == nil {
 		item.Error = "missing resolved project config"
@@ -4494,6 +4512,10 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 		return item, nil
 	}
 	item.Repo = cfg.Repo
+	// #1172 M5: forgejo rows are poll-only — no webhook ingestion exists for them,
+	// so the fleet-global `webhooks` block says nothing about this project.
+	item.Forge = cfg.Forge.EffectiveKind()
+	item.WebhooksApplicable = !cfg.Forge.IsForgejo()
 	item.ProjectID = strings.TrimSpace(cfg.ProjectID)
 	item.ManagementHome = fleetManagementHomeFromConfig(cfg.ManagementHome)
 	item.StateDir = cfg.StateDir

--- a/internal/server/fleet.go
+++ b/internal/server/fleet.go
@@ -1470,11 +1470,15 @@ type fleetProjectState struct {
 	Name string `json:"name"`
 	Repo string `json:"repo"`
 	// Forge is the row's effective code forge kind — "github" (every legacy row)
-	// or "forgejo" (#1172). WebhooksApplicable reports whether the fleet-global
-	// `webhooks` block says anything about THIS row: forgejo rows are poll-only by
-	// design (the endpoint rejects Gitea-origin deliveries with 422), so a healthy
-	// global webhook block must not be read as covering them. Both are always
-	// present so the SPA never has to infer poll-only from a missing field.
+	// or "forgejo" (#1172). WebhooksApplicable reports whether this row's forge
+	// kind supports webhook ingestion at all: forgejo rows are poll-only by design
+	// (the endpoint rejects Gitea-origin deliveries with 422), so a healthy global
+	// `webhooks` block must not be read as covering them. It is a property of the
+	// forge kind, NOT a statement that ingestion is switched on — the fleet-global
+	// block is absent entirely when the daemon runs without a webhook secret, and
+	// github rows still report true there. It is also false when the config failed
+	// to resolve, where coverage is unknowable. Both fields are always present so
+	// the SPA never has to infer poll-only from a missing field.
 	Forge              string `json:"forge"`
 	WebhooksApplicable bool   `json:"webhooks_applicable"`
 	// ProjectID is the project's stable UUID identity (#869), omitted for legacy
@@ -4507,6 +4511,14 @@ func (s *FleetServer) projectSnapshot(project FleetProject, now time.Time) (flee
 		WebhooksApplicable: true,
 	}
 	if cfg == nil {
+		// Config did not resolve, so the row's forge is a fallback, not a fact —
+		// do NOT also claim webhook coverage for it. A forgejo row with a broken
+		// config would otherwise render as {"forge":"github","webhooks_applicable":
+		// true}: the exact "global webhook health covers this row" misreading the
+		// per-row fields exist to prevent, on the one row an operator is already
+		// worried about. `error` is set alongside, so false here reads as "cannot
+		// say", which is the honest answer.
+		item.WebhooksApplicable = false
 		item.Error = "missing resolved project config"
 		item.OperatorState = buildFleetProjectOperatorState(item)
 		return item, nil

--- a/internal/server/fleet_forge_pollonly_test.go
+++ b/internal/server/fleet_forge_pollonly_test.go
@@ -1,0 +1,146 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/befeast/maestro/internal/config"
+	"github.com/befeast/maestro/internal/webhook"
+	"github.com/befeast/maestro/internal/webhookstore"
+)
+
+// A forgejo row must advertise its forge and that the fleet-global `webhooks`
+// block does not cover it (#1172 M5) — otherwise an operator reads healthy
+// global webhook stats as if they applied to a poll-only project.
+func TestProjectSnapshotMarksForgejoRowPollOnly(t *testing.T) {
+	cfg := &config.Config{
+		Repo:     "owner/svc",
+		StateDir: t.TempDir(),
+		Forge: config.ForgeConfig{
+			Kind:    config.ForgeKindForgejo,
+			BaseURL: "https://forge.example.com",
+		},
+	}
+	proj := NewFleetProject("svc", "", "", cfg)
+	fleet := NewFleet([]FleetProject{proj}, "127.0.0.1", 0, false)
+
+	item, _ := fleet.projectSnapshot(proj, time.Now())
+	if item.Forge != "forgejo" {
+		t.Fatalf("forge = %q, want forgejo", item.Forge)
+	}
+	if item.WebhooksApplicable {
+		t.Fatal("webhooks_applicable = true for a forgejo row, want false (poll-only)")
+	}
+
+	blob, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(blob)
+	for _, want := range []string{`"forge":"forgejo"`, `"webhooks_applicable":false`} {
+		if !strings.Contains(js, want) {
+			t.Fatalf("payload JSON missing %s:\n%s", want, js)
+		}
+	}
+}
+
+// The github arm: both the absent forge block (every legacy row) and an explicit
+// kind: github report the historical shape — forge "github", webhooks applicable.
+// The fields are never omitted, so the SPA never has to infer poll-only from a
+// missing key.
+func TestProjectSnapshotGitHubRowShapeUnchanged(t *testing.T) {
+	for name, cfg := range map[string]*config.Config{
+		"absent forge block": {Repo: "owner/legacy", StateDir: t.TempDir()},
+		"explicit github": {
+			Repo:     "owner/explicit",
+			StateDir: t.TempDir(),
+			Forge:    config.ForgeConfig{Kind: config.ForgeKindGitHub},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			proj := NewFleetProject("p", "", "", cfg)
+			fleet := NewFleet([]FleetProject{proj}, "127.0.0.1", 0, false)
+
+			item, _ := fleet.projectSnapshot(proj, time.Now())
+			if item.Forge != "github" {
+				t.Fatalf("forge = %q, want github", item.Forge)
+			}
+			if !item.WebhooksApplicable {
+				t.Fatal("webhooks_applicable = false for a github row, want true")
+			}
+			blob, _ := json.Marshal(item)
+			js := string(blob)
+			for _, want := range []string{`"forge":"github"`, `"webhooks_applicable":true`} {
+				if !strings.Contains(js, want) {
+					t.Fatalf("payload JSON missing %s:\n%s", want, js)
+				}
+			}
+		})
+	}
+}
+
+// forgeRejectedStore is the minimal webhook.Store the ingestor needs; the
+// rejection path never touches it, which the zero counts assert.
+type forgeRejectedStore struct{}
+
+func (forgeRejectedStore) Insert(context.Context, webhookstore.Delivery) (bool, error) {
+	return false, errors.New("insert must not be reached for a gitea-origin delivery")
+}
+func (forgeRejectedStore) Count(context.Context) (int, error) { return 0, nil }
+func (forgeRejectedStore) CountsByEventType(context.Context) (map[string]int, error) {
+	return map[string]int{}, nil
+}
+func (forgeRejectedStore) LastDelivery(context.Context) (time.Time, string, error) {
+	return time.Time{}, "", nil
+}
+
+// The new rejection counter must reach the fleet snapshot's `webhooks` block
+// under a stable key, so a misconfigured Forgejo hook is visible rather than
+// invisible (#1172 M5 / G3).
+func TestFleetWebhookStatsSurfaceForgeRejected(t *testing.T) {
+	in := webhook.NewIngestor(forgeRejectedStore{}, "shared-secret")
+	fleet := NewFleet(nil, "127.0.0.1", 0, false)
+	fleet.SetWebhookIngestor(in, webhook.DefaultPath)
+
+	if got := fleet.webhookStatsSnapshot(); got == nil || got.ForgeRejected != 0 {
+		t.Fatalf("baseline forge_rejected = %+v, want 0", got)
+	}
+
+	body := []byte(`{"action":"completed","repository":{"full_name":"owner/svc"}}`)
+	req := httptest.NewRequest(http.MethodPost, webhook.DefaultPath, strings.NewReader(string(body)))
+	req.Header.Set(webhook.HeaderEvent, "check_run")
+	req.Header.Set(webhook.HeaderDelivery, "fj-1")
+	req.Header.Set(webhook.HeaderSignature, webhook.Sign("shared-secret", body))
+	req.Header.Set(webhook.HeaderForgejoEvent, "check_run")
+
+	rec := httptest.NewRecorder()
+	in.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("gitea-origin delivery status = %d, want 422 (body=%s)", rec.Code, rec.Body.String())
+	}
+
+	stats := fleet.webhookStatsSnapshot()
+	if stats == nil {
+		t.Fatal("webhook stats block missing")
+	}
+	if stats.ForgeRejected != 1 {
+		t.Fatalf("forge_rejected = %d, want 1", stats.ForgeRejected)
+	}
+	if stats.TotalDeliveries != 0 {
+		t.Fatalf("total_deliveries = %d, want 0 — a rejected delivery must not read as healthy ingestion", stats.TotalDeliveries)
+	}
+
+	blob, err := json.Marshal(stats)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(blob), `"forge_rejected":1`) {
+		t.Fatalf("webhooks block missing forge_rejected key:\n%s", blob)
+	}
+}

--- a/internal/server/fleet_forge_pollonly_test.go
+++ b/internal/server/fleet_forge_pollonly_test.go
@@ -85,6 +85,29 @@ func TestProjectSnapshotGitHubRowShapeUnchanged(t *testing.T) {
 	}
 }
 
+// A row whose config failed to resolve must not ASSERT webhook coverage: the
+// forge kind is a display fallback there, so claiming webhooks_applicable would
+// be a guess presented as fact on the one row an operator is already worried
+// about (a broken forgejo row would render as github + covered).
+func TestProjectSnapshotUnresolvedConfigDoesNotClaimWebhookCoverage(t *testing.T) {
+	proj := NewFleetProject("broken", "", "", nil)
+	fleet := NewFleet([]FleetProject{proj}, "127.0.0.1", 0, false)
+
+	item, workers := fleet.projectSnapshot(proj, time.Now())
+	if workers != nil {
+		t.Fatalf("workers = %v, want nil for an unresolved row", workers)
+	}
+	if item.Error == "" {
+		t.Fatal("unresolved row has no error field")
+	}
+	if item.WebhooksApplicable {
+		t.Fatal("webhooks_applicable = true for a row with no resolved config, want false (coverage unknowable)")
+	}
+	if item.Forge == "" {
+		t.Fatal("forge is empty — the field must always be present")
+	}
+}
+
 // forgeRejectedStore is the minimal webhook.Store the ingestor needs; the
 // rejection path never touches it, which the zero counts assert.
 type forgeRejectedStore struct{}

--- a/internal/webhook/ingest.go
+++ b/internal/webhook/ingest.go
@@ -76,9 +76,14 @@ type Ingestor struct {
 	duplicates        int64
 	signatureFailures int64
 	badRequests       int64
-	byEventType       map[string]int64
-	lastDeliveryAt    time.Time
-	lastEventType     string
+	// forgeRejected counts signed-but-Gitea/Forgejo-origin deliveries turned away
+	// with 422 (#1172 M5). Transient per-process like the other rejection counters
+	// — nothing is stored, so there is nothing durable to seed it from. A non-zero
+	// value means someone pointed a Forgejo hook at the GitHub endpoint.
+	forgeRejected  int64
+	byEventType    map[string]int64
+	lastDeliveryAt time.Time
+	lastEventType  string
 }
 
 // NewIngestor builds an Ingestor over store with the given webhook secret and
@@ -209,6 +214,34 @@ func (in *Ingestor) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Origin guard (#1172 M5): forgejo rows are poll-only by design. A Forgejo /
+	// Gitea hook aimed here with the right secret passes VerifySignature (identical
+	// sha256= HMAC scheme) and carries GitHub-aliased X-GitHub-* headers, so without
+	// this check it would be stored AND projected into mirror_* rows keyed by the
+	// bare owner/name — the same key the GitHub mirror uses for the mirrored repo.
+	//
+	// Placed AFTER the signature check on purpose: an unauthenticated prober must
+	// still get 401 and learn nothing about which forges this endpoint distinguishes.
+	//
+	// Rejected with 422 rather than 202-and-ignore: a stored-but-unprojected Gitea
+	// delivery would inflate webhooks.total_deliveries / by_event_type and read as
+	// healthy ingestion on the fleet snapshot, so the misconfiguration would be
+	// invisible exactly where an operator would look for it. 422 fails loud, never
+	// stores, never projects, and Forgejo surfaces the non-2xx in its hook delivery
+	// log. 4xx (not 5xx) because retrying unchanged cannot help.
+	if origin, ok := GiteaOriginHeader(r.Header); ok {
+		in.countForgeRejected()
+		log.Printf("[webhook] rejected delivery: gitea/forgejo-origin (%s present) — forgejo rows are poll-only (event=%q delivery=%q)",
+			origin, r.Header.Get(HeaderEvent), r.Header.Get(HeaderDelivery))
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{
+			"error":  "gitea/forgejo-origin delivery rejected",
+			"origin": origin,
+			"reason": "this endpoint ingests GitHub deliveries only; the mirror read model is keyed for GitHub, so a Forgejo delivery would contaminate the mirrored repo's rows",
+			"remedy": "forgejo rows are poll-only by design — remove this webhook from the Forgejo repository; see docs/webhook-ingestion-runbook.md",
+		})
+		return
+	}
+
 	deliveryID := strings.TrimSpace(r.Header.Get(HeaderDelivery))
 	if deliveryID == "" {
 		in.countBadRequest()
@@ -282,6 +315,12 @@ func (in *Ingestor) countSignatureFailure() {
 	in.mu.Unlock()
 }
 
+func (in *Ingestor) countForgeRejected() {
+	in.mu.Lock()
+	in.forgeRejected++
+	in.mu.Unlock()
+}
+
 func (in *Ingestor) countBadRequest() {
 	in.mu.Lock()
 	in.badRequests++
@@ -319,7 +358,11 @@ type Stats struct {
 	Duplicates        int64
 	SignatureFailures int64
 	BadRequests       int64
-	ByEventType       map[string]int64
+	// ForgeRejected is the count of Gitea/Forgejo-origin deliveries refused with
+	// 422 (#1172 M5). Surfaced so a misconfigured Forgejo hook is visible instead
+	// of silent.
+	ForgeRejected int64
+	ByEventType   map[string]int64
 }
 
 // Stats returns a snapshot of the observability counters.
@@ -337,6 +380,7 @@ func (in *Ingestor) Stats() Stats {
 		Duplicates:        in.duplicates,
 		SignatureFailures: in.signatureFailures,
 		BadRequests:       in.badRequests,
+		ForgeRejected:     in.forgeRejected,
 		ByEventType:       byType,
 	}
 }

--- a/internal/webhook/origin_test.go
+++ b/internal/webhook/origin_test.go
@@ -1,0 +1,211 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestGiteaOriginDetectorsEachHeaderAlone asserts every documented detector
+// header is sufficient on its own. Forgejo/Gitea send the whole family on every
+// delivery, but the guard must not depend on that — a proxy that strips some
+// headers must still be caught by whichever one survives.
+func TestGiteaOriginDetectorsEachHeaderAlone(t *testing.T) {
+	// The exact list the spec fixes, plus the siblings verified against Forgejo
+	// services/webhook/shared/payloader.go and Gitea services/webhook/deliver.go.
+	want := []string{
+		"X-Gitea-Event",
+		"X-Forgejo-Event",
+		"X-Gitea-Event-Type",
+		"X-Gitea-Hook-Installation-Target-Type",
+		"X-Gitea-Signature",
+		"X-Gogs-Event",
+		"X-Forgejo-Event-Type",
+		"X-Forgejo-Delivery",
+		"X-Forgejo-Signature",
+		"X-Gitea-Delivery",
+		"X-Gogs-Event-Type",
+		"X-Gogs-Delivery",
+		"X-Gogs-Signature",
+	}
+	have := make(map[string]bool, len(GiteaOriginHeaders))
+	for _, name := range GiteaOriginHeaders {
+		have[name] = true
+	}
+	for _, name := range want {
+		if !have[name] {
+			t.Errorf("GiteaOriginHeaders is missing detector %q", name)
+		}
+	}
+	if len(GiteaOriginHeaders) != len(want) {
+		t.Errorf("GiteaOriginHeaders = %d entries, want %d: %v", len(GiteaOriginHeaders), len(want), GiteaOriginHeaders)
+	}
+
+	for _, name := range GiteaOriginHeaders {
+		t.Run(name, func(t *testing.T) {
+			h := http.Header{}
+			// Every delivery also carries the GitHub-aliased headers; the detector
+			// must fire despite them.
+			h.Set(HeaderEvent, "push")
+			h.Set(HeaderDelivery, "uuid-1")
+			h.Set(name, "value")
+			got, ok := GiteaOriginHeader(h)
+			if !ok {
+				t.Fatalf("GiteaOriginHeader(%s alone) = not detected", name)
+			}
+			if got != name {
+				t.Fatalf("GiteaOriginHeader reported %q, want %q", got, name)
+			}
+			if !IsGiteaOrigin(h) {
+				t.Fatalf("IsGiteaOrigin(%s alone) = false", name)
+			}
+		})
+	}
+}
+
+// TestGiteaOriginIgnoresGitHubOnlyDelivery pins the false-positive side: a real
+// GitHub delivery (including the sha1 X-Hub-Signature and the GitHub-prefixed
+// event-type header, both deliberately NOT detectors) must not be flagged.
+func TestGiteaOriginIgnoresGitHubOnlyDelivery(t *testing.T) {
+	h := http.Header{}
+	h.Set(HeaderEvent, "pull_request")
+	h.Set(HeaderDelivery, "b1f0e2ac-0000-4000-8000-000000000000")
+	h.Set(HeaderSignature, "sha256=deadbeef")
+	h.Set(HeaderHookID, "42")
+	h.Set("X-Hub-Signature", "sha1=deadbeef")
+	h.Set("X-GitHub-Event-Type", "pull_request")
+	h.Set("X-GitHub-Hook-Installation-Target-Type", "repository")
+	h.Set("User-Agent", "GitHub-Hookshot/044aadd")
+	if name, ok := GiteaOriginHeader(h); ok {
+		t.Fatalf("GitHub-only delivery flagged as gitea-origin via %q", name)
+	}
+
+	if _, ok := GiteaOriginHeader(nil); ok {
+		t.Fatal("nil header flagged as gitea-origin")
+	}
+	if _, ok := GiteaOriginHeader(http.Header{}); ok {
+		t.Fatal("empty header flagged as gitea-origin")
+	}
+}
+
+// TestGiteaOriginHeaderLookupIsCaseInsensitive covers http.Header.Get semantics:
+// net/textproto canonicalises header names on the wire, and Gitea writes some of
+// its GitHub-compat headers into the map without canonicalising, so the detector
+// must not depend on the caller's capitalisation. A present-but-empty header is
+// not a detector.
+func TestGiteaOriginHeaderLookupIsCaseInsensitive(t *testing.T) {
+	for _, spelling := range []string{"x-gitea-event", "X-GITEA-EVENT", "X-Gitea-Event"} {
+		h := http.Header{}
+		h.Set(spelling, "push")
+		if _, ok := GiteaOriginHeader(h); !ok {
+			t.Errorf("spelling %q not detected", spelling)
+		}
+	}
+
+	blank := http.Header{}
+	blank.Set(HeaderGiteaEvent, "   ")
+	if _, ok := GiteaOriginHeader(blank); ok {
+		t.Fatal("blank X-Gitea-Event counted as a detector")
+	}
+}
+
+// TestIngestRejectsGiteaOriginDelivery is the G1 acceptance: a correctly SIGNED
+// Forgejo delivery (Forgejo uses the identical sha256= HMAC scheme, so the
+// signature is genuinely valid) is refused with 422 — not stored, not projected,
+// no after-accepted wake — and counted in ForgeRejected.
+func TestIngestRejectsGiteaOriginDelivery(t *testing.T) {
+	in, store := newTestIngestor(t)
+	proj := &recordingProjector{}
+	in.SetProjector(proj)
+	var woke []string
+	in.SetAfterAccepted(func(eventType, repo string) { woke = append(woke, eventType) })
+
+	body := []byte(`{"action":"completed","repository":{"full_name":"BeFeast/maestro"}}`)
+	req := signedRequest(t, DefaultPath, "check_run", "forgejo-del-1", body, true)
+	req.Header.Set(HeaderForgejoEvent, "check_run")
+	req.Header.Set(HeaderGiteaEvent, "check_run")
+	req.Header.Set(HeaderGiteaSignature, "0f0f0f")
+
+	rec := httptest.NewRecorder()
+	in.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("gitea-origin delivery: status=%d body=%s, want 422", rec.Code, rec.Body.String())
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("response body is not JSON: %v (%s)", err, rec.Body.String())
+	}
+	if payload["origin"] == "" || payload["error"] == "" || payload["reason"] == "" || payload["remedy"] == "" {
+		t.Fatalf("422 body must name cause and remedy, got %v", payload)
+	}
+
+	if _, ok, err := store.Get(context.Background(), "forgejo-del-1"); err != nil || ok {
+		t.Fatalf("gitea-origin delivery was stored: ok=%v err=%v", ok, err)
+	}
+	if n, err := store.Count(context.Background()); err != nil || n != 0 {
+		t.Fatalf("store count = %d (err=%v), want 0", n, err)
+	}
+	if events := proj.events(); len(events) != 0 {
+		t.Fatalf("gitea-origin delivery was projected: %v", events)
+	}
+	if len(woke) != 0 {
+		t.Fatalf("gitea-origin delivery ran the after-accepted hook: %v", woke)
+	}
+
+	stats := in.Stats()
+	if stats.ForgeRejected != 1 {
+		t.Fatalf("ForgeRejected = %d, want 1 (stats=%+v)", stats.ForgeRejected, stats)
+	}
+	if stats.Accepted != 0 || stats.Duplicates != 0 || stats.BadRequests != 0 || stats.SignatureFailures != 0 {
+		t.Fatalf("rejection leaked into other counters: %+v", stats)
+	}
+}
+
+// TestIngestGiteaOriginWithBadSignatureIs401 pins the ordering: the origin check
+// runs AFTER signature validation, so an unauthenticated caller cannot probe
+// which forges this endpoint distinguishes.
+func TestIngestGiteaOriginWithBadSignatureIs401(t *testing.T) {
+	in, store := newTestIngestor(t)
+	body := []byte(`{"action":"opened","repository":{"full_name":"BeFeast/maestro"}}`)
+	req := signedRequest(t, DefaultPath, "issues", "forgejo-del-2", body, false)
+	req.Header.Set(HeaderGiteaEvent, "issues")
+
+	rec := httptest.NewRecorder()
+	in.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("bad-signature gitea-origin delivery: status=%d, want 401", rec.Code)
+	}
+	stats := in.Stats()
+	if stats.SignatureFailures != 1 {
+		t.Fatalf("SignatureFailures = %d, want 1", stats.SignatureFailures)
+	}
+	if stats.ForgeRejected != 0 {
+		t.Fatalf("ForgeRejected = %d, want 0 — signature must be checked first", stats.ForgeRejected)
+	}
+	if n, err := store.Count(context.Background()); err != nil || n != 0 {
+		t.Fatalf("store count = %d (err=%v), want 0", n, err)
+	}
+}
+
+// TestIngestGitHubDeliveryUnaffectedByOriginGuard is the regression arm: adding
+// the guard must leave the GitHub happy path byte-identical.
+func TestIngestGitHubDeliveryUnaffectedByOriginGuard(t *testing.T) {
+	in, store := newTestIngestor(t)
+	body := readFixture(t, "issues_opened.json")
+
+	rec := httptest.NewRecorder()
+	in.ServeHTTP(rec, signedRequest(t, DefaultPath, "issues", "github-del-1", body, true))
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("github delivery: status=%d body=%s, want 202", rec.Code, rec.Body.String())
+	}
+	if _, ok, err := store.Get(context.Background(), "github-del-1"); err != nil || !ok {
+		t.Fatalf("github delivery not stored: ok=%v err=%v", ok, err)
+	}
+	if stats := in.Stats(); stats.ForgeRejected != 0 || stats.Accepted != 1 {
+		t.Fatalf("github delivery counters: %+v", stats)
+	}
+}

--- a/internal/webhook/origin_test.go
+++ b/internal/webhook/origin_test.go
@@ -30,20 +30,32 @@ func TestGiteaOriginDetectorsEachHeaderAlone(t *testing.T) {
 		"X-Gogs-Delivery",
 		"X-Gogs-Signature",
 	}
-	have := make(map[string]bool, len(GiteaOriginHeaders))
-	for _, name := range GiteaOriginHeaders {
+	detectors := GiteaOriginHeaderNames()
+	have := make(map[string]bool, len(detectors))
+	for _, name := range detectors {
 		have[name] = true
 	}
 	for _, name := range want {
 		if !have[name] {
-			t.Errorf("GiteaOriginHeaders is missing detector %q", name)
+			t.Errorf("detector list is missing %q", name)
 		}
 	}
-	if len(GiteaOriginHeaders) != len(want) {
-		t.Errorf("GiteaOriginHeaders = %d entries, want %d: %v", len(GiteaOriginHeaders), len(want), GiteaOriginHeaders)
+	if len(detectors) != len(want) {
+		t.Errorf("detector list = %d entries, want %d: %v", len(detectors), len(want), detectors)
 	}
 
-	for _, name := range GiteaOriginHeaders {
+	// The accessor hands back a copy: mutating it must not disarm the guard.
+	if len(detectors) > 0 {
+		detectors[0] = "X-Not-A-Detector"
+		h := http.Header{}
+		h.Set(HeaderForgejoEvent, "push")
+		if _, ok := GiteaOriginHeader(h); !ok {
+			t.Fatal("mutating the returned detector list disarmed the guard — accessor must return a copy")
+		}
+		detectors = GiteaOriginHeaderNames()
+	}
+
+	for _, name := range detectors {
 		t.Run(name, func(t *testing.T) {
 			h := http.Header{}
 			// Every delivery also carries the GitHub-aliased headers; the detector
@@ -90,11 +102,12 @@ func TestGiteaOriginIgnoresGitHubOnlyDelivery(t *testing.T) {
 	}
 }
 
-// TestGiteaOriginHeaderLookupIsCaseInsensitive covers http.Header.Get semantics:
-// net/textproto canonicalises header names on the wire, and Gitea writes some of
-// its GitHub-compat headers into the map without canonicalising, so the detector
-// must not depend on the caller's capitalisation. A present-but-empty header is
-// not a detector.
+// TestGiteaOriginHeaderLookupIsCaseInsensitive pins http.Header.Get semantics:
+// both Set and Get canonicalise the name they are given, so however a caller
+// spells the header the detector still fires. This is a property of the map
+// accessors, not of the wire: a header parsed off a real request is already
+// canonical, whatever capitalisation Forgejo/Gitea put on the wire. A
+// present-but-empty header is not a detector.
 func TestGiteaOriginHeaderLookupIsCaseInsensitive(t *testing.T) {
 	for _, spelling := range []string{"x-gitea-event", "X-GITEA-EVENT", "X-Gitea-Event"} {
 		h := http.Header{}
@@ -102,6 +115,16 @@ func TestGiteaOriginHeaderLookupIsCaseInsensitive(t *testing.T) {
 		if _, ok := GiteaOriginHeader(h); !ok {
 			t.Errorf("spelling %q not detected", spelling)
 		}
+	}
+
+	// Documented limit of Get-based lookup: a map key written RAW (bypassing Set)
+	// in non-canonical form is invisible to Get. Unreachable on the ingest path —
+	// net/http canonicalises every header it parses, so r.Header never holds such
+	// a key — but pinned here so nobody reads the case-insensitivity above as a
+	// promise about hand-built maps.
+	raw := http.Header{"x-gitea-event": {"push"}}
+	if _, ok := GiteaOriginHeader(raw); ok {
+		t.Fatal("raw non-canonical map key detected — behaviour changed; update this test and the ingest-path reasoning")
 	}
 
 	blank := http.Header{}

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -14,6 +14,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"net/http"
 	"strings"
 )
 
@@ -25,6 +26,84 @@ const (
 	HeaderSignature = "X-Hub-Signature-256"
 	HeaderHookID    = "X-GitHub-Hook-ID"
 )
+
+// Gitea/Forgejo-origin delivery header names (#1172 M5). Forgejo and Gitea
+// deliver GitHub-ALIASED headers — X-GitHub-Event, X-GitHub-Delivery and
+// X-Hub-Signature-256 with the identical "sha256="+hex HMAC scheme — so a
+// Forgejo hook pointed at this endpoint with the same secret is otherwise
+// indistinguishable from GitHub and would be stored and projected into the
+// GitHub-keyed mirror tables under the bare owner/name key. These headers are
+// the unambiguous discriminators: GitHub never sends any of them.
+//
+// Verified against source, not guessed:
+//   - Forgejo services/webhook/shared/payloader.go sends X-Forgejo-{Delivery,
+//     Event,Event-Type,Signature}, X-Gitea-{Delivery,Event,Event-Type,Signature}
+//     and X-Gogs-{Delivery,Event,Event-Type,Signature} on EVERY delivery.
+//   - Gitea services/webhook/deliver.go (addDefaultHeaders) sends the same set
+//     plus X-Gitea-Hook-Installation-Target-Type.
+//
+// Deliberately NOT detectors: X-Hub-Signature (sha1) and X-GitHub-Event-Type —
+// the first is a real historical GitHub header, and the second is GitHub-prefixed,
+// so treating either as Gitea-origin risks rejecting genuine GitHub traffic. The
+// list errs toward MORE detectors only where the header prefix makes the origin
+// unambiguous.
+const (
+	HeaderForgejoEvent     = "X-Forgejo-Event"
+	HeaderForgejoEventType = "X-Forgejo-Event-Type"
+	HeaderForgejoDelivery  = "X-Forgejo-Delivery"
+	HeaderForgejoSignature = "X-Forgejo-Signature"
+	HeaderGiteaEvent       = "X-Gitea-Event"
+	HeaderGiteaEventType   = "X-Gitea-Event-Type"
+	HeaderGiteaDelivery    = "X-Gitea-Delivery"
+	HeaderGiteaSignature   = "X-Gitea-Signature"
+	HeaderGiteaHookTarget  = "X-Gitea-Hook-Installation-Target-Type"
+	HeaderGogsEvent        = "X-Gogs-Event"
+	HeaderGogsEventType    = "X-Gogs-Event-Type"
+	HeaderGogsDelivery     = "X-Gogs-Delivery"
+	HeaderGogsSignature    = "X-Gogs-Signature"
+)
+
+// GiteaOriginHeaders is the exact detector list. Exposed (rather than inlined as
+// string literals at the call site) so tests and any future diagnostic enumerate
+// the same set the handler enforces.
+var GiteaOriginHeaders = []string{
+	HeaderForgejoEvent,
+	HeaderForgejoEventType,
+	HeaderForgejoDelivery,
+	HeaderForgejoSignature,
+	HeaderGiteaEvent,
+	HeaderGiteaEventType,
+	HeaderGiteaDelivery,
+	HeaderGiteaSignature,
+	HeaderGiteaHookTarget,
+	HeaderGogsEvent,
+	HeaderGogsEventType,
+	HeaderGogsDelivery,
+	HeaderGogsSignature,
+}
+
+// GiteaOriginHeader returns the first detector header present on h and whether
+// the delivery is Gitea/Forgejo-origin. Lookup goes through http.Header.Get, so
+// it is header-name case-insensitive (net/textproto canonicalises on parse) and
+// a header present but empty does NOT count as a detector — Gitea/Forgejo always
+// populate these with a non-empty event name, UUID or digest.
+func GiteaOriginHeader(h http.Header) (string, bool) {
+	if h == nil {
+		return "", false
+	}
+	for _, name := range GiteaOriginHeaders {
+		if strings.TrimSpace(h.Get(name)) != "" {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+// IsGiteaOrigin reports whether h carries any Gitea/Forgejo-origin marker.
+func IsGiteaOrigin(h http.Header) bool {
+	_, ok := GiteaOriginHeader(h)
+	return ok
+}
 
 // signaturePrefix is the algorithm tag GitHub prepends to the hex digest in the
 // X-Hub-Signature-256 header ("sha256=<hexdigest>"). The older X-Hub-Signature

--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -35,12 +35,16 @@ const (
 // GitHub-keyed mirror tables under the bare owner/name key. These headers are
 // the unambiguous discriminators: GitHub never sends any of them.
 //
-// Verified against source, not guessed:
-//   - Forgejo services/webhook/shared/payloader.go sends X-Forgejo-{Delivery,
-//     Event,Event-Type,Signature}, X-Gitea-{Delivery,Event,Event-Type,Signature}
-//     and X-Gogs-{Delivery,Event,Event-Type,Signature} on EVERY delivery.
-//   - Gitea services/webhook/deliver.go (addDefaultHeaders) sends the same set
-//     plus X-Gitea-Hook-Installation-Target-Type.
+// Verified against source, not guessed. The two forges emit OVERLAPPING but not
+// identical sets, so the list is their union — do not trim it on the assumption
+// that both send all thirteen:
+//   - Forgejo services/webhook/shared/payloader.go (AddDefaultHeaders) sends
+//     X-Forgejo-{Delivery,Event,Event-Type,Signature},
+//     X-Gitea-{Delivery,Event,Event-Type,Signature} and
+//     X-Gogs-{Delivery,Event,Event-Type,Signature} on EVERY delivery.
+//   - Gitea services/webhook/deliver.go (addDefaultHeaders) sends the X-Gitea-*
+//     and X-Gogs-* quartets plus X-Gitea-Hook-Installation-Target-Type, and
+//     NO X-Forgejo-* header at all (that prefix is Forgejo-only).
 //
 // Deliberately NOT detectors: X-Hub-Signature (sha1) and X-GitHub-Event-Type —
 // the first is a real historical GitHub header, and the second is GitHub-prefixed,
@@ -63,10 +67,13 @@ const (
 	HeaderGogsSignature    = "X-Gogs-Signature"
 )
 
-// GiteaOriginHeaders is the exact detector list. Exposed (rather than inlined as
+// giteaOriginHeaders is the exact detector list. Named (rather than inlined as
 // string literals at the call site) so tests and any future diagnostic enumerate
-// the same set the handler enforces.
-var GiteaOriginHeaders = []string{
+// the same set the handler enforces. Deliberately UNexported and read only
+// through GiteaOriginHeaderNames: an exported slice is mutable package state, so
+// any importer could disable the write-side guard with a single assignment and
+// no test would fail.
+var giteaOriginHeaders = []string{
 	HeaderForgejoEvent,
 	HeaderForgejoEventType,
 	HeaderForgejoDelivery,
@@ -82,16 +89,26 @@ var GiteaOriginHeaders = []string{
 	HeaderGogsSignature,
 }
 
+// GiteaOriginHeaderNames returns a copy of the detector list for tests and
+// diagnostics. A copy, not the backing slice, so a caller cannot mutate what the
+// handler enforces.
+func GiteaOriginHeaderNames() []string {
+	out := make([]string, len(giteaOriginHeaders))
+	copy(out, giteaOriginHeaders)
+	return out
+}
+
 // GiteaOriginHeader returns the first detector header present on h and whether
-// the delivery is Gitea/Forgejo-origin. Lookup goes through http.Header.Get, so
-// it is header-name case-insensitive (net/textproto canonicalises on parse) and
-// a header present but empty does NOT count as a detector — Gitea/Forgejo always
-// populate these with a non-empty event name, UUID or digest.
+// the delivery is Gitea/Forgejo-origin. Lookup goes through http.Header.Get,
+// which canonicalises the name it is given, so the caller's capitalisation of
+// the constants does not matter. A header present but empty does NOT count as a
+// detector — Gitea/Forgejo always populate these with a non-empty event name,
+// UUID or digest.
 func GiteaOriginHeader(h http.Header) (string, bool) {
 	if h == nil {
 		return "", false
 	}
-	for _, name := range GiteaOriginHeaders {
+	for _, name := range giteaOriginHeaders {
 		if strings.TrimSpace(h.Get(name)) != "" {
 			return name, true
 		}

--- a/maestro.yaml.example
+++ b/maestro.yaml.example
@@ -18,6 +18,10 @@ worktree_base: /path/to/worktrees/repo
 # Note (#1172 M4): forgejo rows must also set review_gate: llm-review (or
 # none) — the default greptile gate is a GitHub-only reviewer and is rejected
 # at parse time on forgejo rows.
+# Note (#1172 M5): forgejo rows are poll-only — no webhook ingestion. The
+# /api/v1/webhooks/github endpoint rejects Gitea/Forgejo-origin deliveries with
+# 422 (the mirror read model is GitHub-keyed); see
+# docs/webhook-ingestion-runbook.md.
 # forge:
 #   kind: forgejo
 #   base_url: https://forge.example.com


### PR DESCRIPTION
## Summary

M5 of the Forgejo migration (#1172): forgejo rows are **poll-only, explicitly and enforced**. Chosen over a Gitea-format adapter deliberately — the mirror read path is already forgejo-guarded (config rejects `mirror-first`; `newReadSource`/`runMirrorReconcile` return early), and an adapter would have to key Forgejo entities into a mirror store that validation documents as GitHub-webhook-fed, reopening exactly what M2/M4 closed.

## The hole this closes

Forgejo and Gitea deliver **GitHub-aliased headers** — `X-GitHub-Event`, `X-GitHub-Delivery`, and `X-Hub-Signature-256` with the *identical* `sha256=`+hex HMAC scheme — alongside their own `X-Gitea-*`/`X-Forgejo-*`/`X-Gogs-*` set. So a Forgejo hook pointed at `/api/v1/webhooks/github` with a matching secret **passed the signature check, was stored (202), and was projected** into `mirror_*` rows keyed by the bare `owner/name` — the same key the GitHub mirror uses for the mirrored repo. Every guard added in M2/M4 was on the read side; the write side had none.

- **Ingest guard**: Gitea/Forgejo-origin deliveries are rejected with **422**, never stored, never projected. Detection is a 13-header union verified against Forgejo `services/webhook/shared/payloader.go` and Gitea `addDefaultHeaders` (not from memory). `X-Hub-Signature` (sha1) and `X-GitHub-Event-Type` are deliberately **excluded** as detectors — both are names GitHub itself can emit, and rejecting genuine GitHub traffic would be worse than the bug.
- **Ordering matters**: the check runs *after* the signature check, so an unsigned probe still gets 401 and learns nothing about endpoint behaviour. Pinned by a test (Gitea-origin + bad signature → 401, not 422).
- **Why 422 and not "accept and ignore"**: a stored-but-unprojected delivery would inflate `webhooks.*` and read as healthy ingestion. The rejection increments a dedicated `forge_rejected` counter and emits one journal line, so a misconfigured hook is visible rather than invisible.

## Also fixed

- **Mirrored-pair flow wake**: `refreshPRGateFromWebhook` matched flows by `owner/name` alone, so GitHub-side CI events woke forgejo flows of the mirrored repo. Now skips forgejo rows; github behaviour byte-identical.
- **Operator honesty**: the `webhooks` block in `GET /api/v1/fleet` is fleet-global, so a green `enabled: true` + fresh `last_delivery_at` read as coverage for rows that are 100% poll-driven. Each project entry now carries `forge` and `webhooks_applicable` (both always present, so nothing infers poll-only from a missing key). Review caught a real case: when a row's config fails to resolve, the snapshot claimed webhook coverage — now `false`, with a test that fails if the fix is reverted.
- **Runbook was lying**: `docs/webhook-ingestion-runbook.md` still claimed *"ingestion only (phase B) — nothing consumes the stored deliveries"*, false since #825/#826. Corrected, plus a Forgejo section (why the guard exists, symptom→fix, and how to clean up deliveries accepted before the guard existed — reconcile converges the mirror; the `webhook_deliveries` rows stay but are inert).

## Testing

`go build ./...`, `go vet ./...` clean; webhook, webhookstore, daemon, server, mirrorstore, config green; full suite green except the 3 pre-existing `internal/worker` umask-0002 failures (reproduced on clean main). New tests pin: each detector header alone and alongside GitHub aliases; a real GitHub delivery (incl. sha1 `X-Hub-Signature`, `X-GitHub-Event-Type`, Hookshot UA) is *not* flagged; 422 leaves the store empty, the projector uncalled, the after-accepted hook unrun and the other counters untouched; the 401-before-422 ordering; forgejo flows not woken while two github flows sharing the same repo name are; and the fleet JSON shape for both forge kinds.

## Carried flags (not fixed here)

1. **Defence in depth for header-stripping proxies** — detection is header-only. A payload-shape belt was proposed but needs a GHES allowed-host option to avoid rejecting GitHub Enterprise traffic; that is a design change, not a two-line guard.
2. **`webhook_deliveries` has no retention or pruning of any kind** — the table grows unbounded with full raw payloads. Pre-existing and forge-independent; now documented in the runbook, deserves its own issue.
3. Mission Control does not render the new `forge` / `webhooks_applicable` fields (API-only).
4. `mirror.reads.hit_rate` has no per-forge breakdown, so it under-reports GitHub-row effectiveness on a mixed fleet.

Part of #1172 (M5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the webhook auth/ingest path and fleet diagnostics for forge routing, but fails closed and leaves the GitHub happy path unchanged. Risk is mainly mis-rejecting traffic or operator confusion if detectors are wrong.
> 
> **Overview**
> Enforces **poll-only Forgejo** (#1172 M5): Gitea/Forgejo deliveries that would otherwise pass GitHub-aliased signature checks are rejected with **422**, never stored or projected into the GitHub-keyed `mirror_*` tables.
> 
> Detection uses a 13-header union (`X-Forgejo-*` / `X-Gitea-*` / `X-Gogs-*`) after signature validation so unsigned probes still get `401`. Rejections increment a new `forge_rejected` fleet counter instead of looking like healthy ingestion.
> 
> Also stops GitHub gate webhooks from waking forgejo flows that share a mirrored `owner/name`, and adds always-present per-project `forge` / `webhooks_applicable` fields so global webhook health is not read as covering poll-only rows. Runbook and example config document the policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ccf900388b4d1cbeb2762b2deb36b94bfa8f8b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change rejects Gitea/Forgejo-origin deliveries at the GitHub webhook endpoint, prevents webhook wake-ups for poll-only Forgejo projects, and adds forge-specific webhook metadata and operations guidance. The cleanup guidance needs correction: automatic reconciliation repairs issue and pull-request rows, but previously projected comments, reviews, checks, and project items remain visible and continue appearing in stale diagnostics.

<h3>Confidence Score: 4/5</h3>

The documentation should be corrected before merge so operators do not assume contaminated related mirror records are removed automatically.

A targeted SQLite reconciliation test established the affected data state, ran the real reconciliation path, and confirmed that issue and pull-request repairs do not extend to related projected entities or their stale counters.

**Files Needing Attention:** docs/webhook-ingestion-runbook.md lines 167-170 should describe the limited reconciliation scope and the remaining cleanup needed for comments, reviews, checks, and project items.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced two finding-comment proofs for the posted P2 finding and attached supporting artifacts including the harness source and the reconciliation script.
- T-Rex validated the reconciliation contract, showing that the process now updates IssuesRepaired:1 and PRsRepaired:1 and preserves the related flags, with the relevant code paths handling issues/PRs only.
- Before and after reconcile observations and the targeted reconciliation test output were captured to support review.

<a href="https://app.greptile.com/trex/runs/18461154/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Runbook incorrectly promises complete mirror convergence from phase-E reconcile**

   - **Bug**
     - `docs/webhook-ingestion-runbook.md:167-170` says the GitHub phase-E `runMirrorReconcile` loop “rewrites whatever diverged” and that “the mirror converges.” The executed harness shows that it repairs issue/PR rows only; old Forgejo-projected comments, reviews, checks, and project items stay visible in their mirror point reads and still contribute to stale diagnostics.
   - **Cause**
     - `Reconciler.Reconcile` snapshots and reconciles only `ListAllOpenIssues` and `ListAllOpenPRs` (`internal/mirrorstore/reconcile.go:106-165`). It neither enumerates nor removes related-row tables. Those tables retain their rows through `GetComment`, `GetReview`, `Checks`, and `GetProjectItem` (`internal/mirrorstore/store.go:695-778`) and are included in `StaleCounts` (`internal/mirrorstore/store.go:854-894`).
   - **Fix**
     - Revise runbook lines 167-170 to state that phase-E reconciliation repairs only issue and PR rows (and issue labels); it does not purge or reconcile previously projected comments, reviews, checks, or project items, which can remain visible and stale until separately removed/repaired. Proposed reviewer comment: “P2: This overstates phase-E reconciliation. `runMirrorReconcile` only snapshots/reconciles open issues and PRs; it does not enumerate or delete `mirror_comments`, `mirror_reviews`, `mirror_checks`, or `mirror_project_items`. Consequently, pre-guard Forgejo projections in those tables can remain point-readable and inflate stale diagnostics after the issue/PR rows are repaired. Please narrow the claimed convergence in lines 167-170.”

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
docs/webhook-ingestion-runbook.md:167-170
**Cleanup overstates mirror convergence**

`runMirrorReconcile` only snapshots and reconciles open issues and pull requests; it does not enumerate or remove `mirror_comments`, `mirror_reviews`, `mirror_checks`, or `mirror_project_items`. Pre-guard Forgejo projections in those tables therefore remain available through point reads and continue contributing to stale diagnostics after the issue/PR rows are repaired. Narrow this guidance to the entities reconciliation actually repairs, or document the additional cleanup required for related projections.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(webhook): address M5 review findings..."](https://github.com/befeast/maestro/commit/8ccf900388b4d1cbeb2762b2deb36b94bfa8f8b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52503614)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->